### PR TITLE
Stop a health check repairing the connection it reports on, and lease the driver an import writes through

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MongoDB connections reading as healthy after the server went away. (#2700)
 - Password prompt raised by a background reconnect, on whichever window was in front. (#2700)
 - Health check entering the same connection as a running import. (#2700)
+- Startup commands, query timeout, database and schema lost after a health check quietly reconnected. (#2700)
+- Table transfer abortable by Stop from an unrelated tab, part-applied. (#2700)
 - SQLite, DuckDB and Teradata connections pinged every 30 seconds despite opting out of health checks. (#2700)
 - Data grid dropping the UTC offset from a `timestamp with time zone` value. (#2702)
 - Oracle `TIMESTAMP` values carrying a `Z` the column never stored. (#2702)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Idle metadata connections held open for the life of the app, up to six per connection. (#2700)
+- MongoDB connections reading as healthy after the server went away. (#2700)
+- Password prompt raised by a background reconnect, on whichever window was in front. (#2700)
+- Health check entering the same connection as a running import. (#2700)
 - SQLite, DuckDB and Teradata connections pinged every 30 seconds despite opting out of health checks. (#2700)
 - Data grid dropping the UTC offset from a `timestamp with time zone` value. (#2702)
 - Oracle `TIMESTAMP` values carrying a `Z` the column never stored. (#2702)

--- a/Plugins/MongoDBDriverPlugin/MongoDBPluginDriver.swift
+++ b/Plugins/MongoDBDriverPlugin/MongoDBPluginDriver.swift
@@ -106,6 +106,23 @@ final class MongoDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         scriptRuntime = MongoScriptRuntime(connection: conn)
     }
 
+    /// Reports a server that has gone away, instead of the PluginKit default routing through
+    /// `execute`.
+    ///
+    /// `MongoDBConnection.ping()` answers with a Bool, and the "select 1" arm of `execute` threw
+    /// that answer away and returned a fabricated `ok = 1` row. So a paused Atlas cluster, a
+    /// replica-set failover or a dropped network read as healthy for as long as the app ran: the
+    /// health monitor never entered its reconnect and `ConnectionSession.liveness` stayed `.live`,
+    /// which is what `ensureConnected` returns early on.
+    func ping() async throws {
+        guard let conn = mongoConnection else {
+            throw MongoDBPluginError.notConnected
+        }
+        guard try await conn.ping() else {
+            throw MongoDBPluginError.notConnected
+        }
+    }
+
     func disconnect() {
         scriptRuntime?.reset()
         scriptRuntime = nil
@@ -128,9 +145,13 @@ final class MongoDBPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
 
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
 
-        // Health monitor sends "SELECT 1" as a ping
+        /// `ping()` above is what the health monitor calls now. This arm remains for a user who
+        /// types `SELECT 1` into a MongoDB tab, and it reports the real answer rather than a row
+        /// saying the server replied when it did not.
         if trimmed.lowercased() == "select 1" {
-            _ = try await conn.ping()
+            guard try await conn.ping() else {
+                throw MongoDBPluginError.notConnected
+            }
             return PluginQueryResult(
                 columns: ["ok"],
                 columnTypeNames: ["Int32"],

--- a/Plugins/MySQLDriverPlugin/MySQLPluginDriver.swift
+++ b/Plugins/MySQLDriverPlugin/MySQLPluginDriver.swift
@@ -165,9 +165,22 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     /// And a released connection is healthy by definition: nothing is wrong with it, it is waiting
     /// to be used, so reconnecting to prove it works would undo the release 30 seconds after it
     /// happened and pay the reconnect cost for nothing.
+    /// And it never reconnects, through either door, which is what makes the answer mean anything.
+    ///
+    /// A private reconnect restores none of the session state the app put there: the startup
+    /// commands, the query timeout, the database and the schema all belong to
+    /// `DatabaseManager.reconnectDriver`. A ping that healed itself would report success into a
+    /// server session reset behind the user's back, and their next statement would run without the
+    /// role, search path or time zone their startup SQL set. Failing instead routes recovery
+    /// through the manager, which restores all of it.
+    ///
+    /// It still takes an operation slot, because `release(idleFor:)` only hands the connection
+    /// back while `activeOperations` is zero and would otherwise null the handle mid-ping.
     func ping() async throws {
         guard !sessionLock.withLock({ isReleased }) else { return }
-        _ = try await executeWithReconnect(query: "SELECT 1", isRetry: false, countsAsActivity: false)
+        let conn = try requireLiveConnection()
+        defer { endOperation() }
+        _ = try await conn.executeQuery("SELECT 1", rowCap: nil)
     }
 
     // MARK: - Transaction Management
@@ -338,6 +351,20 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         }
         sessionLock.withLock { activeOperations += 1 }
         return conn
+    }
+
+    /// `requireConnection` without the reacquire. It is the second reconnect door: a nil handle
+    /// sends it through `reacquireOnce()`, which opens a fresh server connection and re-applies
+    /// only the query timeout. Anything that must not silently rebuild the session asks for the
+    /// connection this way instead.
+    private func requireLiveConnection() throws -> MariaDBPluginConnection {
+        try sessionLock.withLock {
+            guard !isDisconnected, let conn = mariadbConnection else {
+                throw MariaDBPluginError.notConnected
+            }
+            activeOperations += 1
+            return conn
+        }
     }
 
     private func endOperation() {

--- a/Plugins/PostgreSQLDriverPlugin/LibPQDriverCore.swift
+++ b/Plugins/PostgreSQLDriverPlugin/LibPQDriverCore.swift
@@ -100,8 +100,19 @@ final class LibPQDriverCore: @unchecked Sendable {
         libpqConnection = nil
     }
 
+    /// Non-reconnecting on purpose, which is what makes the answer mean anything.
+    ///
+    /// `execute` recovers a dropped connection privately, and that recovery restores none of the
+    /// session state the app put there: the startup commands, the query timeout, the database and
+    /// the schema all belong to `DatabaseManager.reconnectDriver`. A ping that healed itself that
+    /// way would report success into a server session reset behind the user's back, and the next
+    /// statement would run without the role, search path or time zone their startup SQL set.
+    /// Failing instead routes recovery through the manager, which restores all of it.
     func ping() async throws {
-        _ = try await execute(query: "SELECT 1")
+        guard let pqConn = libpqConnection else {
+            throw LibPQPluginError.notConnected
+        }
+        _ = try await pqConn.executeQuery("SELECT 1")
     }
 
     // MARK: - Query Execution

--- a/Plugins/RedisDriverPlugin/RedisPluginDriver.swift
+++ b/Plugins/RedisDriverPlugin/RedisPluginDriver.swift
@@ -147,11 +147,19 @@ final class RedisPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         redisConnection = nil
     }
 
-    /// The health monitor asks this every 30 seconds, and a reconnect is what it does with a no.
-    /// So the only answer worth failing on is the one a reconnect fixes: the session no longer
+    /// The health monitor asks this on its own schedule, and a reconnect is what it does with a
+    /// no. So the only answer worth failing on is the one a reconnect fixes: the session no longer
     /// holds an identity. Any reply at all, an error included, is the server answering on a live
     /// socket, and reconnecting cannot talk a restricted user into `+ping` or hurry a busy script
-    /// along. A lost socket does not reach here; it throws out of `executeCommand`.
+    /// along.
+    ///
+    /// A lost socket does not reach here either, but not for the reason this used to give: rather
+    /// than throwing, `executeCommand` reconnects and replays through
+    /// `executeCommandSyncRetrying`. That is survivable for Redis in a way it is not for the SQL
+    /// engines, whose pings are deliberately non-reconnecting, because `reconnectSync` re-selects
+    /// the database and Redis carries almost no other session state. What it does not restore is
+    /// the connection's startup commands, so a probe can still report success on a session that
+    /// lost them.
     func ping() async throws {
         guard let conn = redisConnection else {
             throw RedisPluginError.notConnected

--- a/TablePro/Core/Database/DatabaseManager+Health.swift
+++ b/TablePro/Core/Database/DatabaseManager+Health.swift
@@ -61,6 +61,15 @@ extension DatabaseManager {
                         Self.logger.debug("Ping skipped — query in-flight for \(connectionId)")
                         return true // Query still within expected time
                     }
+                    /// The stale override exists for a read that hung, where pinging past it costs
+                    /// nothing. A protected write is the opposite case: an import or a dump runs
+                    /// for as long as it runs, legitimately past any query timeout, and a ping that
+                    /// fails there reconnects and disconnects the handle out from under a batch
+                    /// halfway through applying it.
+                    if await self.holdsProtectedWrite(connectionId) {
+                        Self.logger.debug("Ping skipped, protected write in flight for \(connectionId)")
+                        return true
+                    }
                     Self.logger.warning("Ping proceeding despite in-flight query (stale after \(maxStale)s) for \(connectionId)")
                 }
                 guard let mainDriver = await self.activeSessions[connectionId]?.driver else {
@@ -132,7 +141,14 @@ extension DatabaseManager {
 
         do {
             guard let result = try await trackOperation(sessionId: connectionId, operation: {
-                try await self.reconnectDriver(for: session)
+                /// Nobody asked for this reconnect, so it must not interrupt whatever the user is
+                /// doing to ask for a password. A `prompt-for-password` connection whose password
+                /// was rotated server-side used to raise a modal sheet on whichever window
+                /// happened to be key, for a connection that might not even be the one on screen,
+                /// and it blocked Disconnect and Quit until it was answered. Failing quietly puts
+                /// the connection into its inline unavailable state instead, where Reconnect is a
+                /// deliberate act and prompting is expected.
+                try await self.reconnectDriver(for: session, allowsCredentialPrompt: false)
             }) else {
                 updateSession(connectionId) { session in
                     session.status = .disconnected
@@ -221,7 +237,10 @@ extension DatabaseManager {
 
     /// Creates a fresh driver, connects, and applies timeout for the given session.
     /// For SSH-tunneled sessions, rebuilds the tunnel before connecting the driver.
-    internal func reconnectDriver(for session: ConnectionSession) async throws -> ReconnectResult? {
+    internal func reconnectDriver(
+        for session: ConnectionSession,
+        allowsCredentialPrompt: Bool
+    ) async throws -> ReconnectResult? {
         session.driver?.disconnect()
 
         // Rebuild the tunnel if needed; otherwise reuse effective connection
@@ -235,7 +254,8 @@ extension DatabaseManager {
         guard let connectResult = try await connectReconnectDriver(
             for: session,
             effectiveConnection: connectionForDriver,
-            passwordOverride: session.cachedPassword
+            passwordOverride: session.cachedPassword,
+            allowsCredentialPrompt: allowsCredentialPrompt
         ) else {
             return nil
         }
@@ -369,7 +389,8 @@ extension DatabaseManager {
             guard let connectResult = try await connectReconnectDriver(
                 for: session,
                 effectiveConnection: effectiveConnection,
-                passwordOverride: passwordOverride
+                passwordOverride: passwordOverride,
+                allowsCredentialPrompt: true
             ) else {
                 updateSession(sessionId) { $0.status = .disconnected }
                 markSessionUnreachable(sessionId, startedWith: attemptedDriver, info: Self.declinedReconnectInfo)
@@ -437,7 +458,8 @@ extension DatabaseManager {
     internal func connectReconnectDriver(
         for session: ConnectionSession,
         effectiveConnection: DatabaseConnection,
-        passwordOverride initialPasswordOverride: String?
+        passwordOverride initialPasswordOverride: String?,
+        allowsCredentialPrompt: Bool
     ) async throws -> (driver: DatabaseDriver, cachedPassword: String?)? {
         var passwordOverride = initialPasswordOverride
 
@@ -457,7 +479,8 @@ extension DatabaseManager {
                 switch await reconnectCredentialResolution(
                     for: session,
                     error: error,
-                    currentPassword: passwordOverride
+                    currentPassword: passwordOverride,
+                    allowsCredentialPrompt: allowsCredentialPrompt
                 ) {
                 case .retry(let newPassword):
                     passwordOverride = newPassword
@@ -476,8 +499,11 @@ extension DatabaseManager {
         for session: ConnectionSession,
         error: Error,
         currentPassword: String?,
+        allowsCredentialPrompt: Bool = true,
         prompt: @escaping @MainActor (_ connectionName: String, _ isAPIToken: Bool, _ window: NSWindow?) async -> String? = PasswordPromptHelper.prompt
     ) async -> ReconnectCredentialResolution {
+        /// An unattended reconnect never asks. See `performHealthMonitorReconnect`.
+        guard allowsCredentialPrompt else { return .fail }
         guard session.connection.promptForPassword,
               !pluginManager.hidesPassword(for: session.connection),
               isAuthenticationFailure(error)

--- a/TablePro/Core/Database/DatabaseManager+ScopedDriver.swift
+++ b/TablePro/Core/Database/DatabaseManager+ScopedDriver.swift
@@ -174,6 +174,11 @@ extension DatabaseManager {
         }
     }
 
+    /// Whether the connection is running work that must not be interrupted, whatever its age.
+    internal func holdsProtectedWrite(_ connectionId: UUID) -> Bool {
+        (runningDrivers[connectionId] ?? [:]).values.contains { $0.policy == .protectedWrite }
+    }
+
     private func withPinnedSessionDriver<T: Sendable>(
         scope: DatabaseScope,
         _ body: @Sendable @escaping (DatabaseDriver) async throws -> T

--- a/TablePro/Core/Database/DatabaseManager+Sessions.swift
+++ b/TablePro/Core/Database/DatabaseManager+Sessions.swift
@@ -703,8 +703,12 @@ extension DatabaseManager {
     }
 
     #if DEBUG
+    /// Stands in for a completed connect, so it stamps what a completed connect stamps. Without
+    /// the timestamp every injected session reads as never having answered, and the first scoped
+    /// operation in a test pays a check that production would never make.
     internal func injectSession(_ session: ConnectionSession, for connectionId: UUID) {
         setSession(session, for: connectionId)
+        markSessionVerified(connectionId)
     }
 
     internal func removeSession(for connectionId: UUID) {

--- a/TablePro/Core/Services/Export/ImportService.swift
+++ b/TablePro/Core/Services/Export/ImportService.swift
@@ -62,28 +62,19 @@ final class ImportService {
             throw PluginImportError.importFailed("Import format '\(formatId)' not found")
         }
 
-        /// An import is often the first thing done after a long idle spell, and it writes. With
-        /// scheduled checks turned down or off nothing else would have noticed the socket had gone,
-        /// so it is checked here rather than discovered partway through a batch of inserts.
-        await DatabaseManager.shared.verifyBeforeUse(connection.id)
-        guard DatabaseManager.shared.isUsable(connection.id),
-              let driver = DatabaseManager.shared.driver(for: connection.id)
-        else {
+        /// The scope the driver is already on, not the connection's saved default: a tab may have
+        /// moved it, and on an engine that reconnects to change database, pinning somewhere else
+        /// would refuse the import outright.
+        guard let scope = DatabaseManager.shared.browseScope(for: connection.id) else {
             throw DatabaseError.notConnected
         }
+        let route = DatabaseManager.shared.executionRoute(for: scope)
 
         state = ImportState(isImporting: true)
         defer {
             state.isImporting = false
             currentProgress = nil
         }
-
-        let sink = ImportDataSinkAdapter(
-            driver: driver,
-            databaseType: connection.type,
-            targetTable: targetTable,
-            columnMapping: columnMapping
-        )
 
         let source: any PluginImportSource
         if type(of: plugin).requiresTargetTable {
@@ -135,17 +126,37 @@ final class ImportService {
         let startedAt = Date()
         let operationStart = ContinuousClock.Instant.now
         do {
-            result = try await plugin.performImport(
-                source: source,
-                sink: sink,
-                progress: progress
-            )
+            /// The whole import runs inside one lease, because the plugin's own `BEGIN` spans the
+            /// run: a per-statement lease would let another tab's statement execute inside the
+            /// import's transaction and be committed or rolled back with it. Taking the lease is
+            /// also what registers the import, so the health check no longer enters the same
+            /// non-thread-safe driver partway through a batch of inserts. `.protectedWrite`
+            /// because an import writes, so Stop in another tab must not reach it.
+            result = try await DatabaseManager.shared.withScopedDriver(
+                scope: scope,
+                route: route,
+                workload: .bulk,
+                cancellation: .protectedWrite
+            ) { driver in
+                try await self.runImport(
+                    plugin: plugin,
+                    driver: driver,
+                    source: source,
+                    progress: progress,
+                    targetTable: targetTable,
+                    columnMapping: columnMapping
+                )
+            }
         } catch {
             state.errorMessage = error.localizedDescription
 
             // An import the user cancelled is not a failed import, and the query paths already
             // keep cancellations out of history for the same reason.
             guard !(error is PluginImportCancellationError) else { throw error }
+            /// Cancelling while the import is still queued behind another tab's operation throws
+            /// before a single statement runs. That is the same "they stopped it" case, arriving
+            /// from the gate rather than from the plugin.
+            guard !(error is CancellationError) else { throw error }
 
             await historyRecorder.record(
                 QueryHistoryRecordRequest(
@@ -192,6 +203,26 @@ final class ImportService {
         )
 
         return result
+    }
+
+    /// The sink is built here rather than before the lease so it cannot outlive the driver it
+    /// wraps, and so every statement it issues lands on the leased, pinned connection.
+    @MainActor
+    private func runImport(
+        plugin: any ImportFormatPlugin,
+        driver: DatabaseDriver,
+        source: any PluginImportSource,
+        progress: PluginImportProgress,
+        targetTable: String?,
+        columnMapping: [String: String]
+    ) async throws -> PluginImportResult {
+        let sink = ImportDataSinkAdapter(
+            driver: driver,
+            databaseType: connection.type,
+            targetTable: targetTable,
+            columnMapping: columnMapping
+        )
+        return try await plugin.performImport(source: source, sink: sink, progress: progress)
     }
 
     /// An import the user cancelled reports nothing, matching what history already does with one

--- a/TablePro/Views/Export/TableTransferSheet.swift
+++ b/TablePro/Views/Export/TableTransferSheet.swift
@@ -476,11 +476,15 @@ struct TableTransferSheet: View {
             try await DatabaseManager.shared.withMetadataDriver(
                 scope: sourceScope, workload: .bulk
             ) { sourceDriver in
+                /// A transfer writes, inside its own transaction, across many statements. Left
+                /// untracked it registers nothing, so an unrelated Stop falls back to the session
+                /// driver and aborts it part-applied, and the health check counts the connection
+                /// as idle and pings straight into it.
                 try await DatabaseManager.shared.withScopedDriver(
                     scope: destinationScope,
                     route: destinationRoute,
                     workload: .bulk,
-                    cancellation: .untracked
+                    cancellation: .protectedWrite
                 ) { destinationDriver in
                     try await service.transfer(
                         request: request,

--- a/TablePro/Views/Import/RowImportSheet.swift
+++ b/TablePro/Views/Import/RowImportSheet.swift
@@ -909,9 +909,6 @@ struct RowImportSheet: View {
 
     @MainActor
     private func clearRows(of tableName: String) async throws {
-        guard let driver = DatabaseManager.shared.driver(for: connection.id) else {
-            throw DatabaseError.notConnected
-        }
         let generator = try SQLStatementGenerator(
             tableName: tableName,
             columns: [],
@@ -922,17 +919,33 @@ struct RowImportSheet: View {
         try await authorize(
             sql: sql, kind: .destructiveQuery, description: String(localized: "Clear Table")
         )
-        _ = try await driver.execute(query: sql)
+        try await runOnLeasedDriver(sql)
     }
 
     private func createTable(sql: String) async throws {
-        guard let driver = DatabaseManager.shared.driver(for: connection.id) else {
-            throw DatabaseError.notConnected
-        }
         try await authorize(
             sql: sql, kind: .schemaMutation, description: String(localized: "Create Table")
         )
-        _ = try await driver.execute(query: sql)
+        try await runOnLeasedDriver(sql)
+    }
+
+    /// The sheet's own statements take the same lease the import does, one at a time and always
+    /// after `authorize` has returned. Taking it earlier would hold the connection's gate open
+    /// across a safe-mode confirmation the user has not answered yet, and the gate is not
+    /// reentrant, so the import that follows would then wait on a sheet waiting on the user.
+    @MainActor
+    private func runOnLeasedDriver(_ sql: String) async throws {
+        guard let scope = DatabaseManager.shared.browseScope(for: connection.id) else {
+            throw DatabaseError.notConnected
+        }
+        let route = DatabaseManager.shared.executionRoute(for: scope)
+        _ = try await DatabaseManager.shared.withScopedDriver(
+            scope: scope,
+            route: route,
+            cancellation: .protectedWrite
+        ) { driver in
+            try await driver.execute(query: sql)
+        }
     }
 
     /// Every statement this sheet issues on its own account goes through the gate. The retry path's

--- a/TableProTests/Core/Database/ProtectedWritePingSuppressionTests.swift
+++ b/TableProTests/Core/Database/ProtectedWritePingSuppressionTests.swift
@@ -1,0 +1,65 @@
+//
+//  ProtectedWritePingSuppressionTests.swift
+//  TableProTests
+//
+//  The health check skips a connection with a query on it, but only for max(queryTimeout, 300)
+//  seconds. An import or a dump runs legitimately past that, and a check that goes ahead there can
+//  fail, reconnect, and disconnect the handle out from under a batch halfway through applying it.
+//
+
+import Foundation
+@testable import TablePro
+import TableProPluginKit
+import Testing
+
+@Suite("Protected write ping suppression", .serialized)
+@MainActor
+struct ProtectedWritePingSuppressionTests {
+    private func seed(_ policy: DriverCancellationPolicy, for connectionId: UUID) {
+        let connection = TestFixtures.makeConnection(type: .postgresql)
+        DatabaseManager.shared.runningDrivers[connectionId] = [
+            UUID(): RunningDriver(driver: MockDatabaseDriver(connection: connection), policy: policy)
+        ]
+    }
+
+    @Test("a write in flight is reported, whatever its age")
+    func protectedWriteIsReported() {
+        let connectionId = UUID()
+        defer { DatabaseManager.shared.runningDrivers.removeValue(forKey: connectionId) }
+
+        seed(.protectedWrite, for: connectionId)
+
+        #expect(DatabaseManager.shared.holdsProtectedWrite(connectionId))
+    }
+
+    /// The override was written for a read that hung, where pinging past it costs nothing. That
+    /// case has to keep working, or a genuinely stuck connection is never noticed.
+    @Test("a read that hung is still not treated as a protected write")
+    func cancellableReadIsNotProtected() {
+        let connectionId = UUID()
+        defer { DatabaseManager.shared.runningDrivers.removeValue(forKey: connectionId) }
+
+        seed(.cancellableRead, for: connectionId)
+
+        #expect(!DatabaseManager.shared.holdsProtectedWrite(connectionId))
+    }
+
+    @Test("a connection running nothing holds no write")
+    func idleConnectionHoldsNothing() {
+        #expect(!DatabaseManager.shared.holdsProtectedWrite(UUID()))
+    }
+
+    @Test("a write alongside a read still counts as a write")
+    func aWriteBesideAReadStillCounts() {
+        let connectionId = UUID()
+        defer { DatabaseManager.shared.runningDrivers.removeValue(forKey: connectionId) }
+        let connection = TestFixtures.makeConnection(type: .postgresql)
+
+        DatabaseManager.shared.runningDrivers[connectionId] = [
+            UUID(): RunningDriver(driver: MockDatabaseDriver(connection: connection), policy: .cancellableRead),
+            UUID(): RunningDriver(driver: MockDatabaseDriver(connection: connection), policy: .protectedWrite),
+        ]
+
+        #expect(DatabaseManager.shared.holdsProtectedWrite(connectionId))
+    }
+}

--- a/TableProTests/Core/Database/ReconnectCredentialRecoveryTests.swift
+++ b/TableProTests/Core/Database/ReconnectCredentialRecoveryTests.swift
@@ -17,6 +17,37 @@ struct ReconnectCredentialRecoveryTests {
         #expect(DatabaseManager.shared.isAuthenticationFailure(error))
     }
 
+    /// Nobody asked for a background reconnect, so it must not raise a modal sheet on whatever
+    /// window happens to be key, for a connection that may not even be the one on screen, and
+    /// block Disconnect and Quit until it is answered.
+    @Test("An unattended reconnect never asks for a password")
+    func unattendedReconnectDoesNotPrompt() async {
+        let manager = DatabaseManager.shared
+        var connection = TestFixtures.makeConnection(name: "Prod")
+        connection.promptForPassword = true
+        let session = ConnectionSession(connection: connection)
+        let error = FakePluginAuthError(
+            pluginErrorMessage: "Access denied",
+            pluginErrorCode: 1_045,
+            pluginSqlState: "28000"
+        )
+        let prompted = PromptFlag()
+
+        let resolution = await manager.reconnectCredentialResolution(
+            for: session,
+            error: error,
+            currentPassword: "expired-secret",
+            allowsCredentialPrompt: false,
+            prompt: { _, _, _ in
+                prompted.value = true
+                return "fresh-secret"
+            }
+        )
+
+        #expect(resolution == .fail)
+        #expect(!prompted.value)
+    }
+
     @Test("Prompt-for-password connections retry with fresh password")
     func retriesWithFreshPassword() async {
         let manager = DatabaseManager.shared
@@ -115,4 +146,8 @@ private struct FakePluginAuthError: PluginDriverError {
     let pluginErrorMessage: String
     let pluginErrorCode: Int?
     let pluginSqlState: String?
+}
+
+private final class PromptFlag: @unchecked Sendable {
+    var value = false
 }

--- a/TableProTests/Core/Plugins/PingNeverReconnectsTests.swift
+++ b/TableProTests/Core/Plugins/PingNeverReconnectsTests.swift
@@ -1,0 +1,104 @@
+//
+//  PingNeverReconnectsTests.swift
+//  TableProTests
+//
+//  A ping that heals its own connection reports success into a server session the app has just
+//  lost: the startup commands, the query timeout, the database and the schema all belong to
+//  `DatabaseManager.reconnectDriver`, and a private reconnect inside the driver re-runs none of
+//  them. Failing instead is what routes recovery through the manager (#2700).
+//
+//  The driver sources are not in the test target, because they need their C bridges, so this is a
+//  source scan rather than a behavioural test.
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("Ping never reconnects")
+struct PingNeverReconnectsTests {
+    /// Snowflake is the one deliberate exception. Its probe goes through `withReauthentication`,
+    /// and an expired token is ordinary rather than a fault, so failing the ping would rebuild the
+    /// driver every few hours instead of renewing the session it already has.
+    private static let allowed: Set<String> = ["SnowflakeConnection.swift"]
+
+    /// Calls that recover a dropped connection and replay, rather than reporting it.
+    private static let reconnectingCalls = ["executeWithReconnect(", "SyncRetrying(", "boundedQueryWithReconnect("]
+
+    @Test("no driver's ping routes through a call that reconnects and replays")
+    func pingsDoNotHealThemselves() throws {
+        var offenders: [String] = []
+
+        for source in try Self.pluginSources() {
+            guard !Self.allowed.contains(source.url.lastPathComponent) else { continue }
+            /// A driver that has a reconnecting execute path must not reach its plain `execute`
+            /// from a ping either: that is the indirection PostgreSQL's ping used, where the
+            /// reconnect is a layer further down than the call site shows.
+            let heals = source.text.contains("func executeWithReconnect(")
+            for body in Self.pingBodies(in: source.text) {
+                for call in Self.reconnectingCalls where body.contains(call) {
+                    offenders.append("\(source.url.lastPathComponent): ping() calls \(call)")
+                }
+                if heals, body.contains("execute(query:") {
+                    offenders.append("\(source.url.lastPathComponent): ping() calls execute(query:), which reconnects")
+                }
+            }
+        }
+
+        #expect(
+            offenders.isEmpty,
+            """
+            A ping must report a dropped connection rather than repair it, or the health check \
+            succeeds against a session that lost its startup commands, query timeout, database and \
+            schema: \(offenders.sorted())
+            """
+        )
+    }
+
+    /// Everything from a `func ping(` line to the first line closing it at the declaration's own
+    /// indentation, which is enough to tell one function's body from its neighbours'.
+    private static func pingBodies(in text: String) -> [String] {
+        let lines = text.components(separatedBy: .newlines)
+        var bodies: [String] = []
+        for (index, line) in lines.enumerated() where line.contains("func ping(") {
+            let indent = line.prefix { $0 == " " }.count
+            let closing = String(repeating: " ", count: indent) + "}"
+            guard let end = lines[(index + 1)...].firstIndex(of: closing) else { continue }
+            bodies.append(lines[index ... end].joined(separator: "\n"))
+        }
+        return bodies
+    }
+
+    private struct PluginSource {
+        let url: URL
+        let text: String
+    }
+
+    private static func pluginSources(file: StaticString = #filePath) throws -> [PluginSource] {
+        let root = try repositoryRoot(file: file).appendingPathComponent("Plugins")
+        guard let walker = FileManager.default.enumerator(at: root, includingPropertiesForKeys: nil) else {
+            throw ScanError.sourcesNotFound
+        }
+        var sources: [PluginSource] = []
+        for case let url as URL in walker where url.pathExtension == "swift" {
+            guard let text = try? String(contentsOf: url, encoding: .utf8), text.contains("func ping(") else { continue }
+            sources.append(PluginSource(url: url, text: text))
+        }
+        guard !sources.isEmpty else { throw ScanError.sourcesNotFound }
+        return sources
+    }
+
+    private static func repositoryRoot(file: StaticString) throws -> URL {
+        var directory = URL(fileURLWithPath: "\(file)").deletingLastPathComponent()
+        while directory.path != "/" {
+            let candidate = directory.appendingPathComponent("Plugins/TableProPluginKit/DriverPlugin.swift")
+            if FileManager.default.fileExists(atPath: candidate.path) { return directory }
+            directory = directory.deletingLastPathComponent()
+        }
+        throw ScanError.sourcesNotFound
+    }
+
+    private enum ScanError: Error {
+        case sourcesNotFound
+    }
+}


### PR DESCRIPTION
The collateral register from #2700. Every defect that investigation found and #2706 reported rather than shipped, plus two more the review of this work turned up. All independently verified; none of them needed #2706 to be wrong.

## The theme

Three of these are one bug wearing different clothes: **something that reports on a connection was allowed to change it, or to run beside work that owns it.** A check that repairs what it was asked to report on cannot be believed. A write that registers nothing looks idle to everything that asks.

## What changed

**A health check no longer repairs the connection it is checking.** PostgreSQL's `ping()` ran `SELECT 1` through `execute` → `executeWithReconnect`, which recovers a dropped connection privately. MySQL's did the same. That recovery restores none of the session state the app put there: the startup commands, the query timeout, the database and the schema all belong to `DatabaseManager.reconnectDriver`. So after a long idle disconnect a check reported success into a server session that had been reset behind the user's back, and their next statement ran without the role, search path or time zone their startup SQL set. Both pings are now non-reconnecting, so a dropped socket fails the check and routes recovery through the manager, which restores all of it.

MySQL needed two doors closed, not one. Passing `isRetry: true` disables the reconnect arm in `executeWithReconnect`, but `requireConnection()` is a second one: a nil handle sends it through `reacquireOnce()`. `ping()` now takes the connection through a new `requireLiveConnection()` that throws instead, while keeping both halves of its existing contract, the early return when the connection is idle-released and never counting as activity, and still taking an operation slot so `release(idleFor:)` cannot null the handle mid-ping.

The PostgreSQL edit is one line in `LibPQDriverCore` but covers four drivers: PostgreSQL, Redshift, CockroachDB and PGlite all take `ping()` from the `LibPQBackedDriver` protocol extension.

**Snowflake is deliberately left alone**, and `PingNeverReconnectsTests` allowlists it by name with the reason inline. Its probe goes through `withReauthentication`, and an expired token is ordinary rather than a fault, so failing the ping would rebuild the driver every few hours instead of renewing the session it already has.

**Redis is left alone too, but its comment was wrong.** It claimed "a lost socket does not reach here; it throws out of `executeCommand`". It does not throw: `executeCommandSyncRetrying` reconnects and replays. That is survivable for Redis in a way it is not for the SQL engines, because `reconnectSync` re-selects the database and Redis carries almost no other session state, so the behaviour stands and the comment now says what the code does. The residue, that a replay does not restore the connection's startup commands, is written down rather than fixed, because the change needs its own non-replaying entry point on the shared command channel and that path is the survival guarantee for every ordinary Redis command.

**MongoDB stops reporting a dead server as healthy.** `MongoDBPluginDriver` declared no `ping()`, so it used the PluginKit default, which runs `SELECT 1`; MongoDB's `execute` special-cases that string, calls `MongoDBConnection.ping()`, throws away the `Bool` it returns and fabricates an `ok = 1` row. A paused Atlas cluster, a replica-set failover or a dropped network read as healthy for as long as the app ran, the monitor never entered its reconnect, and liveness stayed `.live`, which is what `ensureConnected` returns early on. It has a real `ping()` now, and the `SELECT 1` arm reports the true answer for a user who types it.

**An import runs on a leased driver.** `ImportService` took the raw session driver and ran a whole multi-statement import on it with no `sessionDriverGate` and no `trackOperation`, so the health check could enter the same non-thread-safe driver mid-batch and a reconnect could disconnect the handle out from under it. The whole import now runs inside one `withScopedDriver` lease, on `browseScope` where the driver actually is, `workload: .bulk`, `cancellation: .protectedWrite`, with the sink built inside so it cannot outlive the driver it wraps.

One lease for the whole run, not one per statement: the plugin's own `BEGIN` spans the import, so a per-statement lease would let another tab's statement execute inside the import's transaction and be committed or rolled back with it.

**The stale-ping override no longer defeats that.** The check skips a connection with a query on it, but only for `max(queryTimeout, 300)` seconds, and an import legitimately runs past that. `holdsProtectedWrite` is now consulted in that branch, so a protected write is never pinged whatever its age, while a read that hung still is, which is what the override was written for.

**`RowImportSheet`'s own `CREATE TABLE` and `DELETE FROM`** take the same lease, one statement at a time, always after `authorize` returns. The order is load-bearing: `ExecutionGateProvider.authorize` can raise a safe-mode confirmation, and the gate is not reentrant, so holding it across an unanswered modal would deadlock the import that follows.

**A table transfer is no longer abortable by an unrelated Stop.** `TableTransferSheet` leased the destination `.untracked` for a multi-statement write inside its own transaction. Registering nothing means `cancellationTargets` falls back to the session driver on any Stop, so a Stop in another tab could abort a transfer part-applied, and the new ping suppression would never see it either. It is `.protectedWrite` now. `ExportDialog` keeps `.untracked` deliberately: export reads.

**A background reconnect never asks for a password.** `performHealthMonitorReconnect` reached `PasswordPromptHelper.prompt` on an auth failure, so a `prompt-for-password` connection whose password was rotated server-side raised a modal sheet on whichever window happened to be key, for a connection that might not be the one on screen, and blocked Disconnect and Quit until answered. `allowsCredentialPrompt` is threaded through; the unattended path fails quietly into the inline unavailable state, and the user-initiated `reconnectSession` still prompts, which is where prompting belongs.

## Verified

- `generate` PASS, `build` PASS, `lint` 0 violations across `TablePro`, `TableProTests` and the four plugin paths.
- `plugins` (AllPlugins): MySQL, PostgreSQL and MongoDB all compile. The aggregate fails locally only on the vendored `oracle-nio` `@TaskLocal` macro (`unknown attribute 'usableFromInlinenonisolated'`), which reproduces on `main` with this toolchain and is unrelated.
- Tests: 51 across `PingNeverReconnectsTests`, `ProtectedWritePingSuppressionTests`, the three `ScopedDriver*` suites, `ConnectionVerificationTests`, `ReconnectCredentialRecoveryTests`, `HealthMonitorReconnectTests` and `HealthMonitorOptOutParityTests`. All green.
- `PingNeverReconnectsTests` is a source scan, because the driver sources need their C bridges and are not in the test target. It catches both shapes that shipped: a ping naming a reconnecting call, and a ping reaching a plain `execute(query:` in a file that has a reconnecting execute path, which is the indirection PostgreSQL's used.
- `injectSession` now stamps the verification timestamp, because it stands in for a completed connect and a completed connect stamps. Without it every injected session read as never having answered and the first scoped operation in a test paid a check production would never make.

## Not covered by automation

A real import crossing the five-minute stale window needs a live server and a file large enough to take that long, so there is no deterministic UI test for the ping suppression end to end. The predicate it turns on is unit-tested; the integration is not.

## Still open

**Redis's ping still replays over a reconnect**, as described above. It preserves the selected database and loses the connection's startup commands. Fixing it means adding a non-replaying entry point to `RedisCommandChannel` with a forwarding default and overriding it only on the direct connection, leaving Cluster and Sentinel on the shared path. Worth doing, not worth bundling into this.

https://claude.ai/code/session_0133D7mARM8FyNgNnXfhrKRJ
