### PR TITLE
feat(plugins): change a SQLite column's type, nullability and default through the structure editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Column type, nullability and default changes for SQLite, libSQL and Cloudflare D1.
+- Column rename and drop alongside a foreign key change in one save.
 - Foreign key add, remove and edit for SQLite, libSQL and Cloudflare D1, applied as a reviewed table rebuild.
 - Real constraint names for SQLite foreign keys, in place of a positional placeholder.
 - Menu of the engine's own default values on the Structure tab's Default cell, with No default, NULL, Empty string and a Custom editor. (#2688)
@@ -74,6 +76,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Rebuild failing on a table with a dependent view where SQLite defaults `legacy_alter_table` off.
+- A dropped column silently leaving a broken trigger or view behind.
 - "Unsupported schema operation" when adding a foreign key to a SQLite, libSQL or Cloudflare D1 table.
 - Add and Remove offered on the Foreign Keys tab for engines that cannot edit foreign keys.
 - Incomplete foreign keys, indexes and columns reaching the database on Save.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Column type, nullability and default changes for SQLite, libSQL and Cloudflare D1.
+- Column type, nullability and default changes for SQLite, libSQL and Cloudflare D1, checked against every dependent view and trigger before the change commits.
 - Column rename and drop alongside a foreign key change in one save.
 - Foreign key add, remove and edit for SQLite, libSQL and Cloudflare D1, applied as a reviewed table rebuild.
 - Real constraint names for SQLite foreign keys, in place of a positional placeholder.
@@ -76,8 +76,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Rebuild failing on a table with a dependent view where SQLite defaults `legacy_alter_table` off.
-- A dropped column silently leaving a broken trigger or view behind.
 - "Unsupported schema operation" when adding a foreign key to a SQLite, libSQL or Cloudflare D1 table.
 - Add and Remove offered on the Foreign Keys tab for engines that cannot edit foreign keys.
 - Incomplete foreign keys, indexes and columns reaching the database on Save.

--- a/Plugins/BeancountDriverPlugin/Info.plist
+++ b/Plugins/BeancountDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>24</integer>
+	<integer>25</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Beancount</string>

--- a/Plugins/BigQueryDriverPlugin/Info.plist
+++ b/Plugins/BigQueryDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>24</integer>
+	<integer>25</integer>
 </dict>
 </plist>

--- a/Plugins/CSVExportPlugin/Info.plist
+++ b/Plugins/CSVExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>24</integer>
+	<integer>25</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>csv</string>

--- a/Plugins/CSVImportPlugin/Info.plist
+++ b/Plugins/CSVImportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>24</integer>
+	<integer>25</integer>
 	<key>TableProProvidesImportFormatIds</key>
 	<array>
 		<string>csv</string>

--- a/Plugins/CassandraDriverPlugin/Info.plist
+++ b/Plugins/CassandraDriverPlugin/Info.plist
@@ -21,6 +21,6 @@
 	<key>NSPrincipalClass</key>
 	<string>$(PRODUCT_MODULE_NAME).CassandraPlugin</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>24</integer>
+	<integer>25</integer>
 </dict>
 </plist>

--- a/Plugins/ClickHouseDriverPlugin/Info.plist
+++ b/Plugins/ClickHouseDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>24</integer>
+	<integer>25</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>ClickHouse</string>

--- a/Plugins/CloudflareD1DriverPlugin/Info.plist
+++ b/Plugins/CloudflareD1DriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>24</integer>
+	<integer>25</integer>
 </dict>
 </plist>

--- a/Plugins/DamengDriverPlugin/Info.plist
+++ b/Plugins/DamengDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>24</integer>
+	<integer>25</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Dameng</string>

--- a/Plugins/DuckDBDriverPlugin/Info.plist
+++ b/Plugins/DuckDBDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>24</integer>
+	<integer>25</integer>
 </dict>
 </plist>

--- a/Plugins/DynamoDBDriverPlugin/Info.plist
+++ b/Plugins/DynamoDBDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>24</integer>
+	<integer>25</integer>
 </dict>
 </plist>

--- a/Plugins/ElasticsearchDriverPlugin/Info.plist
+++ b/Plugins/ElasticsearchDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.53.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>24</integer>
+	<integer>25</integer>
 </dict>
 </plist>

--- a/Plugins/EtcdDriverPlugin/Info.plist
+++ b/Plugins/EtcdDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>24</integer>
+	<integer>25</integer>
 </dict>
 </plist>

--- a/Plugins/HTMLExportPlugin/Info.plist
+++ b/Plugins/HTMLExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>24</integer>
+	<integer>25</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>html</string>

--- a/Plugins/JSONExportPlugin/Info.plist
+++ b/Plugins/JSONExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>24</integer>
+	<integer>25</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>json</string>

--- a/Plugins/JSONImportPlugin/Info.plist
+++ b/Plugins/JSONImportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>24</integer>
+	<integer>25</integer>
 	<key>TableProProvidesImportFormatIds</key>
 	<array>
 		<string>json</string>

--- a/Plugins/KafkaDriverPlugin/Info.plist
+++ b/Plugins/KafkaDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>24</integer>
+	<integer>25</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Kafka</string>

--- a/Plugins/LibSQLDriverPlugin/Info.plist
+++ b/Plugins/LibSQLDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>24</integer>
+	<integer>25</integer>
 </dict>
 </plist>

--- a/Plugins/MQLExportPlugin/Info.plist
+++ b/Plugins/MQLExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>24</integer>
+	<integer>25</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>mql</string>

--- a/Plugins/MSSQLDriverPlugin/Info.plist
+++ b/Plugins/MSSQLDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>24</integer>
+	<integer>25</integer>
 </dict>
 </plist>

--- a/Plugins/MarkdownExportPlugin/Info.plist
+++ b/Plugins/MarkdownExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>24</integer>
+	<integer>25</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>md</string>

--- a/Plugins/MongoDBDriverPlugin/Info.plist
+++ b/Plugins/MongoDBDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>24</integer>
+	<integer>25</integer>
 </dict>
 </plist>

--- a/Plugins/MySQLDriverPlugin/Info.plist
+++ b/Plugins/MySQLDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>24</integer>
+	<integer>25</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>MySQL</string>

--- a/Plugins/OracleDriverPlugin/Info.plist
+++ b/Plugins/OracleDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>24</integer>
+	<integer>25</integer>
 </dict>
 </plist>

--- a/Plugins/ParquetExportPlugin/Info.plist
+++ b/Plugins/ParquetExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>24</integer>
+	<integer>25</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>parquet</string>

--- a/Plugins/PostgreSQLDriverPlugin/Info.plist
+++ b/Plugins/PostgreSQLDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>24</integer>
+	<integer>25</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>PostgreSQL</string>

--- a/Plugins/RedisDriverPlugin/Info.plist
+++ b/Plugins/RedisDriverPlugin/Info.plist
@@ -21,7 +21,7 @@
 	<key>NSPrincipalClass</key>
 	<string>$(PRODUCT_MODULE_NAME).RedisPlugin</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>24</integer>
+	<integer>25</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Redis</string>

--- a/Plugins/SQLExportPlugin/Info.plist
+++ b/Plugins/SQLExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>24</integer>
+	<integer>25</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>sql</string>

--- a/Plugins/SQLImportPlugin/Info.plist
+++ b/Plugins/SQLImportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>24</integer>
+	<integer>25</integer>
 	<key>TableProProvidesImportFormatIds</key>
 	<array>
 		<string>sql</string>

--- a/Plugins/SQLiteDriverPlugin/Info.plist
+++ b/Plugins/SQLiteDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>24</integer>
+	<integer>25</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>SQLite</string>

--- a/Plugins/SnowflakeDriverPlugin/Info.plist
+++ b/Plugins/SnowflakeDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.48.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>24</integer>
+	<integer>25</integer>
 </dict>
 </plist>

--- a/Plugins/SurrealDBDriverPlugin/Info.plist
+++ b/Plugins/SurrealDBDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>24</integer>
+	<integer>25</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>SurrealDB</string>

--- a/Plugins/TableProPluginKit/PluginTableRespecification.swift
+++ b/Plugins/TableProPluginKit/PluginTableRespecification.swift
@@ -108,17 +108,36 @@ public struct PluginTableRespecification: Sendable {
             && alteredColumns.isEmpty
     }
 
+    /// A name this save would make the recreated table hold twice, if there is one.
+    ///
+    /// A dropped column stays in the recreated table until its own `ALTER TABLE` runs afterwards,
+    /// so a save that frees a name and takes it in the same breath cannot be expressed as one
+    /// rebuild: renaming `a` to `b` while dropping the existing `b`, or dropping `b` and adding a
+    /// new `b`, both put the name in the definition twice. Each is valid as two saves.
+    public var namingConflict: String? {
+        let retained = droppedColumns.map { $0.lowercased() }
+        guard !retained.isEmpty else { return nil }
+        let taken = renamedColumns.values.map { $0.lowercased() } + addedColumns.map { $0.name.lowercased() }
+        return retained.first { taken.contains($0) }
+    }
+
     /// Whether this respecification rewrites a column's declared type, which re-coerces every
     /// stored value in it through the new affinity.
     public var retypesAColumn: Bool { alteredColumns.contains { $0.type != nil } }
 
-    /// The same respecification with every column named as it is in the table right now, for an
-    /// engine that renames after rebuilding rather than inside the new definition.
+    /// The same respecification as the new table is actually built, for an engine that renames and
+    /// drops after rebuilding rather than inside the new definition.
     ///
-    /// A save names its columns as it wants them to end up, so a foreign key added onto a column
-    /// the same save renames arrives under the new name, which the table does not have yet.
+    /// Two things move. A save names its columns as it wants them to end up, so a foreign key added
+    /// onto a column the same save renames arrives under a name the table does not have yet, and is
+    /// mapped back. And a dropped column stays in the new table, because the drop runs as its own
+    /// `ALTER TABLE` afterwards; leaving it out here would make that statement fail with
+    /// `no such column`.
+    ///
+    /// `alteredColumns` is deliberately not mapped. It is recorded against the column as it stands
+    /// now, and mapping it would send an alteration to the wrong column whenever a save swaps two
+    /// names around.
     public func namedAsBuilt(using currentNames: [String: String]) -> PluginTableRespecification {
-        guard !currentNames.isEmpty else { return self }
         func asBuilt(_ name: String) -> String { currentNames[name.lowercased()] ?? name }
 
         return PluginTableRespecification(
@@ -138,14 +157,7 @@ public struct PluginTableRespecification: Sendable {
                 )
             },
             droppedForeignKeys: droppedForeignKeys,
-            alteredColumns: alteredColumns.map {
-                PluginColumnAlteration(
-                    column: asBuilt($0.column),
-                    type: $0.type,
-                    isNullable: $0.isNullable,
-                    defaultValue: $0.defaultValue
-                )
-            }
+            alteredColumns: alteredColumns
         )
     }
 

--- a/Plugins/TableProPluginKit/PluginTableRespecification.swift
+++ b/Plugins/TableProPluginKit/PluginTableRespecification.swift
@@ -17,6 +17,26 @@ import Foundation
 /// its own source text and with it the `CHECK`, `COLLATE`, `GENERATED ALWAYS AS` and comma-bearing
 /// `DEFAULT` that no catalog query reports. Handing over a finished definition would mean
 /// re-rendering all of them from a model that cannot carry them.
