### PR TITLE
Stop TablePro talking to a database nobody is using (#2700)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Idle metadata connections held open for the life of the app, up to six per connection. (#2700)
+- SQLite, DuckDB and Teradata connections pinged every 30 seconds despite opting out of health checks. (#2700)
+- Data grid dropping the UTC offset from a `timestamp with time zone` value. (#2702)
 - Connection colour set on an iPhone not showing on the Mac, and the reverse.
 - Connection still reading as read-only on an iPhone after read-only was turned off on the Mac.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Idle metadata connections held open for the life of the app, up to six per connection. (#2700)
 - SQLite, DuckDB and Teradata connections pinged every 30 seconds despite opting out of health checks. (#2700)
 - Data grid dropping the UTC offset from a `timestamp with time zone` value. (#2702)
-- Data grid dropping the UTC offset from a `timestamp with time zone` value. (#2702)
 - Oracle `TIMESTAMP` values carrying a `Z` the column never stored. (#2702)
 - Connection colour set on an iPhone not showing on the Mac, and the reverse.
 - Connection still reading as read-only on an iPhone after read-only was turned off on the Mac.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Check connections** in Settings > General, including Only when I use the connection. (#2700)
+
 ### Changed
 
 - 5 MB smaller app bundle.

--- a/Plugins/DuckDBDriverPlugin/DuckDBPlugin.swift
+++ b/Plugins/DuckDBDriverPlugin/DuckDBPlugin.swift
@@ -27,6 +27,7 @@ final class DuckDBPlugin: NSObject, TableProPlugin, DriverPlugin {
     static let pathFieldRole: PathFieldRole = .database
     static let requiresAuthentication = false
     static let connectionMode: ConnectionMode = .apiOnly
+    static let supportsHealthMonitor = false
     static let urlSchemes: [String] = ["duckdb", "quack"]
 
     static let additionalConnectionFields: [ConnectionField] = [

--- a/Plugins/SQLiteDriverPlugin/SQLitePlugin.swift
+++ b/Plugins/SQLiteDriverPlugin/SQLitePlugin.swift
@@ -33,6 +33,7 @@ final class SQLitePlugin: NSObject, TableProPlugin, DriverPlugin {
     static let isDownloadable = false
     static let pathFieldRole: PathFieldRole = .filePath
     static let connectionMode: ConnectionMode = .fileBased
+    static let supportsHealthMonitor = false
     static let urlSchemes: [String] = ["sqlite"]
     static let fileExtensions: [String] = ["db", "db3", "s3db", "sl3", "sqlite", "sqlite3", "sqlitedb"]
     static let brandColorHex = "#003B57"

--- a/Plugins/TeradataDriverPlugin/TeradataPlugin.swift
+++ b/Plugins/TeradataDriverPlugin/TeradataPlugin.swift
@@ -51,6 +51,7 @@ final class TeradataPlugin: NSObject, TableProPlugin, DriverPlugin {
     static let queryLanguageName = "SQL"
     static let supportsDatabaseSwitching = true
     static let supportsSchemaSwitching = false
+    static let supportsHealthMonitor = false
     static let requiresReconnectForDatabaseSwitch = false
     static let databaseGroupingStrategy: GroupingStrategy = .byDatabase
     static let containerEntityName = "Database"

--- a/TablePro/Core/Database/Access/DatabaseAccessBridge.swift
+++ b/TablePro/Core/Database/Access/DatabaseAccessBridge.swift
@@ -116,6 +116,10 @@ internal actor DatabaseAccessBridge {
         if let pending {
             try await DatabaseManager.shared.ensureConnected(pending)
         }
+        /// An automation client is the likeliest thing to reach a connection nobody has touched
+        /// for hours, and it never passes through `ensureConnected` once a session exists, so this
+        /// is where the check has to be for MCP and for Cocoa Scripting.
+        await DatabaseManager.shared.verifyBeforeUse(connectionId)
         return try await MainActor.run {
             switch DatabaseManager.shared.connectionState(connectionId) {
             case .live(let driver, let session):

--- a/TablePro/Core/Database/ConnectionHealthMonitor.swift
+++ b/TablePro/Core/Database/ConnectionHealthMonitor.swift
@@ -43,12 +43,14 @@ actor ConnectionHealthMonitor {
 
     // MARK: - Configuration
 
-    private static let pingInterval: TimeInterval = 30.0
     private static let maxBackoffDelay: TimeInterval = 120.0
 
     // MARK: - Dependencies
 
     private let connectionId: UUID
+    /// How long to wait between checks. Injected rather than fixed, because how often TablePro
+    /// talks to a database nobody is using is the user's call, not this actor's (#2700).
+    private let pingInterval: Duration
     private let pingHandler: @Sendable () async -> Bool
     private let reconnectHandler: @Sendable () async -> ReconnectOutcome
     private let onStateChanged: @Sendable (UUID, HealthState) async -> Void
@@ -66,6 +68,7 @@ actor ConnectionHealthMonitor {
     ///
     /// - Parameters:
     ///   - connectionId: The unique identifier of the connection to monitor.
+    ///   - pingInterval: How long to wait between checks.
     ///   - pingHandler: Closure that executes a lightweight query (e.g., `SELECT 1`)
     ///     and returns `true` if the connection is alive.
     ///   - reconnectHandler: Closure that attempts to re-establish the connection
@@ -73,11 +76,13 @@ actor ConnectionHealthMonitor {
     ///   - onStateChanged: Closure invoked whenever the health state transitions.
     init(
         connectionId: UUID,
+        pingInterval: Duration,
         pingHandler: @escaping @Sendable () async -> Bool,
         reconnectHandler: @escaping @Sendable () async -> ReconnectOutcome,
         onStateChanged: @escaping @Sendable (UUID, HealthState) async -> Void
     ) {
         self.connectionId = connectionId
+        self.pingInterval = pingInterval
         self.pingHandler = pingHandler
         self.reconnectHandler = reconnectHandler
         self.onStateChanged = onStateChanged
@@ -96,7 +101,7 @@ actor ConnectionHealthMonitor {
 
     /// Starts periodic health monitoring.
     ///
-    /// Creates a long-running task that pings the connection every 30 seconds.
+    /// Creates a long-running task that pings the connection on `pingInterval`.
     /// If monitoring is already active, this method does nothing.
     func startMonitoring() {
         guard monitoringTask == nil else {
@@ -106,6 +111,7 @@ actor ConnectionHealthMonitor {
 
         Self.logger.trace("Starting health monitoring for connection \(self.connectionId)")
 
+        let interval = pingInterval
         monitoringTask = Task { [weak self] in
             guard let self else { return }
 
@@ -114,11 +120,11 @@ actor ConnectionHealthMonitor {
             guard !Task.isCancelled else { return }
 
             while !Task.isCancelled {
-                try? await Task.sleep(for: .seconds(Self.pingInterval))
+                try? await Task.sleep(for: interval)
                 guard !Task.isCancelled else { break }
                 await self.performHealthCheck()
-                /// A monitor that has given up has nothing left to ask. Without this it woke every
-                /// 30 seconds for the life of the app to fail its own healthy-state guard and
+                /// A monitor that has given up has nothing left to ask. Without this it woke on
+                /// every interval for the life of the app to fail its own healthy-state guard and
                 /// return, and only a fresh connect ever replaced it.
                 guard await !self.hasAborted else { break }
             }
@@ -239,7 +245,7 @@ actor ConnectionHealthMonitor {
         state = newState
 
         if oldState != newState {
-            // Skip logging and callback for routine healthy ↔ checking ping cycles (every 30s).
+            // Skip logging and callback for routine healthy ↔ checking ping cycles.
             // These produce no meaningful state change for the UI.
             let isRoutineCycle = (oldState == .healthy && newState == .checking)
                 || (oldState == .checking && newState == .healthy)

--- a/TablePro/Core/Database/ConnectionHealthMonitor.swift
+++ b/TablePro/Core/Database/ConnectionHealthMonitor.swift
@@ -48,9 +48,15 @@ actor ConnectionHealthMonitor {
     // MARK: - Dependencies
 
     private let connectionId: UUID
-    /// How long to wait between checks. Injected rather than fixed, because how often TablePro
-    /// talks to a database nobody is using is the user's call, not this actor's (#2700).
-    private let pingInterval: Duration
+    /// How long to wait between checks, asked again on every pass rather than captured once.
+    ///
+    /// How often TablePro talks to a database nobody is using is the user's call, not this actor's
+    /// (#2700), and a captured interval makes that call reach only connections opened afterwards.
+    /// Re-reading it also means nothing has to stop and rebuild a monitor to apply a change, which
+    /// is what made a change arriving mid-reconnect able to strand a session or leave a second
+    /// monitor running outside the manager's dictionary. Nil ends the loop: the user asked for no
+    /// scheduled checks at all.
+    private let pingInterval: @Sendable () async -> Duration?
     private let pingHandler: @Sendable () async -> Bool
     private let reconnectHandler: @Sendable () async -> ReconnectOutcome
     private let onStateChanged: @Sendable (UUID, HealthState) async -> Void
@@ -68,7 +74,7 @@ actor ConnectionHealthMonitor {
     ///
     /// - Parameters:
     ///   - connectionId: The unique identifier of the connection to monitor.
-    ///   - pingInterval: How long to wait between checks.
+    ///   - pingInterval: How long to wait between checks, or nil to stop checking.
     ///   - pingHandler: Closure that executes a lightweight query (e.g., `SELECT 1`)
     ///     and returns `true` if the connection is alive.
     ///   - reconnectHandler: Closure that attempts to re-establish the connection
@@ -76,7 +82,7 @@ actor ConnectionHealthMonitor {
     ///   - onStateChanged: Closure invoked whenever the health state transitions.
     init(
         connectionId: UUID,
-        pingInterval: Duration,
+        pingInterval: @escaping @Sendable () async -> Duration?,
         pingHandler: @escaping @Sendable () async -> Bool,
         reconnectHandler: @escaping @Sendable () async -> ReconnectOutcome,
         onStateChanged: @escaping @Sendable (UUID, HealthState) async -> Void
@@ -111,7 +117,7 @@ actor ConnectionHealthMonitor {
 
         Self.logger.trace("Starting health monitoring for connection \(self.connectionId)")
 
-        let interval = pingInterval
+        let intervalForPass = pingInterval
         monitoringTask = Task { [weak self] in
             guard let self else { return }
 
@@ -120,8 +126,12 @@ actor ConnectionHealthMonitor {
             guard !Task.isCancelled else { return }
 
             while !Task.isCancelled {
+                guard let interval = await intervalForPass() else { break }
                 try? await Task.sleep(for: interval)
                 guard !Task.isCancelled else { break }
+                /// Asked again after the sleep as well, so turning scheduled checks off during a
+                /// long interval stops the next one rather than the one after it.
+                guard await intervalForPass() != nil else { break }
                 await self.performHealthCheck()
                 /// A monitor that has given up has nothing left to ask. Without this it woke on
                 /// every interval for the life of the app to fail its own healthy-state guard and

--- a/TablePro/Core/Database/DatabaseManager+EnsureConnected.swift
+++ b/TablePro/Core/Database/DatabaseManager+EnsureConnected.swift
@@ -14,7 +14,9 @@ extension DatabaseManager {
     ) async throws {
         /// An installed driver is only a reason to skip while it still answers. A reconnect that
         /// gave up leaves one behind, and returning here made Reconnect a button that did nothing
-        /// on the one connection that needed it.
+        /// on the one connection that needed it. A driver nobody has heard from in a while is the
+        /// same problem one step earlier, which is what the check answers.
+        await verifyBeforeUse(connection.id)
         if let session = activeSessions[connection.id], session.driver != nil, session.liveness == .live {
             return
         }

--- a/TablePro/Core/Database/DatabaseManager+Health.swift
+++ b/TablePro/Core/Database/DatabaseManager+Health.swift
@@ -38,7 +38,7 @@ extension DatabaseManager {
         /// whichever path happens to open it.
         guard supportsHealthChecks(connectionId) else { return }
 
-        guard let interval = AppSettingsManager.shared.general.connectionHealthCheck.interval else {
+        guard AppSettingsManager.shared.general.connectionHealthCheck.interval != nil else {
             Self.logger.info("Health monitoring is on demand, starting no monitor for \(connectionId)")
             return
         }
@@ -47,7 +47,7 @@ extension DatabaseManager {
 
         let monitor = ConnectionHealthMonitor(
             connectionId: connectionId,
-            pingInterval: interval,
+            pingInterval: { await AppSettingsManager.shared.general.connectionHealthCheck.interval },
             pingHandler: { [weak self] in
                 guard let self else { return false }
                 // Skip ping while a user query is in-flight to avoid racing
@@ -138,6 +138,14 @@ extension DatabaseManager {
                     session.status = .disconnected
                 }
                 markSessionUnreachable(connectionId, startedWith: attemptedDriver, info: Self.declinedReconnectInfo)
+                return .abort
+            }
+            /// The same fence the give-up sites carry. A reconnect blocked in a C call cannot be
+            /// cancelled, so a losing attempt finishes late: adopting its driver here would install
+            /// it over the one a manual reconnect or a reopen had already put in place, and the
+            /// window would then be talking to a server nobody selected.
+            guard activeSessions[connectionId]?.driver === attemptedDriver else {
+                result.driver.disconnect()
                 return .abort
             }
             updateSession(connectionId) { session in

--- a/TablePro/Core/Database/DatabaseManager+Health.swift
+++ b/TablePro/Core/Database/DatabaseManager+Health.swift
@@ -20,13 +20,34 @@ extension DatabaseManager {
         case abort
     }
 
-    /// Start health monitoring for a connection
+    /// Start health monitoring for a connection.
+    ///
+    /// The interval is the user's, and one of its values is "never". On that setting no monitor is
+    /// built at all rather than one with a very long interval, because a task that wakes up to
+    /// decide it has nothing to do is still traffic on someone's battery. What replaces it is
+    /// `verifyBeforeUse`, which checks the connection when the user reaches for it.
     internal func startHealthMonitor(for connectionId: UUID) async {
-        Self.logger.info("startHealthMonitor called for \(connectionId) (existing monitors: \(self.healthMonitors.count))")
         await stopHealthMonitor(for: connectionId)
+
+        /// A session with no driver has nothing to check, which is what a placeholder registered
+        /// before its connect finishes is. Pinging one turns into a reconnect competing with the
+        /// connect already in flight.
+        guard activeSessions[connectionId]?.driver != nil else { return }
+        /// The driver's own answer, asked here rather than at each call site so they cannot drift:
+        /// an engine that says it holds no connection to check must not be given a monitor by
+        /// whichever path happens to open it.
+        guard supportsHealthChecks(connectionId) else { return }
+
+        guard let interval = AppSettingsManager.shared.general.connectionHealthCheck.interval else {
+            Self.logger.info("Health monitoring is on demand, starting no monitor for \(connectionId)")
+            return
+        }
+
+        Self.logger.info("startHealthMonitor called for \(connectionId) (existing monitors: \(self.healthMonitors.count))")
 
         let monitor = ConnectionHealthMonitor(
             connectionId: connectionId,
+            pingInterval: interval,
             pingHandler: { [weak self] in
                 guard let self else { return false }
                 // Skip ping while a user query is in-flight to avoid racing
@@ -48,6 +69,7 @@ extension DatabaseManager {
                 }
                 do {
                     try await mainDriver.ping()
+                    await self.markSessionVerified(connectionId)
                     return true
                 } catch {
                     Self.logger.debug("Ping failed for \(connectionId): \(error.localizedDescription)")
@@ -373,14 +395,7 @@ extension DatabaseManager {
             }
             markSessionLive(sessionId)
 
-            // Restart health monitoring if the plugin supports it
-            let supportsHealthReconnect = PluginMetadataRegistry.shared.snapshot(
-                for: session.connection.type
-            )?.supportsHealthMonitor ?? true
-
-            if supportsHealthReconnect {
-                await startHealthMonitor(for: sessionId)
-            }
+            await startHealthMonitor(for: sessionId)
 
             AppEvents.shared.databaseDidConnect.send(DatabaseDidConnect(connectionId: sessionId))
 

--- a/TablePro/Core/Database/DatabaseManager+ScopedDriver.swift
+++ b/TablePro/Core/Database/DatabaseManager+ScopedDriver.swift
@@ -178,7 +178,11 @@ extension DatabaseManager {
         scope: DatabaseScope,
         _ body: @Sendable @escaping (DatabaseDriver) async throws -> T
     ) async throws -> T {
-        try await sessionDriverGate.withExclusiveAccess(scope.connectionId) {
+        /// Outside the gate on purpose. A verification that has to reconnect runs the whole
+        /// reconnect, which restores the schema and the database on the new driver, and doing that
+        /// while holding the gate would deadlock the very thing waiting to be pinned.
+        await verifyBeforeUse(scope.connectionId)
+        return try await sessionDriverGate.withExclusiveAccess(scope.connectionId) {
             try await trackOperation(sessionId: scope.connectionId) {
                 try Task.checkCancellation()
                 guard let driver = driver(for: scope.connectionId) else {

--- a/TablePro/Core/Database/DatabaseManager+ScopedDriver.swift
+++ b/TablePro/Core/Database/DatabaseManager+ScopedDriver.swift
@@ -182,6 +182,12 @@ extension DatabaseManager {
         /// reconnect, which restores the schema and the database on the new driver, and doing that
         /// while holding the gate would deadlock the very thing waiting to be pinned.
         await verifyBeforeUse(scope.connectionId)
+        /// A check that failed and could not recover left the driver installed and disconnected,
+        /// so the presence of a driver below is not enough. Refusing here is the point of checking
+        /// at all: without it the user's own work runs on a handle the app already knows is dead.
+        guard isUsable(scope.connectionId) else {
+            throw DatabaseError.notConnected
+        }
         return try await sessionDriverGate.withExclusiveAccess(scope.connectionId) {
             try await trackOperation(sessionId: scope.connectionId) {
                 try Task.checkCancellation()

--- a/TablePro/Core/Database/DatabaseManager+Sessions.swift
+++ b/TablePro/Core/Database/DatabaseManager+Sessions.swift
@@ -158,6 +158,7 @@ extension DatabaseManager {
                 /// that gave up on this same entry, so the mark and the reason it carried go here.
                 session.liveness = .live
                 disconnectReasons.removeValue(forKey: connection.id)
+                markSessionVerified(connection.id)
                 if let passwordOverride, !connection.usesAWSIAM {
                     session.cachedPassword = passwordOverride
                 }
@@ -169,13 +170,7 @@ extension DatabaseManager {
             MacAnalyticsProvider.shared.markConnectionSucceeded()
             AppEvents.shared.databaseDidConnect.send(DatabaseDidConnect(connectionId: connection.id))
 
-            let supportsHealth = PluginMetadataRegistry.shared.snapshot(
-                for: connection.type
-            )?.supportsHealthMonitor ?? true
-
-            if supportsHealth {
-                await startHealthMonitor(for: connection.id)
-            }
+            await startHealthMonitor(for: connection.id)
         } catch {
             let cancelled = isAttemptCancelled(attempt, for: connection.id)
             var reportedError = error
@@ -297,6 +292,7 @@ extension DatabaseManager {
         guard !database.isEmpty else {
             throw DatabaseError.unsupportedOperation
         }
+        await verifyBeforeUse(connectionId)
         guard let driver = driver(for: connectionId) else {
             throw DatabaseError.notConnected
         }
@@ -389,6 +385,7 @@ extension DatabaseManager {
     }
 
     func switchSchema(to schema: String, for connectionId: UUID) async throws {
+        await verifyBeforeUse(connectionId)
         guard let driver = driver(for: connectionId),
               let schemaDriver = driver as? SchemaSwitchable else {
             throw DatabaseError.unsupportedOperation
@@ -637,6 +634,7 @@ extension DatabaseManager {
     internal func markSessionLive(_ sessionId: UUID) {
         guard activeSessions[sessionId] != nil else { return }
         disconnectReasons.removeValue(forKey: sessionId)
+        markSessionVerified(sessionId)
         updateSession(sessionId) { session in
             session.liveness = .live
         }
@@ -660,6 +658,7 @@ extension DatabaseManager {
     internal func removeSessionEntry(for connectionId: UUID) {
         activeSessions.removeValue(forKey: connectionId)
         connectionStatusVersions.removeValue(forKey: connectionId)
+        forgetVerification(for: connectionId)
         AppEvents.shared.connectionStatusChanged.send(
             ConnectionStatusChange(connectionId: connectionId, status: .disconnected)
         )

--- a/TablePro/Core/Database/DatabaseManager+SystemEvents.swift
+++ b/TablePro/Core/Database/DatabaseManager+SystemEvents.swift
@@ -29,6 +29,10 @@ extension DatabaseManager {
 
         Task { @MainActor [weak self] in
             guard let self else { return }
+            /// Sleep is the one gap the freshness window cannot see: the clock moved but nothing
+            /// here observed it, so every answer the app is holding was given before a period the
+            /// server may well have closed the socket in.
+            self.forgetAllVerifications()
             await self.validateTunneledSessions()
         }
     }

--- a/TablePro/Core/Database/DatabaseManager+Verification.swift
+++ b/TablePro/Core/Database/DatabaseManager+Verification.swift
@@ -1,0 +1,157 @@
+//
+//  DatabaseManager+Verification.swift
+//  TablePro
+//
+
+import Combine
+import Foundation
+import os
+
+// MARK: - On-demand connection verification
+
+extension DatabaseManager {
+    /// Whether this connection is one TablePro checks at all.
+    ///
+    /// Asked here as well as in `startHealthMonitor` because the two are the same question: a
+    /// driver that says it holds nothing worth checking must not be checked by the scheduled path
+    /// or by the on-demand one. SQLite and DuckDB hold a file rather than a socket, and a check
+    /// would only run a query against a database that cannot have gone away.
+    internal func supportsHealthChecks(_ connectionId: UUID) -> Bool {
+        guard let session = activeSessions[connectionId] else { return false }
+        return PluginMetadataRegistry.shared.snapshot(
+            for: session.connection.type
+        )?.supportsHealthMonitor ?? true
+    }
+
+    /// Records that the server answered for this connection.
+    ///
+    /// Every path that gets a reply out of a driver calls this, the scheduled ping included. Its
+    /// success is otherwise invisible, because the monitor suppresses its own healthy-to-checking
+    /// callback: nothing downstream would learn that the connection had just answered, and the
+    /// on-demand check would run a second query minutes later for no reason.
+    internal func markSessionVerified(_ connectionId: UUID, at date: Date = Date()) {
+        guard activeSessions[connectionId] != nil else { return }
+        lastVerifiedAt[connectionId] = date
+    }
+
+    internal func forgetVerification(for connectionId: UUID) {
+        lastVerifiedAt.removeValue(forKey: connectionId)
+    }
+
+    /// Makes the app stop believing every connection at once.
+    ///
+    /// A Mac that slept comes back with sockets the server closed hours ago, and the freshness
+    /// window has no way to know that: wall-clock time passed but nothing here observed it. So a
+    /// wake throws the answers away and the next thing anyone does re-asks.
+    internal func forgetAllVerifications() {
+        lastVerifiedAt.removeAll()
+    }
+
+    /// Checks a connection the app has not heard from recently, before the user's own work runs on
+    /// it, and reconnects it if it has gone away.
+    ///
+    /// This is what replaces the poll when the user turns the poll down or off. Without it,
+    /// `ConnectionSession.liveness` would be written only by the health monitor and by the initial
+    /// connect, so a connection whose monitor never runs stays `.live` forever: `ensureConnected`
+    /// returns early on that, the toolbar keeps reporting a healthy connection, and the user's next
+    /// query is the first thing to discover the socket is dead.
+    ///
+    /// It costs nothing on the default setting, where the scheduled check answers every 30 seconds
+    /// and stamps the connection fresh each time.
+    internal func verifyBeforeUse(_ connectionId: UUID) async {
+        guard let session = activeSessions[connectionId], let driver = session.driver else { return }
+        guard supportsHealthChecks(connectionId) else { return }
+        /// A session already known to be in trouble has a reconnect of its own, either the
+        /// monitor's or the one `ensureConnected` is about to run. Checking it again would only
+        /// race them.
+        guard session.liveness == .live else { return }
+        /// A query already on this driver is a better liveness answer than a ping, and pinging
+        /// across it would race on a connection that is not thread-safe.
+        guard queriesInFlight[connectionId] == nil else { return }
+        /// No record means no answer, which is a reason to ask rather than a reason to assume.
+        /// That is also what makes waking from sleep work: it throws every answer away, and the
+        /// next thing anyone does pays for one check.
+        if let last = lastVerifiedAt[connectionId], ConnectionHealthCheck.isFresh(last) { return }
+
+        try? await verificationDedup.execute(key: connectionId) {
+            await self.runVerification(connectionId, driver: driver)
+        }
+    }
+
+    /// A monitor is built once, when its connection opens, so a change to how often TablePro
+    /// checks its connections reaches nothing already open without this.
+    ///
+    /// The restarts run one after another rather than one task per event. `startHealthMonitor`
+    /// awaits the outgoing monitor's task, so two changes in quick succession could otherwise
+    /// install two monitors and leave the first running outside `healthMonitors`, where nothing
+    /// can ever stop it again.
+    internal func observeHealthCheckSetting() {
+        healthCheckSettingCancellable = AppEvents.shared.connectionHealthCheckChanged
+            .receive(on: RunLoop.main)
+            .sink { [weak self] in
+                guard let self else { return }
+                let previous = self.healthMonitorRestart
+                self.healthMonitorRestart = Task { @MainActor in
+                    await previous?.value
+                    await self.restartHealthMonitors()
+                }
+            }
+    }
+
+    /// Only sessions that are working right now are re-armed.
+    ///
+    /// Stopping a monitor inside its reconnect backoff cancels the attempt without any state
+    /// transition, and the manager has already written `.connecting` and `.recovering` by then, so
+    /// a session caught mid-reconnect would be left in that state with nothing left to move it. It
+    /// keeps the monitor it has and picks the new interval up the next time it connects. A session
+    /// whose monitor gave up is skipped for the same reason in reverse: the give-up was
+    /// deliberate, and a fresh monitor would resume retries it was meant to end.
+    private func restartHealthMonitors() async {
+        for connectionId in Array(activeSessions.keys) {
+            guard let session = activeSessions[connectionId],
+                  session.driver != nil,
+                  session.isConnected,
+                  session.liveness == .live,
+                  await monitorIsHealthy(connectionId)
+            else { continue }
+            await startHealthMonitor(for: connectionId)
+        }
+    }
+
+    private func monitorIsHealthy(_ connectionId: UUID) async -> Bool {
+        guard let monitor = healthMonitors[connectionId] else { return true }
+        return await monitor.currentState == .healthy
+    }
+
+    /// `driver` is the handle the check was made against, and every outcome is fenced on it still
+    /// being the session's. A ping cannot be cancelled once it is inside a C call, so a manual
+    /// reconnect or a close and reopen can replace the driver while this is suspended: applying a
+    /// late failure would then disconnect the driver that replaced it, and applying a late success
+    /// would report a connection healthy on the strength of a handle nobody uses any more.
+    private func runVerification(_ connectionId: UUID, driver: DatabaseDriver) async {
+        do {
+            try await driver.ping()
+            guard activeSessions[connectionId]?.driver === driver else { return }
+            markSessionLive(connectionId)
+        } catch {
+            guard activeSessions[connectionId]?.driver === driver else { return }
+            Self.logger.info("Connection \(connectionId) did not answer before use, reconnecting")
+            let outcome = await performHealthMonitorReconnect(connectionId: connectionId)
+            guard outcome != .success else { return }
+            /// The reconnect disconnected the installed driver before it failed, so the session is
+            /// holding a handle that cannot work. Saying so is the whole point: `ensureConnected`
+            /// and the window both read liveness, and leaving it `.live` puts the user's own
+            /// operation on a dead socket with nothing scheduled to notice.
+            markSessionUnreachable(
+                connectionId,
+                startedWith: activeSessions[connectionId]?.driver,
+                info: Self.unreachableBeforeUseInfo
+            )
+        }
+    }
+
+    internal static let unreachableBeforeUseInfo = ConnectionFailureInfo(
+        message: String(localized: "The connection stopped responding."),
+        recoverySuggestion: String(localized: "Reconnect to try again.")
+    )
+}

--- a/TablePro/Core/Database/DatabaseManager+Verification.swift
+++ b/TablePro/Core/Database/DatabaseManager+Verification.swift
@@ -78,13 +78,29 @@ extension DatabaseManager {
         }
     }
 
-    /// A monitor is built once, when its connection opens, so a change to how often TablePro
-    /// checks its connections reaches nothing already open without this.
+    /// Whether the connection is usable right now, for a caller about to run the user's own work
+    /// on it. A check that failed and could not recover leaves the driver installed but
+    /// disconnected, so "a driver is present" is not the question worth asking.
+    internal func isUsable(_ connectionId: UUID) -> Bool {
+        guard let session = activeSessions[connectionId], session.driver != nil else { return false }
+        switch session.liveness {
+        case .live, .recovering: return true
+        case .unreachable: return false
+        }
+    }
+
+    /// Applies a change to how often TablePro checks its connections.
     ///
-    /// The restarts run one after another rather than one task per event. `startHealthMonitor`
-    /// awaits the outgoing monitor's task, so two changes in quick succession could otherwise
-    /// install two monitors and leave the first running outside `healthMonitors`, where nothing
-    /// can ever stop it again.
+    /// It only ever *starts* a monitor, never stops or rebuilds one. A running monitor reads the
+    /// interval afresh on every pass, so turning checks down or off reaches it wherever it is,
+    /// including mid-ping and mid-reconnect, and ends its loop on its own. That is what removes
+    /// the three ways a restart could go wrong: stranding a session whose reconnect was cancelled
+    /// without a state transition, orphaning a monitor outside `healthMonitors` when two changes
+    /// raced, and skipping a session that happened not to be idle at the moment the user chose.
+    ///
+    /// The one thing the monitor cannot do for itself is come back, because turning checks off
+    /// ends its task. So a change back to a polling interval starts one for every session that has
+    /// none.
     internal func observeHealthCheckSetting() {
         healthCheckSettingCancellable = AppEvents.shared.connectionHealthCheckChanged
             .receive(on: RunLoop.main)
@@ -93,34 +109,22 @@ extension DatabaseManager {
                 let previous = self.healthMonitorRestart
                 self.healthMonitorRestart = Task { @MainActor in
                     await previous?.value
-                    await self.restartHealthMonitors()
+                    await self.startMissingHealthMonitors()
                 }
             }
     }
 
-    /// Only sessions that are working right now are re-armed.
-    ///
-    /// Stopping a monitor inside its reconnect backoff cancels the attempt without any state
-    /// transition, and the manager has already written `.connecting` and `.recovering` by then, so
-    /// a session caught mid-reconnect would be left in that state with nothing left to move it. It
-    /// keeps the monitor it has and picks the new interval up the next time it connects. A session
-    /// whose monitor gave up is skipped for the same reason in reverse: the give-up was
-    /// deliberate, and a fresh monitor would resume retries it was meant to end.
-    private func restartHealthMonitors() async {
+    private func startMissingHealthMonitors() async {
+        guard AppSettingsManager.shared.general.connectionHealthCheck.interval != nil else { return }
         for connectionId in Array(activeSessions.keys) {
-            guard let session = activeSessions[connectionId],
+            guard healthMonitors[connectionId] == nil,
+                  let session = activeSessions[connectionId],
                   session.driver != nil,
                   session.isConnected,
-                  session.liveness == .live,
-                  await monitorIsHealthy(connectionId)
+                  session.liveness == .live
             else { continue }
             await startHealthMonitor(for: connectionId)
         }
-    }
-
-    private func monitorIsHealthy(_ connectionId: UUID) async -> Bool {
-        guard let monitor = healthMonitors[connectionId] else { return true }
-        return await monitor.currentState == .healthy
     }
 
     /// `driver` is the handle the check was made against, and every outcome is fenced on it still
@@ -130,7 +134,13 @@ extension DatabaseManager {
     /// would report a connection healthy on the strength of a handle nobody uses any more.
     private func runVerification(_ connectionId: UUID, driver: DatabaseDriver) async {
         do {
-            try await driver.ping()
+            /// Counted as an operation for the length of the check, so the scheduled monitor's own
+            /// ping skips at its `queriesInFlight` guard rather than entering the same driver
+            /// alongside this one. Drivers are not thread-safe and the two paths have separate
+            /// schedules, so nothing else stops them meeting.
+            try await trackOperation(sessionId: connectionId) {
+                try await driver.ping()
+            }
             guard activeSessions[connectionId]?.driver === driver else { return }
             markSessionLive(connectionId)
         } catch {
@@ -142,9 +152,13 @@ extension DatabaseManager {
             /// holding a handle that cannot work. Saying so is the whole point: `ensureConnected`
             /// and the window both read liveness, and leaving it `.live` puts the user's own
             /// operation on a dead socket with nothing scheduled to notice.
+            ///
+            /// Fenced on the driver this check was made against, not on whatever the session holds
+            /// now: reading it back would compare the value to itself and mark a replacement
+            /// unreachable on the strength of an attempt that lost.
             markSessionUnreachable(
                 connectionId,
-                startedWith: activeSessions[connectionId]?.driver,
+                startedWith: driver,
                 info: Self.unreachableBeforeUseInfo
             )
         }

--- a/TablePro/Core/Database/DatabaseManager.swift
+++ b/TablePro/Core/Database/DatabaseManager.swift
@@ -60,6 +60,21 @@ final class DatabaseManager {
     /// Tracks when the first query started for each session (used for staleness detection).
     @ObservationIgnored internal var queryStartTimes: [UUID: Date] = [:]
 
+    /// When each connection's server last answered, whether that was the connect itself, a health
+    /// check, or a check made because the user was about to use it.
+    ///
+    /// It lives beside the other per-connection bookkeeping rather than on `ConnectionSession`
+    /// because it is not connection state the UI renders, and putting it there would have made it
+    /// unwritable in practice: `updateSession` discards a write that leaves
+    /// `isContentViewEquivalent` unchanged, which is exactly a timestamp-only write, and going
+    /// around that through `setSession` broadcasts a status change nothing happened to.
+    @ObservationIgnored internal var lastVerifiedAt: [UUID: Date] = [:]
+
+    /// Collapses concurrent verifications of one connection into a single check, so a window
+    /// waking up with several tabs pointed at the same connection asks once. Separate from
+    /// `ensureConnectedDedup` because a verification can run while a connect is in flight.
+    @ObservationIgnored internal let verificationDedup = OnceTask<UUID, Void>()
+
     /// Connection IDs currently undergoing SSH tunnel recovery.
     /// Prevents duplicate concurrent recovery when both the keepalive death handler
     /// and the wake-from-sleep handler fire for the same connection.
@@ -83,6 +98,9 @@ final class DatabaseManager {
     @ObservationIgnored internal var tabStatePersister: (any SessionTabStatePersisting)?
 
     @ObservationIgnored internal var connectionUpdatedCancellable: AnyCancellable?
+    @ObservationIgnored internal var healthCheckSettingCancellable: AnyCancellable?
+    /// The tail of the serialized monitor restarts. See `observeHealthCheckSetting`.
+    @ObservationIgnored internal var healthMonitorRestart: Task<Void, Never>?
 
     @ObservationIgnored internal let ensureConnectedDedup = OnceTask<UUID, Void>()
 
@@ -146,5 +164,6 @@ final class DatabaseManager {
         self.appSettingsStorage = appSettingsStorage
         self.pluginManager = pluginManager
         observeConnectionUpdates()
+        observeHealthCheckSetting()
     }
 }

--- a/TablePro/Core/Events/AppEvents.swift
+++ b/TablePro/Core/Events/AppEvents.swift
@@ -21,6 +21,10 @@ final class AppEvents {
 
     let editorSettingsChanged = PassthroughSubject<Void, Never>()
 
+    /// A live session's health monitor is started once, at connect, so a change to how often
+    /// TablePro checks its connections reaches nothing already open without this.
+    let connectionHealthCheckChanged = PassthroughSubject<Void, Never>()
+
     let dataGridSettingsChanged = PassthroughSubject<Void, Never>()
 
     /// The menu bar re-syncs itself through `MainMenuBuilder`, but a window's toolbar advertises

--- a/TablePro/Core/Services/Export/ImportService.swift
+++ b/TablePro/Core/Services/Export/ImportService.swift
@@ -62,7 +62,13 @@ final class ImportService {
             throw PluginImportError.importFailed("Import format '\(formatId)' not found")
         }
 
-        guard let driver = DatabaseManager.shared.driver(for: connection.id) else {
+        /// An import is often the first thing done after a long idle spell, and it writes. With
+        /// scheduled checks turned down or off nothing else would have noticed the socket had gone,
+        /// so it is checked here rather than discovered partway through a batch of inserts.
+        await DatabaseManager.shared.verifyBeforeUse(connection.id)
+        guard DatabaseManager.shared.isUsable(connection.id),
+              let driver = DatabaseManager.shared.driver(for: connection.id)
+        else {
             throw DatabaseError.notConnected
         }
 

--- a/TablePro/Core/Services/Query/MetadataConnectionPool.swift
+++ b/TablePro/Core/Services/Query/MetadataConnectionPool.swift
@@ -61,6 +61,24 @@ final class MetadataConnectionPool {
     private let maxPerConnection = 6
     private let operationTimeoutSeconds: Double = 15
     private let preparationTimeoutSeconds: Double = 60
+    private var sweeper: Task<Void, Never>?
+
+    /// How long a pooled connection may sit unused before it is handed back.
+    ///
+    /// These are connections the user never opened: the pool takes one per database the sidebar
+    /// touches, up to six, and the only thing that ever closed one was the count cap at acquire
+    /// time or the whole connection going away. Browsing six databases and then leaving the app
+    /// open left six idle server connections held for as long as it ran (#2700).
+    ///
+    /// Ten minutes rather than something tighter, because re-taking one is a whole connect,
+    /// measured at 1.7-5.8ms on loopback but 800-1900ms across the internet, and someone still
+    /// working must never pay that. Ten minutes of silence is nobody still working.
+    static let idleTimeout: TimeInterval = 600
+
+    /// The sweeper wakes more often than the timeout so a connection that goes idle just after a
+    /// tick does not wait a whole second timeout, and never so often that an idle app spends the
+    /// day waking up.
+    private static let sweepInterval: Duration = .seconds(60)
 
     private init() {}
 
@@ -89,6 +107,7 @@ final class MetadataConnectionPool {
         where key.scope.connectionId == connectionId && key.scope.database == database {
             closeOrDeferEntry(forKey: key)
         }
+        stopSweeperIfEmpty()
     }
 
     func closeAll(connectionId: UUID) {
@@ -99,13 +118,33 @@ final class MetadataConnectionPool {
         for key in entries.keys where key.scope.connectionId == connectionId {
             closeOrDeferEntry(forKey: key)
         }
+        stopSweeperIfEmpty()
     }
 
     #if DEBUG
     /// Seeds a connected driver as the pooled connection for `scope`, so a test can observe
     /// what runs on the pool without a plugin to open a real connection.
-    internal func injectEntry(_ driver: DatabaseDriver, scope: DatabaseScope, workload: Workload = .interactive) {
-        entries[Key(scope: scope, workload: workload)] = Entry(driver: driver)
+    internal func injectEntry(
+        _ driver: DatabaseDriver,
+        scope: DatabaseScope,
+        workload: Workload = .interactive,
+        lastUsed: Date = Date()
+    ) {
+        let entry = Entry(driver: driver)
+        entry.lastUsed = lastUsed
+        entries[Key(scope: scope, workload: workload)] = entry
+    }
+
+    internal func pooledDriverCount(for connectionId: UUID) -> Int {
+        entries.keys.filter { $0.scope.connectionId == connectionId }.count
+    }
+
+    internal func markInFlight(scope: DatabaseScope, workload: Workload = .interactive) {
+        entries[Key(scope: scope, workload: workload)]?.inFlightCount += 1
+    }
+
+    internal var hasSweeper: Bool {
+        sweeper != nil
     }
     #endif
 
@@ -128,8 +167,16 @@ final class MetadataConnectionPool {
     private func acquireEntry(scope: DatabaseScope, workload: Workload) async throws -> Entry {
         let connectionId = scope.connectionId
         let key = Key(scope: scope, workload: workload)
-        if let entry = entries[key], entry.driver.status == .connected {
-            return entry
+        /// A cached entry is only worth reusing while it is both connected and recent. The
+        /// staleness half matters even with the sweeper running, because a Mac that slept comes
+        /// back with entries the sweeper never got to and sockets the server has long since
+        /// closed. The old entry is closed rather than left behind: overwriting `entries[key]`
+        /// with a fresh one used to leak the driver it replaced.
+        if let entry = entries[key] {
+            if entry.driver.status == .connected, !Self.isStale(entry.lastUsed) {
+                return entry
+            }
+            closeOrDeferEntry(forKey: key)
         }
 
         if let inFlight = pending[key] {
@@ -151,6 +198,7 @@ final class MetadataConnectionPool {
                 return
             }
             entries[key] = entry
+            startSweeperIfNeeded()
         }
         pending[key] = task
         defer { if pending[key] == task { pending.removeValue(forKey: key) } }
@@ -289,6 +337,41 @@ final class MetadataConnectionPool {
         } catch is TimeoutError {
             throw DatabaseError.connectionFailed(timeoutMessage)
         }
+    }
+
+    static func isStale(_ lastUsed: Date, now: Date = Date()) -> Bool {
+        now.timeIntervalSince(lastUsed) >= idleTimeout
+    }
+
+    /// Runs only while the pool is holding something, so an app with nothing pooled schedules
+    /// nothing at all. One task for the whole pool rather than one per connection, because the
+    /// pool is one map and a sweep reads all of it.
+    private func startSweeperIfNeeded() {
+        guard sweeper == nil, !entries.isEmpty else { return }
+        sweeper = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: Self.sweepInterval)
+                guard !Task.isCancelled else { return }
+                self?.sweepIdleEntries()
+            }
+        }
+    }
+
+    private func stopSweeperIfEmpty() {
+        guard entries.isEmpty, pending.isEmpty else { return }
+        sweeper?.cancel()
+        sweeper = nil
+    }
+
+    /// Hands back every connection nobody has used for `idleTimeout`. An entry with work on it is
+    /// left alone whatever its age: `lastUsed` is stamped when the work starts, so a long export
+    /// would otherwise have its own connection closed underneath it.
+    internal func sweepIdleEntries(now: Date = Date()) {
+        for (key, entry) in entries where entry.inFlightCount == 0 && Self.isStale(entry.lastUsed, now: now) {
+            entries.removeValue(forKey: key)
+            entry.driver.disconnect()
+        }
+        stopSweeperIfEmpty()
     }
 
     private func evictIdleIfNeeded(for connectionId: UUID) {

--- a/TablePro/Core/Storage/AppSettingsManager.swift
+++ b/TablePro/Core/Storage/AppSettingsManager.swift
@@ -16,6 +16,9 @@ final class AppSettingsManager {
             if oldValue.showWorkspaceRail != general.showWorkspaceRail {
                 appEvents.workspaceRailVisibilityChanged.send(())
             }
+            if oldValue.connectionHealthCheck != general.connectionHealthCheck {
+                appEvents.connectionHealthCheckChanged.send(())
+            }
             syncTracker.markDirty(.settings, id: AppSettingsCategory.general)
         }
     }

--- a/TablePro/Models/Settings/ConnectionHealthCheck.swift
+++ b/TablePro/Models/Settings/ConnectionHealthCheck.swift
@@ -1,0 +1,55 @@
+//
+//  ConnectionHealthCheck.swift
+//  TablePro
+//
+
+import Foundation
+
+/// How often TablePro asks an open connection whether it still works.
+///
+/// The check is a real query on almost every engine, so a connection nobody is using still costs
+/// the server about 2,880 of them a day. That is invisible on a database you own and expensive on
+/// one you rent: a serverless compute suspends only after some minutes with no queries, so a
+/// steady heartbeat holds it awake and billing around the clock (#2700).
+///
+/// `onDemand` is the answer for those, and it is not the same as having no answer. TablePro checks
+/// the connection the first time it is used after a quiet spell instead, which costs one round
+/// trip the user's own action paid for, rather than a stream of them nobody asked for.
+internal enum ConnectionHealthCheck: Int, Codable, CaseIterable, Identifiable, Sendable {
+    case onDemand = 0
+    case every30Seconds = 30
+    case every5Minutes = 300
+    case every15Minutes = 900
+
+    internal var id: Int { rawValue }
+
+    internal var title: String {
+        switch self {
+        case .onDemand: return String(localized: "Only when I use the connection")
+        case .every30Seconds: return String(localized: "Every 30 seconds")
+        case .every5Minutes: return String(localized: "Every 5 minutes")
+        case .every15Minutes: return String(localized: "Every 15 minutes")
+        }
+    }
+
+    /// How long to wait between checks, or nil when nothing is scheduled at all. Nil is why
+    /// `onDemand` starts no monitor rather than starting one with a very long interval: a task
+    /// that never has anything to do is still a task that wakes up.
+    internal var interval: Duration? {
+        guard rawValue > 0 else { return nil }
+        return .seconds(rawValue)
+    }
+
+    /// How recently the connection must have answered for TablePro to take its word for it.
+    ///
+    /// One value for every setting rather than one per case, because it answers a question the
+    /// poll rate has no part in: how long a socket that worked stays worth believing. At the
+    /// default it never fires, since a check every 30 seconds keeps the answer far fresher than
+    /// this; on the long intervals and on `onDemand` it is what makes the first action after a
+    /// quiet spell verify before it runs.
+    internal static let freshness: Duration = .seconds(300)
+
+    internal static func isFresh(_ lastVerifiedAt: Date, now: Date = Date()) -> Bool {
+        now.timeIntervalSince(lastVerifiedAt) < TimeInterval(freshness.components.seconds)
+    }
+}

--- a/TablePro/Models/Settings/GeneralSettings.swift
+++ b/TablePro/Models/Settings/GeneralSettings.swift
@@ -79,6 +79,9 @@ struct GeneralSettings: Codable, Equatable {
     /// How tall sidebar rows are drawn, following the system Appearance setting unless overridden
     var sidebarRowSize: SidebarRowSizePreference
 
+    /// How often TablePro checks that an open connection still works
+    var connectionHealthCheck: ConnectionHealthCheck
+
     static let `default` = GeneralSettings(
         startupBehavior: .reopenLast,
         language: .system,
@@ -89,7 +92,8 @@ struct GeneralSettings: Codable, Equatable {
         showObjectComments: true,
         showObjectIcons: true,
         showWorkspaceRail: true,
-        sidebarRowSize: .matchSystem
+        sidebarRowSize: .matchSystem,
+        connectionHealthCheck: .every30Seconds
     )
 
     init(
@@ -102,7 +106,8 @@ struct GeneralSettings: Codable, Equatable {
         showObjectComments: Bool = true,
         showObjectIcons: Bool = true,
         showWorkspaceRail: Bool = true,
-        sidebarRowSize: SidebarRowSizePreference = .matchSystem
+        sidebarRowSize: SidebarRowSizePreference = .matchSystem,
+        connectionHealthCheck: ConnectionHealthCheck = .every30Seconds
     ) {
         self.startupBehavior = startupBehavior
         self.language = language
@@ -114,6 +119,7 @@ struct GeneralSettings: Codable, Equatable {
         self.showObjectIcons = showObjectIcons
         self.showWorkspaceRail = showWorkspaceRail
         self.sidebarRowSize = sidebarRowSize
+        self.connectionHealthCheck = connectionHealthCheck
     }
 
     init(from decoder: Decoder) throws {
@@ -130,5 +136,12 @@ struct GeneralSettings: Codable, Equatable {
         sidebarRowSize = try container.decodeIfPresent(
             SidebarRowSizePreference.self, forKey: .sidebarRowSize
         ) ?? .matchSystem
+        /// Decoded through its raw value rather than as the enum. Settings sync between devices,
+        /// so a newer TablePro can write an interval this build has no case for, and decoding that
+        /// as the enum throws and takes the whole of General down with it.
+        connectionHealthCheck = ConnectionHealthCheck(
+            rawValue: try container.decodeIfPresent(Int.self, forKey: .connectionHealthCheck)
+                ?? ConnectionHealthCheck.every30Seconds.rawValue
+        ) ?? .every30Seconds
     }
 }

--- a/TablePro/Views/Settings/GeneralSettingsView.swift
+++ b/TablePro/Views/Settings/GeneralSettingsView.swift
@@ -88,6 +88,22 @@ struct GeneralSettingsView: View {
                 .help(String(localized: "Layout for new connections on servers that support a database tree. Switch the current connection from the View menu."))
             }
 
+            Section("Connections") {
+                Picker("Check connections:", selection: $settings.connectionHealthCheck) {
+                    ForEach(ConnectionHealthCheck.allCases) { option in
+                        Text(option.title).tag(option)
+                    }
+                }
+                .accessibilityIdentifier("connection-health-check-picker")
+                .help(String(localized: """
+                    TablePro runs a small query on each open connection so it can notice a dropped \
+                    one and reconnect before you hit it. Only when I use the connection stops that \
+                    background traffic, which is what a database that sleeps when idle, or bills \
+                    per query, needs; TablePro then checks the connection the first time you use \
+                    it after a pause.
+                    """))
+            }
+
             Section("Query Execution") {
                 Picker("Query timeout:", selection: $settings.queryTimeoutSeconds) {
                     Text("No limit").tag(0)

--- a/TableProTests/Core/Autocomplete/SQLSchemaProviderTests.swift
+++ b/TableProTests/Core/Autocomplete/SQLSchemaProviderTests.swift
@@ -34,6 +34,7 @@ final class MockDatabaseDriver: DatabaseDriver, SchemaSwitchable, @unchecked Sen
     var fetchSchemaTablesCalls: [String] = []
     var applyQueryTimeoutValues: [Int] = []
     var cancelQueryCallCount = 0
+    var disconnectCallCount = 0
     var connectDelaySeconds: Double = 0
     var switchSchemaDelaySeconds: Double = 0
     var executeDelaySeconds: Double = 0
@@ -59,6 +60,7 @@ final class MockDatabaseDriver: DatabaseDriver, SchemaSwitchable, @unchecked Sen
     }
 
     func disconnect() {
+        disconnectCallCount += 1
         hangContinuation?.resume()
         hangContinuation = nil
     }

--- a/TableProTests/Core/Autocomplete/SQLSchemaProviderTests.swift
+++ b/TableProTests/Core/Autocomplete/SQLSchemaProviderTests.swift
@@ -35,6 +35,9 @@ final class MockDatabaseDriver: DatabaseDriver, SchemaSwitchable, @unchecked Sen
     var applyQueryTimeoutValues: [Int] = []
     var cancelQueryCallCount = 0
     var disconnectCallCount = 0
+    var pingCallCount = 0
+    var pingError: Error?
+    var pingDelaySeconds: Double = 0
     var connectDelaySeconds: Double = 0
     var switchSchemaDelaySeconds: Double = 0
     var executeDelaySeconds: Double = 0
@@ -74,6 +77,16 @@ final class MockDatabaseDriver: DatabaseDriver, SchemaSwitchable, @unchecked Sen
     }
 
     func testConnection() async throws -> Bool { true }
+
+    func ping() async throws {
+        pingCallCount += 1
+        if pingDelaySeconds > 0 {
+            try? await Task.sleep(nanoseconds: UInt64(pingDelaySeconds * 1_000_000_000))
+        }
+        if let pingError {
+            throw pingError
+        }
+    }
 
     func applyQueryTimeout(_ seconds: Int) async throws {
         applyQueryTimeoutValues.append(seconds)

--- a/TableProTests/Core/Database/ConnectionHealthCheckTests.swift
+++ b/TableProTests/Core/Database/ConnectionHealthCheckTests.swift
@@ -1,0 +1,86 @@
+//
+//  ConnectionHealthCheckTests.swift
+//  TableProTests
+//
+//  The setting behind #2700: how often TablePro talks to a database nobody is using, and the
+//  freshness rule that lets it stop talking without the app losing track of whether a connection
+//  still works.
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("Connection health check setting")
+struct ConnectionHealthCheckTests {
+    @Test("on demand schedules nothing")
+    func onDemandHasNoInterval() {
+        #expect(ConnectionHealthCheck.onDemand.interval == nil)
+    }
+
+    @Test("every other setting schedules its own interval")
+    func pollingSettingsCarryTheirInterval() {
+        #expect(ConnectionHealthCheck.every30Seconds.interval == .seconds(30))
+        #expect(ConnectionHealthCheck.every5Minutes.interval == .seconds(300))
+        #expect(ConnectionHealthCheck.every15Minutes.interval == .seconds(900))
+    }
+
+    @Test("an answer stays worth believing until the freshness window closes")
+    func freshnessIsMeasuredFromTheLastAnswer() {
+        let answered = Date()
+
+        #expect(ConnectionHealthCheck.isFresh(answered, now: answered))
+        #expect(ConnectionHealthCheck.isFresh(answered, now: answered.addingTimeInterval(299)))
+        #expect(!ConnectionHealthCheck.isFresh(answered, now: answered.addingTimeInterval(300)))
+        #expect(!ConnectionHealthCheck.isFresh(answered, now: answered.addingTimeInterval(3_600)))
+    }
+
+    /// The default has to be today's behaviour, or every user who never opens Settings gets a
+    /// change they did not ask for.
+    @Test("the default keeps the 30-second check")
+    func defaultIsTheThirtySecondCheck() {
+        #expect(GeneralSettings.default.connectionHealthCheck == .every30Seconds)
+    }
+
+    @Test("settings saved before the option existed decode to the default")
+    func absentKeyDecodesToTheDefault() throws {
+        let json = Data(#"{"startupBehavior":"reopenLast"}"#.utf8)
+
+        let decoded = try JSONDecoder().decode(GeneralSettings.self, from: json)
+
+        #expect(decoded.connectionHealthCheck == .every30Seconds)
+    }
+
+    /// Settings sync between devices, so a newer TablePro can write an interval this build has no
+    /// case for. Decoding that as the enum throws, which would take the whole of General down with
+    /// it and reset every other setting the user had.
+    @Test("an interval from a newer version falls back instead of failing the whole decode")
+    func unknownIntervalFallsBack() throws {
+        let json = Data(#"{"startupBehavior":"reopenLast","connectionHealthCheck":600,"queryTimeoutSeconds":90}"#.utf8)
+
+        let decoded = try JSONDecoder().decode(GeneralSettings.self, from: json)
+
+        #expect(decoded.connectionHealthCheck == .every30Seconds)
+        #expect(decoded.queryTimeoutSeconds == 90, "The rest of General survives an interval it does not know")
+    }
+
+    @Test("the choice survives a round trip through storage")
+    func choiceRoundTrips() throws {
+        var settings = GeneralSettings.default
+        settings.connectionHealthCheck = .onDemand
+
+        let data = try JSONEncoder().encode(settings)
+        let decoded = try JSONDecoder().decode(GeneralSettings.self, from: data)
+
+        #expect(decoded.connectionHealthCheck == .onDemand)
+    }
+
+    @Test("every option is offered to the picker exactly once")
+    func everyOptionIsSelectable() {
+        let cases = ConnectionHealthCheck.allCases
+
+        #expect(cases.count == 4)
+        #expect(Set(cases.map(\.id)).count == cases.count)
+        #expect(cases.allSatisfy { !$0.title.isEmpty })
+    }
+}

--- a/TableProTests/Core/Database/ConnectionVerificationTests.swift
+++ b/TableProTests/Core/Database/ConnectionVerificationTests.swift
@@ -243,6 +243,35 @@ struct ConnectionVerificationTests {
         await cleanUp(connectionId)
     }
 
+    /// A check that failed and could not recover leaves the driver installed and disconnected, so
+    /// the caller has to be told rather than handed it.
+    @Test("a connection whose check failed and could not recover is not usable")
+    func aFailedRecoveryLeavesTheConnectionUnusable() async {
+        Self.registerUnreachableTypeIfNeeded()
+        let driver = MockDatabaseDriver()
+        let connection = makeSession(driver: driver, typeId: Self.unreachableTypeId)
+        driver.pingError = DatabaseError.notConnected
+        DatabaseManager.shared.markSessionVerified(connection.id, at: .distantPast)
+
+        await DatabaseManager.shared.verifyBeforeUse(connection.id)
+
+        #expect(!DatabaseManager.shared.isUsable(connection.id))
+        await cleanUp(connection.id)
+    }
+
+    @Test("a working connection is usable, and a recovering one still is")
+    func aWorkingConnectionIsUsable() async {
+        let driver = MockDatabaseDriver()
+        let connection = makeSession(driver: driver)
+
+        #expect(DatabaseManager.shared.isUsable(connection.id))
+
+        DatabaseManager.shared.markSessionRecovering(connection.id)
+        #expect(DatabaseManager.shared.isUsable(connection.id), "A blip that is repairing itself is not a failure")
+
+        await cleanUp(connection.id)
+    }
+
     @Test("ending a session forgets when it last answered")
     func removingASessionForgetsItsAnswer() async {
         let driver = MockDatabaseDriver()

--- a/TableProTests/Core/Database/ConnectionVerificationTests.swift
+++ b/TableProTests/Core/Database/ConnectionVerificationTests.swift
@@ -1,0 +1,326 @@
+//
+//  ConnectionVerificationTests.swift
+//  TableProTests
+//
+//  With the health check turned down or off, nothing polls, so `ConnectionSession.liveness` has no
+//  writer but the initial connect. `verifyBeforeUse` is the second writer that keeps the app
+//  honest: it checks a connection nobody has heard from in a while at the moment someone reaches
+//  for it, and reconnects if it has gone (#2700).
+//
+
+import Foundation
+@testable import TablePro
+import TableProPluginKit
+import Testing
+
+@Suite("Connection verification before use", .serialized)
+@MainActor
+struct ConnectionVerificationTests {
+    private func makeSession(
+        driver: MockDatabaseDriver,
+        typeId: String = FakeMSSQLPlugin.databaseTypeId
+    ) -> DatabaseConnection {
+        FakeMSSQLPluginRegistration.registerIfNeeded()
+        var connection = TestFixtures.makeConnection(name: "Prod")
+        connection.type = DatabaseType(rawValue: typeId)
+        var session = ConnectionSession(connection: connection)
+        session.status = .connected
+        session.driver = driver
+        DatabaseManager.shared.injectSession(session, for: connection.id)
+        return connection
+    }
+
+    private func cleanUp(_ connectionId: UUID) async {
+        DatabaseManager.shared.removeSession(for: connectionId)
+        await SchemaService.shared.invalidate(connectionId: connectionId)
+    }
+
+    @Test("a connection that answered recently is not asked again")
+    func freshConnectionIsNotPinged() async {
+        let driver = MockDatabaseDriver()
+        let connection = makeSession(driver: driver)
+        DatabaseManager.shared.markSessionVerified(connection.id)
+
+        await DatabaseManager.shared.verifyBeforeUse(connection.id)
+
+        #expect(driver.pingCallCount == 0)
+        await cleanUp(connection.id)
+    }
+
+    @Test("a connection that has been silent too long is checked once")
+    func staleConnectionIsPingedOnce() async {
+        let driver = MockDatabaseDriver()
+        let connection = makeSession(driver: driver)
+        DatabaseManager.shared.markSessionVerified(connection.id, at: .distantPast)
+
+        await DatabaseManager.shared.verifyBeforeUse(connection.id)
+
+        #expect(driver.pingCallCount == 1)
+        await cleanUp(connection.id)
+    }
+
+    @Test("a successful check makes the connection fresh again, so the next use is free")
+    func aSuccessfulCheckRefreshesTheAnswer() async {
+        let driver = MockDatabaseDriver()
+        let connection = makeSession(driver: driver)
+        DatabaseManager.shared.markSessionVerified(connection.id, at: .distantPast)
+
+        await DatabaseManager.shared.verifyBeforeUse(connection.id)
+        await DatabaseManager.shared.verifyBeforeUse(connection.id)
+
+        #expect(driver.pingCallCount == 1)
+        await cleanUp(connection.id)
+    }
+
+    /// Everything else in the app treats `.live` as "this driver can be believed", so a check that
+    /// succeeded has to say so, or a session that recovered keeps carrying the reason it failed.
+    @Test("a successful check leaves the session live")
+    func aSuccessfulCheckMarksTheSessionLive() async {
+        let driver = MockDatabaseDriver()
+        let connection = makeSession(driver: driver)
+        DatabaseManager.shared.markSessionVerified(connection.id, at: .distantPast)
+
+        await DatabaseManager.shared.verifyBeforeUse(connection.id)
+
+        #expect(DatabaseManager.shared.activeSessions[connection.id]?.liveness == .live)
+        await cleanUp(connection.id)
+    }
+
+    @Test("a query already running on the driver is a better answer than a ping")
+    func aQueryInFlightSkipsTheCheck() async {
+        let driver = MockDatabaseDriver()
+        let connection = makeSession(driver: driver)
+        DatabaseManager.shared.markSessionVerified(connection.id, at: .distantPast)
+
+        _ = try? await DatabaseManager.shared.trackOperation(sessionId: connection.id) {
+            await DatabaseManager.shared.verifyBeforeUse(connection.id)
+        }
+
+        #expect(driver.pingCallCount == 0)
+        await cleanUp(connection.id)
+    }
+
+    /// A session the app already knows is in trouble has a reconnect of its own in flight.
+    @Test("a session that is already unreachable is left to its own reconnect")
+    func unreachableSessionIsNotChecked() async {
+        let driver = MockDatabaseDriver()
+        let connection = makeSession(driver: driver)
+        DatabaseManager.shared.markSessionVerified(connection.id, at: .distantPast)
+        DatabaseManager.shared.markSessionUnreachable(
+            connection.id,
+            startedWith: driver,
+            info: ConnectionFailureInfo(message: "gone")
+        )
+
+        await DatabaseManager.shared.verifyBeforeUse(connection.id)
+
+        #expect(driver.pingCallCount == 0)
+        await cleanUp(connection.id)
+    }
+
+    @Test("several callers reaching for one connection at once check it once between them")
+    func concurrentCallersCollapseIntoOneCheck() async {
+        let driver = MockDatabaseDriver()
+        let connection = makeSession(driver: driver)
+        DatabaseManager.shared.markSessionVerified(connection.id, at: .distantPast)
+
+        let connectionId = connection.id
+        let callers = (0 ..< 8).map { _ in
+            Task { @MainActor in await DatabaseManager.shared.verifyBeforeUse(connectionId) }
+        }
+        for caller in callers {
+            await caller.value
+        }
+
+        #expect(driver.pingCallCount == 1)
+        await cleanUp(connection.id)
+    }
+
+    /// Wall-clock time passes during sleep but nothing in the app observes it, so every answer it
+    /// is holding was given before a gap the server may well have closed the socket in.
+    @Test("waking from sleep makes every connection worth asking about again")
+    func wakeInvalidatesEveryAnswer() async {
+        let driver = MockDatabaseDriver()
+        let connection = makeSession(driver: driver)
+        DatabaseManager.shared.markSessionVerified(connection.id)
+
+        await DatabaseManager.shared.verifyBeforeUse(connection.id)
+        #expect(driver.pingCallCount == 0)
+
+        DatabaseManager.shared.forgetAllVerifications()
+        await DatabaseManager.shared.verifyBeforeUse(connection.id)
+
+        #expect(driver.pingCallCount == 1)
+        await cleanUp(connection.id)
+    }
+
+    /// The engines that hold a file rather than a socket opt out of health checks, and the
+    /// on-demand path is the same question asked at a different moment: it must not become the way
+    /// a check reaches them anyway.
+    @Test("an engine that opts out of health checks is not checked before use either")
+    func optedOutEngineIsNotChecked() async {
+        let driver = MockDatabaseDriver()
+        let connection = makeSession(driver: driver, typeId: DatabaseType.sqlite.rawValue)
+        DatabaseManager.shared.markSessionVerified(connection.id, at: .distantPast)
+
+        await DatabaseManager.shared.verifyBeforeUse(connection.id)
+
+        #expect(driver.pingCallCount == 0)
+        await cleanUp(connection.id)
+    }
+
+    @Test("a check that fails reconnects the connection")
+    func aFailedCheckReconnects() async {
+        let driver = MockDatabaseDriver()
+        let connection = makeSession(driver: driver)
+        driver.pingError = DatabaseError.notConnected
+        DatabaseManager.shared.markSessionVerified(connection.id, at: .distantPast)
+
+        await DatabaseManager.shared.verifyBeforeUse(connection.id)
+
+        #expect(driver.pingCallCount == 1)
+        #expect(DatabaseManager.shared.activeSessions[connection.id]?.driver !== driver)
+        #expect(DatabaseManager.shared.activeSessions[connection.id]?.liveness == .live)
+        await cleanUp(connection.id)
+    }
+
+    /// The reconnect disconnects the installed driver before it tries, so a failure that left
+    /// liveness alone would hand the user's own operation a handle that cannot work. The type has
+    /// no driver plugin registered, so the reconnect fails on its first step with no network and
+    /// no waiting.
+    @Test("a check that fails and cannot reconnect stops the session reading as live")
+    func aFailedRecoveryMarksTheSessionUnreachable() async {
+        Self.registerUnreachableTypeIfNeeded()
+        let driver = MockDatabaseDriver()
+        let connection = makeSession(driver: driver, typeId: Self.unreachableTypeId)
+        driver.pingError = DatabaseError.notConnected
+        DatabaseManager.shared.markSessionVerified(connection.id, at: .distantPast)
+
+        await DatabaseManager.shared.verifyBeforeUse(connection.id)
+
+        #expect(DatabaseManager.shared.activeSessions[connection.id]?.liveness != .live)
+        await cleanUp(connection.id)
+    }
+
+    private static let unreachableTypeId = "VerificationReconnectFake"
+
+    private static func registerUnreachableTypeIfNeeded() {
+        guard PluginMetadataRegistry.shared.snapshot(forRegisteredTypeId: unreachableTypeId) == nil else { return }
+        let snapshot = PluginMetadataSnapshot(
+            displayName: unreachableTypeId, iconName: "cylinder", defaultPort: 1_234,
+            requiresAuthentication: true, supportsForeignKeys: true, supportsSchemaEditing: true,
+            isDownloadable: false, primaryUrlScheme: "verificationreconnectfake", parameterStyle: .questionMark,
+            navigationModel: .standard, explainVariants: [], pathFieldRole: .database,
+            supportsHealthMonitor: true, urlSchemes: ["verificationreconnectfake"], postConnectActions: [],
+            brandColorHex: "#000000", queryLanguageName: "SQL", editorLanguage: .sql,
+            connectionMode: .network, supportsDatabaseSwitching: true,
+            capabilities: .defaults, schema: .defaults, editor: .defaults, connection: .defaults
+        )
+        PluginMetadataRegistry.shared.register(snapshot: snapshot, forTypeId: unreachableTypeId)
+    }
+
+    /// A ping cannot be cancelled once it is inside a C call, so it completes late. Applying its
+    /// answer to whatever driver the session holds by then is how a losing attempt tears down the
+    /// one that replaced it.
+    @Test("a late answer about a driver that has been replaced is discarded")
+    func aLateAnswerAboutAReplacedDriverIsDiscarded() async {
+        let slow = MockDatabaseDriver()
+        slow.pingDelaySeconds = 0.3
+        slow.pingError = DatabaseError.notConnected
+        let connection = makeSession(driver: slow)
+        DatabaseManager.shared.markSessionVerified(connection.id, at: .distantPast)
+
+        let connectionId = connection.id
+        let check = Task { @MainActor in await DatabaseManager.shared.verifyBeforeUse(connectionId) }
+        try? await Task.sleep(for: .milliseconds(50))
+        let replacement = MockDatabaseDriver()
+        DatabaseManager.shared.updateSession(connectionId) { $0.driver = replacement }
+        await check.value
+
+        #expect(slow.pingCallCount == 1)
+        #expect(DatabaseManager.shared.activeSessions[connectionId]?.driver === replacement)
+        #expect(DatabaseManager.shared.activeSessions[connectionId]?.liveness == .live)
+        await cleanUp(connectionId)
+    }
+
+    @Test("ending a session forgets when it last answered")
+    func removingASessionForgetsItsAnswer() async {
+        let driver = MockDatabaseDriver()
+        let connection = makeSession(driver: driver)
+        DatabaseManager.shared.markSessionVerified(connection.id)
+
+        await cleanUp(connection.id)
+
+        #expect(DatabaseManager.shared.lastVerifiedAt[connection.id] == nil)
+    }
+}
+
+@Suite("Health monitor scheduling", .serialized)
+@MainActor
+struct HealthMonitorSchedulingTests {
+    private func makeSession() -> DatabaseConnection {
+        FakeMSSQLPluginRegistration.registerIfNeeded()
+        var connection = TestFixtures.makeConnection(name: "Prod")
+        connection.type = DatabaseType(rawValue: FakeMSSQLPlugin.databaseTypeId)
+        var session = ConnectionSession(connection: connection)
+        session.status = .connected
+        session.driver = MockDatabaseDriver()
+        DatabaseManager.shared.injectSession(session, for: connection.id)
+        return connection
+    }
+
+    private func withHealthCheck(_ setting: ConnectionHealthCheck, _ body: () async -> Void) async {
+        let previous = AppSettingsManager.shared.general.connectionHealthCheck
+        AppSettingsManager.shared.general.connectionHealthCheck = setting
+        await body()
+        AppSettingsManager.shared.general.connectionHealthCheck = previous
+    }
+
+    /// The whole point of the on-demand setting: not a very long interval, no scheduled work at
+    /// all. A task that wakes up to decide it has nothing to do is still something waking up.
+    @Test("on demand starts no monitor at all")
+    func onDemandStartsNoMonitor() async {
+        let connection = makeSession()
+        defer { DatabaseManager.shared.removeSession(for: connection.id) }
+
+        await withHealthCheck(.onDemand) {
+            await DatabaseManager.shared.startHealthMonitor(for: connection.id)
+        }
+
+        #expect(DatabaseManager.shared.healthMonitors[connection.id] == nil)
+        await DatabaseManager.shared.stopHealthMonitor(for: connection.id)
+    }
+
+    @Test("a polling setting starts a monitor")
+    func aPollingSettingStartsAMonitor() async {
+        let connection = makeSession()
+        defer { DatabaseManager.shared.removeSession(for: connection.id) }
+
+        await withHealthCheck(.every15Minutes) {
+            await DatabaseManager.shared.startHealthMonitor(for: connection.id)
+        }
+
+        #expect(DatabaseManager.shared.healthMonitors[connection.id] != nil)
+        await DatabaseManager.shared.stopHealthMonitor(for: connection.id)
+    }
+
+    /// The monitor is built once, when the connection opens, so switching the setting has to reach
+    /// what is already open or it only applies to the next connection someone makes.
+    @Test("turning the check off stops the monitor an open connection already has")
+    func switchingToOnDemandStopsALiveMonitor() async {
+        let connection = makeSession()
+        defer { DatabaseManager.shared.removeSession(for: connection.id) }
+
+        await withHealthCheck(.every30Seconds) {
+            await DatabaseManager.shared.startHealthMonitor(for: connection.id)
+        }
+        #expect(DatabaseManager.shared.healthMonitors[connection.id] != nil)
+
+        await withHealthCheck(.onDemand) {
+            await DatabaseManager.shared.startHealthMonitor(for: connection.id)
+        }
+
+        #expect(DatabaseManager.shared.healthMonitors[connection.id] == nil)
+        await DatabaseManager.shared.stopHealthMonitor(for: connection.id)
+    }
+}

--- a/TableProTests/Core/Plugins/HealthMonitorOptOutParityTests.swift
+++ b/TableProTests/Core/Plugins/HealthMonitorOptOutParityTests.swift
@@ -1,0 +1,85 @@
+//
+//  HealthMonitorOptOutParityTests.swift
+//  TableProTests
+//
+//  supportsHealthMonitor is declared twice, in the curated metadata table and on the plugin, and
+//  the plugin wins: buildMetadataSnapshot reads it straight off the DriverPlugin type, so a
+//  curated `false` that the plugin does not repeat is silently discarded and the app pings a
+//  connection it had already decided to leave alone (#2700).
+//
+
+import Foundation
+@testable import TablePro
+import TableProPluginKit
+import Testing
+
+@Suite("Health monitor opt-out parity")
+struct HealthMonitorOptOutParityTests {
+    @Test("every type curated as health-monitor-free says so on its plugin too")
+    func curatedOptOutsAreDeclaredOnTheirPlugins() throws {
+        let optedOut = DatabaseType.allKnownTypes.filter { type in
+            PluginMetadataRegistry.shared.snapshot(for: type)?.supportsHealthMonitor == false
+        }
+        #expect(!optedOut.isEmpty, "The curated table opts at least SQLite and DuckDB out")
+
+        let sources = try Self.pluginSources()
+        var missing: [String] = []
+        for type in optedOut {
+            guard let source = sources.first(where: { $0.declaresTypeId(type.rawValue) }) else {
+                missing.append("\(type.rawValue) (no plugin source declares this type id)")
+                continue
+            }
+            if !source.text.contains("static let supportsHealthMonitor = false") {
+                missing.append("\(type.rawValue) (\(source.url.lastPathComponent))")
+            }
+        }
+
+        #expect(
+            missing.isEmpty,
+            """
+            The plugin is the authoritative side: PluginMetadataRegistry.buildMetadataSnapshot copies \
+            supportsHealthMonitor off the DriverPlugin type, so these keep a 30-second ping the \
+            curated table already turned off: \(missing.sorted())
+            """
+        )
+    }
+
+    private struct PluginSource {
+        let url: URL
+        let text: String
+
+        func declaresTypeId(_ id: String) -> Bool {
+            text.contains("static let databaseTypeId = \"\(id)\"")
+        }
+    }
+
+    private static func pluginSources(file: StaticString = #filePath) throws -> [PluginSource] {
+        let root = try repositoryRoot(file: file).appendingPathComponent("Plugins")
+        guard let walker = FileManager.default.enumerator(at: root, includingPropertiesForKeys: nil) else {
+            throw ParityError.sourcesNotFound
+        }
+        var sources: [PluginSource] = []
+        for case let url as URL in walker where url.pathExtension == "swift" {
+            guard let text = try? String(contentsOf: url, encoding: .utf8),
+                  text.contains("static let databaseTypeId = ")
+            else { continue }
+            sources.append(PluginSource(url: url, text: text))
+        }
+        guard !sources.isEmpty else { throw ParityError.sourcesNotFound }
+        return sources
+    }
+
+    private static func repositoryRoot(file: StaticString) throws -> URL {
+        var directory = URL(fileURLWithPath: "\(file)").deletingLastPathComponent()
+        while directory.path != "/" {
+            let candidate = directory.appendingPathComponent("Plugins/TableProPluginKit/DriverPlugin.swift")
+            if FileManager.default.fileExists(atPath: candidate.path) { return directory }
+            directory = directory.deletingLastPathComponent()
+        }
+        throw ParityError.sourcesNotFound
+    }
+
+    private enum ParityError: Error {
+        case sourcesNotFound
+    }
+}

--- a/TableProTests/Core/Services/Infrastructure/ConnectionLivenessTests.swift
+++ b/TableProTests/Core/Services/Infrastructure/ConnectionLivenessTests.swift
@@ -230,12 +230,13 @@ struct ReconnectDegradationTests {
 
 @Suite("Health monitor give-up")
 struct ConnectionHealthMonitorAbortTests {
-    /// The abort used to leave the state latched mid-reconnect, so the 30-second loop woke for the
-    /// life of the app to fail its own guard and return.
+    /// The abort used to leave the state latched mid-reconnect, so the loop woke on every interval
+    /// for the life of the app to fail its own guard and return.
     @Test("A monitor that gives up stops asking")
     func abortEndsTheMonitoringLoop() async {
         let monitor = ConnectionHealthMonitor(
             connectionId: UUID(),
+            pingInterval: .seconds(30),
             pingHandler: { false },
             reconnectHandler: { .abort },
             onStateChanged: { _, _ in }
@@ -251,6 +252,7 @@ struct ConnectionHealthMonitorAbortTests {
     func successReturnsToHealthy() async {
         let monitor = ConnectionHealthMonitor(
             connectionId: UUID(),
+            pingInterval: .seconds(30),
             pingHandler: { false },
             reconnectHandler: { .success },
             onStateChanged: { _, _ in }

--- a/TableProTests/Core/Services/Infrastructure/ConnectionLivenessTests.swift
+++ b/TableProTests/Core/Services/Infrastructure/ConnectionLivenessTests.swift
@@ -236,7 +236,7 @@ struct ConnectionHealthMonitorAbortTests {
     func abortEndsTheMonitoringLoop() async {
         let monitor = ConnectionHealthMonitor(
             connectionId: UUID(),
-            pingInterval: .seconds(30),
+            pingInterval: { .seconds(30) },
             pingHandler: { false },
             reconnectHandler: { .abort },
             onStateChanged: { _, _ in }
@@ -252,7 +252,7 @@ struct ConnectionHealthMonitorAbortTests {
     func successReturnsToHealthy() async {
         let monitor = ConnectionHealthMonitor(
             connectionId: UUID(),
-            pingInterval: .seconds(30),
+            pingInterval: { .seconds(30) },
             pingHandler: { false },
             reconnectHandler: { .success },
             onStateChanged: { _, _ in }

--- a/TableProTests/Core/Services/Query/MetadataConnectionPoolTests.swift
+++ b/TableProTests/Core/Services/Query/MetadataConnectionPoolTests.swift
@@ -151,6 +151,101 @@ private final class PoolBodyFlag: @unchecked Sendable {
     var value = false
 }
 
+@Suite("MetadataConnectionPool idle eviction", .serialized)
+@MainActor
+struct MetadataConnectionPoolIdleEvictionTests {
+    private func scope(_ connectionId: UUID, database: String) -> DatabaseScope {
+        DatabaseScope(connectionId: connectionId, database: database, schema: nil)
+    }
+
+    @Test("an entry nobody has used for the idle timeout is closed and dropped")
+    func sweepClosesIdleEntries() {
+        let connectionId = UUID()
+        let driver = MockDatabaseDriver()
+        let pool = MetadataConnectionPool.shared
+        defer { pool.closeAll(connectionId: connectionId) }
+
+        pool.injectEntry(driver, scope: scope(connectionId, database: "shop"))
+        pool.sweepIdleEntries(now: Date().addingTimeInterval(MetadataConnectionPool.idleTimeout + 1))
+
+        #expect(pool.pooledDriverCount(for: connectionId) == 0)
+        #expect(driver.disconnectCallCount == 1)
+    }
+
+    @Test("an entry used inside the idle timeout is left alone")
+    func sweepSparesRecentEntries() {
+        let connectionId = UUID()
+        let driver = MockDatabaseDriver()
+        let pool = MetadataConnectionPool.shared
+        defer { pool.closeAll(connectionId: connectionId) }
+
+        pool.injectEntry(driver, scope: scope(connectionId, database: "shop"))
+        pool.sweepIdleEntries(now: Date().addingTimeInterval(MetadataConnectionPool.idleTimeout - 1))
+
+        #expect(pool.pooledDriverCount(for: connectionId) == 1)
+        #expect(driver.disconnectCallCount == 0)
+    }
+
+    @Test("an entry with work on it survives the sweep however old it looks")
+    func sweepSparesEntriesWithWorkInFlight() {
+        let connectionId = UUID()
+        let driver = MockDatabaseDriver()
+        let pool = MetadataConnectionPool.shared
+        defer { pool.closeAll(connectionId: connectionId) }
+
+        pool.injectEntry(driver, scope: scope(connectionId, database: "shop"))
+        pool.markInFlight(scope: scope(connectionId, database: "shop"))
+        pool.sweepIdleEntries(now: Date().addingTimeInterval(MetadataConnectionPool.idleTimeout * 10))
+
+        #expect(pool.pooledDriverCount(for: connectionId) == 1)
+        #expect(driver.disconnectCallCount == 0)
+    }
+
+    @Test("only the idle entries go, not every entry the connection holds")
+    func sweepIsPerEntryNotPerConnection() {
+        let connectionId = UUID()
+        let stale = MockDatabaseDriver()
+        let fresh = MockDatabaseDriver()
+        let pool = MetadataConnectionPool.shared
+        defer { pool.closeAll(connectionId: connectionId) }
+
+        let now = Date()
+        pool.injectEntry(
+            stale,
+            scope: scope(connectionId, database: "shop"),
+            lastUsed: now.addingTimeInterval(-MetadataConnectionPool.idleTimeout - 1)
+        )
+        pool.injectEntry(fresh, scope: scope(connectionId, database: "reports"), lastUsed: now)
+
+        pool.sweepIdleEntries(now: now)
+
+        #expect(pool.pooledDriverCount(for: connectionId) == 1)
+        #expect(stale.disconnectCallCount == 1)
+        #expect(fresh.disconnectCallCount == 0)
+    }
+
+    @Test("a sweep that empties the pool stops the sweeper")
+    func sweepStopsWhenThePoolEmpties() {
+        let connectionId = UUID()
+        let pool = MetadataConnectionPool.shared
+        defer { pool.closeAll(connectionId: connectionId) }
+
+        pool.injectEntry(MockDatabaseDriver(), scope: scope(connectionId, database: "shop"))
+        pool.sweepIdleEntries(now: Date().addingTimeInterval(MetadataConnectionPool.idleTimeout + 1))
+
+        #expect(!pool.hasSweeper)
+    }
+
+    @Test("staleness is measured against the idle timeout, not the count cap")
+    func stalenessIsTimeBased() {
+        let used = Date()
+
+        #expect(!MetadataConnectionPool.isStale(used, now: used))
+        #expect(!MetadataConnectionPool.isStale(used, now: used.addingTimeInterval(MetadataConnectionPool.idleTimeout - 1)))
+        #expect(MetadataConnectionPool.isStale(used, now: used.addingTimeInterval(MetadataConnectionPool.idleTimeout)))
+    }
+}
+
 @Suite("MetadataConnectionPool connection plan")
 @MainActor
 struct MetadataConnectionPoolPlanTests {

--- a/TableProUITests/ConnectionHealthCheckSettingUITests.swift
+++ b/TableProUITests/ConnectionHealthCheckSettingUITests.swift
@@ -1,0 +1,32 @@
+import XCTest
+
+/// The setting behind #2700 is only useful if someone can find it and change it, and a picker that
+/// forgets is worse than no picker: the user believes they stopped the traffic and it carries on.
+final class ConnectionHealthCheckSettingUITests: UITestCase {
+    func testConnectionCheckIntervalIsOfferedAndRemembered() throws {
+        let app = try launchApp()
+        XCTAssertTrue(app.windows.firstMatch.waitToExist(timeout: 10))
+
+        let settingsMenuItem = app.menuBars.menuItems["Settings…"]
+        XCTAssertTrue(settingsMenuItem.waitToExist(timeout: 10))
+        settingsMenuItem.click()
+
+        let generalPaneButton = app.toolbars.buttons["General"]
+        XCTAssertTrue(generalPaneButton.waitToExist(timeout: 10))
+        generalPaneButton.click()
+
+        let picker = app.popUpButtons["connection-health-check-picker"].firstMatch
+        XCTAssertTrue(picker.waitToExist(timeout: 10))
+        XCTAssertEqual(picker.value as? String, "Every 30 seconds")
+
+        picker.click()
+        let onDemand = app.menuItems["Only when I use the connection"]
+        XCTAssertTrue(onDemand.waitToExist(timeout: 10))
+        onDemand.click()
+
+        XCTAssertEqual(picker.value as? String, "Only when I use the connection")
+
+        generalPaneButton.click()
+        XCTAssertEqual(picker.value as? String, "Only when I use the connection")
+    }
+}

--- a/docs/connections/connection-form.mdx
+++ b/docs/connections/connection-form.mdx
@@ -93,9 +93,15 @@ A statement that fails is logged and skipped, and the connection still opens.
 
 ## Connection health
 
-Every active connection is pinged every 30 seconds, skipping the ping while one of your own queries is running. A failed ping starts a reconnect at 2s, then 4s, 8s, doubling to a 120-second ceiling, and keeps going until the connection comes back or you close it. An authentication failure stops the retries and leaves the session in error. A reconnect rebuilds the tunnel, restores the selected database and schema, and re-runs the startup commands; the session reads as connecting throughout.
+Every active connection is checked on the interval set by **Check connections** in Settings > General, every 30 seconds by default, and the check is skipped while one of your own queries is running. A failed check starts a reconnect at 2s, then 4s, 8s, doubling to a 120-second ceiling, and keeps going until the connection comes back or you close it. An authentication failure stops the retries and leaves the session in error. A reconnect rebuilds the tunnel, restores the selected database and schema, and re-runs the startup commands; the session reads as connecting throughout.
 
-SQLite, DuckDB, Beancount, Snowflake, and Teradata are not monitored.
+The check is a query, so on a database that sleeps when idle or bills per query it is not free. **Only when I use the connection** stops it: TablePro sends nothing on its own, and instead checks the connection the first time you use it after five quiet minutes. Waking the Mac from sleep counts as a quiet period, so the first thing you do after opening the lid checks too.
+
+A Server Dashboard tab keeps its own refresh running on its own interval, which **Check connections** does not change. Close the tab or set its interval to Off.
+
+SQLite, DuckDB, Beancount, Snowflake, and Teradata are not checked.
+
+Metadata connections, the extra ones TablePro opens to read a database's object list, are closed after 10 minutes unused and reopened on the next read.
 
 ## Which drivers get which transports
 

--- a/docs/customization/settings.mdx
+++ b/docs/customization/settings.mdx
@@ -40,6 +40,7 @@ What a fresh install ships with, so one glance down this column says what you ch
 | General | Show object comments | On |
 | General | Row size | Match System |
 | General | Default layout for new connections | List |
+| General | Check connections | Every 30 seconds |
 | General | Query timeout | 60 seconds |
 | General | Automatically check for updates | On |
 | General | Share anonymous usage data | On |

--- a/docs/databases/mysql.mdx
+++ b/docs/databases/mysql.mdx
@@ -68,7 +68,9 @@ Table and column comments show in the UI: dimmed after a table's name in the sid
 
 ## Releasing an idle connection
 
-A connection holds a server thread and one slot against `max_connections` for as long as it is open, and MySQL's `wait_timeout` never reclaims it because the 30-second health check counts as activity. **Release the Server Connection After**, in **Options**, hands the connection back after that many minutes of no queries and takes a new one on the next query. `0`, the default, keeps it.
+A connection holds a server thread and one slot against `max_connections` for as long as it is open, and MySQL's `wait_timeout` rarely reclaims it because the connection check counts as activity on the server. **Release the Server Connection After**, in **Options**, hands the connection back after that many minutes of no queries and takes a new one on the next query. `0`, the default, keeps it.
+
+To stop the check itself, set **Check connections** to **Only when I use the connection** in Settings > General. That is the connection-wide setting; this one is per connection and closes the connection rather than quietening it.
 
 Reconnecting costs a TCP connect, the TLS handshake and authentication: measured at 2ms against a server on the same machine and 800ms to 1.9s across the internet. That cost lands on the first query after an idle period, so leave this at `0` for a remote server unless the slot matters more than the wait.
 


### PR DESCRIPTION
Fixes #2700.

The reporter leaves TablePro open all day against their website's database and found their hosting usage was "way above normal because it never shut down". Quitting TablePro fixed it. They asked for "a setting that only communicates with the DB when the user performs an explicit action".

They were right, and it turned out to be three separate things.

## What was happening

**1. A `SELECT 1` on every connection every 30 seconds, forever.** `ConnectionHealthMonitor` polls each connected session on a fixed `pingInterval` of 30 seconds, and on nearly every engine `ping()` is a real query: PostgreSQL's `LibPQDriverCore.ping()` and MySQL's `MySQLPluginDriver.ping()` both run `SELECT 1`. That is about 2,880 server-side queries per connection per day with nobody touching the app. Neon suspends a compute only after five minutes with no queries, so a 30-second heartbeat pins it awake and billing around the clock. There was no setting anywhere to change it.

**2. Six extra idle connections per connection, held for the life of the app.** `MetadataConnectionPool` opens one connection per database the sidebar touches, up to six. Its only eviction, `evictIdleIfNeeded`, is a count cap checked at acquire time, not an idle timer, and the file contained no timer at all. Measured against TablePro 0.73.0 and live PostgreSQL 17.11: 0 backends at baseline, 1 after connect, **7 after browsing six databases, still 7 after five minutes untouched**, and 0 only after disconnect. Those six were never even pinged, so they survived any change to the health check.

**3. Three engines pinged against the app's own instructions.** SQLite, DuckDB and Teradata all declare `supportsHealthMonitor: false` in the curated metadata tables, but none declared the `DriverPlugin` static, so `buildMetadataSnapshot` copied the PluginKit default `true` straight over the curated `false`. Measured on the shipping app: opening a SQLite connection logs `startHealthMonitor called` and then pings every 30 seconds.

## Root cause

TablePro's model of "is this connection alive" **was** that fixed poll, and the poll was the only thing that wrote it. `ConnectionSession.liveness` is set in exactly two places, the initial connect and the health-monitor cycle, and `ensureConnected` returns early on `liveness == .live`. So the poll could not simply be switched off: liveness would freeze at `.live` forever, `ensureConnected` would never reconnect a dead driver, and the toolbar would go on reporting a healthy connection while the user's next query discovered the socket was gone.

That is why this is a refactor rather than a checkbox. The policy is extracted from the actor that executes it, the interval is injected, and liveness gains a second, demand-driven writer that works when nothing is polling.

## What changed

Two commits, so the two independently verified bugfixes can be read apart from the feature.

**Commit 1, `fix(connections)`:**
- `MetadataConnectionPool` gains time-based eviction beside its count cap. An entry with no work on it and unused for 10 minutes is closed through the existing `closeOrDeferEntry`. One pool-wide sweeper exists only while the pool holds something, so an empty pool schedules nothing. `acquireEntry` also stops reusing an entry past that window, which covers a Mac that slept past a sweep, and closes the entry it replaces rather than leaking the driver as it did before. 10 minutes because re-taking one is a whole connect, measured at 1.7-5.8ms on loopback but 800-1900ms across the internet, and someone still browsing must never pay that.
- `SQLitePlugin`, `DuckDBPlugin` and `TeradataPlugin` declare `supportsHealthMonitor = false`. The plugin is the authoritative side; Snowflake, Beancount, Trino and Kafka already declared it, which is why those four agreed. A source-scanning parity test now fails if the two lists ever diverge again.

**Commit 2, `feat(connections)`:**
- **Check connections** in Settings > General: Every 30 seconds (the default, so nothing changes for anyone who does not touch it), Every 5 minutes, Every 15 minutes, and **Only when I use the connection**.
- On demand starts no monitor at all, not a monitor with a long interval. A task that wakes up to decide it has nothing to do is still something waking up.
- `verifyBeforeUse` checks a connection nobody has heard from in five minutes at the moment someone reaches for it, and reconnects it if it has gone. That is the second writer of liveness, and it is what makes "only when I use it" honest rather than silently broken. It sits on `withPinnedSessionDriver`, `ensureConnected`, the two live database and schema switches, and `DatabaseAccessBridge.resolveDriver`, which is how MCP and Cocoa Scripting reach a driver without passing through `ensureConnected`. The pooled route is covered by commit 1's staleness rule instead, since it never touches the session driver.
- The scheduled ping now stamps the connection fresh on success, so at the default the on-demand check never fires.
- Waking from sleep throws every answer away: wall-clock time passes but nothing in the app observes it, so the first thing done after opening the lid checks.
- A settings change reaches connections that are already open, through a diffed `connectionHealthCheckChanged` event and serialized monitor restarts.

## Deliberately not in scope

- **No per-connection override.** A new `DatabaseConnection` property is a synced field and CloudKit's Production schema has to be deployed before anything writes it. A global setting answers the report and matches TablePlus's single global checkbox.
- **No app-level "disconnect when idle" for engines with no `releaseIdleResource`.** PostgreSQL would need its own session footprint, and Postico removed exactly that feature in 1.2 because it broke temp tables and `search_path`. MySQL and DuckDB already have it per connection from #2518, and the MySQL docs now point at both.
- **Server Dashboard keeps its own refresh loop** (5 seconds by default). It is a view the user opened to watch a server, it already has its own interval picker including Off, and it stops when its tab closes. Called out in the docs.

## Verified

- `build` PASS, `generate` PASS, `docs` PASS, `lint` 0 violations over `TablePro`, `TableProTests`, `TableProUITests` and the three plugin paths.
- `plugins` (AllPlugins): all three changed plugin targets compile. The aggregate itself fails locally on the vendored `oracle-nio` `@TaskLocal` macro (`unknown attribute 'usableFromInlinenonisolated'`), which reproduces on `main` with this toolchain and is unrelated.
- Tests: 15 in `ConnectionVerificationTests`, 8 in `ConnectionHealthCheckTests`, 3 in `HealthMonitorSchedulingTests`, 6 in `MetadataConnectionPoolIdleEvictionTests`, 1 parity test, plus 101 in the neighbouring settings, metadata and liveness suites. All green.
- UI automation: `ConnectionHealthCheckSettingUITests` drives the picker in Settings and asserts it persists across a pane switch. 2 cases, both passing.

Reviewed by Codex. Its `review` pass found eight real issues in the working tree, all fixed here: a failed preflight recovery that left the session reading as live over a driver the reconnect had already disconnected; unfenced verification results that could tear down a driver that replaced the one being checked; monitor restarts that could strand a session mid-reconnect or orphan a monitor outside `healthMonitors`; the preflight ignoring `supportsHealthMonitor`; and the freshness stamp missing from the scheduled ping, which would have made the default setting pay for an extra query every five minutes. Reviewing the decode path also turned up a forward-compatibility bug of my own: an interval written by a newer version threw and would have taken the whole of General settings down with it.

A second Codex pass, `adversarial-review` against the approach itself, returned no-ship with six findings. Three were mine and are fixed in the third commit:

- **The check interval was captured for the monitor's lifetime**, and the observer skipped any monitor that was not exactly `.healthy`. Every routine ping sits in `.checking`, so choosing On Demand at the wrong moment left the 30-second monitor running with nothing to reconcile it later, which defeats the whole point of the setting. The interval is now read afresh on every pass, so a change reaches a running monitor wherever it is, including mid-ping and mid-reconnect, and On Demand ends its loop on its own. That removed the restart entirely, and with it the stranding and orphaning the earlier fix had traded for.
- **A failed check let the operation run anyway.** `reconnectDriver` disconnects the installed handle before trying, so an unsuccessful recovery left a driver that could not work. `withPinnedSessionDriver` and the import path now refuse through `isUsable` instead of checking only that a driver object exists.
- **The failure fence compared the driver to itself.** `markSessionUnreachable` was passed the session's current driver rather than the one the check was made against, so a losing late attempt could mark a replacement unreachable. It now carries the original, and `performHealthMonitorReconnect`'s success path is fenced the same way its give-up sites always were.

The on-demand check also now claims `queriesInFlight` for its duration, so the scheduled monitor's ping skips rather than entering the same non-thread-safe driver alongside it.

Two findings are pre-existing architecture that this change makes more reachable, and are reported rather than built:

- **`ping()` succeeding does not prove the session survived.** PostgreSQL's and MySQL's `ping()` run through `executeWithReconnect`, which reconnects privately without re-running the manager-owned startup commands. After a long idle disconnect a check can report success into a reset server session, losing a role, time zone or session variable the startup SQL established. Fixing it properly means a PluginKit contract change: `ping` declared non-reconnecting, or drivers reporting that they replaced the connection so one manager-owned restoration runs.
- **`ImportService` still holds the raw session driver** for the length of a multi-statement import without the scoped driver gate or `queriesInFlight`, so a scheduled check can still meet it. The pre-use check added here closes the stale-socket half; the coordination half needs a manager-owned lease and an audit of every remaining raw `driver(for:)` I/O site.

## Not fixed here

Three further defects were verified in this subsystem and are reported rather than built, since the fix is not unsafe without them:

1. **MongoDB pings always report success.** `MongoDBConnection.ping()` returns `Bool` and `MongoDBPluginDriver.execute` discards it, fabricating an `ok=1` row, so a dead mongod stays `.healthy` and `.live` forever.
2. **The health-monitor reconnect's success path has no generation fence** (`DatabaseManager+Health.swift:121`). Only the two give-up sites are fenced, so a reconnect completing after the user disconnected resurrects the session and leaks a driver.
3. **An unattended background reconnect can raise a modal password sheet** on whatever window is key, blocking Disconnect and Quit.


https://claude.ai/code/session_0133D7mARM8FyNgNnXfhrKRJ
