### PR TITLE
fix(er-diagram): draw a table's relationship with itself, and read the schema to VoiceOver (#2692)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- VoiceOver navigation of the ER diagram, table by table and column by column, with what each table is joined to. (#2692)
 - Column type, nullability and default changes for SQLite, libSQL and Cloudflare D1, checked against every dependent view and trigger before the change commits.
 - Column rename and drop alongside a foreign key change in one save.
 - Foreign key add, remove and edit for SQLite, libSQL and Cloudflare D1, applied as a reviewed table rebuild.
@@ -79,6 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Half the ER diagram left unpainted at its fit-to-window zoom, and the query plan's arrows gone below 50%. (#2692)
+- A table's relationship with itself drawn underneath the table, so a `manager_id` style foreign key was invisible. (#2692)
 - Table dragged past the ER diagram's top-left corner disappearing, with the position saved. (#2692)
 - ER diagram back at 100% in the top-left corner after leaving its editor tab and returning. (#2692)
 - "Unsupported schema operation" when adding a foreign key to a SQLite, libSQL or Cloudflare D1 table.

--- a/TablePro/Views/ERDiagram/ERDiagramAccessibility.swift
+++ b/TablePro/Views/ERDiagram/ERDiagramAccessibility.swift
@@ -1,0 +1,217 @@
+//
+//  ERDiagramAccessibility.swift
+//  TablePro
+//
+//  The diagram is drawn, so there is no view per table to carry a name. These publish one
+//  accessibility element per table, and one per column under it, so VoiceOver reads the schema
+//  instead of announcing a single image.
+//
+//  Nothing here is `@MainActor`. `accessibilityFrame()` and `accessibilityChildren()` override
+//  members AppKit declares without isolation, so the overrides are nonisolated whatever the class
+//  says, and an isolated member called from one of them will not compile. Every call still arrives
+//  on the main thread, which is what the unchecked conformances rest on; the file touches only its
+//  own stored values, nonisolated `setAccessibility*` setters and
+//  `NSAccessibility.screenRect(fromView:rect:)`.
+//
+
+import AppKit
+
+/// A table in the diagram.
+///
+/// The frame is computed on demand rather than stored. Measured on macOS 27:
+/// `accessibilityFrameInParentSpace` honours neither the view's flip nor the scroll view's
+/// magnification, so an element written that way is announced over a different table at any zoom
+/// but 100%, and a *stored* `accessibilityFrame` goes stale on every zoom, scroll, window move and
+/// layout pass. Computing it from the owning view answers correctly at every magnification and
+/// scroll offset with nothing to invalidate.
+final class ERDiagramNodeElement: NSAccessibilityElement, @unchecked Sendable {
+    fileprivate weak var owner: NSView?
+    fileprivate private(set) var rect: CGRect = .zero
+    private var columns: [ERColumnDisplay] = []
+    private var columnIdentities: [String] = []
+    private var builtColumns: [ERDiagramColumnElement]?
+
+    func configure(owner: NSView, node: ERTableNode, rect: CGRect, relationships: String?) {
+        self.owner = owner
+        self.rect = rect
+
+        setAccessibilityRole(.layoutItem)
+        setAccessibilityRoleDescription(String(localized: "table"))
+        setAccessibilityLabel(node.tableName)
+        setAccessibilityValue(String(format: String(localized: "%d columns"), node.displayColumns.count))
+        setAccessibilityHelp(relationships)
+        setAccessibilityParent(owner)
+
+        // A drag rewrites the rect on every pointer event, and the column elements read their row
+        // from this one, so they only have to be rebuilt when the columns themselves change.
+        let identities = node.displayColumns.map(\.id)
+        guard identities != columnIdentities else { return }
+        columnIdentities = identities
+        columns = node.displayColumns
+        builtColumns = nil
+    }
+
+    fileprivate func rowRect(at index: Int) -> CGRect {
+        CGRect(
+            x: rect.minX,
+            y: rect.minY + ERDiagramLayout.headerHeight + CGFloat(index) * ERDiagramLayout.columnRowHeight,
+            width: rect.width,
+            height: ERDiagramLayout.columnRowHeight
+        )
+    }
+
+    override func accessibilityFrame() -> NSRect {
+        guard let owner else { return .zero }
+        return NSAccessibility.screenRect(fromView: owner, rect: rect)
+    }
+
+    /// Built on the first question rather than with the table, so a schema of five hundred tables
+    /// does not pay for every column of every one of them before anything asks.
+    override func accessibilityChildren() -> [Any]? {
+        if let builtColumns { return builtColumns }
+        let built = columns.enumerated().map { index, column -> ERDiagramColumnElement in
+            let element = ERDiagramColumnElement()
+            element.configure(node: self, column: column, index: index)
+            return element
+        }
+        builtColumns = built
+        return built
+    }
+}
+
+/// One column row inside a table. Its rectangle follows the table's, so dragging a table carries
+/// its columns along and nothing has to be rebuilt.
+final class ERDiagramColumnElement: NSAccessibilityElement, @unchecked Sendable {
+    private weak var node: ERDiagramNodeElement?
+    private var index = 0
+
+    func configure(node: ERDiagramNodeElement, column: ERColumnDisplay, index: Int) {
+        self.node = node
+        self.index = index
+
+        var traits: [String] = [column.dataType]
+        if column.isPrimaryKey { traits.append(String(localized: "primary key")) }
+        if column.isForeignKey { traits.append(String(localized: "foreign key")) }
+        traits.append(column.isNullable ? String(localized: "optional") : String(localized: "required"))
+
+        setAccessibilityRole(.staticText)
+        setAccessibilityLabel(column.name)
+        setAccessibilityValue(traits.joined(separator: ", "))
+        setAccessibilityParent(node)
+    }
+
+    override func accessibilityFrame() -> NSRect {
+        guard let node, let owner = node.owner else { return .zero }
+        return NSAccessibility.screenRect(fromView: owner, rect: node.rowRect(at: index))
+    }
+}
+
+/// The element tree the scene view publishes, rebuilt only when something asks for it.
+///
+/// A node drag rewrites the scene on every pointer event. Building the tree there would rebuild
+/// every element hundreds of times a second whether or not anything was listening, and would hand
+/// a client a new object for the table it is reading.
+final class ERDiagramAccessibilityTree {
+    private var byNode: [UUID: ERDiagramNodeElement] = [:]
+    private var ordered: [ERDiagramNodeElement] = []
+    private var isStale = true
+
+    /// Whether anything has ever asked. Nothing is posted before that: the elements do not exist
+    /// yet, so a notification has nowhere to land, and asking for one is itself what builds them.
+    private(set) var hasBeenAsked = false
+
+    func invalidate() {
+        isStale = true
+    }
+
+    func elements(for scene: ERDiagramScene, owner: NSView) -> [ERDiagramNodeElement] {
+        hasBeenAsked = true
+        guard isStale else { return ordered }
+        isStale = false
+
+        let joins = Joins(scene: scene)
+        var kept: [UUID: ERDiagramNodeElement] = [:]
+        var next: [ERDiagramNodeElement] = []
+        for node in scene.nodes {
+            guard let rect = scene.nodeRects[node.id] else { continue }
+            let element = byNode[node.id] ?? ERDiagramNodeElement()
+            element.configure(
+                owner: owner,
+                node: node,
+                rect: rect,
+                relationships: joins.description(of: node.tableName)
+            )
+            kept[node.id] = element
+            next.append(element)
+        }
+        byNode = kept
+        ordered = next
+        return next
+    }
+
+    func element(for nodeId: UUID) -> ERDiagramNodeElement? {
+        byNode[nodeId]
+    }
+
+    static func summary(of scene: ERDiagramScene) -> String {
+        String(
+            format: String(localized: "%1$d tables, %2$d relationships"),
+            scene.nodes.count,
+            scene.edges.count
+        )
+    }
+
+    /// What each table is joined to, so the shape of the schema is reachable without an element per
+    /// relationship: a connector carries no text of its own, and a list of them read in isolation
+    /// says nothing a table's own entry cannot.
+    ///
+    /// Built once per rebuild rather than per table, because asking every table to scan every edge
+    /// is quadratic on a schema large enough to need this.
+    struct Joins {
+        private var references: [String: Set<String>] = [:]
+        private var referencedBy: [String: Set<String>] = [:]
+        private var related: [String: Set<String>] = [:]
+        private var selfReferencing: Set<String> = []
+
+        init(scene: ERDiagramScene) {
+            for edge in scene.edges {
+                guard edge.fromTable != edge.toTable else {
+                    selfReferencing.insert(edge.fromTable)
+                    continue
+                }
+                // A collapsed junction becomes one synthetic edge between the two parents, and that
+                // relationship is symmetric: the hidden table owns both foreign keys, so neither
+                // parent references the other.
+                if edge.cardinality == .manyToMany {
+                    related[edge.fromTable, default: []].insert(edge.toTable)
+                    related[edge.toTable, default: []].insert(edge.fromTable)
+                    continue
+                }
+                references[edge.fromTable, default: []].insert(edge.toTable)
+                referencedBy[edge.toTable, default: []].insert(edge.fromTable)
+            }
+        }
+
+        func description(of table: String) -> String? {
+            var parts: [String] = []
+            if let names = list(references[table]) {
+                parts.append(String(format: String(localized: "references %@"), names))
+            }
+            if let names = list(referencedBy[table]) {
+                parts.append(String(format: String(localized: "referenced by %@"), names))
+            }
+            if let names = list(related[table]) {
+                parts.append(String(format: String(localized: "related to %@"), names))
+            }
+            if selfReferencing.contains(table) {
+                parts.append(String(localized: "references itself"))
+            }
+            return parts.isEmpty ? nil : parts.joined(separator: ", ")
+        }
+
+        private func list(_ names: Set<String>?) -> String? {
+            guard let names, !names.isEmpty else { return nil }
+            return names.sorted().joined(separator: ", ")
+        }
+    }
+}

--- a/TablePro/Views/ERDiagram/ERDiagramEdgeRenderer.swift
+++ b/TablePro/Views/ERDiagram/ERDiagramEdgeRenderer.swift
@@ -31,9 +31,20 @@ enum ERDiagramEdgeRenderer {
             return ResolvedEdge(edge: edge, fromId: fromId, toId: toId, fromRect: fromRect, toRect: toRect)
         }
 
+        // A self edge gets its own loop and never a border port, so it is kept out of the counts
+        // and the pools: letting it take a spread slot would push a real edge off centre for a
+        // port that is never used.
+        let pairs = resolved.filter { $0.fromId != $0.toId }
+        var selfLoopIndex: [String: Int] = [:]
+        var selfLoopCounts: [UUID: Int] = [:]
+        for item in resolved where item.fromId == item.toId {
+            selfLoopIndex[edgeKey(item)] = selfLoopCounts[item.fromId, default: 0]
+            selfLoopCounts[item.fromId, default: 0] += 1
+        }
+
         var srcCounts: [UUID: Int] = [:]
         var dstCounts: [UUID: Int] = [:]
-        for item in resolved {
+        for item in pairs {
             srcCounts[item.fromId, default: 0] += 1
             dstCounts[item.toId, default: 0] += 1
         }
@@ -41,7 +52,7 @@ enum ERDiagramEdgeRenderer {
         // Group by source, sort each group by destination X → left dest gets left port
         var edgesBySource: [UUID: [ResolvedEdge]] = [:]
         var edgesByDest: [UUID: [ResolvedEdge]] = [:]
-        for item in resolved {
+        for item in pairs {
             edgesBySource[item.fromId, default: []].append(item)
             edgesByDest[item.toId, default: []].append(item)
         }
@@ -57,14 +68,12 @@ enum ERDiagramEdgeRenderer {
         var dstPortIndex: [String: Int] = [:]
         for (_, group) in edgesBySource {
             for (idx, item) in group.enumerated() {
-                let edgeKey = "\(item.edge.fromTable).\(item.edge.fkName).\(item.edge.fromColumn)"
-                srcPortIndex[edgeKey] = idx
+                srcPortIndex[edgeKey(item)] = idx
             }
         }
         for (_, group) in edgesByDest {
             for (idx, item) in group.enumerated() {
-                let edgeKey = "\(item.edge.fromTable).\(item.edge.fkName).\(item.edge.fromColumn)"
-                dstPortIndex[edgeKey] = idx
+                dstPortIndex[edgeKey(item)] = idx
             }
         }
 
@@ -75,16 +84,35 @@ enum ERDiagramEdgeRenderer {
         context.setLineJoin(.round)
 
         for item in resolved {
-            let edgeKey = "\(item.edge.fromTable).\(item.edge.fkName).\(item.edge.fromColumn)"
-            let si = srcPortIndex[edgeKey] ?? 0
-            let di = dstPortIndex[edgeKey] ?? 0
+            let key = edgeKey(item)
+            let path: CGPath
+            let srcPort: CGPoint
+            let dstPort: CGPoint
+            let cp1: CGPoint
+            let cp2: CGPoint
 
-            let (srcPort, dstPort, verticalPorts) = computePorts(
-                from: item.fromRect, to: item.toRect,
-                srcIdx: si, srcTotal: srcCounts[item.fromId] ?? 1,
-                dstIdx: di, dstTotal: dstCounts[item.toId] ?? 1
-            )
-            let (path, cp1, cp2) = bezierPath(from: srcPort, to: dstPort, verticalPorts: verticalPorts)
+            if item.fromId == item.toId {
+                let loop = selfLoop(in: item.fromRect, index: selfLoopIndex[key] ?? 0)
+                srcPort = loop.source
+                dstPort = loop.destination
+                cp1 = loop.sourceControl
+                cp2 = loop.destinationControl
+                path = loop.path
+            } else {
+                let (source, destination, verticalPorts) = computePorts(
+                    from: item.fromRect, to: item.toRect,
+                    srcIdx: srcPortIndex[key] ?? 0, srcTotal: srcCounts[item.fromId] ?? 1,
+                    dstIdx: dstPortIndex[key] ?? 0, dstTotal: dstCounts[item.toId] ?? 1
+                )
+                let (curve, control1, control2) = bezierPath(
+                    from: source, to: destination, verticalPorts: verticalPorts
+                )
+                srcPort = source
+                dstPort = destination
+                cp1 = control1
+                cp2 = control2
+                path = curve
+            }
 
             context.addPath(path)
             context.strokePath()
@@ -94,6 +122,84 @@ enum ERDiagramEdgeRenderer {
 
         context.restoreGState()
     }
+
+    private static func edgeKey(_ item: ResolvedEdge) -> String {
+        "\(item.edge.fromTable).\(item.edge.fkName).\(item.edge.fromColumn)"
+    }
+
+    // MARK: - Self Loop
+
+    struct SelfLoop {
+        let source: CGPoint
+        let destination: CGPoint
+        let sourceControl: CGPoint
+        let destinationControl: CGPoint
+
+        var path: CGPath {
+            let path = CGMutablePath()
+            path.move(to: source)
+            path.addCurve(to: destination, control1: sourceControl, control2: destinationControl)
+            return path
+        }
+    }
+
+    /// A relationship a table has with itself, `employees.manager_id -> employees.id`, drawn as a
+    /// loop out of one side rather than as an edge between two nodes.
+    ///
+    /// `computePorts` cannot serve it. With one rect for both ends the vertical gap is negative, so
+    /// it takes the side-port branch, and the equality makes it choose the left border for the
+    /// source and the right border for the destination: a curve straight through the table, drawn
+    /// before the node's own opaque fill and therefore erased by it. Measured on a 220x80 node, 4
+    /// of 444 curve pixels survived, and both cardinality markers pointed into the body.
+    ///
+    /// Both ports go on the trailing edge and the control points push out past it, which is what
+    /// Graphviz does for a self edge (TSE93 5.1.3, "loops on the sides of nodes"). The horizontal
+    /// distance along the curve is `3 * bow * t * (1 - t)`, never negative, so the loop provably
+    /// never re-enters the node whatever its size; the bulge peaks at three quarters of `bow`.
+    /// The bow is capped at the layout's own column gap, unscaled, because that gap is what the
+    /// packer leaves to the right of a node and it does not grow with the text size.
+    static func selfLoop(in rect: CGRect, index: Int) -> SelfLoop {
+        let scale = ERDiagramLayout.typeScale
+        let spread = min(
+            max(14 * scale, rect.height * 0.25) + CGFloat(index) * 8 * scale,
+            max(8 * scale, rect.height / 2 - 8)
+        )
+        let bow = min(
+            min(max(40 * scale, spread * 1.6), ERDiagramLayout.horizontalGap) + CGFloat(index) * 16,
+            maximumBow
+        )
+
+        return SelfLoop(
+            source: CGPoint(x: rect.maxX, y: rect.midY + spread),
+            destination: CGPoint(x: rect.maxX, y: rect.midY - spread),
+            sourceControl: CGPoint(x: rect.maxX + bow, y: rect.midY + spread),
+            destinationControl: CGPoint(x: rect.maxX + bow, y: rect.midY - spread)
+        )
+    }
+
+    /// A ceiling on how far a nested loop can reach, so the 80pt of canvas padding the view model
+    /// adds is always enough to scroll to one: the bulge is three quarters of the bow and the
+    /// markers reach further still. Loops past the second on a single table coincide, which is the
+    /// better trade for a schema that has three.
+    private static let maximumBow: CGFloat = 84
+
+    /// Every point the loop and its two markers touch, which is more than the node rect: the export
+    /// crops to the drawn content, and cropping to the tables alone cuts the apex off.
+    static func selfLoopBounds(in rect: CGRect, index: Int) -> CGRect {
+        let loop = selfLoop(in: rect, index: index)
+        let apex = rect.maxX + (loop.sourceControl.x - rect.maxX) * 0.75
+        return CGRect(
+            x: rect.maxX,
+            y: loop.destination.y,
+            width: apex - rect.maxX,
+            height: loop.source.y - loop.destination.y
+        )
+        .insetBy(dx: -markerReach, dy: -markerReach)
+    }
+
+    /// The crow's foot reaches 12pt along the tangent and spreads 8pt across it, and the stroke
+    /// adds its own half width.
+    private static let markerReach: CGFloat = 14
 
     // MARK: - Cardinality Markers
 

--- a/TablePro/Views/ERDiagram/ERDiagramScene.swift
+++ b/TablePro/Views/ERDiagram/ERDiagramScene.swift
@@ -23,6 +23,22 @@ struct ERDiagramScene {
 enum ERDiagramSceneRenderer {
     static let exportPadding: CGFloat = 40
 
+    /// Everything the scene puts on the canvas, which is more than the tables: a self-referencing
+    /// table loops out past its own trailing edge, and cropping the export to the table rects alone
+    /// cuts the apex off.
+    static func drawnBounds(of scene: ERDiagramScene) -> CGRect {
+        var bounds = scene.nodeRects.values.reduce(CGRect.null) { $0.union($1) }
+
+        var selfLoopIndex: [UUID: Int] = [:]
+        for edge in scene.edges where edge.fromTable == edge.toTable {
+            guard let nodeId = scene.nodeIndex[edge.fromTable], let rect = scene.nodeRects[nodeId] else { continue }
+            let index = selfLoopIndex[nodeId, default: 0]
+            selfLoopIndex[nodeId] = index + 1
+            bounds = bounds.union(ERDiagramEdgeRenderer.selfLoopBounds(in: rect, index: index))
+        }
+        return bounds
+    }
+
     /// The context is expected to be flipped, which is what both callers hand it: the diagram view
     /// is `isFlipped`, and the export builds a flipped `NSGraphicsContext` over its bitmap.
     static func draw(_ scene: ERDiagramScene, dirtyRect: CGRect, in context: CGContext) {
@@ -52,7 +68,7 @@ enum ERDiagramSceneRenderer {
     /// bitmap has none of its own, so the caller's appearance is made current for the whole render
     /// or a dark window exports light chrome.
     static func image(_ scene: ERDiagramScene, appearance: NSAppearance, scale: CGFloat) -> NSImage? {
-        let bounds = scene.nodeRects.values.reduce(CGRect.null) { $0.union($1) }
+        let bounds = drawnBounds(of: scene)
         let size = bounds.isNull
             ? CGSize(width: 100, height: 100)
             : CGSize(width: bounds.width + exportPadding * 2, height: bounds.height + exportPadding * 2)

--- a/TablePro/Views/ERDiagram/ERDiagramSceneView.swift
+++ b/TablePro/Views/ERDiagram/ERDiagramSceneView.swift
@@ -23,8 +23,14 @@ import SwiftUI
 
 final class ERDiagramSceneView: NSView {
     var scene = ERDiagramScene() {
-        didSet { needsDisplay = true }
+        didSet {
+            needsDisplay = true
+            accessibilityTree.invalidate()
+            announceSelectionChange(from: oldValue.selectedNodeId)
+        }
     }
+
+    private let accessibilityTree = ERDiagramAccessibilityTree()
 
     override var isFlipped: Bool { true }
 
@@ -36,6 +42,49 @@ final class ERDiagramSceneView: NSView {
         guard let context = NSGraphicsContext.current?.cgContext else { return }
         ERDiagramSceneRenderer.draw(scene, dirtyRect: dirtyRect, in: context)
     }
+
+    // MARK: - Accessibility
+
+    /// The diagram is a canvas of tables rather than one picture, so it is published as a layout
+    /// area with an element per table. Nothing is mounted for it: a plain `NSView` publishes
+    /// `NSAccessibilityElement` children directly, which is the part of the data grid's rule that
+    /// does not generalise (`NSTableView` builds its cell tree from cell views alone, and this is
+    /// not a table view). Measured on macOS 27: those children reach an assistive client through
+    /// the enclosing `NSHostingView`, and a pointer query descends into them.
+    override func isAccessibilityElement() -> Bool { true }
+
+    override func accessibilityRole() -> NSAccessibility.Role? { .layoutArea }
+
+    override func accessibilityLabel() -> String? {
+        ERDiagramAccessibilityTree.summary(of: scene)
+    }
+
+    override func accessibilityChildren() -> [Any]? {
+        accessibilityTree.elements(for: scene, owner: self)
+    }
+
+    override func accessibilitySelectedChildren() -> [Any]? {
+        selectedElement.map { [$0] } ?? []
+    }
+
+    /// A layout area answers for its focus as well as its selection, or VoiceOver never moves to
+    /// the table a click just selected.
+    override var accessibilityFocusedUIElement: Any? {
+        selectedElement ?? self
+    }
+
+    private var selectedElement: ERDiagramNodeElement? {
+        guard let selected = scene.selectedNodeId else { return nil }
+        _ = accessibilityTree.elements(for: scene, owner: self)
+        return accessibilityTree.element(for: selected)
+    }
+
+    private func announceSelectionChange(from previous: UUID?) {
+        guard accessibilityTree.hasBeenAsked, previous != scene.selectedNodeId else { return }
+        NSAccessibility.post(element: self, notification: .selectedChildrenChanged)
+        guard let element = selectedElement else { return }
+        NSAccessibility.post(element: element, notification: .focusedUIElementChanged)
+    }
 }
 
 struct ERDiagramSceneCanvas: NSViewRepresentable {
@@ -43,7 +92,6 @@ struct ERDiagramSceneCanvas: NSViewRepresentable {
 
     func makeNSView(context: Context) -> ERDiagramSceneView {
         let view = ERDiagramSceneView()
-        view.setAccessibilityElement(false)
         view.scene = scene
         return view
     }

--- a/TablePro/Views/ERDiagram/ERDiagramView.swift
+++ b/TablePro/Views/ERDiagram/ERDiagramView.swift
@@ -74,11 +74,10 @@ struct ERDiagramView: View {
         return ERDiagramSceneCanvas(scene: scene)
             .frame(width: canvasSize.width, height: canvasSize.height)
             .contentShape(Rectangle())
-            .accessibilityElement()
-            .accessibilityLabel(
-                Text("\(viewModel.graph.nodes.count) tables, \(viewModel.graph.edges.count) relationships")
-            )
-            .accessibilityAddTraits(.isImage)
+            // `.contain`, not the default `.ignore`: ignoring hides every child element, which is
+            // what left the whole schema as one image with a count for a label. The scene view
+            // carries the summary and the per-table elements itself.
+            .accessibilityElement(children: .contain)
             .onTapGesture { location in
                 viewModel.selectedNodeId = viewModel.nodeId(at: location)
             }

--- a/TableProTests/Views/ERDiagram/DiagramPaintCoverageTests.swift
+++ b/TableProTests/Views/ERDiagram/DiagramPaintCoverageTests.swift
@@ -78,6 +78,10 @@ struct DiagramPaintCoverageTests {
             backing: .buffered,
             defer: false
         )
+        // Every assertion here samples a colour, and a dynamic NSColor resolves against whatever
+        // appearance is current while drawing. Left to the machine's own setting these pass in
+        // Light and fail in Dark.
+        window.appearance = NSAppearance(named: .aqua)
         window.contentView?.addSubview(scrollView)
 
         scrollView.magnification = magnification
@@ -176,16 +180,27 @@ struct DiagramPaintCoverageTests {
         }
         probe.scrollView.cacheDisplay(in: probe.scrollView.bounds, to: rep)
 
+        // The badge is a small antialiased glyph over the node's own fill, so an absolute colour
+        // threshold only holds for one appearance: the blend carries the fill's blue up on a light
+        // background and down on a dark one. What survives either is that yellow ink leaves the
+        // pixel far redder than it is blue, which the fill alone never does.
+        // The bitmap is at the display's backing scale, so a document point is not a pixel.
+        let scale = CGFloat(rep.pixelsWide) / probe.scrollView.bounds.width
+        // The badge is a small antialiased glyph over the node's own fill, so an absolute colour
+        // threshold only holds for one appearance: the blend carries the fill's blue up on a light
+        // background and down on a dark one. What survives either is that yellow ink leaves the
+        // pixel far redder than it is blue, which neither the fill nor the text ever does.
         var foundYellow = false
-        for dx in -4...4 where !foundYellow {
-            for dy in -4...4 where !foundYellow {
-                let x = Int(badgeCentre.x.rounded()) + dx
-                let y = Int(badgeCentre.y.rounded()) + dy
+        let centre = CGPoint(x: badgeCentre.x * scale, y: badgeCentre.y * scale)
+        let radius = Int((6 * scale).rounded())
+        for dx in -radius...radius where !foundYellow {
+            for dy in -radius...radius where !foundYellow {
+                let x = Int(centre.x.rounded()) + dx
+                let y = Int(centre.y.rounded()) + dy
                 guard x >= 0, y >= 0, x < rep.pixelsWide, y < rep.pixelsHigh else { continue }
                 guard let colour = rep.colorAt(x: x, y: y)?.usingColorSpace(.sRGB) else { continue }
-                foundYellow = colour.redComponent > 0.5
-                    && colour.greenComponent > 0.4
-                    && colour.blueComponent < 0.4
+                foundYellow = colour.redComponent - colour.blueComponent > 0.15
+                    && colour.greenComponent - colour.blueComponent > 0.1
             }
         }
         #expect(foundYellow)

--- a/TableProTests/Views/ERDiagram/ERDiagramAccessibilityTests.swift
+++ b/TableProTests/Views/ERDiagram/ERDiagramAccessibilityTests.swift
@@ -1,0 +1,280 @@
+//
+//  ERDiagramAccessibilityTests.swift
+//  TableProTests
+//
+//  The diagram used to publish one image element for the whole schema, so VoiceOver announced a
+//  count and stopped. These pin the per-table tree and the frames it reports, which are the part
+//  that silently goes wrong: a frame written in the wrong space lands the cursor on another table.
+//
+
+import AppKit
+@testable import TablePro
+import Testing
+
+@Suite("ER diagram accessibility")
+@MainActor
+struct ERDiagramAccessibilityTests {
+    private func column(_ name: String, primaryKey: Bool = false, foreignKey: Bool = false) -> ERColumnDisplay {
+        ERColumnDisplay(
+            id: "c.\(name)",
+            name: name,
+            dataType: "integer",
+            isPrimaryKey: primaryKey,
+            isForeignKey: foreignKey,
+            isNullable: !primaryKey
+        )
+    }
+
+    private func node(_ name: String, columns: [ERColumnDisplay]) -> ERTableNode {
+        ERTableNode(id: UUID(), tableName: name, columns: columns, displayColumns: columns, clusterId: nil)
+    }
+
+    private func makeScene() -> ERDiagramScene {
+        let employees = node("employees", columns: [column("id", primaryKey: true), column("company_id", foreignKey: true)])
+        let organization = node("organization", columns: [column("id", primaryKey: true)])
+        let edge = EREdge(
+            id: UUID(),
+            fkName: "fk_company",
+            fromTable: "employees",
+            fromColumn: "company_id",
+            toTable: "organization",
+            toColumn: "id",
+            cardinality: .zeroOrManyToOne
+        )
+        return ERDiagramScene(
+            nodes: [employees, organization],
+            edges: [edge],
+            nodeRects: [
+                employees.id: CGRect(x: 40, y: 40, width: ERDiagramLayout.nodeWidth, height: 80),
+                organization.id: CGRect(x: 400, y: 300, width: ERDiagramLayout.nodeWidth, height: 60)
+            ],
+            nodeIndex: ["employees": employees.id, "organization": organization.id],
+            clusterColors: [:],
+            selectedNodeId: nil,
+            size: CGSize(width: 800, height: 600)
+        )
+    }
+
+    private func makeView(_ scene: ERDiagramScene, magnification: CGFloat = 1.0) -> (ERDiagramSceneView, NSScrollView) {
+        let scrollView = NSScrollView(frame: CGRect(x: 0, y: 0, width: 400, height: 300))
+        scrollView.allowsMagnification = true
+        scrollView.minMagnification = DiagramZoom.minimum
+        scrollView.maxMagnification = DiagramZoom.maximum
+
+        let view = ERDiagramSceneView(frame: CGRect(origin: .zero, size: scene.size))
+        view.scene = scene
+        scrollView.documentView = view
+
+        let window = NSWindow(
+            contentRect: CGRect(x: 120, y: 100, width: 400, height: 300),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView?.addSubview(scrollView)
+        scrollView.magnification = magnification
+        window.layoutIfNeeded()
+        return (view, scrollView)
+    }
+
+    @Test("The canvas publishes one element per table instead of a single image")
+    func publishesOneElementPerTable() {
+        let scene = makeScene()
+        let (view, _) = makeView(scene)
+
+        #expect(view.isAccessibilityElement())
+        #expect(view.accessibilityRole() == .layoutArea)
+        #expect(view.accessibilityLabel() == "2 tables, 1 relationships")
+
+        let children = view.accessibilityChildren() as? [ERDiagramNodeElement] ?? []
+        #expect(children.count == 2)
+        #expect(Set(children.compactMap { $0.accessibilityLabel() }) == ["employees", "organization"])
+        #expect(children.allSatisfy { $0.accessibilityRole() == .layoutItem })
+    }
+
+    @Test("A table reads its column count and what it is joined to")
+    func tableCarriesItsSummary() {
+        let scene = makeScene()
+        let (view, _) = makeView(scene)
+        let children = view.accessibilityChildren() as? [ERDiagramNodeElement] ?? []
+        let employees = children.first { $0.accessibilityLabel() == "employees" }
+        let organization = children.first { $0.accessibilityLabel() == "organization" }
+
+        #expect(employees?.accessibilityValue() as? String == "2 columns")
+        #expect(employees?.accessibilityHelp() == "references organization")
+        #expect(organization?.accessibilityHelp() == "referenced by employees")
+    }
+
+    @Test("A table's columns are reachable, with their type and key role")
+    func columnsAreReachable() {
+        let scene = makeScene()
+        let (view, _) = makeView(scene)
+        let children = view.accessibilityChildren() as? [ERDiagramNodeElement] ?? []
+        guard let employees = children.first(where: { $0.accessibilityLabel() == "employees" }) else {
+            Issue.record("no employees element")
+            return
+        }
+
+        let columns = employees.accessibilityChildren() as? [ERDiagramColumnElement] ?? []
+        #expect(columns.count == 2)
+        #expect(columns.first?.accessibilityLabel() == "id")
+        #expect(columns.first?.accessibilityValue() as? String == "integer, primary key, required")
+        #expect(columns.last?.accessibilityValue() as? String == "integer, foreign key, optional")
+    }
+
+    /// The frame is the part that fails silently. `accessibilityFrameInParentSpace` honours neither
+    /// the flip nor the magnification, so an element written that way is announced over a
+    /// different table at any zoom but 100%.
+    @Test("Every element reports the rectangle it is actually drawn in", arguments: [1.0, 0.41, 2.0] as [CGFloat])
+    func framesTrackMagnification(magnification: CGFloat) {
+        let scene = makeScene()
+        let (view, _) = makeView(scene, magnification: magnification)
+        let children = view.accessibilityChildren() as? [ERDiagramNodeElement] ?? []
+
+        for element in children {
+            guard let name = element.accessibilityLabel(),
+                  let node = scene.nodes.first(where: { $0.tableName == name }),
+                  let rect = scene.nodeRects[node.id] else {
+                Issue.record("unmatched element")
+                continue
+            }
+            let expected = NSAccessibility.screenRect(fromView: view, rect: rect)
+            let reported = element.accessibilityFrame()
+
+            #expect(abs(reported.origin.x - expected.origin.x) < 0.01)
+            #expect(abs(reported.origin.y - expected.origin.y) < 0.01)
+            #expect(abs(reported.width - expected.width) < 0.01)
+            #expect(abs(reported.height - expected.height) < 0.01)
+        }
+    }
+
+    @Test("A column element lands on its own row, not on the whole table")
+    func columnFramesFollowTheirRow() {
+        let scene = makeScene()
+        let (view, _) = makeView(scene)
+        let children = view.accessibilityChildren() as? [ERDiagramNodeElement] ?? []
+        guard let employees = children.first(where: { $0.accessibilityLabel() == "employees" }),
+              let columns = employees.accessibilityChildren() as? [ERDiagramColumnElement],
+              columns.count == 2 else {
+            Issue.record("no column elements")
+            return
+        }
+
+        let first = columns[0].accessibilityFrame()
+        let second = columns[1].accessibilityFrame()
+        #expect(first.height == ERDiagramLayout.columnRowHeight)
+        #expect(first != second)
+        #expect(employees.accessibilityFrame().contains(first.insetBy(dx: 1, dy: 1)))
+    }
+
+    /// A collapsed junction becomes one synthetic edge between the two parents, and the hidden
+    /// table owns both foreign keys, so neither parent references the other.
+    @Test("A collapsed many-to-many reads the same from both sides")
+    func manyToManyIsSymmetric() {
+        let left = node("users", columns: [column("id", primaryKey: true)])
+        let right = node("roles", columns: [column("id", primaryKey: true)])
+        let scene = ERDiagramScene(
+            nodes: [left, right],
+            edges: [
+                EREdge(
+                    id: UUID(),
+                    fkName: "user_roles",
+                    fromTable: "users",
+                    fromColumn: "user_id",
+                    toTable: "roles",
+                    toColumn: "role_id",
+                    cardinality: .manyToMany
+                )
+            ],
+            nodeRects: [
+                left.id: CGRect(x: 40, y: 40, width: ERDiagramLayout.nodeWidth, height: 60),
+                right.id: CGRect(x: 400, y: 40, width: ERDiagramLayout.nodeWidth, height: 60)
+            ],
+            nodeIndex: ["users": left.id, "roles": right.id],
+            clusterColors: [:],
+            selectedNodeId: nil,
+            size: CGSize(width: 800, height: 600)
+        )
+        let joins = ERDiagramAccessibilityTree.Joins(scene: scene)
+
+        #expect(joins.description(of: "users") == "related to roles")
+        #expect(joins.description(of: "roles") == "related to users")
+    }
+
+    @Test("Moving a table keeps the elements a client is holding")
+    func elementsAreReusedAcrossSceneChanges() {
+        var scene = makeScene()
+        let (view, _) = makeView(scene)
+        let before = view.accessibilityChildren() as? [ERDiagramNodeElement] ?? []
+        #expect(before.count == 2)
+
+        guard let moved = scene.nodes.first else {
+            Issue.record("no node")
+            return
+        }
+        scene.nodeRects[moved.id] = CGRect(x: 500, y: 500, width: ERDiagramLayout.nodeWidth, height: 80)
+        view.scene = scene
+
+        let after = view.accessibilityChildren() as? [ERDiagramNodeElement] ?? []
+        #expect(after.count == 2)
+        #expect(zip(before, after).allSatisfy { $0 === $1 })
+        let element = after.first { $0.accessibilityLabel() == moved.tableName }
+        #expect(element?.accessibilityFrame() == NSAccessibility.screenRect(
+            fromView: view,
+            rect: CGRect(x: 500, y: 500, width: ERDiagramLayout.nodeWidth, height: 80)
+        ))
+    }
+
+    @Test("The selected table is what the canvas reports as focused")
+    func selectionIsFocused() {
+        var scene = makeScene()
+        let (view, _) = makeView(scene)
+        #expect(view.accessibilityFocusedUIElement as? ERDiagramSceneView === view)
+
+        scene.selectedNodeId = scene.nodes.first?.id
+        view.scene = scene
+
+        let focused = view.accessibilityFocusedUIElement as? ERDiagramNodeElement
+        #expect(focused?.accessibilityLabel() == scene.nodes.first?.tableName)
+    }
+
+    @Test("Selecting a table selects its element")
+    func selectionIsPublished() {
+        var scene = makeScene()
+        let (view, _) = makeView(scene)
+        #expect((view.accessibilitySelectedChildren() ?? []).isEmpty)
+
+        scene.selectedNodeId = scene.nodes.first?.id
+        view.scene = scene
+
+        let selected = view.accessibilitySelectedChildren() as? [ERDiagramNodeElement] ?? []
+        #expect(selected.count == 1)
+        #expect(selected.first?.accessibilityLabel() == scene.nodes.first?.tableName)
+    }
+
+    @Test("A self-referencing table says so")
+    func selfReferenceIsAnnounced() {
+        let employees = node("employees", columns: [column("id", primaryKey: true), column("manager_id", foreignKey: true)])
+        let scene = ERDiagramScene(
+            nodes: [employees],
+            edges: [
+                EREdge(
+                    id: UUID(),
+                    fkName: "fk_manager",
+                    fromTable: "employees",
+                    fromColumn: "manager_id",
+                    toTable: "employees",
+                    toColumn: "id",
+                    cardinality: .zeroOrManyToOne
+                )
+            ],
+            nodeRects: [employees.id: CGRect(x: 40, y: 40, width: ERDiagramLayout.nodeWidth, height: 80)],
+            nodeIndex: ["employees": employees.id],
+            clusterColors: [:],
+            selectedNodeId: nil,
+            size: CGSize(width: 800, height: 600)
+        )
+
+        #expect(ERDiagramAccessibilityTree.Joins(scene: scene).description(of: "employees") == "references itself")
+    }
+}

--- a/TableProTests/Views/ERDiagram/ERDiagramSelfReferenceTests.swift
+++ b/TableProTests/Views/ERDiagram/ERDiagramSelfReferenceTests.swift
@@ -1,0 +1,261 @@
+//
+//  ERDiagramSelfReferenceTests.swift
+//  TableProTests
+//
+//  A table that references itself used to be routed from its left border to its own right border,
+//  so the curve and both cardinality markers were painted inside the node and then covered by the
+//  node's own opaque fill. These pin the loop outside the body.
+//
+
+import AppKit
+@testable import TablePro
+import Testing
+
+/// Smallest possible node (one column), a mid-sized one, and a very tall one.
+private let selfLoopNodeHeights: [CGFloat] = [58, 212, 916]
+
+@Suite("ER diagram self-referencing relationships")
+@MainActor
+struct ERDiagramSelfReferenceTests {
+
+    private func rect(height: CGFloat) -> CGRect {
+        CGRect(x: 400, y: 300, width: ERDiagramLayout.nodeWidth, height: height)
+    }
+
+    private func curvePoints(_ loop: ERDiagramEdgeRenderer.SelfLoop, samples: Int = 401) -> [CGPoint] {
+        (0...samples).map { step in
+            let t = CGFloat(step) / CGFloat(samples)
+            let u = 1 - t
+            let x = u * u * u * loop.source.x
+                + 3 * u * u * t * loop.sourceControl.x
+                + 3 * u * t * t * loop.destinationControl.x
+                + t * t * t * loop.destination.x
+            let y = u * u * u * loop.source.y
+                + 3 * u * u * t * loop.sourceControl.y
+                + 3 * u * t * t * loop.destinationControl.y
+                + t * t * t * loop.destination.y
+            return CGPoint(x: x, y: y)
+        }
+    }
+
+    @Test("The loop never enters the table it belongs to", arguments: selfLoopNodeHeights)
+    func loopStaysOutsideTheNode(height: CGFloat) {
+        let node = rect(height: height)
+        let loop = ERDiagramEdgeRenderer.selfLoop(in: node, index: 0)
+        let body = node.insetBy(dx: 0.5, dy: 0.5)
+
+        #expect(curvePoints(loop).allSatisfy { !body.contains($0) })
+    }
+
+    @Test("Both ports sit on the trailing edge, spread far enough apart for two markers")
+    func portsAreOnTheTrailingEdge() {
+        for height in selfLoopNodeHeights {
+            let node = rect(height: height)
+            let loop = ERDiagramEdgeRenderer.selfLoop(in: node, index: 0)
+
+            #expect(loop.source.x == node.maxX)
+            #expect(loop.destination.x == node.maxX)
+            #expect(loop.source.y > loop.destination.y)
+            #expect(abs(loop.source.y - loop.destination.y) >= 28)
+            #expect(node.insetBy(dx: 0, dy: -1).contains(CGPoint(x: node.maxX - 1, y: loop.source.y)))
+        }
+    }
+
+    /// The crow's foot and the one-bar are drawn from a port toward a control point, so an inward
+    /// control point would put both markers inside the table.
+    @Test("Both cardinality markers point away from the table")
+    func markersPointAway() {
+        let loop = ERDiagramEdgeRenderer.selfLoop(in: rect(height: 212), index: 0)
+
+        #expect(atan2(loop.sourceControl.y - loop.source.y, loop.sourceControl.x - loop.source.x) == 0)
+        #expect(atan2(loop.destinationControl.y - loop.destination.y, loop.destinationControl.x - loop.destination.x) == 0)
+    }
+
+    @Test("A second self-referencing key nests outside the first")
+    func loopsNest() {
+        let node = rect(height: 212)
+        let first = ERDiagramEdgeRenderer.selfLoop(in: node, index: 0)
+        let second = ERDiagramEdgeRenderer.selfLoop(in: node, index: 1)
+
+        #expect(second.sourceControl.x > first.sourceControl.x)
+        #expect(second.source.y > first.source.y)
+        #expect(second.destination.y < first.destination.y)
+        #expect(curvePoints(second).allSatisfy { !node.insetBy(dx: 0.5, dy: 0.5).contains($0) })
+    }
+
+    /// The packer leaves `horizontalGap` to the right of a node and never widens it for a self
+    /// loop, so a first loop has to fit inside that gap.
+    @Test("The first loop's bulge fits the gap the layout leaves beside a table")
+    func bulgeFitsTheColumnGap() {
+        for height in selfLoopNodeHeights {
+            let node = rect(height: height)
+            let loop = ERDiagramEdgeRenderer.selfLoop(in: node, index: 0)
+            let bulge = (curvePoints(loop).map(\.x).max() ?? node.maxX) - node.maxX
+
+            #expect(bulge > 0)
+            #expect(bulge < ERDiagramLayout.horizontalGap)
+        }
+    }
+
+    /// The export crops to the drawn content, so a loop the crop does not know about loses its
+    /// apex in the PNG and on the clipboard.
+    @Test("The drawn bounds reach past the table, far enough for the loop and its markers")
+    func drawnBoundsCoverTheLoop() {
+        let table = node("employees", columns: [column("id", primaryKey: true), column("manager_id", foreignKey: true)])
+        let nodeRect = CGRect(x: 60, y: 60, width: ERDiagramLayout.nodeWidth, height: 212)
+        let scene = ERDiagramScene(
+            nodes: [table],
+            edges: [selfEdge()],
+            nodeRects: [table.id: nodeRect],
+            nodeIndex: ["employees": table.id],
+            clusterColors: [:],
+            selectedNodeId: nil,
+            size: CGSize(width: 800, height: 600)
+        )
+
+        let bounds = ERDiagramSceneRenderer.drawnBounds(of: scene)
+        let loop = ERDiagramEdgeRenderer.selfLoop(in: nodeRect, index: 0)
+        let apex = nodeRect.maxX + (loop.sourceControl.x - nodeRect.maxX) * 0.75
+
+        #expect(bounds.contains(nodeRect))
+        #expect(bounds.maxX > apex)
+    }
+
+    /// The canvas the scroll view can reach is the node bounds plus a fixed padding, so a nested
+    /// loop has to stay inside that padding or it cannot be scrolled to.
+    @Test("A nested loop never reaches past the canvas padding")
+    func nestedLoopsStayOnTheCanvas() {
+        let nodeRect = CGRect(x: 60, y: 60, width: ERDiagramLayout.nodeWidth, height: 916)
+
+        for index in 0..<8 {
+            let bulge = ERDiagramEdgeRenderer.selfLoopBounds(in: nodeRect, index: index).maxX - nodeRect.maxX
+            #expect(bulge < 80)
+        }
+    }
+
+    private func selfEdge() -> EREdge {
+        EREdge(
+            id: UUID(),
+            fkName: "fk_manager",
+            fromTable: "employees",
+            fromColumn: "manager_id",
+            toTable: "employees",
+            toColumn: "id",
+            cardinality: .zeroOrManyToOne
+        )
+    }
+
+    private func column(_ name: String, primaryKey: Bool = false, foreignKey: Bool = false) -> ERColumnDisplay {
+        ERColumnDisplay(
+            id: "employees.\(name)",
+            name: name,
+            dataType: "integer",
+            isPrimaryKey: primaryKey,
+            isForeignKey: foreignKey,
+            isNullable: !primaryKey
+        )
+    }
+
+    private func node(_ name: String, columns: [ERColumnDisplay]) -> ERTableNode {
+        ERTableNode(id: UUID(), tableName: name, columns: columns, displayColumns: columns, clusterId: nil)
+    }
+
+    @Test("A foreign key that references its own table becomes an edge")
+    func graphBuilderKeepsASelfForeignKey() {
+        let columns: [String: [ColumnInfo]] = [
+            "employees": [
+                ColumnInfo(name: "id", dataType: "integer", isNullable: false, isPrimaryKey: true),
+                ColumnInfo(name: "manager_id", dataType: "integer", isNullable: true, isPrimaryKey: false)
+            ]
+        ]
+        let keys: [String: [ForeignKeyInfo]] = [
+            "employees": [
+                ForeignKeyInfo(name: "fk_manager", column: "manager_id", referencedTable: "employees", referencedColumn: "id")
+            ]
+        ]
+
+        let graph = ERDiagramGraphBuilder.build(allColumns: columns, allForeignKeys: keys, allIndexes: [:])
+        let selfEdges = graph.edges.filter { $0.fromTable == $0.toTable }
+
+        #expect(selfEdges.count == 1)
+        #expect(selfEdges.first?.fromColumn == "manager_id")
+    }
+
+    /// The end-to-end proof: the scene draws edges before it fills the nodes, so a loop routed
+    /// through the body leaves nothing behind. Sampling the strip beside the node is what tells
+    /// the two apart.
+    @Test("A self-referencing table paints its relationship beside itself")
+    func selfLoopSurvivesTheNodeFill() {
+        let node = ERTableNode(
+            id: UUID(),
+            tableName: "employees",
+            columns: [],
+            displayColumns: [
+                ERColumnDisplay(
+                    id: "employees.id", name: "id", dataType: "integer",
+                    isPrimaryKey: true, isForeignKey: false, isNullable: false
+                ),
+                ERColumnDisplay(
+                    id: "employees.manager_id", name: "manager_id", dataType: "integer",
+                    isPrimaryKey: false, isForeignKey: true, isNullable: true
+                )
+            ],
+            clusterId: nil
+        )
+        let height = ERDiagramLayout.estimateHeight(columnCount: 2)
+        let nodeRect = CGRect(x: 60, y: 60, width: ERDiagramLayout.nodeWidth, height: height)
+        let edge = EREdge(
+            id: UUID(),
+            fkName: "fk_manager",
+            fromTable: "employees",
+            fromColumn: "manager_id",
+            toTable: "employees",
+            toColumn: "id",
+            cardinality: .zeroOrManyToOne
+        )
+        let scene = ERDiagramScene(
+            nodes: [node],
+            edges: [edge],
+            nodeRects: [node.id: nodeRect],
+            nodeIndex: ["employees": node.id],
+            clusterColors: [:],
+            selectedNodeId: nil,
+            size: CGSize(width: nodeRect.maxX + 160, height: nodeRect.maxY + 160)
+        )
+
+        let view = ERDiagramSceneView(frame: CGRect(origin: .zero, size: scene.size))
+        view.scene = scene
+        let window = NSWindow(
+            contentRect: CGRect(origin: .zero, size: scene.size),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.appearance = NSAppearance(named: .aqua)
+        window.contentView?.addSubview(view)
+        window.layoutIfNeeded()
+
+        guard let rep = view.bitmapImageRepForCachingDisplay(in: view.bounds) else {
+            Issue.record("no bitmap")
+            return
+        }
+        view.cacheDisplay(in: view.bounds, to: rep)
+
+        // The bitmap is at the display's backing scale, so a document point is not a pixel. Left
+        // unscaled the strip lands inside the node, where the opaque fill passes the assertion
+        // whether or not the loop was drawn at all.
+        let scale = CGFloat(rep.pixelsWide) / view.bounds.width
+        var painted = 0
+        let firstColumn = Int((nodeRect.maxX * scale).rounded()) + 1
+        let lastColumn = Int(((nodeRect.maxX + ERDiagramLayout.horizontalGap) * scale).rounded())
+        for x in firstColumn...lastColumn {
+            for y in Int((nodeRect.minY * scale).rounded())...Int((nodeRect.maxY * scale).rounded()) {
+                guard x >= 0, y >= 0, x < rep.pixelsWide, y < rep.pixelsHigh else { continue }
+                guard let colour = rep.colorAt(x: x, y: y) else { continue }
+                if colour.alphaComponent > 0.05 { painted += 1 }
+            }
+        }
+
+        #expect(painted > 40)
+    }
+}

--- a/docs/features/er-diagram.mdx
+++ b/docs/features/er-diagram.mdx
@@ -33,6 +33,9 @@ Edges use crow's foot notation. The referenced end always carries a single bar, 
 | Not unique, NOT NULL | fork + bar | Many-to-one |
 | Not unique, nullable | fork + circle | Zero-or-many-to-one |
 
+A foreign key that points at its own table, `employees.manager_id` to `employees.id`, is drawn as a
+loop out of the table's right edge and back, with the same two markers.
+
 ## Navigation
 
 | Action | Input |
@@ -45,6 +48,11 @@ Edges use crow's foot notation. The referenced end always carries a single bar, 
 | Copy diagram | `Cmd+C` |
 
 Drag a node to move it, toward the edge of the viewport to auto-scroll. Positions are saved and survive across sessions; **Reset Layout**, the circular arrow button, puts every table back where the automatic layout had it.
+
+VoiceOver reads the diagram as a layout area of tables. Each table announces its name, its column
+count and what it is joined to; step into one to hear each column with its type and whether it is a
+primary key, a foreign key, or optional. Selecting a table in the diagram moves the VoiceOver cursor
+to it.
 
 ## Compact mode
 


### PR DESCRIPTION
Two ER diagram defects found while fixing #2692 and reported on #2698, now fixed. Both are in the
drawing path that PR rewrote.

## A table's relationship with itself was invisible

`employees.manager_id -> employees.id`, `categories.parent_id -> categories.id`: the relationship
was built, counted, and announced, and nothing was drawn.

`computePorts` has no case for one rect at both ends. With `fromRect == toRect` the vertical gap is
`-height`, never above the 30pt threshold, so it takes the side-port branch; `fromCenter.x <
toCenter.x` is false at equality, so it returns the table's **left** border as the source and its
**right** border as the destination. `bezierPath` then puts both control points inside the rect,
because the offset is `width * 0.4` against a fixed 220pt node width. The scene draws edges before
it fills the nodes, so the node's own opaque `controlBackgroundColor` erases the result.

Measured with the three functions copied verbatim into a harness, a 220x80 node: ports
`(100,140) -> (320,140)`, control points `(188,140)` and `(232,140)`, the path's bounding box
inside the rect, and **4 of 444 curve pixels surviving** in the app's own draw order. The 28 that
do survive are the two cardinality markers straddling the borders, both pointing inward.

Self edges now get their own geometry, both ports on the trailing edge with the control points
pushed out past it, which is what Graphviz does for a self edge (TSE93 5.1.3, "loops on the sides
of nodes"):

```
spread = min(max(14 * scale, height * 0.25) + index * 8 * scale, max(8 * scale, height / 2 - 8))
bow    = min(min(max(40 * scale, spread * 1.6), horizontalGap) + index * 16, 84)
source      = (maxX, midY + spread)   control1 = (maxX + bow, midY + spread)
destination = (maxX, midY - spread)   control2 = (maxX + bow, midY - spread)
```

The horizontal distance along that curve is `3 * bow * t * (1 - t)`, never negative, so the loop
provably never re-enters the table whatever its size; the bulge peaks at three quarters of `bow`
and is capped at the gap the packer leaves beside a node. The cap is unscaled because that gap is.
A second self-referencing key on one table nests outside the first.

Self edges also stop taking a border-port slot in the spread, which was pushing a real edge off
centre for a port that was never used.

## The whole schema was one image to VoiceOver

The diagram announced "28 tables, 41 relationships" and stopped: no table, no column, no
relationship, no selection. The query plan diagram one tab over reads per node, because its nodes
are ordinary SwiftUI views.

Two things suppressed it. `.accessibilityElement()` defaults to `children: .ignore`, documented as
"any child accessibility elements become hidden", so nothing the `NSView` published could reach a
client; and the view called `setAccessibilityElement(false)`, so it was not a container either.

The scene view is now a layout area publishing one element per table, each with the table's name,
its column count and what it is joined to, and each table's columns as its own children with type,
key role and nullability. Columns are built on the first question rather than with the table, so a
five-hundred-table schema does not pay for every column of every one of them up front.

The measurements that shaped this, all on macOS 27 with a probe mirroring production
(`NSScrollView(allowsMagnification:)` -> `NSHostingView` -> `NSViewRepresentable` -> flipped
`NSView` whose `hitTest` returns nil):

- `.accessibilityElement(children: .contain)` **does** surface the `NSView`'s own
  `accessibilityChildren` through `NSHostingView`. Client tree at magnification 1.0 and 0.41:
  `AXScrollArea > AXGroup(AXHostingView) > AXGroup > AXLayoutArea > 3 x AXLayoutItem`, labels
  delivered on `AXDescription`.
- `AXUIElementCopyElementAtPosition` **descends into** those elements when their frames are right,
  so a pointer query reaches a table rather than stopping at the hosting view.
- `accessibilityFrameInParentSpace` honours **neither** the view's flip nor the scroll view's
  magnification. Written that way, a client pointing at one table is handed a different one:
  measured, a point over `BoxB` returned `BoxA`. Silent misreporting, not an empty result.
- A **computed** `accessibilityFrame()` override is exact. Measured against
  `NSAccessibility.screenRect(fromView:rect:)` at magnification 1.0, at 0.41, and after scrolling:
  x, width and height match to the digit and y matches once the client's flipped screen space is
  accounted for, with nothing to invalidate. That is why nothing here listens for zoom, scroll,
  window move or resize.
- Cost is not a concern: 500 elements build in 0.45ms, `setAccessibilityChildren` is flat, and a
  full client-side walk of 5,000 elements is 15ms. So this needs no equivalent of the data grid's
  `DataGridAccessibility.isActive` gate.

`hitTest` still returns nil, so every gesture, the hover cursor and the tap selection are unchanged.
CLAUDE.md's "a drawn cell can only speak through a mounted view" is about `NSTableView`, which
builds its cell tree from cell views alone; a plain `NSView` publishes `NSAccessibilityElement`
children directly, which is what this uses.

## Also here: two colour-sampling tests that only passed in one appearance

`DiagramPaintCoverageTests` came in with #2698 and its assertions sample pixels. Two of them failed
the moment this machine switched to Dark Mode, and one of those was passing for the wrong reason:
it sampled document points as if they were bitmap pixels, so on a Retina display it read the scroll
view's background instead of the badge. Both are fixed: the probe window pins its appearance, the
badge assertion asks whether the pixel is far redder than it is blue rather than matching absolute
components, and both samplers scale document points by the bitmap's backing scale. The same scaling
bug is fixed in the new self-reference test before it could ship.

## From the Codex review

All five findings held up and are fixed:

- The tree was rebuilt on every scene assignment, which a node drag performs on every pointer
  event, scanning all edges per table and handing a client new objects for tables it was reading.
  It is built on the first accessibility question and reconciled by node id after that, so a drag
  updates rectangles and nothing else; column elements read their row from the table's rect, so
  moving a table carries them along without rebuilding.
- A layout area answers for its focus as well as its selection. The selected table is now the
  canvas's `accessibilityFocusedUIElement`, and a selection change posts both notifications, but
  only once something has asked for the tree.
- A collapsed junction is one synthetic edge between two parents and the relationship is
  symmetric, so it read as a direction it does not have. It reads "related to" from both sides now.
- The export crops to the drawn content, and cropping to the table rects cut the loop's apex off.
  The bounds include every loop and its markers, and the bow is capped so a nested loop always
  fits inside the canvas padding the scroll view can reach.
- `AXLayoutArea` defines its children as `AXLayoutItem`. They were `AXGroup`.

## Verified

- `verify.sh test` over the thirteen suites that own the changed types: PASS, 140 cases.
- New `ERDiagramSelfReferenceTests`: the loop never enters the table at 58pt, 212pt and 916pt tall;
  both ports on the trailing edge with the markers pointing away; a second key nests outside the
  first; the bulge fits the layout's gap; the graph builder keeps a self foreign key; and a
  rasterising test that a self-referencing table paints its relationship in the strip beside itself,
  which is the assertion the old geometry fails.
- New `ERDiagramAccessibilityTests`: one element per table with the right role and label, the column
  count and join summary, columns reachable with type and key role, every frame equal to the
  rectangle the renderer draws at magnification 1.0, 0.41 and 2.0, column frames on their own row,
  selection published, and a self-referencing table saying so.
- `swiftlint --strict`: clean for every file this change touches.
- `docs/scripts/check-writing-style.sh` and `check-docs-against-source.py`: both clean.

No `TableProUITests` coverage: the diagram's content is drawn rather than published as controls, and
both claims are pinned by the rasterising and accessibility-tree tests above.