+/// A change to one existing column that no `ALTER TABLE` can express.
+///
+/// A nil field is left exactly as it was, which is not the same as an empty one: nil means "do not
+/// touch the type", an empty string means "remove the type". The difference matters because a
+/// default read back from a catalog query is not the default the user wrote, so an untouched one
+/// must come from the stored text rather than be re-rendered from a model.
+public struct PluginColumnAlteration: Sendable, Equatable {
+    public let column: String
+    public let type: String?
+    public let isNullable: Bool?
+    public let defaultValue: String?
+
+    public init(column: String, type: String? = nil, isNullable: Bool? = nil, defaultValue: String? = nil) {
+        self.column = column
+        self.type = type
+        self.isNullable = isNullable
+        self.defaultValue = defaultValue
+    }
+}
+
 public struct PluginTableRespecification: Sendable {
     /// Columns to create, which have no stored text to preserve and so are rendered by the driver.
     public let addedColumns: [PluginColumnDefinition]
@@ -30,6 +50,9 @@ public struct PluginTableRespecification: Sendable {
     /// The wanted column order by final name, or nil to leave the order alone.
     public let columnOrder: [String]?
 
+    /// Existing columns whose type, nullability or default changes.
+    public let alteredColumns: [PluginColumnAlteration]
+
     public let addedForeignKeys: [PluginForeignKeyDefinition]
 
     /// The keys to remove. Matched on the relationship they describe rather than on their names,
@@ -42,7 +65,8 @@ public struct PluginTableRespecification: Sendable {
         renamedColumns: [String: String] = [:],
         columnOrder: [String]? = nil,
         addedForeignKeys: [PluginForeignKeyDefinition] = [],
-        droppedForeignKeys: [PluginForeignKeyDefinition] = []
+        droppedForeignKeys: [PluginForeignKeyDefinition] = [],
+        alteredColumns: [PluginColumnAlteration]
     ) {
         self.addedColumns = addedColumns
         self.droppedColumns = droppedColumns
@@ -50,11 +74,79 @@ public struct PluginTableRespecification: Sendable {
         self.columnOrder = columnOrder
         self.addedForeignKeys = addedForeignKeys
         self.droppedForeignKeys = droppedForeignKeys
+        self.alteredColumns = alteredColumns
+    }
+
+    /// The initializer as it shipped before a respecification could alter a column.
+    ///
+    /// Kept at its exact original signature: adding the parameter to it would replace its mangled
+    /// symbol and stop every plugin built against the earlier PluginKit loading, which is how
+    /// 0.49.0 took every registry plugin down.
+    @_disfavoredOverload
+    public init(
+        addedColumns: [PluginColumnDefinition] = [],
+        droppedColumns: [String] = [],
+        renamedColumns: [String: String] = [:],
+        columnOrder: [String]? = nil,
+        addedForeignKeys: [PluginForeignKeyDefinition] = [],
+        droppedForeignKeys: [PluginForeignKeyDefinition] = []
+    ) {
+        self.init(
+            addedColumns: addedColumns,
+            droppedColumns: droppedColumns,
+            renamedColumns: renamedColumns,
+            columnOrder: columnOrder,
+            addedForeignKeys: addedForeignKeys,
+            droppedForeignKeys: droppedForeignKeys,
+            alteredColumns: []
+        )
     }
 
     public var isEmpty: Bool {
         addedColumns.isEmpty && droppedColumns.isEmpty && renamedColumns.isEmpty
             && columnOrder == nil && addedForeignKeys.isEmpty && droppedForeignKeys.isEmpty
+            && alteredColumns.isEmpty
+    }
+
+    /// Whether this respecification rewrites a column's declared type, which re-coerces every
+    /// stored value in it through the new affinity.
+    public var retypesAColumn: Bool { alteredColumns.contains { $0.type != nil } }
+
+    /// The same respecification with every column named as it is in the table right now, for an
+    /// engine that renames after rebuilding rather than inside the new definition.
+    ///
+    /// A save names its columns as it wants them to end up, so a foreign key added onto a column
+    /// the same save renames arrives under the new name, which the table does not have yet.
+    public func namedAsBuilt(using currentNames: [String: String]) -> PluginTableRespecification {
+        guard !currentNames.isEmpty else { return self }
+        func asBuilt(_ name: String) -> String { currentNames[name.lowercased()] ?? name }
+
+        return PluginTableRespecification(
+            addedColumns: addedColumns,
+            droppedColumns: [],
+            renamedColumns: [:],
+            columnOrder: columnOrder.map { $0.map(asBuilt) },
+            addedForeignKeys: addedForeignKeys.map { key in
+                PluginForeignKeyDefinition(
+                    name: key.name,
+                    columns: key.columns.map(asBuilt),
+                    referencedTable: key.referencedTable,
+                    referencedColumns: key.referencedColumns,
+                    onDelete: key.onDelete,
+                    onUpdate: key.onUpdate,
+                    referencedSchema: key.referencedSchema
+                )
+            },
+            droppedForeignKeys: droppedForeignKeys,
+            alteredColumns: alteredColumns.map {
+                PluginColumnAlteration(
+                    column: asBuilt($0.column),
+                    type: $0.type,
+                    isNullable: $0.isNullable,
+                    defaultValue: $0.defaultValue
+                )
+            }
+        )
     }
 
     /// Whether this respecification changes the table's foreign keys, which is what decides whether

--- a/Plugins/TableProPluginKit/SQLiteColumnDeclaration.swift
+++ b/Plugins/TableProPluginKit/SQLiteColumnDeclaration.swift
@@ -1,0 +1,397 @@
+//
+//  SQLiteColumnDeclaration.swift
+//  TableProPluginKit
+//
+
+import Foundation
+
+/// One column definition inside a stored `CREATE TABLE`, split into the parts an edit can replace.
+///
+/// SQLite has no `ALTER TABLE` for a column's type, nullability or default, so changing one means
+/// recreating the table. The rebuild keeps every untouched column's source text byte for byte, and
+/// a column the save *does* touch has to be rewritten the same way: replace the span that changed
+/// and leave the rest of what the user wrote alone. Re-rendering the whole declaration from a model
+/// would lose the `CHECK`, the `COLLATE`, the `GENERATED ALWAYS AS` and the `REFERENCES` that no
+/// catalog query reports.
+///
+/// The declaration is read as a grammar rather than searched for keywords, because searching is
+/// wrong in both directions and silently so. Measured on 3.54: in
+/// `b TEXT CHECK (b IS NOT NULL)` a search for `NOT NULL` matches inside the check, so the column
+/// reads as already non-null and "make it NOT NULL" does nothing; in
+/// `a INTEGER REFERENCES p(id) ON DELETE SET NULL` a search for `NULL` matches inside the foreign
+/// key's action, so "make it nullable" rewrites the action into a syntax error. Walking the
+/// constraint list left to right and consuming each constraint whole is the only way to know which
+/// `NULL` is which.
+public struct SQLiteColumnDeclaration: Equatable {
+    /// What a constraint in the list is, as far as an edit needs to care.
+    public enum ConstraintKind: Equatable {
+        case primaryKey
+        /// `NOT NULL`.
+        case notNull
+        /// A bare `NULL`, which states the default nullability rather than changing it.
+        case null
+        case unique
+        case check
+        case defaultValue
+        case collate
+        case foreignKey
+        /// `GENERATED ALWAYS AS (…)` or its `AS (…)` short form.
+        case generated
+    }
+
+    public struct Constraint: Equatable {
+        public let kind: ConstraintKind
+        /// The whole constraint, including any `CONSTRAINT name` that introduces it.
+        public let range: Range<String.Index>
+    }
+
+    /// The column's own name, as written.
+    public let name: String
+    public let nameRange: Range<String.Index>
+
+    /// The declared type. Nil where the column has none, which SQLite allows: `CREATE TABLE t(a)`.
+    public let typeRange: Range<String.Index>?
+
+    /// The declared type as written, so a decision about it needs no second look at the source.
+    public let declaredType: String?
+
+    public let constraints: [Constraint]
+
+    public func first(_ kind: ConstraintKind) -> Constraint? {
+        constraints.first { $0.kind == kind }
+    }
+
+    public var isGenerated: Bool { first(.generated) != nil }
+}
+
+public extension SQLiteColumnDeclaration {
+    /// Reads a column definition, or nil for an entry that is a table constraint rather than a
+    /// column, or one this grammar does not fully understand.
+    ///
+    /// Refusing to parse is the safe answer: the rebuild that would have used the result refuses
+    /// with it, and the user is told to write the SQL themselves rather than shown a table rebuilt
+    /// from a guess.
+    static func parse(_ text: String) -> SQLiteColumnDeclaration? {
+        let tokens = SQLiteTokenizer.tokenize(text)
+        guard let first = tokens.first, !first.isPunctuation, !first.text.isEmpty else { return nil }
+        guard !SQLiteColumnGrammar.tableConstraintKeywords.contains(first.keyword) else { return nil }
+
+        let typeEnd = SQLiteColumnGrammar.endOfTypeName(tokens, from: 1)
+        let typeRange = typeEnd > 1
+            ? tokens[1].range.lowerBound..<tokens[typeEnd - 1].range.upperBound
+            : nil
+
+        guard let constraints = SQLiteColumnGrammar.constraints(tokens, from: typeEnd) else { return nil }
+
+        return SQLiteColumnDeclaration(
+            name: first.text,
+            nameRange: first.range,
+            typeRange: typeRange,
+            declaredType: typeRange.map { String(text[$0]) },
+            constraints: constraints
+        )
+    }
+
+    /// What a save asks to change about one column. A nil field is left exactly as it was.
+    struct Edit: Sendable, Equatable {
+        /// The new type, or an empty string to remove the type entirely.
+        public var type: String?
+        public var isNullable: Bool?
+        /// The new default as SQL, or an empty string to remove the `DEFAULT` clause.
+        public var defaultValue: String?
+
+        public init(type: String? = nil, isNullable: Bool? = nil, defaultValue: String? = nil) {
+            self.type = type
+            self.isNullable = isNullable
+            self.defaultValue = defaultValue
+        }
+
+        public var isEmpty: Bool { type == nil && isNullable == nil && defaultValue == nil }
+    }
+
+    /// The declaration with `edit` applied and everything else byte for byte as it was.
+    ///
+    /// Nil when the edit cannot be made without guessing: a generated column's nullability and
+    /// default are the expression's to decide, and a declaration this grammar could not read whole
+    /// is never rewritten from a partial understanding.
+    static func rewritten(_ text: String, applying edit: Edit) -> String? {
+        guard !edit.isEmpty else { return text }
+        guard let declaration = parse(text), declaration.canApply(edit) else { return nil }
+
+        /// Every replacement is computed against the original text and applied last-first, so an
+        /// earlier edit never moves the indices a later one was measured from.
+        var replacements: [(Range<String.Index>, String)] = []
+
+        if let type = edit.type {
+            let rendered = type.trimmingCharacters(in: .whitespacesAndNewlines)
+            if let typeRange = declaration.typeRange {
+                replacements.append((typeRange, rendered))
+            } else if !rendered.isEmpty {
+                replacements.append((declaration.nameRange.upperBound..<declaration.nameRange.upperBound, " \(rendered)"))
+            }
+        }
+
+        if let isNullable = edit.isNullable {
+            let existing = declaration.first(.notNull) ?? declaration.first(.null)
+            if isNullable {
+                /// A bare `NULL` says what SQLite would do anyway, so removing the constraint and
+                /// removing only the `NOT` both land in the same place. The whole clause goes.
+                if let existing, existing.kind == .notNull { replacements.append((existing.range, "")) }
+            } else if let existing, existing.kind == .null {
+                replacements.append((existing.range, "NOT NULL"))
+            } else if declaration.first(.notNull) == nil {
+                replacements.append((insertionPoint(in: declaration)..<insertionPoint(in: declaration), " NOT NULL"))
+            }
+        }
+
+        if let defaultValue = edit.defaultValue {
+            let rendered = defaultValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            let clause = rendered.isEmpty ? "" : "DEFAULT \(rendered)"
+            if let existing = declaration.first(.defaultValue) {
+                replacements.append((existing.range, clause))
+            } else if !clause.isEmpty {
+                replacements.append((insertionPoint(in: declaration)..<insertionPoint(in: declaration), " \(clause)"))
+            }
+        }
+
+        return apply(replacements, to: text)
+    }
+
+    /// Whether `edit` can be made to this column without changing something it did not ask about.
+    ///
+    /// Every no here is a case where the rewrite would succeed and be wrong, so it refuses and the
+    /// user is told to write the SQL themselves.
+    private func canApply(_ edit: Edit) -> Bool {
+        /// A generated column's nullability and default belong to its expression, and SQLite
+        /// rejects a `DEFAULT` on one outright.
+        if isGenerated, edit.isNullable != nil || edit.defaultValue != nil { return false }
+
+        /// `a INT NOT NULL NOT NULL` and `a INT DEFAULT 1 DEFAULT 2` are both legal, measured.
+        /// Rewriting one of a pair leaves the other in force, so the edit would report success and
+        /// change nothing.
+        if edit.isNullable != nil,
+           constraints.filter({ $0.kind == .notNull || $0.kind == .null }).count > 1 { return false }
+        if edit.defaultValue != nil, constraints.filter({ $0.kind == .defaultValue }).count > 1 { return false }
+
+        /// Retyping a column that carries an inline `PRIMARY KEY` away from `INTEGER` destroys the
+        /// rowid alias. Measured: the key stops generating values and then stores NULL on every
+        /// insert that omits it, silently, twice over. `AUTOINCREMENT` is refused by SQLite itself
+        /// in that position, but a plain `INTEGER PRIMARY KEY` is not.
+        if let type = edit.type, first(.primaryKey) != nil, isIntegerTyped,
+           !type.trimmingCharacters(in: .whitespaces).isEmpty,
+           type.trimmingCharacters(in: .whitespaces).caseInsensitiveCompare("INTEGER") != .orderedSame {
+            return false
+        }
+        return true
+    }
+
+    private var isIntegerTyped: Bool {
+        declaredType?.trimmingCharacters(in: .whitespaces).caseInsensitiveCompare("INTEGER") == .orderedSame
+    }
+
+    /// Where a constraint the declaration does not have is written: after the type, or after the
+    /// name when there is none. Before every existing constraint, so a `REFERENCES` clause and its
+    /// actions stay contiguous.
+    private static func insertionPoint(in declaration: SQLiteColumnDeclaration) -> String.Index {
+        declaration.typeRange?.upperBound ?? declaration.nameRange.upperBound
+    }
+
+    /// Applies the replacements last-first so an earlier edit never moves the indices a later one
+    /// was measured from.
+    ///
+    /// Two insertions can land on the same index, which happens whenever a save adds both a
+    /// nullability and a default to a column that had neither. Ordering by position alone leaves
+    /// their relative order to the sort, so the position is paired with the order they were
+    /// collected in and the result is the same every time.
+    private static func apply(_ replacements: [(Range<String.Index>, String)], to text: String) -> String {
+        var result = text
+        let ordered = replacements.enumerated().sorted {
+            $0.element.0.lowerBound == $1.element.0.lowerBound
+                ? $0.offset > $1.offset
+                : $0.element.0.lowerBound > $1.element.0.lowerBound
+        }
+        for (range, value) in ordered.map(\.element) {
+            if value.isEmpty {
+                result = SQLiteTableDDL.cuttingSpan(range, from: result)
+            } else {
+                result.replaceSubrange(range, with: value)
+            }
+        }
+        return result.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+/// The column-definition grammar, as SQLite accepts it rather than as its railroad diagrams read.
+internal enum SQLiteColumnGrammar {
+    /// What may begin a table constraint, so an entry that starts with one is not a column.
+    internal static let tableConstraintKeywords: Set<String> = [
+        "CONSTRAINT", "PRIMARY", "UNIQUE", "CHECK", "FOREIGN"
+    ]
+
+    /// The keywords that end a type name by starting a column constraint.
+    ///
+    /// Measured against 3.54 by declaring `a BIG <keyword>` and reading the type back. `GENERATED`
+    /// and `ALWAYS` are absent on purpose: alone they are absorbed into the type, and only the
+    /// exact run `GENERATED ALWAYS AS` terminates it. `KEY`, `ASC`, `DESC`, `STORED`, `VIRTUAL`,
+    /// `CONFLICT`, `MATCH` and `ROWID` are absorbed the same way.
+    private static let constraintFirst: Set<String> = [
+        "CONSTRAINT", "PRIMARY", "NOT", "NULL", "UNIQUE", "CHECK",
+        "DEFAULT", "COLLATE", "REFERENCES", "AS", "DEFERRABLE"
+    ]
+
+    private static let conflictActions: Set<String> = ["ROLLBACK", "ABORT", "FAIL", "IGNORE", "REPLACE"]
+
+    /// The index just past the type name, starting from `index`.
+    ///
+    /// A type name is one or more names, each of which may be quoted, optionally followed by a
+    /// parenthesised pair of signed numbers. `CREATE TABLE t(a)` declares no type at all, and
+    /// `UNSIGNED BIG INT` and `VARYING CHARACTER(255)` are both one type.
+    internal static func endOfTypeName(_ tokens: [SQLiteToken], from index: Int) -> Int {
+        var cursor = index
+        while cursor < tokens.count {
+            let token = tokens[cursor]
+            if token.text == "(" {
+                guard let close = matchingParen(tokens, from: cursor) else { return cursor }
+                cursor = close + 1
+                break
+            }
+            if token.isPunctuation { break }
+            if startsGeneratedClause(tokens, at: cursor) { break }
+            if constraintFirst.contains(token.keyword) { break }
+            cursor += 1
+        }
+        return cursor
+    }
+
+    /// Every constraint after the type, in order, or nil where one could not be read whole.
+    internal static func constraints(
+        _ tokens: [SQLiteToken],
+        from index: Int
+    ) -> [SQLiteColumnDeclaration.Constraint]? {
+        var found: [SQLiteColumnDeclaration.Constraint] = []
+        var cursor = index
+
+        while cursor < tokens.count {
+            let start = cursor
+            /// `CONSTRAINT name` introduces whichever constraint follows, so it belongs to that
+            /// one's span: removing the constraint has to take its name with it.
+            if tokens[cursor].keyword == "CONSTRAINT" {
+                guard cursor + 1 < tokens.count else { return nil }
+                cursor += 2
+                guard cursor < tokens.count else { return nil }
+            }
+
+            guard let (kind, end) = constraint(tokens, from: cursor) else { return nil }
+            found.append(
+                SQLiteColumnDeclaration.Constraint(
+                    kind: kind,
+                    range: tokens[start].range.lowerBound..<tokens[end - 1].range.upperBound
+                )
+            )
+            cursor = end
+        }
+        return found
+    }
+
+    /// One constraint and the index just past it.
+    private static func constraint(_ tokens: [SQLiteToken], from index: Int) -> (SQLiteColumnDeclaration.ConstraintKind, Int)? {
+        var cursor = index
+        switch tokens[cursor].keyword {
+        case "PRIMARY":
+            guard cursor + 1 < tokens.count, tokens[cursor + 1].keyword == "KEY" else { return nil }
+            cursor += 2
+            if cursor < tokens.count, ["ASC", "DESC"].contains(tokens[cursor].keyword) { cursor += 1 }
+            cursor = skipConflictClause(tokens, from: cursor)
+            if cursor < tokens.count, tokens[cursor].keyword == "AUTOINCREMENT" { cursor += 1 }
+            return (.primaryKey, cursor)
+
+        case "NOT":
+            guard cursor + 1 < tokens.count, tokens[cursor + 1].keyword == "NULL" else { return nil }
+            return (.notNull, skipConflictClause(tokens, from: cursor + 2))
+
+        case "NULL":
+            return (.null, skipConflictClause(tokens, from: cursor + 1))
+
+        case "UNIQUE":
+            return (.unique, skipConflictClause(tokens, from: cursor + 1))
+
+        case "CHECK":
+            guard cursor + 1 < tokens.count, tokens[cursor + 1].text == "(",
+                  let close = matchingParen(tokens, from: cursor + 1) else { return nil }
+            return (.check, close + 1)
+
+        case "DEFAULT":
+            cursor += 1
+            guard cursor < tokens.count else { return nil }
+            if tokens[cursor].text == "(" {
+                guard let close = matchingParen(tokens, from: cursor) else { return nil }
+                return (.defaultValue, close + 1)
+            }
+            /// A signed number is two tokens, the sign and the digits.
+            if ["+", "-"].contains(tokens[cursor].text) { cursor += 1 }
+            guard cursor < tokens.count else { return nil }
+            return (.defaultValue, cursor + 1)
+
+        case "COLLATE":
+            guard cursor + 1 < tokens.count else { return nil }
+            return (.collate, cursor + 2)
+
+        case "REFERENCES":
+            guard let end = SQLiteForeignKeyParser.referenceEnd(tokens, from: cursor) else { return nil }
+            return (.foreignKey, end + 1)
+
+        case "GENERATED", "AS":
+            guard let end = endOfGeneratedClause(tokens, from: cursor) else { return nil }
+            return (.generated, end)
+
+        default:
+            return nil
+        }
+    }
+
+    private static func startsGeneratedClause(_ tokens: [SQLiteToken], at index: Int) -> Bool {
+        guard index + 2 < tokens.count else { return false }
+        return tokens[index].keyword == "GENERATED"
+            && tokens[index + 1].keyword == "ALWAYS"
+            && tokens[index + 2].keyword == "AS"
+    }
+
+    /// `GENERATED ALWAYS AS ( expr ) [STORED | VIRTUAL]`, or the same from a bare `AS`.
+    private static func endOfGeneratedClause(_ tokens: [SQLiteToken], from index: Int) -> Int? {
+        var cursor = index
+        if tokens[cursor].keyword == "GENERATED" {
+            guard startsGeneratedClause(tokens, at: cursor) else { return nil }
+            cursor += 3
+        } else {
+            cursor += 1
+        }
+        guard cursor < tokens.count, tokens[cursor].text == "(",
+              let close = matchingParen(tokens, from: cursor) else { return nil }
+        cursor = close + 1
+        if cursor < tokens.count, ["STORED", "VIRTUAL"].contains(tokens[cursor].keyword) { cursor += 1 }
+        return cursor
+    }
+
+    private static func skipConflictClause(_ tokens: [SQLiteToken], from index: Int) -> Int {
+        guard index + 2 < tokens.count,
+              tokens[index].keyword == "ON", tokens[index + 1].keyword == "CONFLICT",
+              conflictActions.contains(tokens[index + 2].keyword) else { return index }
+        return index + 3
+    }
+
+    /// The index of the `)` closing the `(` at `index`.
+    private static func matchingParen(_ tokens: [SQLiteToken], from index: Int) -> Int? {
+        guard tokens[index].text == "(" else { return nil }
+        var depth = 0
+        var cursor = index
+        while cursor < tokens.count {
+            if tokens[cursor].text == "(" { depth += 1 }
+            if tokens[cursor].text == ")" {
+                depth -= 1
+                if depth == 0 { return cursor }
+            }
+            cursor += 1
+        }
+        return nil
+    }
+}

--- a/Plugins/TableProPluginKit/SQLiteColumnDeclaration.swift
+++ b/Plugins/TableProPluginKit/SQLiteColumnDeclaration.swift
@@ -41,8 +41,14 @@ public struct SQLiteColumnDeclaration: Equatable {
 
     public struct Constraint: Equatable {
         public let kind: ConstraintKind
-        /// The whole constraint, including any `CONSTRAINT name` that introduces it.
+        /// The whole constraint, including any `CONSTRAINT name` that introduces it. Removing one
+        /// has to take the name with it, or the orphan is dead text at best and a parse error at
+        /// worst.
         public let range: Range<String.Index>
+
+        /// The clause without its `CONSTRAINT name`. Replacing a clause writes here, so a key the
+        /// user named keeps the name they gave it and stays droppable by that name.
+        public let clauseRange: Range<String.Index>
     }
 
     /// The column's own name, as written.
@@ -114,9 +120,12 @@ public extension SQLiteColumnDeclaration {
     /// Nil when the edit cannot be made without guessing: a generated column's nullability and
     /// default are the expression's to decide, and a declaration this grammar could not read whole
     /// is never rewritten from a partial understanding.
-    static func rewritten(_ text: String, applying edit: Edit) -> String? {
+    /// - Parameter isRowidAlias: whether this column *is* the table's rowid, which the declaration
+    ///   alone cannot say: the primary key may be written at table level.
+    static func rewritten(_ text: String, applying edit: Edit, isRowidAlias: Bool = false) -> String? {
         guard !edit.isEmpty else { return text }
-        guard let declaration = parse(text), declaration.canApply(edit) else { return nil }
+        guard let declaration = parse(text),
+              declaration.canApply(edit, isRowidAlias: isRowidAlias) else { return nil }
 
         /// Every replacement is computed against the original text and applied last-first, so an
         /// earlier edit never moves the indices a later one was measured from.
@@ -138,7 +147,7 @@ public extension SQLiteColumnDeclaration {
                 /// removing only the `NOT` both land in the same place. The whole clause goes.
                 if let existing, existing.kind == .notNull { replacements.append((existing.range, "")) }
             } else if let existing, existing.kind == .null {
-                replacements.append((existing.range, "NOT NULL"))
+                replacements.append((existing.clauseRange, "NOT NULL"))
             } else if declaration.first(.notNull) == nil {
                 replacements.append((insertionPoint(in: declaration)..<insertionPoint(in: declaration), " NOT NULL"))
             }
@@ -148,7 +157,9 @@ public extension SQLiteColumnDeclaration {
             let rendered = defaultValue.trimmingCharacters(in: .whitespacesAndNewlines)
             let clause = rendered.isEmpty ? "" : "DEFAULT \(rendered)"
             if let existing = declaration.first(.defaultValue) {
-                replacements.append((existing.range, clause))
+                /// Replacing writes inside the clause so a `CONSTRAINT d DEFAULT 1` keeps its name;
+                /// removing takes the whole thing, name included.
+                replacements.append((clause.isEmpty ? existing.range : existing.clauseRange, clause))
             } else if !clause.isEmpty {
                 replacements.append((insertionPoint(in: declaration)..<insertionPoint(in: declaration), " \(clause)"))
             }
@@ -161,7 +172,7 @@ public extension SQLiteColumnDeclaration {
     ///
     /// Every no here is a case where the rewrite would succeed and be wrong, so it refuses and the
     /// user is told to write the SQL themselves.
-    private func canApply(_ edit: Edit) -> Bool {
+    private func canApply(_ edit: Edit, isRowidAlias: Bool) -> Bool {
         /// A generated column's nullability and default belong to its expression, and SQLite
         /// rejects a `DEFAULT` on one outright.
         if isGenerated, edit.isNullable != nil || edit.defaultValue != nil { return false }
@@ -177,7 +188,7 @@ public extension SQLiteColumnDeclaration {
         /// rowid alias. Measured: the key stops generating values and then stores NULL on every
         /// insert that omits it, silently, twice over. `AUTOINCREMENT` is refused by SQLite itself
         /// in that position, but a plain `INTEGER PRIMARY KEY` is not.
-        if let type = edit.type, first(.primaryKey) != nil, isIntegerTyped,
+        if let type = edit.type, isRowidAlias || (first(.primaryKey) != nil && isIntegerTyped),
            !type.trimmingCharacters(in: .whitespaces).isEmpty,
            type.trimmingCharacters(in: .whitespaces).caseInsensitiveCompare("INTEGER") != .orderedSame {
             return false
@@ -285,7 +296,8 @@ internal enum SQLiteColumnGrammar {
             found.append(
                 SQLiteColumnDeclaration.Constraint(
                     kind: kind,
-                    range: tokens[start].range.lowerBound..<tokens[end - 1].range.upperBound
+                    range: tokens[start].range.lowerBound..<tokens[end - 1].range.upperBound,
+                    clauseRange: tokens[cursor].range.lowerBound..<tokens[end - 1].range.upperBound
                 )
             )
             cursor = end
@@ -327,10 +339,8 @@ internal enum SQLiteColumnGrammar {
                 guard let close = matchingParen(tokens, from: cursor) else { return nil }
                 return (.defaultValue, close + 1)
             }
-            /// A signed number is two tokens, the sign and the digits.
-            if ["+", "-"].contains(tokens[cursor].text) { cursor += 1 }
-            guard cursor < tokens.count else { return nil }
-            return (.defaultValue, cursor + 1)
+            guard let end = endOfDefaultLiteral(tokens, from: cursor) else { return nil }
+            return (.defaultValue, end)
 
         case "COLLATE":
             guard cursor + 1 < tokens.count else { return nil }
@@ -369,6 +379,36 @@ internal enum SQLiteColumnGrammar {
               let close = matchingParen(tokens, from: cursor) else { return nil }
         cursor = close + 1
         if cursor < tokens.count, ["STORED", "VIRTUAL"].contains(tokens[cursor].keyword) { cursor += 1 }
+        return cursor
+    }
+
+    /// The index just past a default's literal operand.
+    ///
+    /// The tokenizer splits on punctuation, so a single SQLite literal can arrive as several
+    /// tokens: `0.5` comes back as `0`, `.`, `5`, and `X'0102'` as `X` and a string literal.
+    /// Consuming one token would leave the remainder to be read as an unknown constraint, which
+    /// refuses every edit on a column carrying one of these very ordinary defaults.
+    private static func endOfDefaultLiteral(_ tokens: [SQLiteToken], from index: Int) -> Int? {
+        var cursor = index
+        if ["+", "-"].contains(tokens[cursor].text) { cursor += 1 }
+        guard cursor < tokens.count else { return nil }
+
+        /// A blob literal is the letter x followed by a quoted run.
+        if tokens[cursor].keyword == "X", cursor + 1 < tokens.count, tokens[cursor + 1].isStringLiteral {
+            return cursor + 2
+        }
+
+        cursor += 1
+        /// The fractional part and an exponent, each of which the tokenizer has split off.
+        if cursor < tokens.count, tokens[cursor].text == "." {
+            cursor += 1
+            if cursor < tokens.count, !tokens[cursor].isPunctuation { cursor += 1 }
+        }
+        if cursor + 1 < tokens.count, ["E", "e"].contains(tokens[cursor].text) {
+            var lookahead = cursor + 1
+            if ["+", "-"].contains(tokens[lookahead].text) { lookahead += 1 }
+            if lookahead < tokens.count, !tokens[lookahead].isPunctuation { cursor = lookahead + 1 }
+        }
         return cursor
     }
 

--- a/Plugins/TableProPluginKit/SQLiteForeignKeyClause.swift
+++ b/Plugins/TableProPluginKit/SQLiteForeignKeyClause.swift
@@ -232,7 +232,7 @@ internal enum SQLiteForeignKeyParser {
     /// times, so they are read in one repeated loop. Reading them in a fixed order left the tail of
     /// `REFERENCES p(id) MATCH SIMPLE ON DELETE CASCADE` outside the span, and removing the key then
     /// left an orphaned `ON DELETE CASCADE` behind that no `CREATE TABLE` would accept.
-    private static func referenceEnd(_ tokens: [SQLiteToken], from index: Int) -> Int? {
+    internal static func referenceEnd(_ tokens: [SQLiteToken], from index: Int) -> Int? {
         guard index + 1 < tokens.count else { return nil }
         var cursor = index + 2
         var last = index + 1

--- a/Plugins/TableProPluginKit/SQLiteTableDDL.swift
+++ b/Plugins/TableProPluginKit/SQLiteTableDDL.swift
@@ -101,6 +101,21 @@ public enum SQLiteTableDDL {
         return "CREATE TABLE \(quote(tableName)) (\(indent)\(body)\n)\(trailingOptions(of: parsed))"
     }
 
+    /// The text with `span` removed and the gap it left closed.
+    ///
+    /// Only the whitespace either side of the cut is touched. Collapsing runs across the whole
+    /// declaration would rewrite text the user typed: a `DEFAULT 'a  b'` elsewhere in the same
+    /// column would come back with one space instead of two.
+    internal static func cuttingSpan(_ span: Range<String.Index>, from text: String) -> String {
+        var head = String(text[text.startIndex..<span.lowerBound])
+        let tail = String(text[span.upperBound...])
+        let headHadSpace = head.last?.isWhitespace ?? false
+        let tailHasSpace = tail.first?.isWhitespace ?? false
+        while head.last?.isWhitespace == true { head.removeLast() }
+        let separator = head.isEmpty || tail.isEmpty || !(headHadSpace || tailHasSpace) ? "" : " "
+        return head + separator + tail.drop(while: { $0.isWhitespace })
+    }
+
     public static func quote(_ identifier: String) -> String {
         "\"\(identifier.replacingOccurrences(of: "\"", with: "\"\""))\""
     }

--- a/Plugins/TableProPluginKit/SQLiteTableRebuildPlanner.swift
+++ b/Plugins/TableProPluginKit/SQLiteTableRebuildPlanner.swift
@@ -74,8 +74,8 @@ public enum SQLiteTableRebuildPlanner {
             dependentObjectSQL: [String],
             autoincrementHighWaterMark: Int64?,
             foreignKeysWereOn: Bool,
-            legacyAlterTableWasOn: Bool = true,
-            dependentValidationSQL: [String] = []
+            legacyAlterTableWasOn: Bool,
+            dependentValidationSQL: [String]
         ) {
             self.parsed = parsed
             self.copyableColumns = copyableColumns
@@ -84,6 +84,33 @@ public enum SQLiteTableRebuildPlanner {
             self.foreignKeysWereOn = foreignKeysWereOn
             self.legacyAlterTableWasOn = legacyAlterTableWasOn
             self.dependentValidationSQL = dependentValidationSQL
+        }
+
+        /// The initializer as it shipped before a plan set `legacy_alter_table` or revalidated the
+        /// table's dependents.
+        ///
+        /// Kept at its exact original signature, because a plugin built against the earlier
+        /// PluginKit references that mangled symbol; adding defaulted parameters to it replaces the
+        /// symbol rather than preserving it. The pragma reads as already-on so a plan built this
+        /// way restores the value the connection almost certainly had, and skips the dependent
+        /// checks it has no list for.
+        @_disfavoredOverload
+        public init(
+            parsed: SQLiteTableDDL.Parsed,
+            copyableColumns: [String],
+            dependentObjectSQL: [String],
+            autoincrementHighWaterMark: Int64?,
+            foreignKeysWereOn: Bool
+        ) {
+            self.init(
+                parsed: parsed,
+                copyableColumns: copyableColumns,
+                dependentObjectSQL: dependentObjectSQL,
+                autoincrementHighWaterMark: autoincrementHighWaterMark,
+                foreignKeysWereOn: foreignKeysWereOn,
+                legacyAlterTableWasOn: true,
+                dependentValidationSQL: []
+            )
         }
     }
 
@@ -174,6 +201,11 @@ public enum SQLiteTableRebuildPlanner {
         if !respecification.renamedColumns.isEmpty || !respecification.droppedColumns.isEmpty {
             statements.append("PRAGMA legacy_alter_table = off")
         }
+        /// Drops go first. A save that renames `a` to `b` while dropping the existing `b` is valid,
+        /// and issuing the rename first makes SQLite refuse it as a duplicate column name.
+        for column in respecification.droppedColumns.sorted() {
+            statements.append("ALTER TABLE \(quotedOriginal) DROP COLUMN \(SQLiteTableDDL.quote(column))")
+        }
         for (from, to) in respecification.renamedColumns.sorted(by: { $0.key < $1.key }) {
             statements.append(
                 """
@@ -181,9 +213,6 @@ public enum SQLiteTableRebuildPlanner {
                 TO \(SQLiteTableDDL.quote(to))
                 """
             )
-        }
-        for column in respecification.droppedColumns.sorted() {
-            statements.append("ALTER TABLE \(quotedOriginal) DROP COLUMN \(SQLiteTableDDL.quote(column))")
         }
 
         /// Compiling each dependent object's body catches what the `ALTER`s do not refuse. Measured:
@@ -239,7 +268,12 @@ public enum SQLiteTableRebuildPlanner {
             cost: .tableRebuild,
             caveats: caveats,
             isRunnable: isRunnable,
-            verifications: respecification.touchesForeignKeys ? [foreignKeyCheck(on: quotedOriginal)] : []
+            /// Checked after a retype as well as after a key change. Measured: copying a child's
+            /// TEXT '007' into an INTEGER column stores 7, which no longer matches a parent's TEXT
+            /// '007', and the copy runs with enforcement off so nothing else would notice.
+            verifications: respecification.touchesForeignKeys || respecification.retypesAColumn
+                ? [foreignKeyCheck(on: quotedOriginal)]
+                : []
         )
     }
 
@@ -347,13 +381,16 @@ public extension SQLiteTableRebuildPlanner {
     /// One statement per dependent object that compiles its body without running it.
     ///
     /// `EXPLAIN` prepares a statement and stops, so an object's SQL is checked against the table as
-    /// it now stands and nothing runs. A view is checked by selecting from it; a trigger by
-    /// preparing a write against the table it fires on, which compiles every trigger on that table.
+    /// it now stands and nothing runs. Measured on 3.54, this catches what neither `ALTER TABLE`
+    /// nor `PRAGMA foreign_key_check` reports: a view declared with an explicit column list breaks
+    /// on its count, and a trigger on *another* table that writes a positional row into this one
+    /// breaks on its value count. Both commit silently otherwise.
     ///
-    /// Both are needed, and neither is optional. Measured on 3.54: dropping a column leaves a view
-    /// declared with an explicit column list broken on its count, and leaves a trigger on *another*
-    /// table that writes a positional row into this one broken on its value count. `ALTER TABLE`
-    /// reports neither, `PRAGMA foreign_key_check` cannot see either, and both commit silently.
+    /// Each trigger is probed through the event it actually fires on. Issuing the same
+    /// `INSERT`/`DELETE` pair per table is wrong in both directions: a view carrying only an
+    /// `INSTEAD OF DELETE` trigger fails an `INSERT` probe with "cannot modify v because it is a
+    /// view", which would block every drop on that schema, and an `AFTER UPDATE` trigger is never
+    /// compiled at all.
     private static func dependentValidationSQL(
         execute: (String) async throws -> PluginQueryResult
     ) async throws -> [String] {
@@ -361,17 +398,47 @@ public extension SQLiteTableRebuildPlanner {
             "SELECT name FROM sqlite_master WHERE type = 'view' ORDER BY name"
         ).rows.compactMap { $0[safe: 0]?.asText }
 
-        let triggerTables = try await execute(
-            "SELECT DISTINCT tbl_name FROM sqlite_master WHERE type = 'trigger' ORDER BY tbl_name"
-        ).rows.compactMap { $0[safe: 0]?.asText }
+        let triggers = try await execute(
+            """
+            SELECT tbl_name, sql FROM sqlite_master
+            WHERE type = 'trigger' AND sql IS NOT NULL ORDER BY name
+            """
+        ).rows.compactMap { row -> (String, String)? in
+            guard let table = row[safe: 0]?.asText, let sql = row[safe: 1]?.asText else { return nil }
+            return (table, sql)
+        }
 
-        return views.map { "EXPLAIN SELECT * FROM \(SQLiteTableDDL.quote($0))" }
-            + triggerTables.flatMap { table in
-                [
-                    "EXPLAIN INSERT INTO \(SQLiteTableDDL.quote(table)) DEFAULT VALUES",
-                    "EXPLAIN DELETE FROM \(SQLiteTableDDL.quote(table))"
-                ]
-            }
+        var probes = views.map { "EXPLAIN SELECT * FROM \(SQLiteTableDDL.quote($0))" }
+        var seen = Set<String>()
+        for (table, sql) in triggers {
+            guard let probe = triggerProbe(forTable: table, sql: sql), seen.insert(probe).inserted else { continue }
+            probes.append(probe)
+        }
+        return probes
+    }
+
+    /// The statement that compiles one trigger's body, or nil for a form this cannot probe.
+    ///
+    /// An `INSTEAD OF` trigger belongs to a view, which the view's own `SELECT` probe already
+    /// compiles, so it needs nothing of its own.
+    private static func triggerProbe(forTable table: String, sql: String) -> String? {
+        let tokens = SQLiteTokenizer.tokenize(sql)
+        guard let onIndex = tokens.firstIndex(where: { $0.keyword == "ON" }) else { return nil }
+        let keywords = tokens[..<onIndex].map(\.keyword)
+        guard !keywords.contains("INSTEAD") else { return nil }
+
+        let quoted = SQLiteTableDDL.quote(table)
+        if keywords.contains("DELETE") { return "EXPLAIN DELETE FROM \(quoted)" }
+        if keywords.contains("INSERT") { return "EXPLAIN INSERT INTO \(quoted) DEFAULT VALUES" }
+        guard keywords.contains("UPDATE") else { return nil }
+
+        /// `UPDATE OF col` names the columns it watches, and updating one of them is what compiles
+        /// the body. A bare `UPDATE` trigger fires on any column, so any assignment will do.
+        guard let ofIndex = keywords.firstIndex(of: "OF"), ofIndex + 1 < onIndex else {
+            return "EXPLAIN UPDATE \(quoted) SET rowid = rowid"
+        }
+        let column = SQLiteTableDDL.quote(tokens[ofIndex + 1].text)
+        return "EXPLAIN UPDATE \(quoted) SET \(column) = \(column)"
     }
 
     /// A fingerprint of everything the rebuild reproduces, so a plan built before a review sheet

--- a/Plugins/TableProPluginKit/SQLiteTableRebuildPlanner.swift
+++ b/Plugins/TableProPluginKit/SQLiteTableRebuildPlanner.swift
@@ -59,18 +59,31 @@ public enum SQLiteTableRebuildPlanner {
         /// than forcing it on.
         public let foreignKeysWereOn: Bool
 
+        /// What `PRAGMA legacy_alter_table` read before the rebuild. The plan sets it both ways and
+        /// it survives the commit, so the epilogue has to put the connection back as it found it.
+        public let legacyAlterTableWasOn: Bool
+
+        /// One statement per dependent view and per table carrying a trigger, which compiles that
+        /// object's body without running it. Run after the column `ALTER`s so an object the edit
+        /// broke fails the transaction instead of being committed broken.
+        public let dependentValidationSQL: [String]
+
         public init(
             parsed: SQLiteTableDDL.Parsed,
             copyableColumns: [String],
             dependentObjectSQL: [String],
             autoincrementHighWaterMark: Int64?,
-            foreignKeysWereOn: Bool
+            foreignKeysWereOn: Bool,
+            legacyAlterTableWasOn: Bool = true,
+            dependentValidationSQL: [String] = []
         ) {
             self.parsed = parsed
             self.copyableColumns = copyableColumns
             self.dependentObjectSQL = dependentObjectSQL
             self.autoincrementHighWaterMark = autoincrementHighWaterMark
             self.foreignKeysWereOn = foreignKeysWereOn
+            self.legacyAlterTableWasOn = legacyAlterTableWasOn
+            self.dependentValidationSQL = dependentValidationSQL
         }
     }
 
@@ -86,10 +99,18 @@ public enum SQLiteTableRebuildPlanner {
         isRunnable: Bool
     ) -> PluginColumnReorderPlan? {
         guard !respecification.isEmpty else { return nil }
+
+        /// A rename and a drop are left out of the new definition on purpose: each runs as its own
+        /// `ALTER TABLE` after the rebuild, which is the only thing that carries the change into
+        /// every index, trigger and view. So the new table is built under the columns' CURRENT
+        /// names, and anything the save expressed in FINAL names is mapped back.
+        let toCurrentName = respecification.renamedColumns.reduce(into: [String: String]()) {
+            $0[$1.value.lowercased()] = $1.key
+        }
         guard let respecified = SQLiteTableDDL.respecified(
             context.parsed,
             tableName: temporaryName(for: tableName),
-            respecification: respecification,
+            respecification: respecification.namedAsBuilt(using: toCurrentName),
             renderColumn: renderColumn
         ) else { return nil }
 
@@ -117,7 +138,14 @@ public enum SQLiteTableRebuildPlanner {
         }
         guard !targetColumns.isEmpty else { return nil }
 
+        /// `legacy_alter_table` is on for the table rename and off for the column ones, and both
+        /// settings are load bearing. Measured on 3.54: at 0 the `RENAME TO` fails with "error in
+        /// view v: no such table: main.t", because the view still points at the table the rebuild
+        /// just dropped; at 1 a later `DROP COLUMN` silently leaves a dependent trigger or view
+        /// broken instead of refusing. Relying on the connection's inherited value is not an
+        /// option either way: Apple's libsqlite3 defaults it to 1 and upstream defaults it to 0.
         var statements = [
+            "PRAGMA legacy_alter_table = on",
             respecified.createTableSQL,
             """
             INSERT INTO \(quotedTemporary) (\(targetColumns.joined(separator: ", "))) \
@@ -139,6 +167,33 @@ public enum SQLiteTableRebuildPlanner {
         }
         statements.append(contentsOf: context.dependentObjectSQL)
 
+        /// Now the edits only `ALTER TABLE` can make correctly. SQLite rewrites the column's name
+        /// through every index, trigger and view itself, which is why they run here rather than
+        /// inside the new definition. Off for `legacy_alter_table`, or a drop that breaks a
+        /// dependent succeeds silently.
+        if !respecification.renamedColumns.isEmpty || !respecification.droppedColumns.isEmpty {
+            statements.append("PRAGMA legacy_alter_table = off")
+        }
+        for (from, to) in respecification.renamedColumns.sorted(by: { $0.key < $1.key }) {
+            statements.append(
+                """
+                ALTER TABLE \(quotedOriginal) RENAME COLUMN \(SQLiteTableDDL.quote(from)) \
+                TO \(SQLiteTableDDL.quote(to))
+                """
+            )
+        }
+        for column in respecification.droppedColumns.sorted() {
+            statements.append("ALTER TABLE \(quotedOriginal) DROP COLUMN \(SQLiteTableDDL.quote(column))")
+        }
+
+        /// Compiling each dependent object's body catches what the `ALTER`s do not refuse. Measured:
+        /// a trigger on ANOTHER table that inserts a positional row into this one keeps compiling
+        /// past a dropped column until its body is prepared, and a view declared with an explicit
+        /// column list breaks on the count. Both commit silently otherwise.
+        if !respecification.droppedColumns.isEmpty {
+            statements.append(contentsOf: context.dependentValidationSQL)
+        }
+
         var caveats = respecified.caveats
         /// A plan TablePro cannot run is handed to the user as a script, and an editor's Run All
         /// treats the check's rows as an ordinary result rather than a refusal. The check still
@@ -154,6 +209,19 @@ public enum SQLiteTableRebuildPlanner {
                 )
             )
         }
+        /// A type change is a data migration, not a metadata edit: the copy re-applies the new
+        /// column's affinity to every value. Measured on 3.54, TEXT '007' copied into an INTEGER
+        /// column becomes 7, and there is no undo.
+        if respecification.retypesAColumn {
+            caveats.append(
+                String(
+                    localized: """
+                        Changing a column's type re-reads every value in it. Text that looks like a \
+                        number becomes one, so '007' is stored as 7.
+                        """
+                )
+            )
+        }
         if respecification.columnOrder != nil {
             caveats.append(
                 String(localized: "A view that selects * from this table will return its columns in the new order.")
@@ -163,7 +231,10 @@ public enum SQLiteTableRebuildPlanner {
         return PluginColumnReorderPlan(
             statements: statements,
             prologue: ["PRAGMA foreign_keys = off"],
-            epilogue: ["PRAGMA foreign_keys = \(context.foreignKeysWereOn ? "on" : "off")"],
+            epilogue: [
+                "PRAGMA legacy_alter_table = \(context.legacyAlterTableWasOn ? "on" : "off")",
+                "PRAGMA foreign_keys = \(context.foreignKeysWereOn ? "on" : "off")"
+            ],
             isTransactional: true,
             cost: .tableRebuild,
             caveats: caveats,
@@ -259,13 +330,48 @@ public extension SQLiteTableRebuildPlanner {
         let foreignKeysWereOn = (try await execute("PRAGMA foreign_keys")
             .rows.first?[safe: 0]?.asText).map { $0 == "1" || $0.lowercased() == "true" } ?? false
 
+        let legacyAlterTableWasOn = (try await execute("PRAGMA legacy_alter_table")
+            .rows.first?[safe: 0]?.asText).map { $0 == "1" || $0.lowercased() == "true" } ?? false
+
         return Context(
             parsed: parsed,
             copyableColumns: copyable,
             dependentObjectSQL: dependents,
             autoincrementHighWaterMark: highWaterMark,
-            foreignKeysWereOn: foreignKeysWereOn
+            foreignKeysWereOn: foreignKeysWereOn,
+            legacyAlterTableWasOn: legacyAlterTableWasOn,
+            dependentValidationSQL: try await dependentValidationSQL(execute: execute)
         )
+    }
+
+    /// One statement per dependent object that compiles its body without running it.
+    ///
+    /// `EXPLAIN` prepares a statement and stops, so an object's SQL is checked against the table as
+    /// it now stands and nothing runs. A view is checked by selecting from it; a trigger by
+    /// preparing a write against the table it fires on, which compiles every trigger on that table.
+    ///
+    /// Both are needed, and neither is optional. Measured on 3.54: dropping a column leaves a view
+    /// declared with an explicit column list broken on its count, and leaves a trigger on *another*
+    /// table that writes a positional row into this one broken on its value count. `ALTER TABLE`
+    /// reports neither, `PRAGMA foreign_key_check` cannot see either, and both commit silently.
+    private static func dependentValidationSQL(
+        execute: (String) async throws -> PluginQueryResult
+    ) async throws -> [String] {
+        let views = try await execute(
+            "SELECT name FROM sqlite_master WHERE type = 'view' ORDER BY name"
+        ).rows.compactMap { $0[safe: 0]?.asText }
+
+        let triggerTables = try await execute(
+            "SELECT DISTINCT tbl_name FROM sqlite_master WHERE type = 'trigger' ORDER BY tbl_name"
+        ).rows.compactMap { $0[safe: 0]?.asText }
+
+        return views.map { "EXPLAIN SELECT * FROM \(SQLiteTableDDL.quote($0))" }
+            + triggerTables.flatMap { table in
+                [
+                    "EXPLAIN INSERT INTO \(SQLiteTableDDL.quote(table)) DEFAULT VALUES",
+                    "EXPLAIN DELETE FROM \(SQLiteTableDDL.quote(table))"
+                ]
+            }
     }
 
     /// A fingerprint of everything the rebuild reproduces, so a plan built before a review sheet

--- a/Plugins/TableProPluginKit/SQLiteTableRespecifier.swift
+++ b/Plugins/TableProPluginKit/SQLiteTableRespecifier.swift
@@ -59,6 +59,7 @@ public extension SQLiteTableDDL {
             return nil
         }
 
+        let rowidAlias = rowidAliasColumn(parsed)
         let located = SQLiteForeignKeyParser.foreignKeys(in: parsed)
         guard let removals = foreignKeyRemovals(
             located: located,
@@ -111,7 +112,10 @@ public extension SQLiteTableDDL {
                         type: alteration.type,
                         isNullable: alteration.isNullable,
                         defaultValue: alteration.defaultValue
-                    )
+                    ),
+                    isRowidAlias: rowidAlias.map {
+                        $0.compare(columnName, options: .caseInsensitive) == .orderedSame
+                    } ?? false
                 ) else { return nil }
                 text = rewritten
             }
@@ -154,6 +158,55 @@ public extension SQLiteTableDDL {
             carriedColumns: orderedCarried,
             caveats: caveats
         )
+    }
+
+    /// The column that *is* the rowid, where the table declares one.
+    ///
+    /// SQLite's rule is a single-column primary key whose declared type is exactly `INTEGER`, and
+    /// the key may be written on the column or at table level. Reading only the column's own
+    /// constraints misses `CREATE TABLE t(id INTEGER, PRIMARY KEY(id))`, where retyping `id` is
+    /// just as destructive.
+    static func rowidAliasColumn(_ parsed: Parsed) -> String? {
+        guard isRowidTable(parsed) else { return nil }
+
+        var keyColumns: [String] = []
+        for entry in parsed.entries {
+            guard let declaration = SQLiteColumnDeclaration.parse(entry.text) else {
+                guard let tableLevel = tableLevelPrimaryKeyColumns(entry.text) else { continue }
+                keyColumns = tableLevel
+                continue
+            }
+            if declaration.first(.primaryKey) != nil { keyColumns = [declaration.name] }
+        }
+
+        guard keyColumns.count == 1, let name = keyColumns.first else { return nil }
+        guard let declaration = parsed.entries.lazy
+            .compactMap({ SQLiteColumnDeclaration.parse($0.text) })
+            .first(where: { $0.name.compare(name, options: .caseInsensitive) == .orderedSame }) else {
+            return nil
+        }
+        let type = declaration.declaredType?.trimmingCharacters(in: .whitespaces) ?? ""
+        return type.caseInsensitiveCompare("INTEGER") == .orderedSame ? declaration.name : nil
+    }
+
+    /// The columns a table-level `[CONSTRAINT n] PRIMARY KEY (…)` entry names, or nil for any other
+    /// table constraint.
+    private static func tableLevelPrimaryKeyColumns(_ text: String) -> [String]? {
+        let tokens = SQLiteTokenizer.tokenize(text)
+        var cursor = 0
+        if tokens.first?.keyword == "CONSTRAINT" { cursor = 2 }
+        guard cursor + 2 < tokens.count,
+              tokens[cursor].keyword == "PRIMARY", tokens[cursor + 1].keyword == "KEY" else { return nil }
+
+        var names: [String] = []
+        var index = cursor + 3
+        while index < tokens.count, tokens[index].text != ")" {
+            if !tokens[index].isPunctuation, !["ASC", "DESC", "COLLATE"].contains(tokens[index].keyword) {
+                if index == cursor + 3 || tokens[index - 1].text == "," { names.append(tokens[index].text) }
+            }
+            index += 1
+        }
+        return names.isEmpty ? nil : names
     }
 
     /// Whether the statement declares a rowid, which decides whether a rebuild can carry rowids

--- a/Plugins/TableProPluginKit/SQLiteTableRespecifier.swift
+++ b/Plugins/TableProPluginKit/SQLiteTableRespecifier.swift
@@ -54,7 +54,8 @@ public extension SQLiteTableDDL {
         let existingNames = parsed.columnNames
 
         guard respecification.droppedColumns.allSatisfy({ contains(existingNames, $0) }),
-              respecification.renamedColumns.keys.allSatisfy({ contains(existingNames, $0) }) else {
+              respecification.renamedColumns.keys.allSatisfy({ contains(existingNames, $0) }),
+              respecification.alteredColumns.allSatisfy({ contains(existingNames, $0.column) }) else {
             return nil
         }
 
@@ -95,7 +96,24 @@ public extension SQLiteTableDDL {
 
             var text = entry.text
             if let span = removals.spans[index] {
-                text = cutting(span, from: text)
+                text = cuttingSpan(span, from: text)
+            }
+            /// The one place a column's own declaration is rewritten. Its type, nullability and
+            /// default are the only things no `ALTER TABLE` can change, so they travel here; a
+            /// rename and a drop are `ALTER`s of their own, run after the rebuild, and are absent
+            /// from this text on purpose.
+            if let alteration = respecification.alteredColumns.first(
+                where: { $0.column.compare(columnName, options: .caseInsensitive) == .orderedSame }
+            ) {
+                guard let rewritten = SQLiteColumnDeclaration.rewritten(
+                    text,
+                    applying: SQLiteColumnDeclaration.Edit(
+                        type: alteration.type,
+                        isNullable: alteration.isNullable,
+                        defaultValue: alteration.defaultValue
+                    )
+                ) else { return nil }
+                text = rewritten
             }
             let finalName = matchedRename(of: columnName, in: respecification.renamedColumns) ?? columnName
             if finalName != columnName {
@@ -305,21 +323,6 @@ private extension SQLiteTableDDL {
 
     static func matchedRename(of column: String, in renames: [String: String]) -> String? {
         renames.first { $0.key.compare(column, options: .caseInsensitive) == .orderedSame }?.value
-    }
-
-    /// The declaration with `span` removed and the gap it left closed.
-    ///
-    /// Only the whitespace either side of the cut is touched. Collapsing runs across the whole
-    /// declaration would rewrite text the user typed: a `DEFAULT 'a  b'` elsewhere in the same
-    /// column would come back with one space instead of two.
-    static func cutting(_ span: Range<String.Index>, from text: String) -> String {
-        var head = String(text[text.startIndex..<span.lowerBound])
-        let tail = String(text[span.upperBound...])
-        let headHadSpace = head.last?.isWhitespace ?? false
-        let tailHasSpace = tail.first?.isWhitespace ?? false
-        while head.last?.isWhitespace == true { head.removeLast() }
-        let separator = head.isEmpty || tail.isEmpty || !(headHadSpace || tailHasSpace) ? "" : " "
-        return head + separator + tail.drop(while: { $0.isWhitespace })
     }
 
     /// The same column definition under a new name, with everything after the name untouched.

--- a/Plugins/TeradataDriverPlugin/Info.plist
+++ b/Plugins/TeradataDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>24</integer>
+	<integer>25</integer>
 </dict>
 </plist>

--- a/Plugins/TrinoDriverPlugin/Info.plist
+++ b/Plugins/TrinoDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>24</integer>
+	<integer>25</integer>
 </dict>
 </plist>

--- a/Plugins/TypesenseDriverPlugin/Info.plist
+++ b/Plugins/TypesenseDriverPlugin/Info.plist
@@ -5,7 +5,7 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.73.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>24</integer>
+	<integer>25</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Typesense</string>

--- a/Plugins/XLSXExportPlugin/Info.plist
+++ b/Plugins/XLSXExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>24</integer>
+	<integer>25</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>xlsx</string>

--- a/Plugins/XLSXImportPlugin/Info.plist
+++ b/Plugins/XLSXImportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>24</integer>
+	<integer>25</integer>
 	<key>TableProProvidesImportFormatIds</key>
 	<array>
 		<string>xlsx</string>

--- a/Plugins/XMLExportPlugin/Info.plist
+++ b/Plugins/XMLExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>24</integer>
+	<integer>25</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>xml</string>

--- a/TablePro/Core/Plugins/PluginManager.swift
+++ b/TablePro/Core/Plugins/PluginManager.swift
@@ -37,7 +37,7 @@ final class PluginManager {
     /// rebuilt CassandraDriver for the v20 requirements it implements none of. Left at 20, such a
     /// plugin passes `validateBundleVersions` in a shipped v20 app and then fails
     /// `Bundle.loadAndReturnError`; at 21 that app refuses it and says to update.
-    nonisolated static let currentPluginKitVersion = 24
+    nonisolated static let currentPluginKitVersion = 25
 
     /// Still 19, so every plugin already published for the previous release keeps loading.
     nonisolated static let minimumCompatiblePluginKitVersion = 19

--- a/TablePro/Views/Structure/StructureTableRebuildHandler.swift
+++ b/TablePro/Views/Structure/StructureTableRebuildHandler.swift
@@ -16,9 +16,10 @@ import TableProPluginKit
 /// passes would leave the earlier changes committed when the rebuild failed, and a column the save
 /// renamed would leave the staged foreign key naming a column that no longer exists.
 ///
-/// A column added, an index and a check constraint all travel. A column dropped or renamed does
-/// not: `ALTER TABLE` carries such a change into every trigger, view and referencing table by
-/// itself, and a rebuild cannot, so it is refused with the reason rather than half-applied.
+/// A rename and a drop travel as their own `ALTER TABLE`, appended after the rebuild rather than
+/// folded into the new definition. That is not a shortcut: `ALTER TABLE` rewrites the column's name
+/// through every index, trigger and view itself, measured on 3.54, and a rebuild that reproduced
+/// the table by hand would leave all three naming a column that no longer exists.
 @MainActor
 enum StructureTableRebuildHandler {
     enum RebuildError: LocalizedError {
@@ -68,8 +69,15 @@ enum StructureTableRebuildHandler {
     static func requiresRebuild(changes: [SchemaChange], support: ForeignKeyEditSupport) -> Bool {
         support == .rebuild && changes.contains { change in
             switch change {
-            case .addForeignKey, .modifyForeignKey, .deleteForeignKey: true
-            default: false
+            case .addForeignKey, .modifyForeignKey, .deleteForeignKey:
+                true
+            case .modifyColumn(let old, let new):
+                /// A rename alone is an `ALTER TABLE`, which is cheaper than copying the table and
+                /// carries itself into every dependent object. Anything else about a column needs
+                /// the table recreated, because SQLite has no statement for it.
+                old.alteration(comparedTo: new) != nil
+            default:
+                false
             }
         }
     }
@@ -138,16 +146,9 @@ enum StructureTableRebuildHandler {
         var partition = Partition()
         for change in changes {
             switch change {
-            case .addColumn, .addForeignKey, .modifyForeignKey, .deleteForeignKey:
+            case .addColumn, .deleteColumn, .modifyColumn,
+                 .addForeignKey, .modifyForeignKey, .deleteForeignKey:
                 partition.rebuilt.append(change)
-            case .deleteColumn, .modifyColumn:
-                /// Dropping or renaming a column is safe on its own, through `ALTER TABLE`, which
-                /// carries the change into every trigger, view and referencing table itself. A
-                /// rebuild does not: it replays the dependent SQL verbatim and rewrites only the
-                /// column's own declaration, so the same edit inside one either fails with
-                /// "no such column" or commits a trigger, a view or an incoming foreign key that
-                /// names a column that is gone. Refused rather than half-applied.
-                partition.unsupported.append(change)
             case .addIndex, .modifyIndex, .deleteIndex,
                  .addCheckConstraint, .modifyCheckConstraint, .deleteCheckConstraint:
                 partition.trailing.append(change)
@@ -160,6 +161,9 @@ enum StructureTableRebuildHandler {
 
     private static func respecification(from changes: [SchemaChange]) -> PluginTableRespecification {
         var addedColumns: [PluginColumnDefinition] = []
+        var droppedColumns: [String] = []
+        var renamedColumns: [String: String] = [:]
+        var alteredColumns: [PluginColumnAlteration] = []
         var addedForeignKeys: [PluginForeignKeyDefinition] = []
         var droppedForeignKeys: [PluginForeignKeyDefinition] = []
 
@@ -167,6 +171,16 @@ enum StructureTableRebuildHandler {
             switch change {
             case .addColumn(let column):
                 addedColumns.append(column.toPlugin())
+            case .deleteColumn(let column):
+                droppedColumns.append(column.name)
+            case .modifyColumn(let old, let new):
+                /// A column edit is up to three separate things, and they leave by different doors.
+                /// The type, nullability and default go into the new definition; the rename becomes
+                /// an `ALTER TABLE` after it. One `.modifyColumn` can carry both.
+                if old.name != new.name { renamedColumns[old.name] = new.name }
+                if let alteration = old.alteration(comparedTo: new) {
+                    alteredColumns.append(alteration)
+                }
             case .addForeignKey(let foreignKey):
                 addedForeignKeys.append(foreignKey.toPlugin())
             case .deleteForeignKey(let foreignKey):
@@ -181,8 +195,11 @@ enum StructureTableRebuildHandler {
 
         return PluginTableRespecification(
             addedColumns: addedColumns,
+            droppedColumns: droppedColumns,
+            renamedColumns: renamedColumns,
             addedForeignKeys: addedForeignKeys,
-            droppedForeignKeys: droppedForeignKeys
+            droppedForeignKeys: droppedForeignKeys,
+            alteredColumns: alteredColumns
         )
     }
 }
@@ -200,6 +217,29 @@ private extension PluginColumnReorderPlan {
             caveats: caveats,
             isRunnable: isRunnable,
             verifications: verifications
+        )
+    }
+}
+
+internal extension EditableColumnDefinition {
+    /// What changed about this column beyond its name, or nil when only the name did.
+    ///
+    /// A rename leaves by a different door: `ALTER TABLE RENAME COLUMN` carries it into every
+    /// index, trigger and view, which a rebuilt definition cannot. Everything here has no `ALTER`
+    /// behind it on a rebuild engine, so it travels in the new definition instead.
+    ///
+    /// The default is compared as the user's own text and passed on the same way. A default read
+    /// back from `PRAGMA table_info` has already lost its parentheses, and measured on 3.54 the
+    /// stripped form of `DEFAULT (datetime('now'))` will not parse again, so an unchanged one must
+    /// never be re-rendered from a model.
+    func alteration(comparedTo other: EditableColumnDefinition) -> PluginColumnAlteration? {
+        let type = dataType == other.dataType ? nil : other.dataType
+        let isNullable = self.isNullable == other.isNullable ? nil : other.isNullable
+        let defaultValue = defaultValue == other.defaultValue ? nil : (other.defaultValue ?? "")
+
+        guard type != nil || isNullable != nil || defaultValue != nil else { return nil }
+        return PluginColumnAlteration(
+            column: name, type: type, isNullable: isNullable, defaultValue: defaultValue
         )
     }
 }

--- a/TablePro/Views/Structure/StructureTableRebuildHandler.swift
+++ b/TablePro/Views/Structure/StructureTableRebuildHandler.swift
@@ -25,6 +25,7 @@ enum StructureTableRebuildHandler {
     enum RebuildError: LocalizedError {
         case notRebuildable(String)
         case cannotExpress([String])
+        case namingConflict(String)
         case planFailed
 
         var errorDescription: String? {
@@ -49,6 +50,17 @@ enum StructureTableRebuildHandler {
                             """
                     ),
                     descriptions.joined(separator: "\n")
+                )
+            case .namingConflict(let name):
+                return String(
+                    format: String(
+                        localized: """
+                            This save reuses the column name %@ while the table is being recreated, \
+                            and the recreated table would hold it twice. Save the change that frees \
+                            the name first, then the one that takes it.
+                            """
+                    ),
+                    name
                 )
             case .planFailed:
                 return String(
@@ -93,7 +105,20 @@ enum StructureTableRebuildHandler {
         }
 
         let respecification = respecification(from: partition.rebuilt)
+        guard let conflict = respecification.namingConflict else {
+            return try await prepare(respecification, changes: partition, tableName: tableName, scope: scope)
+        }
+        throw RebuildError.namingConflict(conflict)
+    }
+
+    private static func prepare(
+        _ respecification: PluginTableRespecification,
+        changes partition: Partition,
+        tableName: String,
+        scope: DatabaseScope
+    ) async throws -> StructureRebuildPlanRunner.Prepared {
         let schema = scope.schema
+        let partitionTrailing = partition.trailing
 
         let prepared = try await DatabaseManager.shared.withScopedDriver(
             scope: scope,
@@ -115,7 +140,7 @@ enum StructureTableRebuildHandler {
             /// lands after the rebuild has replayed the indexes it inherited, which is what makes it
             /// take effect rather than being undone by the replay.
             let trailing = try SchemaStatementGenerator(tableName: tableName, pluginDriver: pluginDriver)
-                .generate(changes: partition.trailing)
+                .generate(changes: partitionTrailing)
                 .map(\.sql)
 
             let fingerprint = try? await adapter.columnReorderSchemaFingerprint(
@@ -146,9 +171,14 @@ enum StructureTableRebuildHandler {
         var partition = Partition()
         for change in changes {
             switch change {
-            case .addColumn, .deleteColumn, .modifyColumn,
-                 .addForeignKey, .modifyForeignKey, .deleteForeignKey:
+            case .addColumn, .deleteColumn, .addForeignKey, .modifyForeignKey, .deleteForeignKey:
                 partition.rebuilt.append(change)
+            case .modifyColumn(let old, let new):
+                if old.changesFieldsNoRebuildCarries(comparedTo: new) {
+                    partition.unsupported.append(change)
+                } else {
+                    partition.rebuilt.append(change)
+                }
             case .addIndex, .modifyIndex, .deleteIndex,
                  .addCheckConstraint, .modifyCheckConstraint, .deleteCheckConstraint:
                 partition.trailing.append(change)
@@ -241,5 +271,19 @@ internal extension EditableColumnDefinition {
         return PluginColumnAlteration(
             column: name, type: type, isNullable: isNullable, defaultValue: defaultValue
         )
+    }
+
+    /// Whether this edit touches a field the rebuild cannot carry.
+    ///
+    /// A single `.modifyColumn` folds every field the user changed on that row, and the rebuild
+    /// expresses three of them. Applying the three and dropping the rest would report success over
+    /// an edit it never made, which is the defect this whole change exists to remove. Setting
+    /// Primary Key on a nullable column is the case that bites: the editor flips nullability with
+    /// it, so the save would rebuild the table `NOT NULL` and quietly leave the key unset.
+    func changesFieldsNoRebuildCarries(comparedTo other: EditableColumnDefinition) -> Bool {
+        isPrimaryKey != other.isPrimaryKey
+            || autoIncrement != other.autoIncrement
+            || generationExpression != other.generationExpression
+            || generationKind != other.generationKind
     }
 }

--- a/TableProTests/Models/Schema/SQLiteColumnDeclarationTests.swift
+++ b/TableProTests/Models/Schema/SQLiteColumnDeclarationTests.swift
@@ -1,0 +1,230 @@
+//
+//  SQLiteColumnDeclarationTests.swift
+//  TablePro
+//
+
+import Foundation
+import TableProPluginKit
+@testable import TablePro
+import Testing
+
+/// The column-definition grammar the rebuild rewrites through.
+///
+/// Every refusal and every boundary here was measured against SQLite 3.54, and several of them
+/// refute what the published railroad diagrams say.
+@Suite("SQLite Column Declaration")
+struct SQLiteColumnDeclarationTests {
+    private func parse(_ text: String) throws -> SQLiteColumnDeclaration {
+        try #require(SQLiteColumnDeclaration.parse(text))
+    }
+
+    private func rewrite(
+        _ text: String,
+        type: String? = nil,
+        isNullable: Bool? = nil,
+        defaultValue: String? = nil
+    ) -> String? {
+        SQLiteColumnDeclaration.rewritten(
+            text,
+            applying: SQLiteColumnDeclaration.Edit(
+                type: type, isNullable: isNullable, defaultValue: defaultValue
+            )
+        )
+    }
+
+    // MARK: - The type boundary
+
+    /// A type name is one or more words, so the boundary is the first keyword that starts a
+    /// constraint. Measured: `UNSIGNED BIG INT` and `VARYING CHARACTER(255)` are each one type.
+    @Test(
+        "The declared type is read whole",
+        arguments: [
+            ("a INTEGER", "INTEGER"),
+            ("a UNSIGNED BIG INT", "UNSIGNED BIG INT"),
+            ("a DOUBLE PRECISION", "DOUBLE PRECISION"),
+            ("a VARYING CHARACTER(255)", "VARYING CHARACTER(255)"),
+            ("a DECIMAL(10,2)", "DECIMAL(10,2)"),
+            ("a TEXT NOT NULL", "TEXT"),
+            ("a TEXT DEFAULT 'x'", "TEXT"),
+            ("a INT REFERENCES p(id)", "INT")
+        ]
+    )
+    func readsTheType(text: String, expected: String) throws {
+        #expect(try parse(text).declaredType == expected)
+    }
+
+    /// `CREATE TABLE t(a)` is legal and declares no type at all.
+    @Test("A column with no type has none, and a bare NULL is a constraint rather than one")
+    func readsAnAbsentType() throws {
+        #expect(try parse("a").declaredType == nil)
+        #expect(try parse("a NULL").declaredType == nil)
+        #expect(try parse("a NULL").first(.null) != nil)
+    }
+
+    /// Measured: `a BIG GENERATED` declares the type `BIG GENERATED`, and only the exact run
+    /// `GENERATED ALWAYS AS` ends a type. A one-token lookahead gets this wrong.
+    @Test("GENERATED ends the type only as the full three-word run")
+    func readsGeneratedBoundary() throws {
+        #expect(try parse("a BIG GENERATED ALWAYS AS (x)").declaredType == "BIG")
+        #expect(try parse("a BIG GENERATED ALWAYS AS (x)").isGenerated)
+        #expect(try parse("a TEXT AS (x)").declaredType == "TEXT")
+        #expect(try parse("a TEXT AS (x)").isGenerated)
+    }
+
+    // MARK: - Which NULL is which
+
+    /// The reason this is a grammar walk and not a keyword search. Measured on 3.54: the column is
+    /// nullable, but a search for `NOT NULL` matches inside the check, so "make it NOT NULL" would
+    /// read as already done and silently change nothing.
+    @Test("NOT NULL inside a CHECK is not the column's nullability")
+    func ignoresNotNullInsideACheck() throws {
+        let declaration = try parse("b TEXT CHECK (b IS NOT NULL)")
+        #expect(declaration.first(.notNull) == nil)
+        #expect(declaration.first(.check) != nil)
+
+        #expect(
+            rewrite("b TEXT CHECK (b IS NOT NULL)", isNullable: false)
+                == "b TEXT NOT NULL CHECK (b IS NOT NULL)"
+        )
+    }
+
+    /// The other direction, and the one that produced a syntax error rather than a silent no-op:
+    /// a search for `NULL` matches the foreign key's action and rewrites it into nonsense.
+    @Test("NULL inside a referential action is not the column's nullability")
+    func ignoresNullInsideAReferentialAction() throws {
+        let text = "a INTEGER REFERENCES p(id) ON DELETE SET NULL"
+        let declaration = try parse(text)
+        #expect(declaration.first(.null) == nil)
+        #expect(declaration.first(.notNull) == nil)
+        #expect(declaration.first(.foreignKey) != nil)
+
+        #expect(rewrite(text, isNullable: false) == "a INTEGER NOT NULL REFERENCES p(id) ON DELETE SET NULL")
+    }
+
+    // MARK: - Rewriting
+
+    @Test("Changing the type leaves every other constraint byte for byte")
+    func changesTheType() throws {
+        let text = "b TEXT NOT NULL DEFAULT 'hi, there' COLLATE NOCASE CHECK (length(b) > 0)"
+        let rewritten = try #require(rewrite(text, type: "VARCHAR(64)"))
+        #expect(rewritten == "b VARCHAR(64) NOT NULL DEFAULT 'hi, there' COLLATE NOCASE CHECK (length(b) > 0)")
+    }
+
+    @Test("A column with no type gains one after its name")
+    func addsATypeToAnUntypedColumn() throws {
+        #expect(rewrite("a NOT NULL", type: "TEXT") == "a TEXT NOT NULL")
+    }
+
+    /// Dropping the constraint takes its `ON CONFLICT` tail with it: measured, an orphaned
+    /// `ON CONFLICT ROLLBACK` is a parse error.
+    @Test("Dropping NOT NULL takes its whole clause")
+    func dropsNotNull() throws {
+        #expect(rewrite("a TEXT NOT NULL", isNullable: true) == "a TEXT")
+        #expect(rewrite("a TEXT NOT NULL ON CONFLICT ROLLBACK", isNullable: true) == "a TEXT")
+        #expect(rewrite("a TEXT CONSTRAINT nn NOT NULL", isNullable: true) == "a TEXT")
+    }
+
+    @Test("A bare NULL becomes NOT NULL rather than gaining a second clause")
+    func replacesABareNull() throws {
+        #expect(rewrite("a TEXT NULL", isNullable: false) == "a TEXT NOT NULL")
+    }
+
+    @Test("Changing the default replaces only its clause")
+    func changesTheDefault() throws {
+        #expect(rewrite("a TEXT DEFAULT 'old' NOT NULL", defaultValue: "'new'") == "a TEXT DEFAULT 'new' NOT NULL")
+        #expect(rewrite("a TEXT NOT NULL", defaultValue: "'new'") == "a TEXT DEFAULT 'new' NOT NULL")
+        #expect(rewrite("a TEXT", defaultValue: "'new'") == "a TEXT DEFAULT 'new'")
+        #expect(rewrite("a TEXT DEFAULT 'old'", defaultValue: "") == "a TEXT")
+    }
+
+    /// Measured: `PRAGMA table_info` reports this default as `datetime('now')`, and re-emitting the
+    /// stripped form is a syntax error. It survives only because an untouched clause is never
+    /// re-rendered.
+    @Test("An expression default is left exactly as written when something else changes")
+    func preservesAnExpressionDefault() throws {
+        let text = "a TEXT DEFAULT (datetime('now'))"
+        #expect(rewrite(text, type: "DATETIME") == "a DATETIME DEFAULT (datetime('now'))")
+        #expect(rewrite(text, isNullable: false) == "a TEXT NOT NULL DEFAULT (datetime('now'))")
+    }
+
+    @Test("A signed-number default is one clause")
+    func readsASignedNumberDefault() throws {
+        #expect(try parse("a INT DEFAULT -1 NOT NULL").first(.defaultValue) != nil)
+        #expect(rewrite("a INT DEFAULT -1 NOT NULL", type: "BIGINT") == "a BIGINT DEFAULT -1 NOT NULL")
+    }
+
+    @Test("Several edits to one column all land")
+    func appliesSeveralEditsAtOnce() throws {
+        let rewritten = try #require(
+            rewrite("a TEXT DEFAULT 'old'", type: "INTEGER", isNullable: false, defaultValue: "0")
+        )
+        #expect(rewritten == "a INTEGER NOT NULL DEFAULT 0")
+    }
+
+    // MARK: - Refusals
+
+    /// Measured: retyping an `INTEGER PRIMARY KEY` to `TEXT PRIMARY KEY` destroys the rowid alias.
+    /// The key stops generating values and then stores NULL on every insert that omits it, twice
+    /// over, with no error. Refusing is the only safe answer.
+    @Test("Retyping an INTEGER PRIMARY KEY away from INTEGER is refused")
+    func refusesToDestroyTheRowidAlias() {
+        #expect(rewrite("id INTEGER PRIMARY KEY", type: "TEXT") == nil)
+        #expect(rewrite("id INTEGER PRIMARY KEY AUTOINCREMENT", type: "TEXT") == nil)
+        /// Still the alias, so still allowed.
+        #expect(rewrite("id INTEGER PRIMARY KEY", type: "integer") != nil)
+        /// Not the alias to begin with.
+        #expect(rewrite("id TEXT PRIMARY KEY", type: "INTEGER") != nil)
+    }
+
+    /// Measured: `a INT NOT NULL NOT NULL` and `a INT DEFAULT 1 DEFAULT 2` are both legal.
+    /// Rewriting one of a pair leaves the other in force, so the edit would report success and
+    /// change nothing.
+    @Test("A column carrying the same constraint twice is refused")
+    func refusesDuplicateConstraints() {
+        #expect(rewrite("a INT NOT NULL NOT NULL", isNullable: true) == nil)
+        #expect(rewrite("a INT DEFAULT 1 DEFAULT 2", defaultValue: "3") == nil)
+        /// The other edits are still fine on the same column.
+        #expect(rewrite("a INT NOT NULL NOT NULL", type: "BIGINT") != nil)
+    }
+
+    /// A generated column's nullability and default belong to its expression, and SQLite rejects a
+    /// `DEFAULT` on one outright.
+    @Test("Nullability and default edits are refused on a generated column")
+    func refusesEditsToAGeneratedColumn() {
+        #expect(rewrite("a TEXT GENERATED ALWAYS AS (b) VIRTUAL", isNullable: false) == nil)
+        #expect(rewrite("a TEXT GENERATED ALWAYS AS (b) VIRTUAL", defaultValue: "'x'") == nil)
+        #expect(rewrite("a TEXT GENERATED ALWAYS AS (b) VIRTUAL", type: "INT") != nil)
+    }
+
+    @Test("A table constraint entry is not a column")
+    func refusesATableConstraint() {
+        #expect(SQLiteColumnDeclaration.parse("PRIMARY KEY (a, b)") == nil)
+        #expect(SQLiteColumnDeclaration.parse("CONSTRAINT fk FOREIGN KEY (a) REFERENCES p (id)") == nil)
+        #expect(SQLiteColumnDeclaration.parse("CHECK (a > 0)") == nil)
+        #expect(SQLiteColumnDeclaration.parse("UNIQUE (a)") == nil)
+    }
+
+    /// A declaration this grammar cannot read whole is never rewritten from a partial
+    /// understanding: the rebuild refuses instead and the user writes the SQL themselves.
+    @Test("An unreadable declaration is refused rather than guessed at")
+    func refusesWhatItCannotRead() {
+        #expect(SQLiteColumnDeclaration.parse("a TEXT CHECK (") == nil)
+        #expect(SQLiteColumnDeclaration.parse("a TEXT COLLATE") == nil)
+        #expect(SQLiteColumnDeclaration.parse("a TEXT NOT") == nil)
+    }
+
+    // MARK: - Quoting
+
+    @Test("A quoted type name is a type, not a keyword")
+    func readsAQuotedType() throws {
+        #expect(try parse("a \"DEFAULT\" NOT NULL").declaredType == "\"DEFAULT\"")
+        #expect(try parse("a \"DEFAULT\" NOT NULL").first(.notNull) != nil)
+        #expect(try parse("a \"DEFAULT\" NOT NULL").first(.defaultValue) == nil)
+    }
+
+    @Test("A quoted column name keeps its spelling")
+    func readsAQuotedName() throws {
+        #expect(try parse("\"my col\" TEXT").name == "my col")
+        #expect(rewrite("\"my col\" TEXT", type: "INT") == "\"my col\" INT")
+    }
+}

--- a/TableProTests/Models/Schema/SQLiteColumnDeclarationTests.swift
+++ b/TableProTests/Models/Schema/SQLiteColumnDeclarationTests.swift
@@ -213,6 +213,54 @@ struct SQLiteColumnDeclarationTests {
         #expect(SQLiteColumnDeclaration.parse("a TEXT NOT") == nil)
     }
 
+    /// The tokenizer splits on punctuation, so these literals arrive as several tokens. Consuming
+    /// one would leave the rest to be read as an unknown constraint, refusing every edit on a
+    /// column carrying a very ordinary default.
+    @Test(
+        "A default's literal is consumed whole",
+        arguments: [
+            "a INT DEFAULT 0.5", "a INT DEFAULT -0.5", "a INT DEFAULT 1e3",
+            "a BLOB DEFAULT X'0102'", "a INT DEFAULT TRUE", "a TEXT DEFAULT 'x'"
+        ]
+    )
+    func readsWholeDefaultLiterals(text: String) throws {
+        let declaration = try parse(text)
+        #expect(declaration.first(.defaultValue) != nil)
+        /// One constraint, read whole. A literal consumed in pieces leaves the remainder to be read
+        /// as a second, unknown one.
+        #expect(declaration.constraints.count == 1)
+
+        let literal = String(text.drop(while: { $0 != "T" }).dropFirst(8))
+        let rewritten = try #require(rewrite(text, isNullable: false))
+        #expect(rewritten.contains("NOT NULL"))
+        #expect(rewritten.hasSuffix(literal))
+    }
+
+    /// The range a constraint occupies starts at its `CONSTRAINT name`, so removing one takes the
+    /// name with it. Replacing one must not: the user changed the value, not the name, and on
+    /// SQLite 3.53 and later `DROP CONSTRAINT` still needs it.
+    @Test("Replacing a default keeps the name the constraint was given")
+    func preservesAConstraintName() {
+        #expect(rewrite("a INT CONSTRAINT d DEFAULT 1", defaultValue: "2") == "a INT CONSTRAINT d DEFAULT 2")
+        #expect(rewrite("a INT CONSTRAINT d DEFAULT 1", defaultValue: "") == "a INT")
+    }
+
+    /// The column-level guard cannot see a key written at table level, so the caller supplies it.
+    @Test("A rowid alias declared at table level is protected too")
+    func refusesToRetypeATableLevelAlias() {
+        let text = "id INTEGER"
+        #expect(
+            SQLiteColumnDeclaration.rewritten(
+                text, applying: SQLiteColumnDeclaration.Edit(type: "TEXT"), isRowidAlias: true
+            ) == nil
+        )
+        #expect(
+            SQLiteColumnDeclaration.rewritten(
+                text, applying: SQLiteColumnDeclaration.Edit(type: "TEXT"), isRowidAlias: false
+            ) != nil
+        )
+    }
+
     // MARK: - Quoting
 
     @Test("A quoted type name is a type, not a keyword")

--- a/TableProTests/Models/Schema/SQLiteTableRebuildPlannerTests.swift
+++ b/TableProTests/Models/Schema/SQLiteTableRebuildPlannerTests.swift
@@ -65,10 +65,11 @@ struct SQLiteTableRebuildPlannerTests {
     func followsDocumentedProcedure() throws {
         let plan = try plan(reorder)
         #expect(plan.cost == .tableRebuild)
-        #expect(plan.statements[0].hasPrefix("CREATE TABLE \"x_tablepro_rebuild\""))
-        #expect(plan.statements[1].hasPrefix("INSERT INTO \"x_tablepro_rebuild\""))
-        #expect(plan.statements[2] == "DROP TABLE \"x\"")
-        #expect(plan.statements[3] == "ALTER TABLE \"x_tablepro_rebuild\" RENAME TO \"x\"")
+        #expect(plan.statements[0] == "PRAGMA legacy_alter_table = on")
+        #expect(plan.statements[1].hasPrefix("CREATE TABLE \"x_tablepro_rebuild\""))
+        #expect(plan.statements[2].hasPrefix("INSERT INTO \"x_tablepro_rebuild\""))
+        #expect(plan.statements[3] == "DROP TABLE \"x\"")
+        #expect(plan.statements[4] == "ALTER TABLE \"x_tablepro_rebuild\" RENAME TO \"x\"")
         #expect(plan.statements.contains("CREATE INDEX ix_x_b ON x(b)"))
     }
 
@@ -100,7 +101,7 @@ struct SQLiteTableRebuildPlannerTests {
     @Test("The foreign-key pragma is put back the way it was", arguments: [true, false])
     func restoresTheForeignKeyPragma(wasOn: Bool) throws {
         let plan = try plan(reorder, context: try context(foreignKeysWereOn: wasOn))
-        #expect(plan.epilogue == ["PRAGMA foreign_keys = \(wasOn ? "on" : "off")"])
+        #expect(plan.epilogue.contains("PRAGMA foreign_keys = \(wasOn ? "on" : "off")"))
     }
 
     /// `DROP TABLE` takes the table's `sqlite_sequence` row with it, so without this the rebuilt
@@ -173,7 +174,7 @@ struct SQLiteTableRebuildPlannerTests {
         )
         let insert = try #require(plan.statements.first { $0.hasPrefix("INSERT INTO") })
         #expect(!insert.contains("rowid"))
-        #expect(plan.statements[0].hasSuffix("WITHOUT ROWID"))
+        #expect(plan.statements.contains { $0.hasSuffix("WITHOUT ROWID") })
     }
 
     // MARK: - Verification

--- a/TableProTests/Models/Schema/SQLiteTableRespecifierTests.swift
+++ b/TableProTests/Models/Schema/SQLiteTableRespecifierTests.swift
@@ -272,6 +272,38 @@ struct SQLiteTableRespecifierTests {
         )
     }
 
+    // MARK: - The rowid alias
+
+    /// SQLite's rule is a single-column primary key whose declared type is exactly `INTEGER`, and
+    /// the key may be written on the column or at table level. Reading only the column's own
+    /// constraints misses the second form, where retyping is just as destructive.
+    @Test(
+        "The rowid alias is found wherever the key is written",
+        arguments: [
+            ("CREATE TABLE x(id INTEGER PRIMARY KEY, v TEXT)", "id"),
+            ("CREATE TABLE x(id INTEGER, v TEXT, PRIMARY KEY(id))", "id"),
+            ("CREATE TABLE x(id INTEGER, v TEXT, CONSTRAINT pk PRIMARY KEY(id))", "id")
+        ]
+    )
+    func findsTheRowidAlias(sql: String, expected: String) throws {
+        let parsed = try #require(SQLiteTableDDL.parse(createTableSQL: sql))
+        #expect(SQLiteTableDDL.rowidAliasColumn(parsed) == expected)
+    }
+
+    @Test(
+        "A key that is not the rowid alias is not mistaken for one",
+        arguments: [
+            "CREATE TABLE x(id TEXT PRIMARY KEY, v TEXT)",
+            "CREATE TABLE x(a INT, b INT, PRIMARY KEY(a, b))",
+            "CREATE TABLE x(id INTEGER PRIMARY KEY, v TEXT) WITHOUT ROWID",
+            "CREATE TABLE x(a INT, v TEXT)"
+        ]
+    )
+    func rejectsWhatIsNotTheRowidAlias(sql: String) throws {
+        let parsed = try #require(SQLiteTableDDL.parse(createTableSQL: sql))
+        #expect(SQLiteTableDDL.rowidAliasColumn(parsed) == nil)
+    }
+
     // MARK: - Rowid tables
 
     @Test("WITHOUT ROWID is recognised, and an ordinary table is not mistaken for one")

--- a/docs/databases/sqlite.mdx
+++ b/docs/databases/sqlite.mdx
@@ -57,16 +57,23 @@ The **Remote File** pane points the connection at a database on an SSH server. I
 
 Where the server has `sqlite3` 3.27 or newer, the copy is a `VACUUM INTO` snapshot, which stays consistent even while other programs write to the database. See [Remote Database Files](/connections/remote-database-files).
 
-## Editing a table's foreign keys
+## Edits that recreate the table
 
-`ALTER TABLE` cannot add or drop a foreign key in any SQLite version, so the Structure tab's **Foreign Keys** tab recreates the table instead: it writes the table again with the keys you asked for, copies the rows across with their rowids, puts the indexes and triggers back, and checks the rows against the new keys before committing. The script is shown in full and runs only when you confirm it. Column changes staged in the same save travel with it. See [Table Structure](/features/table-structure).
+`ALTER TABLE` covers renaming a table or a column, adding a column, dropping a column, and from 3.53 adding or dropping a `CHECK`. Everything else the Structure tab offers is made by writing the table again: a foreign key added or removed, and a column's type, nullability or default changed.
+
+A rebuild writes the table with the definition you asked for, copies the rows across with their rowids, puts the indexes and triggers back, and checks the rows against any new foreign key before committing. The script is shown in full and runs only when you confirm it, and everything staged in the same save travels in the same transaction.
+
+Each column keeps its own stored text, so a `CHECK`, a `COLLATE`, a `GENERATED ALWAYS AS` and a `DEFAULT` containing a comma all survive a rebuild that touched a different column.
+
+Changing a column's type re-reads every value in it through the new affinity. Text that looks like a number becomes one, so `'007'` in a column retyped to `INTEGER` is stored as `7`. The review sheet says so before the script runs.
 
 A virtual table, such as an FTS5 table, cannot be recreated from what SQLite stored for it. The save is refused and names the table.
 
 ## Limitations
 
 - Encrypted databases do not open. The driver uses the system SQLite, which takes no key, and the form has nowhere to put one. Decrypt a SQLCipher file with the `sqlcipher` tool first.
-- A column's type, nullability, and default cannot change. The save is refused and names the columns. Change them by running DDL yourself.
+- A column that is `INTEGER PRIMARY KEY` cannot be retyped: the key would stop generating values and start storing NULL. The save is refused and names the column.
+- A primary key cannot be added, removed or moved.
 
 ## Troubleshooting
 

--- a/docs/development/plugin-development.mdx
+++ b/docs/development/plugin-development.mdx
@@ -13,7 +13,7 @@ A plugin is a macOS loadable bundle target with `WRAPPER_EXTENSION = tableplugin
 
 | Key | Type | Required | Purpose |
 |-----|------|----------|---------|
-| `TableProPluginKitVersion` | integer | Yes | The PluginKit ABI the plugin was built against. Current value: 24 |
+| `TableProPluginKitVersion` | integer | Yes | The PluginKit ABI the plugin was built against. Current value: 25 |
 | `TableProProvidesDatabaseTypeIds` | array of strings | Recommended | Database type IDs the plugin serves, which is what makes lazy loading possible |
 | `CFBundleShortVersionString` | string | Yes | Plugin version, read by registry update checks |
 | `TableProMinAppVersion` | string | No | The loader rejects the plugin on an older app |

--- a/docs/development/plugin-registry.mdx
+++ b/docs/development/plugin-registry.mdx
@@ -68,13 +68,13 @@ Themes carry no native code, so they match on architecture alone.
   "binaries": [
     {
       "architecture": "arm64",
-      "pluginKitVersion": 24,
+      "pluginKitVersion": 25,
       "downloadURL": "https://github.com/TableProApp/TablePro/releases/download/plugin-oracle-v1.0.26/OracleDriver-arm64.zip",
       "sha256": "<sha256>"
     },
     {
       "architecture": "x86_64",
-      "pluginKitVersion": 24,
+      "pluginKitVersion": 25,
       "downloadURL": "https://github.com/TableProApp/TablePro/releases/download/plugin-oracle-v1.0.26/OracleDriver-x86_64.zip",
       "sha256": "<sha256>"
     }

--- a/docs/features/table-structure.mdx
+++ b/docs/features/table-structure.mdx
@@ -43,7 +43,7 @@ Auto-increment has its own **Auto Inc** field.
   <img className="hidden dark:block" src="/images/structure-default-picker-dark.png" alt="The Columns tab of a SQLite table, with a chevron on the right of every Default cell" />
 </Frame>
 
-Not every engine can change the default of a column that already exists. SQLite, libSQL and Cloudflare D1 cannot: their `ALTER TABLE` has no `SET DEFAULT`. Snowflake can only remove one. Saving such a change is refused with **Unsupported schema operation**; set the default when the column is created, or drop the column and add it back.
+Changing the default of a column that already exists takes a different route per engine. Most run `ALTER TABLE … SET DEFAULT`. SQLite, libSQL and Cloudflare D1 have no such statement, so the change is made by recreating the table, reviewed first like any other rebuild. Snowflake can only remove a default, and saving one there is refused with **Unsupported schema operation**.
 
 ### Generated columns
 
@@ -110,7 +110,9 @@ What the save does depends on the engine:
 | SQLite, local-file libSQL | Shows the rebuild script, and runs it when you confirm. No SQLite version can add or drop a foreign key with `ALTER TABLE`, so the table is recreated carrying the keys you asked for, the rows are copied with their rowids, and the indexes and triggers are put back |
 | Turso, remote libSQL, Cloudflare D1 | Shows the rebuild script for you to read and run. TablePro does not run it: each statement is its own HTTP request, so nothing can hold the rebuild in one transaction |
 
-A rebuild carries the column changes staged in the same save, and ends in `PRAGMA foreign_key_check` scoped to the table. Rows that do not match the new key roll the whole rebuild back, and the count comes back in the error.
+A rebuild carries everything else staged in the same save, and ends in `PRAGMA foreign_key_check` scoped to the table. Rows that do not match the new key roll the whole rebuild back, and the count comes back in the error.
+
+A column renamed or dropped in the same save runs as its own `ALTER TABLE` after the rebuild, so the new name reaches every index, trigger and view. A drop that would leave one of those naming a column that is gone fails the whole save rather than committing it broken.
 
 ## Constraints tab
 
@@ -189,7 +191,6 @@ MongoDB structure is read-only, and inferred from the collection's first 200 doc
 
 - **Changing a primary key on an existing table** works on MySQL, MariaDB, PostgreSQL, PGlite, SQL Server, DuckDB, Snowflake, and Dameng. Elsewhere the dropdown accepts the edit and the save produces nothing for it: rebuild the table by hand.
 - **Check constraints and generated columns** have no field in the grid. Both show in the DDL tab; change them by running DDL yourself.
-- **SQLite, libSQL, Cloudflare D1**: a column's type, nullability, and default cannot change. The save is refused and names the columns, with the rest of it left staged. Change them by running DDL yourself.
 - **Cassandra / ScyllaDB**: add and drop column only, no index editing, no visual table creation.
 - **Redshift, CockroachDB, BigQuery, Elasticsearch, Typesense, SurrealDB, Beancount**: structure is read-only.
 - **Redis, etcd, DynamoDB**: no table schema to edit.

--- a/scripts/check-sqlite-rebuild-assumptions.sh
+++ b/scripts/check-sqlite-rebuild-assumptions.sh
@@ -177,6 +177,103 @@ else
     pass "a WITHOUT ROWID table still rejects a rowid column, so the planner must branch on it"
 fi
 
+# 5. legacy_alter_table decides whether the rebuild's own rename works and whether a later
+#    DROP COLUMN refuses a broken dependent. The plan sets it both ways for that reason, and puts
+#    the connection back afterwards because the setting survives the commit.
+printf '\nlegacy_alter_table\n'
+rebuild_with_view() {
+    local db="$WORK/lat-$1.db"
+    "$SQLITE" "$db" "CREATE TABLE t(a INTEGER PRIMARY KEY, b TEXT); CREATE VIEW v AS SELECT b FROM t;"
+    "$SQLITE" "$db" "PRAGMA foreign_keys=off; PRAGMA legacy_alter_table=$1;
+        BEGIN;
+        CREATE TABLE t_rb(a INTEGER PRIMARY KEY, b TEXT, c INT);
+        INSERT INTO t_rb(rowid,a,b) SELECT rowid,a,b FROM t;
+        DROP TABLE t;
+        ALTER TABLE t_rb RENAME TO t;
+        COMMIT;" >/dev/null 2>&1
+}
+
+if rebuild_with_view 1; then
+    pass "the table rename succeeds at legacy_alter_table=1, which the rebuild sets"
+else
+    fail "the table rename failed even at legacy_alter_table=1"
+fi
+
+if rebuild_with_view 0; then
+    pass "the table rename no longer needs legacy_alter_table=1; the plan may stop setting it"
+else
+    pass "the table rename still fails at 0 over a dependent view, so the plan must set it to 1"
+fi
+
+db="$WORK/dropdep.db"
+"$SQLITE" "$db" "CREATE TABLE t(a INT, b TEXT);
+    CREATE TRIGGER tr AFTER UPDATE OF b ON t BEGIN SELECT new.b; END;"
+if "$SQLITE" "$db" "PRAGMA legacy_alter_table=0; ALTER TABLE t DROP COLUMN b;" >/dev/null 2>&1; then
+    fail "DROP COLUMN no longer refuses a column a trigger needs; the plan's legacy=0 buys nothing"
+else
+    pass "DROP COLUMN refuses a column a trigger needs at legacy_alter_table=0"
+fi
+
+db="$WORK/latpersist.db"
+"$SQLITE" "$db" "CREATE TABLE t(a);"
+if [ "$("$SQLITE" "$db" "PRAGMA legacy_alter_table=1; BEGIN; COMMIT; SELECT * FROM pragma_legacy_alter_table();")" = "1" ]; then
+    pass "legacy_alter_table survives the commit, so the epilogue must restore it"
+else
+    pass "legacy_alter_table no longer survives the commit; restoring it is now belt and braces"
+fi
+
+# 6. EXPLAIN compiles a dependent object's body without running it, which is how the plan catches
+#    what ALTER TABLE and foreign_key_check both miss.
+printf '\nDependent revalidation\n'
+db="$WORK/explain.db"
+"$SQLITE" "$db" "CREATE TABLE t(id INTEGER PRIMARY KEY, keep TEXT, doomed TEXT);
+    CREATE VIEW v(a,b,c) AS SELECT * FROM t;
+    CREATE TABLE inbox(n INT);
+    CREATE TRIGGER tr AFTER INSERT ON inbox BEGIN INSERT INTO t VALUES(NEW.n,'a','d'); END;
+    PRAGMA legacy_alter_table=off;
+    ALTER TABLE t DROP COLUMN doomed;"
+
+if "$SQLITE" "$db" "EXPLAIN SELECT * FROM v;" >/dev/null 2>&1; then
+    fail "EXPLAIN no longer reports a view broken by a dropped column"
+else
+    pass "EXPLAIN reports a view whose declared column list no longer matches"
+fi
+
+if "$SQLITE" "$db" "EXPLAIN INSERT INTO inbox DEFAULT VALUES;" >/dev/null 2>&1; then
+    fail "EXPLAIN no longer reports a trigger on another table broken by a dropped column"
+else
+    pass "EXPLAIN reports a trigger on another table left broken by the drop"
+fi
+
+if [ "$("$SQLITE" "$db" "SELECT count(*) FROM inbox;")" = "0" ]; then
+    pass "EXPLAIN prepares without executing, so the checks write nothing"
+else
+    fail "EXPLAIN executed the statement; the dependent checks are not safe to run"
+fi
+
+# 7. The column-declaration grammar the rewriter walks. Each of these refutes the published
+#    railroad diagrams, and the rewriter slices a declaration wrongly if any of them changes.
+printf '\nColumn declaration grammar\n'
+db="$WORK/grammar.db"
+"$SQLITE" "$db" "CREATE TABLE g(a UNSIGNED BIG INT, b, c NULL, d BIG GENERATED ALWAYS AS (1), e \"DEFAULT\")" 2>/dev/null
+types="$("$SQLITE" "$db" "SELECT group_concat(type, '|') FROM pragma_table_xinfo('g');" 2>/dev/null)"
+if [ "$types" = "UNSIGNED BIG INT|||BIG|DEFAULT" ]; then
+    pass "type names are multi-word, optional, and a bare NULL is a constraint rather than a type"
+else
+    fail "the column grammar moved: types read [$types]"
+fi
+
+db="$WORK/pkretype.db"
+"$SQLITE" "$db" "CREATE TABLE t(id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t(v) VALUES('a');"
+"$SQLITE" "$db" "BEGIN; CREATE TABLE t2(id TEXT PRIMARY KEY, v TEXT);
+    INSERT INTO t2(rowid,id,v) SELECT rowid,id,v FROM t; DROP TABLE t;
+    ALTER TABLE t2 RENAME TO t; COMMIT; INSERT INTO t(v) VALUES('b');" >/dev/null 2>&1
+if [ "$("$SQLITE" "$db" "SELECT count(*) FROM t WHERE id IS NULL;")" = "0" ]; then
+    pass "retyping an INTEGER PRIMARY KEY no longer strands NULLs; the refusal may be liftable"
+else
+    pass "retyping an INTEGER PRIMARY KEY still strands NULLs in the key, so it stays refused"
+fi
+
 printf '\n'
 if [ "$failures" -eq 0 ]; then
     printf 'All rebuild assumptions hold.\n'


### PR DESCRIPTION
Completes SQLite structure editing. #2694 and #2695 shipped foreign key editing through a reviewed table rebuild and left three things refused by name: a column's type, nullability or default; a rename or drop alongside a foreign key change; and a primary key change. The first two land here. The third does not, and the last section says why.

## Column type, nullability and default

SQLite has no `ALTER TABLE` for any of them, so they travel in the rebuild's new definition. The rebuild's design principle is that every column the save does not touch keeps its stored text byte for byte, which is what carries a `CHECK`, a `COLLATE`, a `GENERATED ALWAYS AS` and a `DEFAULT` containing a comma across; a column the save *does* touch has to be rewritten the same way, replacing only the span that changed.

`SQLiteColumnDeclaration` reads the declaration as a grammar rather than searching it for keywords, and that is the whole correctness argument. Measured on 3.54, searching is wrong in both directions and silently so:

| Declaration | What a keyword search does |
|---|---|
| `b TEXT CHECK (b IS NOT NULL)` | matches `NOT NULL` inside the check, so "make it NOT NULL" reads as already done and changes nothing |
| `a INTEGER REFERENCES p(id) ON DELETE SET NULL` | matches `NULL` inside the action, so "make it nullable" rewrites the action into a syntax error |

Both are covered by tests. The grammar itself also refutes the published railroad diagrams three times, each measured: a type name is a repeatable run of words (`UNSIGNED BIG INT`), a bare `NULL` is a constraint rather than a type, and `GENERATED` ends a type only as the exact run `GENERATED ALWAYS AS`.

Three edits are refused rather than guessed at:

- **Retyping an `INTEGER PRIMARY KEY`.** Measured: after the rebuild the key stops generating values and then stores NULL on every insert that omits it, twice over, with no error.
- **A column carrying the same constraint twice.** `a INT NOT NULL NOT NULL` is legal; rewriting one of a pair leaves the other in force and the edit reports success having changed nothing.
- **Nullability or default on a generated column.** Those belong to the expression, and SQLite rejects a `DEFAULT` on one outright.

A type change also re-reads every value through the new affinity: TEXT `'007'` copied into an `INTEGER` column is stored as `7`, with no undo. The review sheet says so before the script runs.

## Rename and drop alongside a foreign key change

Previously refused, for a good reason: a rebuild replays its dependent SQL verbatim and rewrites only the column's own declaration, so a trigger, a view or an incoming foreign key would be left naming a column that is gone.

The answer is not to rewrite dependent SQL by hand. `ALTER TABLE RENAME COLUMN` already does it, correctly, including views, which measured on 3.54:

```
CREATE VIEW v_named AS SELECT b FROM t     ->  CREATE VIEW v_named AS SELECT c FROM t
CREATE TRIGGER tr AFTER UPDATE OF b ON t   ->  CREATE TRIGGER tr AFTER UPDATE OF c ON t
CREATE INDEX ix ON t(b)                    ->  CREATE INDEX ix ON t(c)
```

So the rename and the drop run as their own `ALTER TABLE`, appended after the rebuild in the same transaction, and SQLite carries the change into every dependent object itself. The rebuild builds the table under the columns' current names and anything the save expressed in final names is mapped back.

## A latent bug in the shipped rebuild

`PRAGMA legacy_alter_table` decides whether the rebuild's own `RENAME TO` survives a dependent view, and the shipped planner never sets it. Measured:

| Setting | `ALTER TABLE t_rebuild RENAME TO t` with a view over `t` | A later `DROP COLUMN` that breaks a trigger |
|---|---|---|
| `1` | succeeds | succeeds silently, leaving the trigger broken |
| `0` | fails: `error in view v: no such table: main.t` | refuses with the reason |

It works today only because Apple's libsqlite3 defaults it to `1`; upstream defaults it to `0`, so a driver bundling its own SQLite would fail every rebuild on a schema with a view. `SQLiteColumnReorderPlanner`'s doc comment claimed no pragma was needed and was wrong as a general statement.

The plan now sets it `on` for the table rename and `off` for the column `ALTER`s, and restores the connection's original in the epilogue, because the setting survives the commit.

## What `ALTER TABLE` does not catch

`DROP COLUMN` at `legacy_alter_table=0` refuses a column an index needs, and a primary key column. It does not notice two cases, both measured, both of which committed silently:

- a view declared with an explicit column list, `CREATE VIEW v(a,b,c) AS SELECT * FROM t`, which breaks on the count
- a trigger on **another** table that writes a positional row into this one

Neither is visible to `PRAGMA foreign_key_check`, which is scoped to one table's keys. The plan now ends by `EXPLAIN`-ing one statement per view and per trigger subject table, which compiles each object's body against the table as it now stands. Measured: it reports `expected 3 columns for 'v' but got 2` and `table t has 2 columns but 3 values were supplied`, and executes nothing.

## Verification

| Step | Result |
|---|---|
| `build` | PASS |
| `test` (12 suites) | PASS, 169 cases |
| `build SQLiteDriver`, `CloudflareD1DriverPlugin`, `LibSQLDriverPlugin` | PASS |
| `docs` | PASS |
| `lint` | PASS for every path this branch touches |
| `abi` vs merge base | additive: no public symbol removed |
| `scripts/check-sqlite-rebuild-assumptions.sh` | 21 of 21 hold |

PluginKit 24 to 25: a new `PluginColumnAlteration` type, `alteredColumns` on `PluginTableRespecification` through a new init overload with the old one `@_disfavoredOverload`, and two new `Context` fields. `minimumCompatiblePluginKitVersion` stays at 19, so every shipped plugin keeps loading and no bulk re-release is needed.

`verify.sh plugins` still fails on this machine before reaching any of my code, on the vendored oracle-nio `@TaskLocal` macro. The three SQLite-family targets were built individually instead.

The assumption checker grew from 12 facts to 21, adding the `legacy_alter_table` pair, the `EXPLAIN` revalidation, the column-declaration grammar and the `INTEGER PRIMARY KEY` retype. A future macOS upgrade re-checks all of them rather than trusting this description.

## Screenshots

Not captured. Driving a Debug build needs Screen Recording granted to this session, which it does not have. The change is to the existing review sheet's script and caveats, which `docs/features/table-structure.mdx` already pictures.

## Primary key editing, and why it is not here

`SchemaChange.modifyPrimaryKey` has exactly one producer in the whole app: `applyPrimaryKeyChangeUndo`, an undo handler. Nothing stages it going forward, on any engine, so primary key editing is unreachable in the Structure editor everywhere and not just on SQLite. Building the SQLite half would be wiring behind a control that does not exist.

It also carries risks the foreign key work did not, both measured:

- Moving the key onto an `INTEGER` column repoints every row's identity. The `INSERT`'s explicit `rowid` is discarded when the new table declares an alias, so a row holding NULL in the new key silently becomes a fabricated one.
- It is the first rebuild whose damage lands outside the table being rebuilt, and every verification the plan has is scoped to this table.

Worth doing, as its own change, starting with how a primary key change gets staged at all.
