### PR TITLE
fix(datagrid): show the UTC offset a timestamp value carries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Data grid dropping the UTC offset from a `timestamp with time zone` value. (#2702)
+- Oracle `TIMESTAMP` values carrying a `Z` the column never stored. (#2702)
 - Connection colour set on an iPhone not showing on the Mac, and the reverse.
 - Connection still reading as read-only on an iPhone after read-only was turned off on the Mac.
 

--- a/Packages/TableProOracle/Sources/TableProOracleCore/OracleCellFormatting.swift
+++ b/Packages/TableProOracle/Sources/TableProOracleCore/OracleCellFormatting.swift
@@ -5,6 +5,11 @@ public enum OracleCellFormatting {
     public static let maxHexBytes = 4_096
 
     public enum TimestampStyle {
+        /// Oracle's plain `TIMESTAMP` holds a wall clock and no zone, so the text carries none
+        /// either. It used to be stamped `Z`, which claimed a zone the column does not have; the
+        /// grid dropped the suffix on the way to the cell, so the claim was invisible until the
+        /// grid started printing the offset a value arrives with. (#2702)
+        case naive
         case utc
         case local
         case zoned
@@ -15,6 +20,15 @@ public enum OracleCellFormatting {
         formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.timeZone = TimeZone(secondsFromGMT: 0)
         formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
+
+    private static let naiveFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS"
         return formatter
     }()
 
@@ -46,6 +60,8 @@ public enum OracleCellFormatting {
 
     public static func formatTimestamp(_ date: Date, style: TimestampStyle) -> String {
         switch style {
+        case .naive:
+            return naiveFormatter.string(from: date)
         case .utc:
             return utcFormatter.withLockUnchecked { $0.string(from: date) }
         case .local:

--- a/Packages/TableProOracle/Sources/TableProOracleCore/OracleCoreConnection.swift
+++ b/Packages/TableProOracle/Sources/TableProOracleCore/OracleCoreConnection.swift
@@ -489,7 +489,7 @@ public final class OracleCoreConnection: @unchecked Sendable {
                 return OracleCellFormatting.formatDate(try cell.decode(Date.self))
 
             case .timestamp:
-                return OracleCellFormatting.formatTimestamp(try cell.decode(Date.self), style: .utc)
+                return OracleCellFormatting.formatTimestamp(try cell.decode(Date.self), style: .naive)
 
             case .timestampLTZ, .timestampTZ:
                 return OracleCellFormatting.formatTimestamp(try cell.decode(Date.self), style: .local)

--- a/Packages/TableProOracle/Tests/TableProOracleCoreTests/OracleCellFormattingTests.swift
+++ b/Packages/TableProOracle/Tests/TableProOracleCoreTests/OracleCellFormattingTests.swift
@@ -24,6 +24,13 @@ final class OracleCellFormattingTests: XCTestCase {
         XCTAssertEqual(result, "2026-05-03T12:29:44.123Z")
     }
 
+    /// Oracle's plain `TIMESTAMP` names a wall clock and no zone. The text has to say the same, or
+    /// the grid prints an offset the column never held.
+    func testNaiveTimestampCarriesNoZone() {
+        let result = OracleCellFormatting.formatTimestamp(Self.referenceDate, style: .naive)
+        XCTAssertEqual(result, "2026-05-03T12:29:44.123")
+    }
+
     func testTimestampLocalMatchesHostOffset() {
         let result = OracleCellFormatting.formatTimestamp(Self.referenceDate, style: .local)
         let offsetSeconds = TimeZone.current.secondsFromGMT(for: Self.referenceDate)

--- a/TablePro/Core/Services/Formatting/DateEditingService.swift
+++ b/TablePro/Core/Services/Formatting/DateEditingService.swift
@@ -9,10 +9,16 @@
 
 import Foundation
 
-enum TemporalComponents: Equatable {
-    case dateOnly
-    case timeOnly
-    case dateAndTime
+/// Which fields a temporal column offers. The editor asks it to decide which steppers to show and
+/// which parts to write back; the grid asks it to pick a pattern and to decide whether an offset
+/// belongs on the rendered text. One vocabulary, because two would have to agree.
+///
+/// The raw values key the display formatter's cache, so a value formatted for one column shape is
+/// never served to another.
+enum TemporalComponents: String {
+    case dateOnly = "d"
+    case timeOnly = "t"
+    case dateAndTime = "dt"
 }
 
 enum DateEditingService {

--- a/TablePro/Core/Services/Formatting/DateFormatOption.swift
+++ b/TablePro/Core/Services/Formatting/DateFormatOption.swift
@@ -32,9 +32,35 @@ enum DateFormatOption: String, Codable, CaseIterable, Identifiable {
         }
     }
 
-    var formatString: String { rawValue }
+    func formatString(for components: TemporalComponents) -> String {
+        switch components {
+        case .dateOnly: return dateOnlyFormatString
+        case .timeOnly: return timeOnlyFormatString
+        case .dateAndTime: return rawValue
+        }
+    }
 
-    var dateOnlyFormatString: String {
+    /// Whether the text this option produces for a column shape carries a clock, which is what
+    /// decides whether a UTC offset belongs on it: an offset qualifies a time and says nothing
+    /// about a bare date.
+    ///
+    /// Only the date-and-time shape depends on the option, and it is switched exhaustively rather
+    /// than defaulted, so a seventh pattern has to state which it is instead of silently picking.
+    func rendersTime(for components: TemporalComponents) -> Bool {
+        switch components {
+        case .dateOnly:
+            return false
+        case .timeOnly:
+            return true
+        case .dateAndTime:
+            switch self {
+            case .iso8601, .usLong, .euLong: return true
+            case .iso8601Date, .usShort, .euShort: return false
+            }
+        }
+    }
+
+    private var dateOnlyFormatString: String {
         switch self {
         case .iso8601, .iso8601Date: return "yyyy-MM-dd"
         case .usLong, .usShort: return "MM/dd/yyyy"
@@ -42,7 +68,7 @@ enum DateFormatOption: String, Codable, CaseIterable, Identifiable {
         }
     }
 
-    var timeOnlyFormatString: String {
+    private var timeOnlyFormatString: String {
         switch self {
         case .usLong: return "hh:mm:ss a"
         default: return "HH:mm:ss"

--- a/TablePro/Core/Services/Formatting/DateFormattingService.swift
+++ b/TablePro/Core/Services/Formatting/DateFormattingService.swift
@@ -16,7 +16,7 @@ final class DateFormattingService {
     // MARK: - Properties
 
     /// Cached formatter for current user-selected format
-    private var formatter: DateFormatter
+    private var dateTimeFormatter: DateFormatter
     private var dateOnlyFormatter: DateFormatter
     private var timeOnlyFormatter: DateFormatter
 
@@ -31,9 +31,9 @@ final class DateFormattingService {
     private init() {
         // Will be updated by AppSettingsManager after it completes initialization
         self.currentFormat = .iso8601
-        self.formatter = Self.createFormatter(format: DateFormatOption.iso8601.formatString)
-        self.dateOnlyFormatter = Self.createFormatter(format: DateFormatOption.iso8601.dateOnlyFormatString)
-        self.timeOnlyFormatter = Self.createFormatter(format: DateFormatOption.iso8601.timeOnlyFormatString)
+        self.dateTimeFormatter = Self.createFormatter(for: .iso8601, components: .dateAndTime)
+        self.dateOnlyFormatter = Self.createFormatter(for: .iso8601, components: .dateOnly)
+        self.timeOnlyFormatter = Self.createFormatter(for: .iso8601, components: .timeOnly)
         formatCache.countLimit = 100_000
     }
 
@@ -43,9 +43,9 @@ final class DateFormattingService {
     func updateFormat(_ format: DateFormatOption) {
         guard format != currentFormat else { return }
         currentFormat = format
-        formatter = Self.createFormatter(format: format.formatString)
-        dateOnlyFormatter = Self.createFormatter(format: format.dateOnlyFormatString)
-        timeOnlyFormatter = Self.createFormatter(format: format.timeOnlyFormatString)
+        dateTimeFormatter = Self.createFormatter(for: format, components: .dateAndTime)
+        dateOnlyFormatter = Self.createFormatter(for: format, components: .dateOnly)
+        timeOnlyFormatter = Self.createFormatter(for: format, components: .timeOnly)
         // Clear cache when format changes since all cached values are now stale
         formatCache.removeAllObjects()
     }
@@ -54,8 +54,8 @@ final class DateFormattingService {
     /// - Parameter date: The date to format
     /// - Returns: Formatted date string
     func format(_ date: Date) -> String {
-        formatter.timeZone = .current
-        return formatter.string(from: date)
+        dateTimeFormatter.timeZone = .current
+        return dateTimeFormatter.string(from: date)
     }
 
     /// Format a string date value (parse then format).
@@ -66,13 +66,18 @@ final class DateFormattingService {
     /// with no offset is naive and parses in the reader's own zone, so this is the same zone it
     /// always used.
     ///
+    /// The offset itself is printed with it, because a wall clock alone does not name an instant.
+    /// It is the literal text the value arrived with, off the same layout the write-back reads. A
+    /// pattern token cannot serve: it prints the formatter's own zone, which for a value carrying
+    /// no offset is the reader's, so a `DATETIME` would gain an offset the database never held.
+    ///
     /// The cache key needs no zone: the zone is read off the value, so the string determines it.
     /// - Parameter dateString: Date string from database (ISO 8601, MySQL timestamp, etc.)
     /// - Parameter columnType: Column type, used to pick date-only / time-only / datetime variant
     /// - Returns: Formatted date string, or nil if unparseable
     func format(dateString: String, columnType: ColumnType? = nil) -> String? {
-        let targetFormatter = formatter(for: columnType)
-        let cacheKey = "\(formatBucket(for: columnType))|\(dateString)" as NSString
+        let components = temporalComponents(for: columnType)
+        let cacheKey = "\(components.rawValue)|\(dateString)" as NSString
         if let cached = formatCache.object(forKey: cacheKey) {
             return cached.length == 0 ? nil : cached as String
         }
@@ -81,28 +86,28 @@ final class DateFormattingService {
             formatCache.setObject("" as NSString, forKey: cacheKey)
             return nil
         }
+        let targetFormatter = formatter(for: components)
         targetFormatter.timeZone = parsed.timeZone
-        let result = targetFormatter.string(from: parsed.date)
+        var result = targetFormatter.string(from: parsed.date)
+        if currentFormat.rendersTime(for: components), let suffix = parsed.layout.timeZoneSuffix {
+            result += suffix
+        }
         formatCache.setObject(result as NSString, forKey: cacheKey)
         return result
     }
 
-    private func formatter(for columnType: ColumnType?) -> DateFormatter {
-        switch columnType {
-        case .date:
-            return dateOnlyFormatter
-        case .timestamp, .datetime:
-            return columnType?.isTimeOnly == true ? timeOnlyFormatter : formatter
-        default:
-            return formatter
-        }
+    /// A column with no type at all is read as a full timestamp, which is what the grid's own
+    /// fallback did before the editor and the formatter shared this vocabulary.
+    private func temporalComponents(for columnType: ColumnType?) -> TemporalComponents {
+        guard let columnType else { return .dateAndTime }
+        return DateEditingService.components(for: columnType)
     }
 
-    private func formatBucket(for columnType: ColumnType?) -> String {
-        switch columnType {
-        case .date: return "d"
-        case .timestamp, .datetime: return columnType?.isTimeOnly == true ? "t" : "dt"
-        default: return "dt"
+    private func formatter(for components: TemporalComponents) -> DateFormatter {
+        switch components {
+        case .dateOnly: return dateOnlyFormatter
+        case .timeOnly: return timeOnlyFormatter
+        case .dateAndTime: return dateTimeFormatter
         }
     }
 
@@ -113,9 +118,12 @@ final class DateFormattingService {
     /// Japanese calendar and reformats the very value the grid round-trips back to SQL.
     private static let fixedPatternLocale = Locale(identifier: "en_US_POSIX")
 
-    private static func createFormatter(format: String) -> DateFormatter {
+    private static func createFormatter(
+        for format: DateFormatOption,
+        components: TemporalComponents
+    ) -> DateFormatter {
         let formatter = DateFormatter()
-        formatter.dateFormat = format
+        formatter.dateFormat = format.formatString(for: components)
         formatter.locale = fixedPatternLocale
         formatter.calendar = Calendar(identifier: .gregorian)
         formatter.timeZone = TimeZone.current

--- a/TableProTests/Core/Services/DateFormattingServiceTests.swift
+++ b/TableProTests/Core/Services/DateFormattingServiceTests.swift
@@ -87,3 +87,107 @@ struct DateFormattingServiceTests {
         #expect(asDate == "2024-03-01")
     }
 }
+
+/// A wall clock alone does not name an instant, so the offset the database sent is printed with it.
+/// The offset is the literal text off the value, never a pattern token: a token prints the
+/// formatter's zone, which for a value carrying none is the reader's own. (#2702)
+@Suite("DateFormattingService time zone display")
+@MainActor
+struct DateFormattingServiceTimeZoneTests {
+    @Test("An offset-bearing timestamp keeps its offset")
+    func offsetIsShown() {
+        DateFormattingService.shared.updateFormat(.iso8601)
+        let result = DateFormattingService.shared.format(
+            dateString: "2024-12-31 23:59:59+07",
+            columnType: .timestamp(rawType: "TIMESTAMPTZ")
+        )
+        #expect(result == "2024-12-31 23:59:59+07")
+    }
+
+    /// Every spelling measured coming out of PostgreSQL 17, plus the `Z` the MongoDB and Cassandra
+    /// drivers write. Each is printed as the database wrote it rather than normalised, so the grid
+    /// and a `Cmd+C` of the same cell read the same.
+    @Test("Every offset spelling reaches the cell unchanged")
+    func offsetSpellingsAreVerbatim() {
+        DateFormattingService.shared.updateFormat(.iso8601)
+        for spelling in ["+00", "-03:30", "+05:45", "Z", "+0700"] {
+            let result = DateFormattingService.shared.format(
+                dateString: "2024-12-31 23:59:59\(spelling)",
+                columnType: .timestamp(rawType: "TIMESTAMPTZ")
+            )
+            #expect(result == "2024-12-31 23:59:59\(spelling)")
+        }
+    }
+
+    @Test("A value carrying no offset gains none")
+    func naiveValueGainsNoOffset() {
+        DateFormattingService.shared.updateFormat(.iso8601)
+        let result = DateFormattingService.shared.format(
+            dateString: "2024-12-31 23:59:59",
+            columnType: .datetime(rawType: "DATETIME")
+        )
+        #expect(result == "2024-12-31 23:59:59")
+    }
+
+    @Test("A TIMETZ column keeps the offset that qualifies its time")
+    func timeOnlyColumnKeepsItsOffset() {
+        DateFormattingService.shared.updateFormat(.iso8601)
+        let result = DateFormattingService.shared.format(
+            dateString: "09:30:00+05:30",
+            columnType: .timestamp(rawType: "TIMETZ")
+        )
+        #expect(result == "09:30:00+05:30")
+    }
+
+    @Test("A DATE column renders the date alone, because an offset qualifies a time")
+    func dateColumnDropsTheOffset() {
+        DateFormattingService.shared.updateFormat(.iso8601)
+        let result = DateFormattingService.shared.format(
+            dateString: "2024-12-31 23:59:59+07",
+            columnType: .date(rawType: "DATE")
+        )
+        #expect(result == "2024-12-31")
+    }
+
+    @Test("A date-only format on a timestamp column renders no offset either")
+    func dateOnlyFormatDropsTheOffset() {
+        DateFormattingService.shared.updateFormat(.iso8601Date)
+        defer { DateFormattingService.shared.updateFormat(.iso8601) }
+
+        let result = DateFormattingService.shared.format(
+            dateString: "2024-12-31 23:59:59+07",
+            columnType: .timestamp(rawType: "TIMESTAMPTZ")
+        )
+        #expect(result == "2024-12-31")
+    }
+
+    @Test("The offset follows a 12-hour pattern too")
+    func twelveHourFormatKeepsTheOffset() {
+        DateFormattingService.shared.updateFormat(.usLong)
+        defer { DateFormattingService.shared.updateFormat(.iso8601) }
+
+        let result = DateFormattingService.shared.format(
+            dateString: "2024-12-31 23:59:59+07",
+            columnType: .timestamp(rawType: "TIMESTAMPTZ")
+        )
+        #expect(result == "12/31/2024 11:59:59 PM+07")
+    }
+
+    /// The grid opens the cell editor on the raw text, so a value it prints has to be the value the
+    /// write-back reproduces. The suffix travels through the layout for both.
+    @Test("The printed offset is the one the write-back writes")
+    func displayAgreesWithTheWriteBack() throws {
+        DateFormattingService.shared.updateFormat(.iso8601)
+        let wire = "2024-12-31 23:59:59+05:45"
+        let parsed = try #require(DatabaseDateParser.parse(wire))
+
+        let displayed = DateFormattingService.shared.format(
+            dateString: wire,
+            columnType: .timestamp(rawType: "TIMESTAMPTZ")
+        )
+        let written = DateEditingService.string(from: parsed.date, like: parsed, offered: .dateAndTime)
+
+        #expect(displayed == wire)
+        #expect(written == wire)
+    }
+}

--- a/TableProTests/Core/Services/Formatting/DatabaseDateParserTests.swift
+++ b/TableProTests/Core/Services/Formatting/DatabaseDateParserTests.swift
@@ -96,6 +96,25 @@ struct DatabaseDateParserTests {
         #expect(parsed.layout.timeZoneSuffix == "+07:00")
     }
 
+    /// Measured against PostgreSQL 17: the server widens the offset to whatever the zone needs and
+    /// never writes `Z`, so `2024-12-31 23:59:59+00` and `+05:45` are both ordinary output. The grid
+    /// prints this text back, so each spelling has to survive the parse intact.
+    @Test("Every offset spelling PostgreSQL writes is captured verbatim")
+    func offsetSpellingsSurvive() throws {
+        let spellings = ["+07", "+00", "-03:30", "+05:45", "Z", "+0700"]
+        for spelling in spellings {
+            let parsed = try #require(DatabaseDateParser.parse("2024-12-31 23:59:59\(spelling)"))
+            #expect(parsed.layout.timeZoneSuffix == spelling)
+        }
+    }
+
+    @Test("A value with no offset reports none rather than the reader's own")
+    func naiveValueCarriesNoSuffix() throws {
+        let parsed = try #require(DatabaseDateParser.parse("2024-12-31 23:59:59"))
+
+        #expect(parsed.layout.timeZoneSuffix == nil)
+    }
+
     @Test("Text that is not a date stays unparsed rather than becoming a plausible one")
     func rejectsNonDates() {
         #expect(DatabaseDateParser.date(from: "not a date") == nil)

--- a/TableProUITests/GridTimeZoneOffsetUITests.swift
+++ b/TableProUITests/GridTimeZoneOffsetUITests.swift
@@ -1,0 +1,106 @@
+//
+//  GridTimeZoneOffsetUITests.swift
+//  TableProUITests
+//
+//  Covers #2702: a value carrying a UTC offset reached the grid and lost it, so a
+//  `timestamp with time zone` read exactly like a naive one.
+//
+
+import AppKit
+import XCTest
+
+final class GridTimeZoneOffsetUITests: UITestCase {
+    /// The sample database is copied into the test sandbox before it opens, so the table this
+    /// creates lives and dies with the case.
+    ///
+    /// SQLite is the only engine reachable without a server, and it is enough: the column's
+    /// declared type is what routes the cell into date formatting, and `sqlite3_column_decltype`
+    /// reports `TIMESTAMP` for a `SELECT` over a declared column. A bare `SELECT '…'` would not,
+    /// so the value has to come from a real table.
+    private static let setup = """
+    CREATE TABLE IF NOT EXISTS tz_offset_probe (ts TIMESTAMP);
+    DELETE FROM tz_offset_probe;
+    INSERT INTO tz_offset_probe VALUES ('2024-12-31 23:59:59+07');
+    SELECT ts FROM tz_offset_probe;
+    """
+
+    private static let expected = "2024-12-31 23:59:59+07"
+
+    func testAnOffsetBearingValueKeepsItsOffsetInTheGrid() throws {
+        let app = try launchWithSampleDatabase()
+
+        app.typeKey("t", modifierFlags: .command)
+        let queryEditor = editorTextView(in: app)
+        XCTAssertTrue(queryEditor.waitToExist(timeout: 10))
+        queryEditor.click()
+        paste(Self.setup, into: app)
+
+        openExecuteMenu(in: app).menuItems["Execute All Statements"].click()
+        confirmDestructiveExecution(in: app)
+
+        guard waitForPredicate(timeout: 60, { self.offsetCell(in: app) != nil }) else {
+            throw XCTSkip("No result grid published a first row")
+        }
+        XCTAssertEqual(
+            offsetCell(in: app),
+            Self.expected,
+            "The cell must print the offset the value arrived with, not the wall clock alone"
+        )
+    }
+
+    // MARK: - Helpers
+
+    /// A run that creates a table and inserts a row is a destructive operation, so the execution
+    /// gate puts a sheet in front of it before anything reaches the database.
+    private func confirmDestructiveExecution(in app: XCUIApplication) {
+        let confirm = app.windows.firstMatch.sheets.firstMatch.buttons["Execute"]
+        XCTAssertTrue(confirm.waitToExist(timeout: 15), "The execution gate must confirm the write before it runs")
+        confirm.click()
+    }
+
+    /// Typed text would go through the editor's own bracket pairing and completion panel, which
+    /// rewrite parentheses and quotes as they are typed. The pasteboard reaches the same buffer
+    /// with the statement intact.
+    private func paste(_ text: String, into app: XCUIApplication) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+        app.typeKey("v", modifierFlags: .command)
+    }
+
+    /// Every result the run produced is searched rather than only the first, because running four
+    /// statements leaves four results in the tree and only the `SELECT` has a row.
+    ///
+    /// Column 1 is the first data column; the row-number gutter is not published as a cell.
+    private func offsetCell(in app: XCUIApplication) -> String? {
+        let grids = app.windows.firstMatch.tables.matching(identifier: "data-grid")
+        for index in 0 ..< grids.count {
+            let row = grids.element(boundBy: index).tableRows.firstMatch
+            guard row.exists else { continue }
+            let cell = row.staticTexts
+                .matching(NSPredicate(format: "label BEGINSWITH %@", "Row 1, column 1: "))
+                .firstMatch
+            if cell.exists, let value = cell.value as? String {
+                return value
+            }
+        }
+        return nil
+    }
+
+    /// The control is a split button: its leading half runs the query and only its trailing
+    /// chevron opens the menu, so a plain `click()` would execute instead of opening.
+    ///
+    /// The opened menu is scoped to the window rather than matched by identifier, because the CI
+    /// runner's macOS build exposes a just-opened menu without one.
+    private func openExecuteMenu(in app: XCUIApplication) -> XCUIElement {
+        let window = app.windows.firstMatch
+        let executeMenu = window.descendants(matching: .any)
+            .matching(identifier: "query-execute-menu")
+            .firstMatch
+        XCTAssertTrue(
+            waitUntilHittable(executeMenu, timeout: 10),
+            "The editor toolbar must expose the Execute split button"
+        )
+        executeMenu.coordinate(withNormalizedOffset: CGVector(dx: 0.9, dy: 0.5)).click()
+        return window.menus.firstMatch
+    }
+}

--- a/docs/customization/data-settings.mdx
+++ b/docs/customization/data-settings.mdx
@@ -17,7 +17,7 @@ The tab is app-wide, so these values apply to every connection you open; filters
 | Setting | Default | Notes |
 |---------|---------|-------|
 | Row height | Normal | Compact, Normal, Comfortable, Spacious |
-| Date format | ISO 8601 | ISO 8601, ISO Date, US Long, US Short, EU Long, EU Short |
+| Date format | ISO 8601 | ISO 8601, ISO Date, US Long, US Short, EU Long, EU Short. A UTC offset stored with the value is printed wherever the format renders a time, as the server wrote it: `2024-12-31 23:59:59+07`. A value stored without one, such as a MySQL `DATETIME`, never gains one |
 | NULL display | `NULL` | Text shown for NULL cells, up to 20 characters |
 | Show alternate row backgrounds | On | |
 | Show row numbers | On | |


### PR DESCRIPTION
Fixes #2702.

## The bug

A `timestamp with time zone` value reaches the grid as text carrying a UTC offset, `2024-12-31 23:59:59+07`. `DatabaseDateParser` recovers that offset twice: as `ParsedTemporalValue.timeZone`, which picks the wall clock, and as `TemporalLayout.timeZoneSuffix`, the literal text kept so an edit writes back unchanged. `DateFormattingService.format(dateString:columnType:)` read only the first and rendered through a `DateFormatOption` pattern, and all six patterns are zone-free, so the offset was dropped on the way to the cell.

The wall clock shown was right for the value's own zone, which is what made this hard to see. What is missing is which zone that is: two rows naming the same instant in different offsets render as two different times with nothing explaining the difference, and a `timestamptz` reads exactly like a naive `timestamp`.

## The fix

The offset is printed with the value, taken verbatim from `layout.timeZoneSuffix`. Three things follow from taking it off the value rather than from a pattern:

- **A value with no offset gains none.** MySQL `DATETIME`, SQLite text and PostgreSQL `timestamp without time zone` render byte-identically to before.
- **The spelling is the server's.** Measured against PostgreSQL 17, the server writes `+07`, `+00`, `-03:30`, `+05:45`, and never `Z`. A `DateFormatter` zone token would rewrite `+00` to `Z` and `+07` to `+07:00`; the literal text is also what `DateEditingService` writes back and what `Cmd+C` already copies, so the grid, the cell editor and the clipboard now agree.
- **A date-only rendering gets nothing.** A `DATE` column, and the ISO Date / US Short / EU Short formats on a timestamp column, still show the date alone.

A `DateFormatOption` case carrying an `X` or `Z` token was the other candidate and is wrong: measured, the token prints the *formatter's* zone, which for a value with no offset is `TimeZone.current`, so `yyyy-MM-dd HH:mm:ssXXX` renders a MySQL `2024-06-15 12:00:00` as `2024-06-15 12:00:00-04:00`. The gate has to be the value's suffix.

This ships as always-on rather than a preference, which is a deliberate reading of "add an option" in the issue. DataGrip took the identical report (YouTrack DBE-13055) and fixed it the same way in 2021.2, with no setting: "Time zone is always shown for values with the timezone". TablePlus, Postico and Beekeeper Studio ship no such preference at all. Converting a value into a chosen display zone is a separate feature and is not in this PR.

## The Oracle driver ships with it

Codex's adversarial pass named the one case where the rule above would print a fabricated offset, and it is real. `OracleCoreConnection.decodeText` decoded a plain Oracle `TIMESTAMP`, a type that stores no zone, through an `ISO8601DateFormatter` pinned to GMT, so every such value arrived as `...Z` (`OracleCoreConnection.swift:492`). The grid dropped that suffix on the way to the cell, so the claim was invisible; printing the offset would have made every naive Oracle timestamp read as UTC.

`TimestampStyle.naive` is the fix: `yyyy-MM-dd'T'HH:mm:ss.SSS` in GMT, no zone field, and `.timestamp` routes to it. Measured with the formatter compiled standalone, `2026-05-03T12:29:44.123Z` becomes `2026-05-03T12:29:44.123`, and the cell renders the same wall clock it rendered before with no offset appended. This ships here rather than separately because the primary fix is what makes the defect visible.

`TIMESTAMP WITH [LOCAL] TIME ZONE` still uses `.local`. `oracle-nio` hands the driver a `Date`, so the stored region is already gone by then and the host offset at least qualifies the wall clock printed truthfully. Recovering the source region needs driver work and is not in this PR.

## Structural change

`DateFormattingService` had two parallel switches over the same question, `formatter(for:)` and `formatBucket(for:)`, that had to agree with nothing forcing them to, and the offset rule needed a third answer from it. That question was already answered by `TemporalComponents` + `DateEditingService.components(for:)`, which the cell date picker uses. Both switches are gone; the formatter, the cache key and the offset rule all read one value. `TemporalComponents` gains `String` raw values so it can key the cache.

## Before / After

Same window, same query, sample database with a `TIMESTAMP` column holding `2024-12-31 23:59:59+07`.

| | Cell reads |
|---|---|
| Before | `2024-12-31 23:59:59` |
| After | `2024-12-31 23:59:59+07` |

`gh` cannot upload images, so the two PNGs are attached by hand.

## Engines affected

PostgreSQL (`timestamptz`, `timetz`), MongoDB, Oracle `TIMESTAMP WITH [LOCAL] TIME ZONE`, Cassandra, SurrealDB, Kafka, BigQuery, and any SQLite or DuckDB column holding text with an offset. MySQL, MSSQL and ClickHouse never put an offset on the wire and are unchanged.

## Verified

- `verify.sh test`: `DateFormattingServiceTests`, `DateFormattingServiceTimeZoneTests`, `DatabaseDateParserTests`, `DateEditingServiceTests`, `TemporalEditingConsistencyTests`, `CellDisplayFormatterTests`: 79 executed, 79 passed.
- `verify.sh uitest GridTimeZoneOffsetUITests` passes on this branch. Reverting only the three source files and re-running it fails with `("2024-12-31 23:59:59") is not equal to ("2024-12-31 23:59:59+07")`, so the guard bites.
- `verify.sh lint TablePro TableProTests TableProUITests`: 0 violations. (`check-doc-symbols.sh` reports one pre-existing stale `CLAUDE.md` symbol, `NSAccessibilitySortDirectionAttribute`, untouched by this branch.)
- `docs/scripts/check-writing-style.sh` and `check-docs-against-source.py`: both clean.
- `verify.sh plugins` (the `AllPlugins` aggregate) is INCONCLUSIVE here, not green: it stops in `oracle-nio`'s own `@TaskLocal` macro with `unknown attribute 'usableFromInlinenonisolated'` on this local toolchain, a known local-only failure in a vendored dependency. No error names a file this branch touches. CI's toolchain compiles it, so the `Compile every plugin` step is the real gate on the Oracle change.
- The Oracle formatter compiled standalone with `swiftc -swift-version 6` and measured: `.naive` prints `2026-05-03T12:29:44.123`, `.utc` still prints the `Z`.
- Driven by hand against a sandboxed Debug build to confirm the rendered cell.

`OracleCellFormattingTests` gains a case for the new style, but it could not be executed: `swift test --package-path Packages/TableProOracle` fails to build the pinned `oracle-nio` fork on this toolchain, and CI runs package tests for `TableProCore` and `CodeEditTextView` only. The standalone probe above is what actually measured the behaviour.

## Known side effect

A `timestamptz` column whose width was already saved will clip the extra characters until it is resized. `measureColumnWidth` measures the new text, but nothing re-measures a width that is already persisted.

https://claude.ai/code/session_01P6WcfBSJ9Xa2heWLSQGP8m
