### PR TITLE
refactor(connections): name a connect step only where the reader can act on it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - 5 MB smaller app bundle.
 - 7 MB smaller DMG download.
+- Connect progress reads as a labelled bar, with a step named only where the app is waiting on something outside itself.
 
 ### Fixed
 

--- a/TablePro/Core/Database/DatabaseManager+Sessions.swift
+++ b/TablePro/Core/Database/DatabaseManager+Sessions.swift
@@ -130,7 +130,11 @@ extension DatabaseManager {
             try Task.checkCancellation()
             try ensureAttemptIsCurrent(attempt, for: connection.id, driver: driver)
 
-            reportStage(.preparingSession, attempt: attempt, for: connection.id)
+            reportStage(
+                Self.preparingSessionStage(for: resolvedConnection),
+                attempt: attempt,
+                for: connection.id
+            )
             await applyTimeoutAndStartupCommands(
                 on: driver,
                 startupCommands: resolvedConnection.startupCommands,
@@ -619,6 +623,16 @@ extension DatabaseManager {
         AppEvents.shared.connectionStageChanged.send(
             ConnectionStageChange(connectionId: connectionId, stage: stage)
         )
+    }
+
+    /// Preparing the session is the app's own work and says nothing a reader can act on, with one
+    /// exception: it is also where their startup commands run, and a statement that hangs there
+    /// hangs the connect. Naming that case is the difference between a bar with no explanation and
+    /// one the reader knows to blame their own SQL for.
+    private static func preparingSessionStage(for connection: DatabaseConnection) -> ConnectionStage {
+        let commands = connection.startupCommands?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !commands.isEmpty else { return .preparingSession }
+        return .custom(String(localized: "Waiting for your startup commands"))
     }
 
     /// The step an in-flight connect last reported, or nil when none is running.

--- a/TablePro/Models/Connection/ConnectionStageLabelFormatter.swift
+++ b/TablePro/Models/Connection/ConnectionStageLabelFormatter.swift
@@ -6,27 +6,64 @@
 import Foundation
 import TableProPluginKit
 
-/// Two forms of the same stage. `stepLabel` sits under a heading that already names the
-/// connection and its endpoint, so it only has to say which step is running. `announcement`
-/// is spoken with no surrounding context, so it names the connection itself.
+/// Two forms of the same stage, and only one of them is drawn.
 ///
-/// Neither form is ever a bare "Loading" or "Authenticating": the HIG calls those out by name
-/// as descriptions that add nothing, and a step that does not say what it is acting on is
-/// exactly that.
+/// `description` is the line beside the progress bar. It exists for the steps where the app is
+/// blocked on something that is not the database: a hop the reader cannot see, a script they
+/// wrote, or the reader themselves. Every other step restates the card it sits under, which
+/// already carries the connection's name and its endpoint, so it draws nothing at all. The HIG
+/// makes the description conditional in the same words: "If it's helpful, display a description
+/// that provides additional context for the task. Be accurate and succinct. Avoid vague terms
+/// like loading or authenticating because they seldom add value."
+///
+/// Two of those steps were also never comparable between engines. `negotiatingEncryption` is
+/// reported by 2 of the 38 drivers and `authenticating` by 3, so the same connect narrated a
+/// different story depending on which plugin answered, for a difference the reader has no way to
+/// act on.
+///
+/// `announcement` is the spoken form and covers every step, because a progress bar tells VoiceOver
+/// nothing and the step is then the only progress there is. Quiet on screen is not quiet in the
+/// accessibility tree.
 internal enum ConnectionStageLabelFormatter {
-    internal static func stepLabel(for stage: ConnectionStage, connection: DatabaseConnection) -> String {
+    /// What the connecting card draws, or nil where the bar alone says as much.
+    internal static func description(for stage: ConnectionStage, connection: DatabaseConnection) -> String? {
         switch stage {
         case .resolvingTunnel:
             guard let via = tunnelDescription(for: connection) else {
-                return String(localized: "Opening the tunnel")
+                return String(localized: "Waiting for the tunnel")
             }
-            return String(format: String(localized: "Opening the tunnel through %@"), via)
+            return String(format: String(localized: "Waiting for %@"), via)
         case .runningPreConnectScript:
-            return String(localized: "Running the pre-connect script")
+            return String(localized: "Waiting for your pre-connect script")
         case .awaitingCredentials:
             return String(localized: "Waiting for your password")
-        case .openingConnection:
-            return String(localized: "Opening the connection")
+        case .custom(let text):
+            /// A plugin that went to the trouble of naming its own step has said something the
+            /// shared vocabulary does not cover, so it is drawn as written.
+            return text
+        case .openingConnection, .negotiatingEncryption, .authenticating, .preparingSession:
+            return nil
+        @unknown default:
+            return nil
+        }
+    }
+
+    internal static func announcement(for stage: ConnectionStage, connection: DatabaseConnection) -> String {
+        String(
+            format: String(localized: "%1$@ on %2$@"),
+            spokenLabel(for: stage, connection: connection),
+            connection.name
+        )
+    }
+
+    /// Spoken rather than drawn, so it answers for the steps the card stays quiet about. The
+    /// vocabulary is deliberately the plain one: to a reader who cannot see the bar, "Opening the
+    /// connection" is the progress, not a restatement of it.
+    private static func spokenLabel(for stage: ConnectionStage, connection: DatabaseConnection) -> String {
+        if let description = description(for: stage, connection: connection) {
+            return description
+        }
+        switch stage {
         case .negotiatingEncryption:
             return String(localized: "Negotiating encryption")
         case .authenticating:
@@ -35,19 +72,11 @@ internal enum ConnectionStageLabelFormatter {
             return String(format: String(localized: "Authenticating %@"), username)
         case .preparingSession:
             return String(localized: "Preparing the session")
-        case .custom(let text):
-            return text
+        case .openingConnection, .resolvingTunnel, .runningPreConnectScript, .awaitingCredentials, .custom:
+            return String(localized: "Opening the connection")
         @unknown default:
             return String(localized: "Opening the connection")
         }
-    }
-
-    internal static func announcement(for stage: ConnectionStage, connection: DatabaseConnection) -> String {
-        String(
-            format: String(localized: "%1$@ on %2$@"),
-            stepLabel(for: stage, connection: connection),
-            connection.name
-        )
     }
 
     private static func trimmedUsername(of connection: DatabaseConnection) -> String {

--- a/TablePro/Views/Connection/ConnectingStateView.swift
+++ b/TablePro/Views/Connection/ConnectingStateView.swift
@@ -24,6 +24,10 @@ internal struct ConnectingStateView: View {
     @State private var observer: ConnectionStageObserver
     @State private var showsCard = false
 
+    /// The description line keeps its height whether or not it has anything to say, so the bar
+    /// under it and the Cancel button under that never move when a step arrives or goes.
+    @ScaledMetric(relativeTo: .callout) private var descriptionHeight: CGFloat = 16
+
     internal init(connection: DatabaseConnection, onCancel: @escaping () -> Void) {
         self.connection = connection
         self.onCancel = onCancel
@@ -85,16 +89,26 @@ internal struct ConnectingStateView: View {
         .accessibilityLabel(accessibilityStatus)
     }
 
+    /// A bar rather than a spinner, and the description above it rather than beside it.
+    ///
+    /// Measured on macOS 27: Finder's Connect to Server draws "Connecting to smb://… " over a
+    /// horizontal `AXOrientation=AXHorizontalOrientation` busy indicator, and Screen Sharing
+    /// repeats it. That is the shape the HIG's two rules leave standing: "Avoid labeling a
+    /// spinning progress indicator" rules out text next to a spinner, so an operation that has
+    /// something to say uses the control that can carry it. Apple never labels a spinner because
+    /// Apple never reaches for one here.
     @ViewBuilder
     private var progressLine: some View {
         VStack(spacing: 6) {
-            HStack(spacing: 8) {
-                ProgressView()
-                    .controlSize(.small)
-                Text(stepLabel)
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
-            }
+            Text(stepDescription ?? "")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .frame(height: descriptionHeight)
+
+            ProgressView()
+                .progressViewStyle(.linear)
 
             if observer.isTakingLonger {
                 Text(String(localized: "This is taking longer than usual."))
@@ -106,9 +120,9 @@ internal struct ConnectingStateView: View {
         .multilineTextAlignment(.center)
     }
 
-    private var stepLabel: String {
-        guard let stage = observer.stage else { return String(localized: "Opening the connection") }
-        return ConnectionStageLabelFormatter.stepLabel(for: stage, connection: connection)
+    private var stepDescription: String? {
+        guard let stage = observer.stage else { return nil }
+        return ConnectionStageLabelFormatter.description(for: stage, connection: connection)
     }
 
     private var accessibilityStatus: String {

--- a/TableProTests/Models/Connection/ConnectionStageLabelFormatterTests.swift
+++ b/TableProTests/Models/Connection/ConnectionStageLabelFormatterTests.swift
@@ -2,9 +2,14 @@
 //  ConnectionStageLabelFormatterTests.swift
 //  TableProTests
 //
-//  The HIG names "loading" and "authenticating" as descriptions that add nothing. A step label
-//  has to say what it is acting on, and the spoken form has to name the connection because it
-//  is heard without the window around it.
+//  The HIG makes the description beside a progress indicator conditional: "If it's helpful,
+//  display a description that provides additional context for the task. Be accurate and succinct.
+//  Avoid vague terms like loading or authenticating because they seldom add value."
+//
+//  The previous version of this suite claimed to hold that line and did not. It compared the whole
+//  label against a list of banned words with `banned.contains(label)`, so "Authenticating postgres"
+//  passed while being exactly the word the HIG names, and the file's own doc comment asserted a
+//  rule the code had stopped keeping.
 //
 
 import Foundation
@@ -37,60 +42,56 @@ struct ConnectionStageLabelFormatterTests {
         .preparingSession
     ]
 
-    @Test("No step is a bare verb")
-    func noStepIsABareVerb() {
+    /// The steps the card stays quiet about. Each one restates the name and endpoint already above
+    /// it, and two of them are reported by a handful of the 38 drivers, so the same connect read
+    /// differently depending on which plugin answered.
+    private static let silentStages: [ConnectionStage] = [
+        .openingConnection,
+        .negotiatingEncryption,
+        .authenticating,
+        .preparingSession
+    ]
+
+    @Test("A step that only restates the card draws nothing")
+    func genericStepsDrawNothing() {
         let connection = Self.connection()
-        let banned = ["Loading", "Authenticating", "Connecting", "Please wait"]
 
-        for stage in Self.stages {
-            let label = ConnectionStageLabelFormatter.stepLabel(for: stage, connection: connection)
-            #expect(!label.isEmpty)
-            #expect(!banned.contains(label))
+        for stage in Self.silentStages {
+            #expect(
+                ConnectionStageLabelFormatter.description(for: stage, connection: connection) == nil,
+                "\(stage) has nothing to add to the name and endpoint above it"
+            )
         }
     }
 
-    @Test("Authenticating names the user it is authenticating")
-    func authenticatingNamesTheUser() {
-        let label = ConnectionStageLabelFormatter.stepLabel(
-            for: .authenticating,
-            connection: Self.connection(username: "reporting_ro")
-        )
-
-        #expect(label.contains("reporting_ro"))
-    }
-
-    @Test("A connection with no username still gets a usable step")
-    func authenticatingWithoutUsername() {
-        let label = ConnectionStageLabelFormatter.stepLabel(
-            for: .authenticating,
-            connection: Self.connection(username: "  ")
-        )
-
-        #expect(!label.isEmpty)
-        #expect(!label.contains("  "))
-    }
-
-    @Test("Every spoken stage names the connection")
-    func announcementsNameTheConnection() {
-        let connection = Self.connection(name: "Prod DB")
+    /// The rule the old suite meant to enforce, written so that a label merely containing the word
+    /// fails rather than only a label equal to it.
+    @Test("No drawn description uses a bare status verb")
+    func drawnDescriptionsAvoidVagueVerbs() {
+        let connection = Self.connection()
+        let vague = ["loading", "authenticating", "connecting", "please wait", "negotiating"]
 
         for stage in Self.stages {
-            let announcement = ConnectionStageLabelFormatter.announcement(for: stage, connection: connection)
-            #expect(announcement.contains("Prod DB"))
+            guard let description = ConnectionStageLabelFormatter
+                .description(for: stage, connection: connection)?.lowercased() else { continue }
+            for word in vague {
+                #expect(!description.contains(word), "\(stage) drew \"\(description)\"")
+            }
         }
     }
 
-    @Test("A plugin's own wording is passed through untouched")
-    func customStagePassesThrough() {
-        let label = ConnectionStageLabelFormatter.stepLabel(
-            for: .custom("Discovering replica set members"),
-            connection: Self.connection()
-        )
+    /// The three that survive are the ones where the app is blocked on something outside itself.
+    @Test("A step the reader can act on names what the app is waiting for")
+    func actionableStepsNameTheWait() {
+        let connection = Self.connection()
 
-        #expect(label == "Discovering replica set members")
+        for stage in [ConnectionStage.runningPreConnectScript, .awaitingCredentials] {
+            let description = ConnectionStageLabelFormatter.description(for: stage, connection: connection)
+            #expect(description?.isEmpty == false)
+        }
     }
 
-    @Test("An SSH tunnel step names the host it goes through")
+    @Test("A tunnel step names the host it is waiting for")
     func tunnelStepNamesTheJumpHost() {
         var sshConfig = SSHConfiguration()
         sshConfig.enabled = true
@@ -100,8 +101,66 @@ struct ConnectionStageLabelFormatterTests {
         var connection = Self.connection()
         connection.sshTunnelMode = .inline(sshConfig)
 
-        let label = ConnectionStageLabelFormatter.stepLabel(for: .resolvingTunnel, connection: connection)
+        let description = ConnectionStageLabelFormatter.description(
+            for: .resolvingTunnel,
+            connection: connection
+        )
 
-        #expect(label.contains("bastion.example.com"))
+        #expect(description?.contains("bastion.example.com") == true)
+    }
+
+    /// A tunnel with nothing to name still says which of the two ends is holding things up.
+    @Test("A tunnel with no host still draws")
+    func tunnelWithoutAHostStillDraws() {
+        let description = ConnectionStageLabelFormatter.description(
+            for: .resolvingTunnel,
+            connection: Self.connection()
+        )
+
+        #expect(description?.isEmpty == false)
+    }
+
+    @Test("A plugin's own wording is passed through untouched")
+    func customStagePassesThrough() {
+        let description = ConnectionStageLabelFormatter.description(
+            for: .custom("Discovering replica set members"),
+            connection: Self.connection()
+        )
+
+        #expect(description == "Discovering replica set members")
+    }
+
+    /// A progress bar tells VoiceOver nothing, so the steps the card stays quiet about are still
+    /// spoken. Quiet on screen is not quiet in the accessibility tree.
+    @Test("Every stage is spoken, including the ones that draw nothing")
+    func everyStageIsSpoken() {
+        let connection = Self.connection(name: "Prod DB")
+
+        for stage in Self.stages {
+            let announcement = ConnectionStageLabelFormatter.announcement(for: stage, connection: connection)
+            #expect(announcement.contains("Prod DB"))
+            #expect(announcement.count > "Prod DB".count)
+        }
+    }
+
+    @Test("The spoken form of authenticating names the user it is authenticating")
+    func spokenAuthenticationNamesTheUser() {
+        let announcement = ConnectionStageLabelFormatter.announcement(
+            for: .authenticating,
+            connection: Self.connection(username: "reporting_ro")
+        )
+
+        #expect(announcement.contains("reporting_ro"))
+    }
+
+    @Test("A connection with no username is still spoken")
+    func spokenAuthenticationWithoutUsername() {
+        let announcement = ConnectionStageLabelFormatter.announcement(
+            for: .authenticating,
+            connection: Self.connection(username: "  ")
+        )
+
+        #expect(!announcement.isEmpty)
+        #expect(!announcement.contains("  "))
     }
 }


### PR DESCRIPTION
Follow-up to #2705, which left the connect step labels alone and said so. This is that work.

The connecting card reported seven steps as text beside a small circular spinner. Two of them were the words the Human Interface Guidelines names outright, and four of them restated the card they sat under.

## What the HIG actually says, and what I got wrong first

Two rules govern this, quoted verbatim from Apple's own material:

- "If it's helpful, display a description that provides additional context for the task. Be accurate and succinct. **Avoid vague terms like loading or authenticating because they seldom add value.**"
- macOS: "**Avoid labeling a spinning progress indicator.** Because a spinner typically appears when people initiate a process, a label is usually unnecessary."

My first reading of the second rule was that the label had to go. That is wrong, and measuring Apple's own apps on this machine is what showed it. Finder's Connect to Server draws `Connecting to smb://192.0.2.1 …` **above a horizontal bar**, with a cancel at the bar's trailing edge; Screen Sharing repeats the pattern with `Connecting to “192.0.2.1”…`. The accessibility dump of Finder's indicator reads `AXRoleDescription="busy indicator"`, `AXOrientation=AXHorizontalOrientation`.

So Apple never labels a spinner because Apple never reaches for a spinner when there is something to say. **Needing status text is what rules the spinner out.** The connecting surface now uses `ProgressView().progressViewStyle(.linear)`, which is already the idiom in five other places in this app.

## Which steps survive

A description is drawn where the app is blocked on something that is not the database: a hop the reader cannot see, a script they wrote, or the reader themselves. One vocabulary for all of them.

| Step | Drawn |
|---|---|
| `resolvingTunnel` | `Waiting for 103.57.220.28`, or the tunnel's own name |
| `runningPreConnectScript` | `Waiting for your pre-connect script` |
| `awaitingCredentials` | `Waiting for your password` |
| `custom` | the plugin's own words |
| `openingConnection` | nothing |
| `negotiatingEncryption` | nothing |
| `authenticating` | nothing |
| `preparingSession` | nothing, unless startup commands are set |

Two arguments beyond the HIG's wording rule, both from measurement rather than taste:

The card already carries the connection's name and `host · database · via <ssh host>`, so `openingConnection` restated the whole screen.

`negotiatingEncryption` is reported by 2 of the 38 drivers and `authenticating` by 3. The same connect therefore narrated a different story depending on which plugin answered, for a difference nobody can act on.

`preparingSession` had one thing in it worth naming: it is where the reader's own startup commands run, and a statement that hangs there hangs the connect. That case now reports `Waiting for your startup commands` instead of staying silent.

## What did not change

`ConnectionStage` is untouched. It is public PluginKit API and shipped plugins already report `.negotiatingEncryption` and `.authenticating`; removing a case would break them for a wording problem. Only the formatter and the view moved.

VoiceOver still hears all seven steps. A progress bar tells it nothing, so the step is the only progress there is, and quiet on screen is not quiet in the accessibility tree. `announcement(for:connection:)` keeps a sentence for every stage, including the four the card no longer draws.

Cancel keeps its visible label. Both Apple apps ship an icon-only cancel whose only name is an accessibility description, and the two of them disagree on what it says: `stop progress` in Finder, `Cancel` in Screen Sharing. Ours is better as it is.

## Layout

The description line keeps its height whether or not it has anything to say, so the bar under it and the Cancel button under that do not move when a step arrives or goes. That is the whole point of #2705 applied one level down. It costs a line of air on the connects that never draw a description, which is the trade I would make again: the line toggles once per connect on a tunnelled connection, and once more when startup commands are set.

`@ScaledMetric(relativeTo: .callout)` sizes the reservation, so it follows Dynamic Type rather than pinning a number.

## Verification

| Step | Result |
|---|---|
| `verify.sh build` | PASS |
| `verify.sh test` over the label, stage, chrome, resolver and tunnel suites | PASS, 59 cases |
| `verify.sh lint TablePro TableProTests TableProUITests` | 0 violations |

The test suite that guards this rule was rewritten, because the old one claimed to guard it and did not. It compared the whole label against a list of banned words with `banned.contains(label)`, so `Authenticating postgres` passed while being exactly the word the HIG names, and the file's own doc comment asserted a rule the code had quietly stopped keeping. The new suite fails on a label that merely *contains* a vague verb, and pins which steps draw nothing at all.

`verify.sh lint` reports one stale reference at `CLAUDE.md:214` to `NSAccessibilitySortDirectionAttribute`. It is pre-existing and unrelated: the symbol is an Objective-C constant that does not appear in the Swift SDK interface the checker reads.

## Before / After

Attached in a comment. Before is the reported recording: `Authenticating postgres` beside a spinner. After is a Debug build opening a connection to `192.0.2.1`, which is TEST-NET-1 and never answers, showing the bar with no description because none of that connect's steps has anything to add.

The labelled state is covered by unit tests rather than a screenshot: reaching it needs a tunnel that hangs, and the connection form has no accessibility identifier on the SSH username field, so a capture harness cannot save one without adding an identifier this change has no other reason to add.

https://claude.ai/code/session_01E7NyyUtYWAZUvWrBtwpjsA
