### PR TITLE
fix(datagrid): show a timestamp as the database wrote it

### DIFF
--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -73,6 +73,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       run: ${{ steps.decide.outputs.run }}
+      oracle: ${{ steps.decide.outputs.oracle }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -101,6 +102,14 @@ jobs:
             'TableProMobile/project\.yml$' 'project\.yml$' \
             '\.github/workflows/macos-tests\.yml$')
           echo "run=$RUN" >> "$GITHUB_OUTPUT"
+          ORACLE=$(scripts/ci/detect-changed-paths.sh \
+            --event "$EVENT_NAME" \
+            --base "$BASE_SHA" \
+            --ref "$REF" \
+            --skip-release-commit \
+            'Packages/TableProOracle/' \
+            '\.github/workflows/macos-tests\.yml$')
+          echo "oracle=$ORACLE" >> "$GITHUB_OUTPUT"
 
   packages:
     name: Package Tests
@@ -118,6 +127,18 @@ jobs:
 
       - name: Run TableProCore package tests
         run: swift test --package-path Packages/TableProCore
+
+      # The only thing that runs TableProOracleCore's suites. AllPlugins proves the module
+      # compiles and nothing more, and the package is not a TableProTests dependency, so the cases
+      # cannot move there: importing it drags oracle-nio into the app test bundle. Gated on its own
+      # narrower filter because it resolves a second dependency graph, and pinned to the tracked
+      # Package.resolved so a manifest bump that forgets the lockfile fails here rather than
+      # silently floating. It cannot run on a developer Mac with Xcode 27 / Swift 6.4: oracle-nio's
+      # @TaskLocal macro expands to `unknown attribute 'usableFromInlinenonisolated'` there, which
+      # is the dependency and not your diff.
+      - name: Run TableProOracle package tests
+        if: needs.changes.outputs.oracle == 'true'
+        run: swift test --package-path Packages/TableProOracle --force-resolved-versions
 
       # CodeEditSourceEditor is deliberately not run here. `swift test` cannot build it on this
       # runner: its CodeEditSymbols dependency fails with "type 'Bundle' has no member 'module'",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SQLite, DuckDB and Teradata connections pinged every 30 seconds despite opting out of health checks. (#2700)
 - Data grid dropping the UTC offset from a `timestamp with time zone` value. (#2702)
 - Oracle `TIMESTAMP` values carrying a `Z` the column never stored. (#2702)
+- Timestamp shown an hour late, and its time lost on an edit, when the value falls in the reader's daylight-saving gap. (#2702)
+- Timestamp stored on a day the reader's time zone skipped rendering as raw text with no date picker. (#2702)
+- Sub-second precision missing from timestamp cells, merging distinct values into one entry in the column filter. (#2702)
+- Grid cells still reading in the old time zone after the Mac's time zone changed. (#2702)
 - Connection colour set on an iPhone not showing on the Mac, and the reverse.
 - Connection still reading as read-only on an iPhone after read-only was turned off on the Mac.
 - Window rebuilding its own layout three times while a connection opens.

--- a/Packages/TableProOracle/Sources/TableProOracleCore/OracleCellFormatting.swift
+++ b/Packages/TableProOracle/Sources/TableProOracleCore/OracleCellFormatting.swift
@@ -10,9 +10,7 @@ public enum OracleCellFormatting {
         /// grid dropped the suffix on the way to the cell, so the claim was invisible until the
         /// grid started printing the offset a value arrives with. (#2702)
         case naive
-        case utc
         case local
-        case zoned
     }
 
     public static let dateOnlyFormatter: DateFormatter = {
@@ -32,26 +30,11 @@ public enum OracleCellFormatting {
         return formatter
     }()
 
-    private static let utcFormatter: OSAllocatedUnfairLock<ISO8601DateFormatter> = {
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        formatter.timeZone = TimeZone(secondsFromGMT: 0)
-        return OSAllocatedUnfairLock(uncheckedState: formatter)
-    }()
-
     private static let localFormatter: OSAllocatedUnfairLock<ISO8601DateFormatter> = {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        formatter.timeZone = .current
+        formatter.timeZone = .autoupdatingCurrent
         return OSAllocatedUnfairLock(uncheckedState: formatter)
-    }()
-
-    private static let zonedFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = .current
-        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSxxxxx"
-        return formatter
     }()
 
     public static func formatDate(_ date: Date) -> String {
@@ -62,12 +45,8 @@ public enum OracleCellFormatting {
         switch style {
         case .naive:
             return naiveFormatter.string(from: date)
-        case .utc:
-            return utcFormatter.withLockUnchecked { $0.string(from: date) }
         case .local:
             return localFormatter.withLockUnchecked { $0.string(from: date) }
-        case .zoned:
-            return zonedFormatter.string(from: date)
         }
     }
 

--- a/Packages/TableProOracle/Tests/TableProOracleCoreTests/OracleCellFormattingTests.swift
+++ b/Packages/TableProOracle/Tests/TableProOracleCoreTests/OracleCellFormattingTests.swift
@@ -19,11 +19,6 @@ final class OracleCellFormattingTests: XCTestCase {
         XCTAssertEqual(OracleCellFormatting.formatDate(Self.referenceDate), "2026-05-03")
     }
 
-    func testTimestampUTC() {
-        let result = OracleCellFormatting.formatTimestamp(Self.referenceDate, style: .utc)
-        XCTAssertEqual(result, "2026-05-03T12:29:44.123Z")
-    }
-
     /// Oracle's plain `TIMESTAMP` names a wall clock and no zone. The text has to say the same, or
     /// the grid prints an offset the column never held.
     func testNaiveTimestampCarriesNoZone() {
@@ -36,15 +31,6 @@ final class OracleCellFormattingTests: XCTestCase {
         let offsetSeconds = TimeZone.current.secondsFromGMT(for: Self.referenceDate)
         let expectedSuffix = offsetSeconds == 0 ? "Z" : Self.isoOffset(seconds: offsetSeconds)
         XCTAssertTrue(result.hasSuffix(expectedSuffix), "expected \(expectedSuffix) at end of \(result)")
-    }
-
-    func testTimestampZonedAlwaysCarriesAnExplicitOffset() {
-        let result = OracleCellFormatting.formatTimestamp(Self.referenceDate, style: .zoned)
-        let offsetSeconds = TimeZone.current.secondsFromGMT(for: Self.referenceDate)
-        XCTAssertTrue(
-            result.hasSuffix(Self.isoOffset(seconds: offsetSeconds)),
-            "zoned style must spell the offset out even at UTC, got \(result)"
-        )
     }
 
     private static func isoOffset(seconds: Int) -> String {

--- a/TablePro/Core/DataGrid/DataGridDisplayState.swift
+++ b/TablePro/Core/DataGrid/DataGridDisplayState.swift
@@ -21,6 +21,9 @@ struct DataGridDisplayIdentity: Equatable {
     let dateFormat: DateFormatOption
     let nullDisplay: String
     let smartValueDetection: Bool
+    /// A Unix-timestamp column renders an instant in the reader's own zone, so text derived before
+    /// the Mac's zone moved is wrong. Nothing else in this identity moves with it.
+    let systemTimeZoneGeneration: Int
 }
 
 /// Whether the rows under a mounted grid were replaced, as opposed to the grid being rebuilt over

--- a/TablePro/Core/Events/AppEvents.swift
+++ b/TablePro/Core/Events/AppEvents.swift
@@ -17,6 +17,12 @@ final class AppEvents {
 
     let accessibilityTextSizeChanged = PassthroughSubject<Void, Never>()
 
+    // MARK: - System Environment
+
+    /// The Mac's time zone moved. Formatted text that was derived in the old one is now wrong, and
+    /// nothing else re-derives it: a grid keeps its cached strings until the result is re-fetched.
+    let systemTimeZoneChanged = PassthroughSubject<Void, Never>()
+
     // MARK: - Settings
 
     let editorSettingsChanged = PassthroughSubject<Void, Never>()

--- a/TablePro/Core/Services/Formatting/DatabaseDateParser.swift
+++ b/TablePro/Core/Services/Formatting/DatabaseDateParser.swift
@@ -22,8 +22,38 @@ struct TemporalLayout: Equatable {
 /// The instant, the zone it was written in, and the spelling it arrived as.
 struct ParsedTemporalValue: Equatable {
     let date: Date
+    /// The same value with its sub-second digits dropped.
+    ///
+    /// `Date` is a `Double` of seconds, which at 2024 resolves to about 119ns, so a fraction does
+    /// not survive a round trip through it: `.000001` reads back as 953ns and `.999999999` rounds
+    /// the whole second up. Display renders this one and splices the digits from the layout, so a
+    /// value one microsecond before midnight prints its own second rather than the next one.
+    let wholeSecond: Date
     let timeZone: TimeZone
     let layout: TemporalLayout
+
+    /// The instant to plot on a chart's time axis, which is not always the instant the value names.
+    ///
+    /// Swift Charts labels a `Date` axis in the reader's zone and ignores `EnvironmentValues`,
+    /// measured, so a naive value has to be handed the instant whose reader-zone wall clock is the
+    /// text the grid prints. A value that carries its own offset names a real instant and is
+    /// plotted as it is.
+    var plottableDate: Date {
+        guard layout.timeZoneSuffix == nil else { return date }
+        var source = Calendar(identifier: .gregorian)
+        source.timeZone = timeZone
+        var reader = Calendar(identifier: .gregorian)
+        reader.timeZone = .autoupdatingCurrent
+        let wallClock = source.dateComponents(
+            [.year, .month, .day, .hour, .minute, .second, .nanosecond],
+            from: date
+        )
+        return reader.date(from: wallClock) ?? date
+    }
+
+    /// Whether the database supplied a zone at all. A `Z` suffix resolves to GMT and so does a
+    /// value with no suffix, so the zone cannot tell them apart and only this can.
+    var carriesItsOwnZone: Bool { layout.timeZoneSuffix != nil }
 }
 
 enum DatabaseDateParser {
@@ -42,10 +72,19 @@ enum DatabaseDateParser {
     private static let referenceDateComponents = (year: 2_000, month: 1, day: 1)
 
     /// A value carrying no offset is naive: `2024-03-01 12:00:00` names a wall clock, not an
-    /// instant. It resolves in the reader's own zone so the grid, the chart's axis and the picker
-    /// all show it as written, and the zone travels with the value so a write-back reproduces the
-    /// same text.
-    private static var naiveTimeZone: TimeZone { .current }
+    /// instant. It resolves in GMT, the one zone where every wall clock exists exactly once and
+    /// never twice, so display, the cell picker and the write-back cancel exactly instead of
+    /// accidentally. The zone travels with the value, so a write-back reproduces the same text.
+    ///
+    /// The reader's own zone could not do that. A wall clock inside a daylight-saving gap does not
+    /// exist there, so `Calendar` legally moves it: `2024-03-10 02:30:00` read in New York drew as
+    /// 03:30 and, once the picker was opened to change the date alone, wrote 03:30 back over it.
+    /// Worse where a zone skipped a whole day: Samoa has no 2011-12-30, so a value stored on that
+    /// date failed to parse at all and rendered as raw text with no picker.
+    ///
+    /// Anything that reads `date` without `timeZone` therefore holds a UTC anchor and wants
+    /// `plottableDate` instead.
+    private static var naiveTimeZone: TimeZone { .gmt }
 
     static func parse(_ rawValue: String?) -> ParsedTemporalValue? {
         guard let matcher, let raw = rawValue?.trimmingCharacters(in: .whitespaces), !raw.isEmpty else {
@@ -90,7 +129,12 @@ enum DatabaseDateParser {
 
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = timeZone
-        guard let date = calendar.date(from: components), keepsItsDay(components, in: calendar, at: date) else {
+        var wholeSecondComponents = components
+        wholeSecondComponents.nanosecond = 0
+        guard let date = calendar.date(from: components),
+              let wholeSecond = calendar.date(from: wholeSecondComponents),
+              keepsItsDay(components, in: calendar, at: wholeSecond)
+        else {
             return nil
         }
 
@@ -102,7 +146,7 @@ enum DatabaseDateParser {
             fractionalSeconds: fractionalSeconds,
             timeZoneSuffix: timeZoneSuffix
         )
-        return ParsedTemporalValue(date: date, timeZone: timeZone, layout: layout)
+        return ParsedTemporalValue(date: date, wholeSecond: wholeSecond, timeZone: timeZone, layout: layout)
     }
 
     static func date(from text: String) -> Date? {
@@ -123,6 +167,9 @@ enum DatabaseDateParser {
     /// Catches the day a range check cannot, such as `2024-02-30`, which `Calendar` moves into
     /// March. Only the date is compared: a naive wall clock inside a spring-forward gap is legally
     /// shifted by an hour, and that value is still the day it says it is.
+    ///
+    /// It reads the whole-second instant, because a fraction near one second rounds the `Double`
+    /// up: `2024-02-29 23:59:59.9999999999` landed on 1 March and was refused as not a date.
     private static func keepsItsDay(_ components: DateComponents, in calendar: Calendar, at date: Date) -> Bool {
         let rebuilt = calendar.dateComponents([.year, .month, .day], from: date)
         return rebuilt.year == components.year && rebuilt.month == components.month
@@ -132,9 +179,16 @@ enum DatabaseDateParser {
     /// Sub-second precision reaches the `Date` so a chart can separate points inside one second.
     /// The original text is kept in the layout as well, because rebuilding it from a `Double` would
     /// lose digits a database round-trip has to preserve.
+    ///
+    /// Counted in digits rather than scaled through a `Double`, which rounded `.789012` to
+    /// 789_011_955 and, past nine digits, to a whole 1_000_000_000: `Calendar` then rolled that
+    /// second forward and `keepsItsDay` rejected the value, so a high-precision timestamp on the
+    /// last day of a month rendered as raw text.
     private static func nanoseconds(from fractionalSeconds: String?) -> Int {
-        guard let fractionalSeconds, let fraction = Double(fractionalSeconds) else { return 0 }
-        return Int((fraction * 1_000_000_000).rounded())
+        guard let fractionalSeconds else { return 0 }
+        let digits = fractionalSeconds.dropFirst().prefix(9)
+        guard !digits.isEmpty, let value = Int(digits) else { return 0 }
+        return (0 ..< (9 - digits.count)).reduce(value) { scaled, _ in scaled * 10 }
     }
 
     static func timeZone(fromSuffix suffix: String) -> TimeZone {

--- a/TablePro/Core/Services/Formatting/DateFormatOption.swift
+++ b/TablePro/Core/Services/Formatting/DateFormatOption.swift
@@ -32,12 +32,37 @@ enum DateFormatOption: String, Codable, CaseIterable, Identifiable {
         }
     }
 
+    /// The slot a value's own fractional seconds are spliced into after formatting.
+    ///
+    /// A control character, because it has to survive `DateFormatter` as a quoted literal and then
+    /// be found again in text a database supplied. `DateFormatter` cannot render the digits itself:
+    /// measured, it keeps three significant places and zero-pads the rest, so `SSSSSS` turns
+    /// `.789012` into `.789000`, and `Date`'s own resolution at 2024 is about 119ns anyway.
+    static let fractionalSecondsMarker: Character = "\u{1}"
+
     func formatString(for components: TemporalComponents) -> String {
         switch components {
         case .dateOnly: return dateOnlyFormatString
         case .timeOnly: return timeOnlyFormatString
         case .dateAndTime: return rawValue
         }
+    }
+
+    /// The same pattern with the marker quoted in immediately after the seconds, or nil for a
+    /// rendering that carries no clock.
+    ///
+    /// The slot is placed by the pattern rather than by appending, because a fraction qualifies the
+    /// seconds and only the ISO patterns end there: `MM/dd/yyyy hh:mm:ss a` has to read
+    /// `11:59:59.123456 PM`, not `11:59:59 PM.123456`. It is derived from the pattern instead of
+    /// spelled out per case, so a seventh option cannot place it wrong.
+    func fractionalSecondsFormatString(for components: TemporalComponents) -> String? {
+        let pattern = formatString(for: components)
+        guard rendersTime(for: components),
+              let seconds = pattern.range(of: "ss", options: .backwards)
+        else {
+            return nil
+        }
+        return pattern.replacingCharacters(in: seconds, with: "ss'\(Self.fractionalSecondsMarker)'")
     }
 
     /// Whether the text this option produces for a column shape carries a clock, which is what

--- a/TablePro/Core/Services/Formatting/DateFormattingService.swift
+++ b/TablePro/Core/Services/Formatting/DateFormattingService.swift
@@ -6,7 +6,15 @@
 //  Thread-safe singleton that formats dates according to DataGridSettings.dateFormat.
 //
 
+import Combine
 import Foundation
+
+/// The pair of formatters one column shape needs: the pattern as the user chose it, and the same
+/// pattern with a slot for the sub-second digits a value may carry.
+private struct TemporalFormatters {
+    let plain: DateFormatter
+    let withFractionalSeconds: DateFormatter?
+}
 
 /// Centralized date formatting service that respects user settings
 @MainActor
@@ -15,10 +23,29 @@ final class DateFormattingService {
 
     // MARK: - Properties
 
-    /// Cached formatter for current user-selected format
-    private var dateTimeFormatter: DateFormatter
-    private var dateOnlyFormatter: DateFormatter
-    private var timeOnlyFormatter: DateFormatter
+    /// Cached formatters for the current user-selected format.
+    ///
+    /// Two per column shape, not one: the marked variant carries a quoted slot after the seconds
+    /// and is used only for a value that arrived with a fraction, so a value without one pays
+    /// neither the second format nor the splice.
+    private var dateTimeFormatters: TemporalFormatters
+    private var dateOnlyFormatters: TemporalFormatters
+    private var timeOnlyFormatters: TemporalFormatters
+
+    /// The one formatter that renders an instant rather than a wall clock the value already
+    /// carries, so it is the only one whose zone is the reader's.
+    ///
+    /// It holds `.autoupdatingCurrent`, which follows a system time zone change with no
+    /// reassignment; a captured `.current` is frozen for the life of the process, measured. Its
+    /// pattern still tracks the user's chosen format, so `updateFormat` rewrites that and never
+    /// the zone.
+    private let instantFormatter: DateFormatter
+
+    private var systemTimeZoneObserver: NSObjectProtocol?
+
+    /// Rises each time the Mac's zone moves, so a display cache built in the old one compares
+    /// unequal and is replaced rather than repaired.
+    private(set) var systemTimeZoneGeneration = 0
 
     /// Current date format option
     private(set) var currentFormat: DateFormatOption
@@ -31,10 +58,28 @@ final class DateFormattingService {
     private init() {
         // Will be updated by AppSettingsManager after it completes initialization
         self.currentFormat = .iso8601
-        self.dateTimeFormatter = Self.createFormatter(for: .iso8601, components: .dateAndTime)
-        self.dateOnlyFormatter = Self.createFormatter(for: .iso8601, components: .dateOnly)
-        self.timeOnlyFormatter = Self.createFormatter(for: .iso8601, components: .timeOnly)
+        self.dateTimeFormatters = Self.createFormatters(for: .iso8601, components: .dateAndTime)
+        self.dateOnlyFormatters = Self.createFormatters(for: .iso8601, components: .dateOnly)
+        self.timeOnlyFormatters = Self.createFormatters(for: .iso8601, components: .timeOnly)
+        self.instantFormatter = Self.createFormatter(pattern: DateFormatOption.iso8601.formatString(for: .dateAndTime))
+        self.instantFormatter.timeZone = .autoupdatingCurrent
         formatCache.countLimit = 100_000
+        observeSystemTimeZone()
+    }
+
+    /// `NSSystemTimeZoneDidChange` documents no posting thread, and this app has already shipped a
+    /// crash from assuming one, so the observer names the main queue and hops explicitly.
+    private func observeSystemTimeZone() {
+        systemTimeZoneObserver = NotificationCenter.default.addObserver(
+            forName: .NSSystemTimeZoneDidChange,
+            object: nil,
+            queue: .main
+        ) { _ in
+            MainActor.assumeIsolated {
+                DateFormattingService.shared.systemTimeZoneGeneration += 1
+                AppEvents.shared.systemTimeZoneChanged.send(())
+            }
+        }
     }
 
     // MARK: - Public Methods
@@ -43,9 +88,10 @@ final class DateFormattingService {
     func updateFormat(_ format: DateFormatOption) {
         guard format != currentFormat else { return }
         currentFormat = format
-        dateTimeFormatter = Self.createFormatter(for: format, components: .dateAndTime)
-        dateOnlyFormatter = Self.createFormatter(for: format, components: .dateOnly)
-        timeOnlyFormatter = Self.createFormatter(for: format, components: .timeOnly)
+        dateTimeFormatters = Self.createFormatters(for: format, components: .dateAndTime)
+        dateOnlyFormatters = Self.createFormatters(for: format, components: .dateOnly)
+        timeOnlyFormatters = Self.createFormatters(for: format, components: .timeOnly)
+        instantFormatter.dateFormat = format.formatString(for: .dateAndTime)
         // Clear cache when format changes since all cached values are now stale
         formatCache.removeAllObjects()
     }
@@ -54,8 +100,7 @@ final class DateFormattingService {
     /// - Parameter date: The date to format
     /// - Returns: Formatted date string
     func format(_ date: Date) -> String {
-        dateTimeFormatter.timeZone = .current
-        return dateTimeFormatter.string(from: date)
+        instantFormatter.string(from: date)
     }
 
     /// Format a string date value (parse then format).
@@ -63,8 +108,8 @@ final class DateFormattingService {
     /// The value is rendered in the zone it was written in, not the reader's. A value carrying an
     /// offset names an instant in that offset, and the cell editor opens it there, so formatting it
     /// somewhere else made the grid and the picker disagree about which day the row held. A value
-    /// with no offset is naive and parses in the reader's own zone, so this is the same zone it
-    /// always used.
+    /// with no offset is naive and parses in GMT, so it prints the wall clock it was written with
+    /// whatever zone the reader is in.
     ///
     /// The offset itself is printed with it, because a wall clock alone does not name an instant.
     /// It is the literal text the value arrived with, off the same layout the write-back reads. A
@@ -86,9 +131,7 @@ final class DateFormattingService {
             formatCache.setObject("" as NSString, forKey: cacheKey)
             return nil
         }
-        let targetFormatter = formatter(for: components)
-        targetFormatter.timeZone = parsed.timeZone
-        var result = targetFormatter.string(from: parsed.date)
+        var result = render(parsed, with: formatters(for: components))
         if currentFormat.rendersTime(for: components), let suffix = parsed.layout.timeZoneSuffix {
             result += suffix
         }
@@ -103,12 +146,32 @@ final class DateFormattingService {
         return DateEditingService.components(for: columnType)
     }
 
-    private func formatter(for components: TemporalComponents) -> DateFormatter {
+    private func formatters(for components: TemporalComponents) -> TemporalFormatters {
         switch components {
-        case .dateOnly: return dateOnlyFormatter
-        case .timeOnly: return timeOnlyFormatter
-        case .dateAndTime: return dateTimeFormatter
+        case .dateOnly: return dateOnlyFormatters
+        case .timeOnly: return timeOnlyFormatters
+        case .dateAndTime: return dateTimeFormatters
         }
+    }
+
+    /// The value's own sub-second digits are spliced in, not rendered, so `.5` stays `.5` and
+    /// `.789012` stays `.789012`. Two rows one microsecond apart used to draw the same text, which
+    /// also collapsed them into one entry in the column's value filter.
+    ///
+    /// A fraction of nothing but zeros is padding rather than precision, and MySQL writes one on
+    /// every row of a `DATETIME(6)` where PostgreSQL trims it at the server. It is dropped, so such
+    /// a column reads exactly as it did before and only a value that carries real digits grows.
+    private func render(_ parsed: ParsedTemporalValue, with formatters: TemporalFormatters) -> String {
+        guard let fractionalSeconds = parsed.layout.fractionalSeconds,
+              fractionalSeconds.contains(where: { $0 != "0" && $0 != "." }),
+              let marked = formatters.withFractionalSeconds
+        else {
+            formatters.plain.timeZone = parsed.timeZone
+            return formatters.plain.string(from: parsed.wholeSecond)
+        }
+        marked.timeZone = parsed.timeZone
+        return marked.string(from: parsed.wholeSecond)
+            .replacingOccurrences(of: String(DateFormatOption.fractionalSecondsMarker), with: fractionalSeconds)
     }
 
     // MARK: - Private Helper Methods
@@ -118,12 +181,20 @@ final class DateFormattingService {
     /// Japanese calendar and reformats the very value the grid round-trips back to SQL.
     private static let fixedPatternLocale = Locale(identifier: "en_US_POSIX")
 
-    private static func createFormatter(
+    private static func createFormatters(
         for format: DateFormatOption,
         components: TemporalComponents
-    ) -> DateFormatter {
+    ) -> TemporalFormatters {
+        TemporalFormatters(
+            plain: createFormatter(pattern: format.formatString(for: components)),
+            withFractionalSeconds: format.fractionalSecondsFormatString(for: components)
+                .map(createFormatter(pattern:))
+        )
+    }
+
+    private static func createFormatter(pattern: String) -> DateFormatter {
         let formatter = DateFormatter()
-        formatter.dateFormat = format.formatString(for: components)
+        formatter.dateFormat = pattern
         formatter.locale = fixedPatternLocale
         formatter.calendar = Calendar(identifier: .gregorian)
         formatter.timeZone = TimeZone.current

--- a/TablePro/Core/Services/Query/ResultChartProjector.swift
+++ b/TablePro/Core/Services/Query/ResultChartProjector.swift
@@ -193,11 +193,11 @@ actor ResultChartProjector {
         case .date:
             guard case .text(let raw) = cell,
                   raw.utf8.count <= Self.maximumLabelLength,
-                  let date = DatabaseDateParser.date(from: raw.trimmingCharacters(in: .whitespacesAndNewlines))
+                  let parsed = DatabaseDateParser.parse(raw.trimmingCharacters(in: .whitespacesAndNewlines))
             else {
                 return nil
             }
-            return (.date(date), raw)
+            return (.date(parsed.plottableDate), raw)
         case nil:
             return nil
         }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+GridDisplay.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+GridDisplay.swift
@@ -60,7 +60,8 @@ extension MainContentCoordinator {
             displayFormats: displayFormats(for: tab),
             dateFormat: settings.dateFormat,
             nullDisplay: settings.nullDisplay,
-            smartValueDetection: settings.enableSmartValueDetection
+            smartValueDetection: settings.enableSmartValueDetection,
+            systemTimeZoneGeneration: DateFormattingService.shared.systemTimeZoneGeneration
         )
 
         displayStateClock &+= 1

--- a/TablePro/Views/Results/DataGridCoordinator.swift
+++ b/TablePro/Views/Results/DataGridCoordinator.swift
@@ -501,6 +501,7 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
 
     var settingsCancellable: AnyCancellable?
     var themeCancellable: AnyCancellable?
+    var systemTimeZoneCancellable: AnyCancellable?
     private var accessibilityActivationObserver: (any NSObjectProtocol)?
     private var accessibilityMountedRows = NSRange(location: 0, length: 0)
     private var lastDataGridSettings: DataGridSettings
@@ -573,6 +574,7 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
         updateCache()
 
         observeThemeChanges()
+        observeSystemTimeZoneChanges()
         observeAccessibilityActivation()
 
         settingsCancellable = AppEvents.shared.dataGridSettingsChanged
@@ -599,13 +601,7 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
             || previous.enableSmartValueDetection != settings.enableSmartValueDetection
 
         if dataChanged {
-            invalidateDisplayCache()
-            let visibleRect = tableView.visibleRect
-            let visibleRange = tableView.rows(in: visibleRect)
-            if visibleRange.length > 0 {
-                repaintRows(IndexSet(integersIn: visibleRange.location..<(visibleRange.location + visibleRange.length)))
-            }
-            startBackgroundPrewarm()
+            reformatDisplayedText()
         }
     }
 
@@ -693,6 +689,8 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
         settingsCancellable = nil
         themeCancellable?.cancel()
         themeCancellable = nil
+        systemTimeZoneCancellable?.cancel()
+        systemTimeZoneCancellable = nil
         detachAccessibilityActivationObserver()
         visualIndex.clear()
         displayCache.removeAll()

--- a/TablePro/Views/Results/DateTimePickerContentView.swift
+++ b/TablePro/Views/Results/DateTimePickerContentView.swift
@@ -17,10 +17,19 @@ struct DateTimePickerContentView: View {
     private let calendar: Calendar
     @State private var date: Date
 
+    /// The day the today ring belongs on, as calendar fields rather than an instant.
+    ///
+    /// A value with no offset is read in GMT, so each day cell is a GMT midnight; asking whether
+    /// that instant is today in the reader's zone answers for the previous day west of Greenwich.
+    /// Comparing fields asks the question the ring actually poses. A value that carries an offset
+    /// names a real instant, and its own zone is the only one whose today means anything for it.
+    private let today: DateComponents
+
     init(
         initialDate: Date,
         components: TemporalComponents,
         timeZone: TimeZone,
+        carriesItsOwnZone: Bool,
         onCommit: @escaping (Date) -> Void,
         onDismiss: @escaping () -> Void
     ) {
@@ -30,6 +39,11 @@ struct DateTimePickerContentView: View {
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = timeZone
         self.calendar = calendar
+        var todayCalendar = calendar
+        if !carriesItsOwnZone {
+            todayCalendar.timeZone = .autoupdatingCurrent
+        }
+        self.today = todayCalendar.dateComponents([.year, .month, .day], from: Date())
         self._date = State(initialValue: initialDate)
     }
 
@@ -37,7 +51,7 @@ struct DateTimePickerContentView: View {
         VStack(spacing: 0) {
             VStack(spacing: 12) {
                 if components != .timeOnly {
-                    CalendarMonthView(date: $date, calendar: calendar)
+                    CalendarMonthView(date: $date, calendar: calendar, today: today)
                 }
                 if components != .dateOnly {
                     TimeFieldView(date: $date, calendar: calendar)
@@ -67,6 +81,7 @@ struct DateTimePickerContentView: View {
 private struct CalendarMonthView: View {
     @Binding var date: Date
     let calendar: Calendar
+    let today: DateComponents
 
     @State private var visibleMonth: Date
 
@@ -75,9 +90,10 @@ private struct CalendarMonthView: View {
     private let monthTitleFormatter: DateFormatter
     private let dayLabelFormatter: DateFormatter
 
-    init(date: Binding<Date>, calendar: Calendar) {
+    init(date: Binding<Date>, calendar: Calendar, today: DateComponents) {
         self._date = date
         self.calendar = calendar
+        self.today = today
         self._visibleMonth = State(initialValue: date.wrappedValue)
         self.monthTitleFormatter = Self.makeFormatter(calendar: calendar) { $0.dateFormat = "MMMM yyyy" }
         self.dayLabelFormatter = Self.makeFormatter(calendar: calendar) {
@@ -134,7 +150,7 @@ private struct CalendarMonthView: View {
     private func dayCell(_ day: Date?) -> some View {
         if let day {
             let isSelected = calendar.isDate(day, inSameDayAs: date)
-            let isToday = calendar.isDateInToday(day)
+            let isToday = calendar.dateComponents([.year, .month, .day], from: day) == today
             Button {
                 select(day)
             } label: {

--- a/TablePro/Views/Results/Extensions/DataGridView+DisplayInvalidation.swift
+++ b/TablePro/Views/Results/Extensions/DataGridView+DisplayInvalidation.swift
@@ -1,0 +1,36 @@
+//
+//  DataGridView+DisplayInvalidation.swift
+//  TablePro
+//
+//  Throwing away the grid's formatted text when something it was derived from moves.
+//
+
+import AppKit
+import Combine
+import Foundation
+
+extension TableViewCoordinator {
+    /// Throws away every formatted string and derives them again. The settings path takes it when
+    /// the date format, the NULL text or smart detection moves; the system time zone takes it
+    /// because a Unix-timestamp column renders an instant in the reader's own zone.
+    func reformatDisplayedText() {
+        guard let tableView else { return }
+        invalidateDisplayCache()
+        let visibleRange = tableView.rows(in: tableView.visibleRect)
+        if visibleRange.length > 0 {
+            repaintRows(IndexSet(integersIn: visibleRange.location ..< (visibleRange.location + visibleRange.length)))
+        }
+        startBackgroundPrewarm()
+    }
+
+    /// The mounted grid draws again on a zone change. An unmounted tab is covered instead by
+    /// `DataGridDisplayIdentity`, which carries the generation, so its cache is replaced rather
+    /// than repaired the next time the tab is shown.
+    func observeSystemTimeZoneChanges() {
+        systemTimeZoneCancellable = AppEvents.shared.systemTimeZoneChanged
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.reformatDisplayedText()
+            }
+    }
+}

--- a/TablePro/Views/Results/Extensions/DataGridView+Popovers.swift
+++ b/TablePro/Views/Results/Extensions/DataGridView+Popovers.swift
@@ -199,7 +199,9 @@ extension TableViewCoordinator {
 
         let columnType = tableRows.columnTypes[columnIndex]
         let parsed = DatabaseDateParser.parse(cellValue(at: row, column: columnIndex))
-        let initialDate = parsed?.date ?? Date()
+        /// The whole second, not the instant: a fraction near one second rounds the `Double` up, so
+        /// the picker would open a second, and sometimes a day, past the value the cell shows.
+        let initialDate = parsed?.wholeSecond ?? Date()
         let timeZone = parsed?.timeZone ?? DateEditingService.defaultTimeZone
         let components = DateEditingService.components(for: columnType)
 
@@ -213,6 +215,7 @@ extension TableViewCoordinator {
                 initialDate: initialDate,
                 components: components,
                 timeZone: timeZone,
+                carriesItsOwnZone: parsed?.carriesItsOwnZone ?? false,
                 onCommit: { picked in
                     guard picked != initialDate else { return }
                     let newValue = parsed

--- a/TableProTests/Core/Services/DateEditingServiceTests.swift
+++ b/TableProTests/Core/Services/DateEditingServiceTests.swift
@@ -106,23 +106,34 @@ struct DateEditingServiceTests {
         #expect(DatabaseDateParser.parse("Z") == nil)
     }
 
+    /// `defaultString` writes the reader's own wall clock, so the instant it is handed has to be
+    /// built in the reader's zone. Reading it off a parsed naive value would build it in GMT and
+    /// the assertion would only hold on a UTC host.
+    private static func readerLocalInstant() throws -> Date {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = .current
+        return try #require(
+            calendar.date(from: DateComponents(year: 2_024, month: 3, day: 15, hour: 9, minute: 30, second: 45))
+        )
+    }
+
     @Test("default string for a date column emits date only")
     func defaultDateString() throws {
-        let parsed = try #require(DatabaseDateParser.parse("2024-03-15 09:30:45"))
-        #expect(DateEditingService.defaultString(from: parsed.date, columnType: .date(rawType: "DATE")) == "2024-03-15")
+        let instant = try Self.readerLocalInstant()
+        #expect(DateEditingService.defaultString(from: instant, columnType: .date(rawType: "DATE")) == "2024-03-15")
     }
 
     @Test("default string for a timestamp column emits date and time")
     func defaultTimestampString() throws {
-        let parsed = try #require(DatabaseDateParser.parse("2024-03-15 09:30:45"))
-        let value = DateEditingService.defaultString(from: parsed.date, columnType: .timestamp(rawType: "TIMESTAMP"))
+        let instant = try Self.readerLocalInstant()
+        let value = DateEditingService.defaultString(from: instant, columnType: .timestamp(rawType: "TIMESTAMP"))
         #expect(value == "2024-03-15 09:30:45")
     }
 
     @Test("default string for a time column emits time only")
     func defaultTimeString() throws {
-        let parsed = try #require(DatabaseDateParser.parse("2024-03-15 09:30:45"))
-        let value = DateEditingService.defaultString(from: parsed.date, columnType: .timestamp(rawType: "TIME"))
+        let instant = try Self.readerLocalInstant()
+        let value = DateEditingService.defaultString(from: instant, columnType: .timestamp(rawType: "TIME"))
         #expect(value == "09:30:45")
     }
 

--- a/TableProTests/Core/Services/DateFormattingServiceTests.swift
+++ b/TableProTests/Core/Services/DateFormattingServiceTests.swift
@@ -173,6 +173,208 @@ struct DateFormattingServiceTimeZoneTests {
         #expect(result == "12/31/2024 11:59:59 PM+07")
     }
 
+    @Test("Two values one microsecond apart do not draw the same text")
+    func subSecondPrecisionSurvives() {
+        DateFormattingService.shared.updateFormat(.iso8601)
+        let earlier = DateFormattingService.shared.format(
+            dateString: "2024-03-15 09:30:00.123456",
+            columnType: .timestamp(rawType: "TIMESTAMP(6)")
+        )
+        let later = DateFormattingService.shared.format(
+            dateString: "2024-03-15 09:30:00.789012",
+            columnType: .timestamp(rawType: "TIMESTAMP(6)")
+        )
+
+        #expect(earlier == "2024-03-15 09:30:00.123456")
+        #expect(later == "2024-03-15 09:30:00.789012")
+    }
+
+    /// MySQL pads a `DATETIME(6)` to its declared precision on every row, so an all-zero fraction
+    /// is the column's shape rather than the value's, and printing it would widen every row of such
+    /// a column for nothing.
+    @Test("A fraction of nothing but zeros is not printed")
+    func allZeroFractionIsDropped() {
+        DateFormattingService.shared.updateFormat(.iso8601)
+        for fraction in [".0", ".000", ".000000"] {
+            let result = DateFormattingService.shared.format(
+                dateString: "2024-03-15 09:30:00\(fraction)",
+                columnType: .timestamp(rawType: "TIMESTAMP(6)")
+            )
+            #expect(result == "2024-03-15 09:30:00", "\(fraction) should print no fraction")
+        }
+    }
+
+    /// The Unix Timestamp display format renders an instant through its own formatter, which must
+    /// never carry the slot: a control character is invisible on screen and still reaches the
+    /// clipboard, Find and the value filter.
+    @Test("The instant formatter carries no slot")
+    func instantFormatterCarriesNoMarker() {
+        let marker = String(DateFormatOption.fractionalSecondsMarker)
+        for option in DateFormatOption.allCases {
+            DateFormattingService.shared.updateFormat(option)
+            let rendered = DateFormattingService.shared.format(Date(timeIntervalSince1970: 1_700_000_000))
+            #expect(!rendered.contains(marker), "\(option) rendered \(rendered)")
+        }
+        DateFormattingService.shared.updateFormat(.iso8601)
+    }
+
+    @Test("The digits are the value's own, not a rounding of them")
+    func fractionalDigitsAreVerbatim() {
+        DateFormattingService.shared.updateFormat(.iso8601)
+        for fraction in [".5", ".000001", ".123", ".999999999"] {
+            let result = DateFormattingService.shared.format(
+                dateString: "2024-03-15 09:30:00\(fraction)",
+                columnType: .timestamp(rawType: "TIMESTAMP")
+            )
+            #expect(result == "2024-03-15 09:30:00\(fraction)")
+        }
+    }
+
+    /// A fraction qualifies the seconds, so it goes where the seconds end. Appending would put it
+    /// after the designator, `11:59:59 PM.123456`.
+    @Test("A 12-hour format keeps the fraction with the seconds")
+    func twelveHourFormatPlacesTheFractionAtTheSeconds() {
+        DateFormattingService.shared.updateFormat(.usLong)
+        defer { DateFormattingService.shared.updateFormat(.iso8601) }
+
+        let result = DateFormattingService.shared.format(
+            dateString: "2024-03-15 09:30:00.123456+07",
+            columnType: .timestamp(rawType: "TIMESTAMPTZ")
+        )
+        #expect(result == "03/15/2024 09:30:00.123456 AM+07")
+    }
+
+    @Test("A TIMETZ column keeps both its fraction and its offset")
+    func timeOnlyColumnKeepsBoth() {
+        DateFormattingService.shared.updateFormat(.iso8601)
+        let result = DateFormattingService.shared.format(
+            dateString: "09:30:00.123456+05:30",
+            columnType: .timestamp(rawType: "TIMETZ")
+        )
+        #expect(result == "09:30:00.123456+05:30")
+    }
+
+    @Test("A date-only rendering carries no fraction")
+    func dateOnlyRenderingDropsTheFraction() {
+        DateFormattingService.shared.updateFormat(.iso8601)
+        let onDateColumn = DateFormattingService.shared.format(
+            dateString: "2024-03-15 09:30:00.123456",
+            columnType: .date(rawType: "DATE")
+        )
+        #expect(onDateColumn == "2024-03-15")
+
+        DateFormattingService.shared.updateFormat(.euShort)
+        defer { DateFormattingService.shared.updateFormat(.iso8601) }
+        let onShortFormat = DateFormattingService.shared.format(
+            dateString: "2024-03-15 09:30:00.123456",
+            columnType: .timestamp(rawType: "TIMESTAMP")
+        )
+        #expect(onShortFormat == "15/03/2024")
+    }
+
+    /// The slot is a control character, so a splice that failed to run would be invisible on screen
+    /// and would still reach the clipboard, Find and the value filter.
+    @Test("The marker never survives into a cell")
+    func markerNeverReachesACell() {
+        let marker = String(DateFormatOption.fractionalSecondsMarker)
+        for option in DateFormatOption.allCases {
+            DateFormattingService.shared.updateFormat(option)
+            for spelling in DatabaseDateParserTests.wireSpellings {
+                for rawType in ["TIMESTAMP", "DATE", "TIMETZ"] {
+                    let result = DateFormattingService.shared.format(
+                        dateString: spelling,
+                        columnType: .timestamp(rawType: rawType)
+                    )
+                    #expect(result?.contains(marker) != true, "\(option) \(rawType) \(spelling)")
+                }
+            }
+        }
+        DateFormattingService.shared.updateFormat(.iso8601)
+    }
+
+    /// The marked pattern is derived from the plain one, so the two cannot drift: removing the
+    /// quoted slot has to give the pattern back exactly.
+    @Test("The marked pattern is the plain pattern plus a slot")
+    func markedPatternMatchesThePlainOne() {
+        let slot = "'\(DateFormatOption.fractionalSecondsMarker)'"
+        for option in DateFormatOption.allCases {
+            for components in [TemporalComponents.dateOnly, .timeOnly, .dateAndTime] {
+                let plain = option.formatString(for: components)
+                guard let marked = option.fractionalSecondsFormatString(for: components) else {
+                    #expect(!option.rendersTime(for: components) || !plain.contains("ss"))
+                    continue
+                }
+                #expect(marked.replacingOccurrences(of: slot, with: "") == plain)
+                #expect(marked.components(separatedBy: slot).count == 2)
+            }
+        }
+    }
+
+    /// A captured `TimeZone.current` never follows a system time zone change, measured, so the one
+    /// formatter that renders an instant holds `.autoupdatingCurrent` instead.
+    @Test("An instant renders in the reader's live zone")
+    func instantRendersInTheLiveZone() {
+        DateFormattingService.shared.updateFormat(.iso8601)
+        let instant = Date(timeIntervalSince1970: 1_700_000_000)
+
+        let control = DateFormatter()
+        control.locale = Locale(identifier: "en_US_POSIX")
+        control.calendar = Calendar(identifier: .gregorian)
+        control.timeZone = .autoupdatingCurrent
+        control.dateFormat = DateFormatOption.iso8601.formatString(for: .dateAndTime)
+
+        #expect(DateFormattingService.shared.format(instant) == control.string(from: instant))
+    }
+
+    /// Its zone is fixed but its pattern is not: a Unix-timestamp column has to follow the user's
+    /// chosen date format like every other cell.
+    @Test("The instant formatter follows the chosen date format")
+    func instantFormatterFollowsTheChosenFormat() {
+        let instant = Date(timeIntervalSince1970: 1_700_000_000)
+        DateFormattingService.shared.updateFormat(.euLong)
+        defer { DateFormattingService.shared.updateFormat(.iso8601) }
+        let european = DateFormattingService.shared.format(instant)
+
+        DateFormattingService.shared.updateFormat(.iso8601)
+        let iso = DateFormattingService.shared.format(instant)
+
+        #expect(european != iso)
+        #expect(european.contains("/"))
+        #expect(iso.contains("-"))
+    }
+
+    @Test("A system time zone change raises the generation the grid caches on")
+    func systemTimeZoneChangeRaisesTheGeneration() async {
+        let before = DateFormattingService.shared.systemTimeZoneGeneration
+        NotificationCenter.default.post(name: .NSSystemTimeZoneDidChange, object: nil)
+
+        for _ in 0 ..< 100 where DateFormattingService.shared.systemTimeZoneGeneration == before {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(DateFormattingService.shared.systemTimeZoneGeneration > before)
+    }
+
+    /// The grid keeps a tab's formatted text while the tab is unmounted, so the generation has to be
+    /// part of what the cache was built from or nothing replaces it.
+    @Test("The display identity moves with the generation")
+    func displayIdentityMovesWithTheGeneration() {
+        func identity(generation: Int) -> DataGridDisplayIdentity {
+            DataGridDisplayIdentity(
+                bufferEpoch: 1,
+                resultSetId: nil,
+                columns: ["ts"],
+                columnTypes: [.timestamp(rawType: "TIMESTAMP")],
+                displayFormats: [nil],
+                dateFormat: .iso8601,
+                nullDisplay: "NULL",
+                smartValueDetection: true,
+                systemTimeZoneGeneration: generation
+            )
+        }
+        #expect(identity(generation: 1) == identity(generation: 1))
+        #expect(identity(generation: 1) != identity(generation: 2))
+    }
+
     /// The grid opens the cell editor on the raw text, so a value it prints has to be the value the
     /// write-back reproduces. The suffix travels through the layout for both.
     @Test("The printed offset is the one the write-back writes")

--- a/TableProTests/Core/Services/Formatting/DatabaseDateParserTests.swift
+++ b/TableProTests/Core/Services/Formatting/DatabaseDateParserTests.swift
@@ -38,13 +38,13 @@ struct DatabaseDateParserTests {
 
     @Test("An unpadded month or day still reads as a date")
     func unpaddedComponentsParse() throws {
+        let parsed = try #require(DatabaseDateParser.parse("2024-9-1"))
         var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = TimeZone.current
-        let parsed = try #require(DatabaseDateParser.date(from: "2024-9-1"))
+        calendar.timeZone = parsed.timeZone
 
-        #expect(calendar.component(.year, from: parsed) == 2_024)
-        #expect(calendar.component(.month, from: parsed) == 9)
-        #expect(calendar.component(.day, from: parsed) == 1)
+        #expect(calendar.component(.year, from: parsed.date) == 2_024)
+        #expect(calendar.component(.month, from: parsed.date) == 9)
+        #expect(calendar.component(.day, from: parsed.date) == 1)
     }
 
     @Test("A time with an offset reads as a date, the way the same value does with a date in front")
@@ -66,14 +66,67 @@ struct DatabaseDateParserTests {
         #expect(iso == shortOffset)
     }
 
-    @Test("A value with no offset is read in the reader's own time zone")
-    func naiveValuesStayLocal() throws {
+    /// A value with no offset names a wall clock, and GMT is the zone that always has the one it
+    /// names. The answer is the same whatever zone the reader's Mac is in, which is the property
+    /// worth guarding: it used to depend on the host.
+    @Test("A value with no offset keeps its wall clock")
+    func naiveValuesKeepTheirWallClock() throws {
+        let parsed = try #require(DatabaseDateParser.parse("2024-03-01 12:00:00"))
         var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = TimeZone.current
-        let parsed = try #require(DatabaseDateParser.date(from: "2024-03-01 12:00:00"))
+        calendar.timeZone = parsed.timeZone
 
-        #expect(calendar.component(.hour, from: parsed) == 12)
-        #expect(calendar.component(.day, from: parsed) == 1)
+        #expect(parsed.timeZone.secondsFromGMT() == 0)
+        #expect(calendar.component(.hour, from: parsed.date) == 12)
+        #expect(calendar.component(.day, from: parsed.date) == 1)
+    }
+
+    /// 02:30 did not exist in New York on 10 March 2024, so reading the value in the reader's zone
+    /// moved it to 03:30 on screen and an edit to the date alone then wrote 03:30 back over the
+    /// stored time.
+    @Test("A wall clock inside a daylight-saving gap is kept as written")
+    func daylightSavingGapValueIsKept() throws {
+        let text = "2024-03-10 02:30:00"
+        let parsed = try #require(DatabaseDateParser.parse(text))
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = parsed.timeZone
+
+        #expect(calendar.component(.hour, from: parsed.date) == 2)
+        #expect(calendar.component(.minute, from: parsed.date) == 30)
+        #expect(DateEditingService.string(from: parsed.date, like: parsed) == text)
+    }
+
+    /// Samoa skipped 30 December 2011 to cross the date line, so a value stored on that day failed
+    /// to parse in a reader's zone and rendered as raw text with no picker.
+    @Test("A day some zone skipped is still a date")
+    func aDaySomeZoneSkippedStillParses() throws {
+        for text in ["2011-12-30", "2011-12-30 12:00:00"] {
+            let parsed = try #require(DatabaseDateParser.parse(text), "\(text) should parse")
+            #expect(DateEditingService.string(from: parsed.date, like: parsed) == text)
+        }
+    }
+
+    /// Swift Charts labels a date axis in the reader's zone, so a naive value is handed the instant
+    /// whose reader-zone wall clock is the text the grid prints. A value with its own offset names a
+    /// real instant and is plotted as it is.
+    @Test("The chart plots a naive value at the wall clock the grid shows")
+    func plottableDateFollowsTheReadersZone() throws {
+        let naive = try #require(DatabaseDateParser.parse("2024-06-15 12:00:00"))
+        var reader = Calendar(identifier: .gregorian)
+        reader.timeZone = .current
+
+        #expect(reader.component(.hour, from: naive.plottableDate) == 12)
+        #expect(reader.component(.day, from: naive.plottableDate) == 15)
+
+        let zoned = try #require(DatabaseDateParser.parse("2024-06-15 12:00:00+07"))
+        #expect(zoned.plottableDate == zoned.date)
+    }
+
+    /// A `Z` suffix resolves to GMT and so does a value with no suffix, so the zone alone cannot
+    /// tell a UTC value from a naive one.
+    @Test("Only the suffix says whether the database supplied a zone")
+    func carriesItsOwnZoneReadsTheSuffix() throws {
+        #expect(try #require(DatabaseDateParser.parse("2024-06-15 12:00:00Z")).carriesItsOwnZone)
+        #expect(try #require(DatabaseDateParser.parse("2024-06-15 12:00:00")).carriesItsOwnZone == false)
     }
 
     @Test("Sub-second precision reaches the date, so a chart can separate points inside one second")
@@ -106,6 +159,35 @@ struct DatabaseDateParserTests {
             let parsed = try #require(DatabaseDateParser.parse("2024-12-31 23:59:59\(spelling)"))
             #expect(parsed.layout.timeZoneSuffix == spelling)
         }
+    }
+
+    /// `Date` is a `Double` of seconds and cannot hold the digits, so the whole second is carried
+    /// separately and the digits stay in the layout. Display reads both.
+    @Test("Sub-second digits are kept beside the instant, not inside it")
+    func fractionalSecondsAreKeptVerbatim() throws {
+        for fraction in [".5", ".123456", ".789012", ".000000001", ".999999999", ".9999999999"] {
+            let parsed = try #require(DatabaseDateParser.parse("2024-03-15 09:30:00\(fraction)Z"))
+            #expect(parsed.layout.fractionalSeconds == fraction)
+
+            var calendar = Calendar(identifier: .gregorian)
+            calendar.timeZone = TimeZone(secondsFromGMT: 0) ?? .gmt
+            let seconds = calendar.dateComponents([.second, .nanosecond], from: parsed.wholeSecond)
+            #expect(seconds.second == 0, "\(fraction) rolled the second to \(seconds.second ?? -1)")
+            #expect(seconds.nanosecond == 0)
+        }
+    }
+
+    /// A fraction near one second rounds the `Double` up, which rolled the day and made the value
+    /// refuse to parse at all.
+    @Test("A fraction longer than nanosecond precision still parses")
+    func overlongFractionStillParses() throws {
+        let parsed = try #require(DatabaseDateParser.parse("2024-02-29 23:59:59.9999999999"))
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = parsed.timeZone
+        let day = calendar.dateComponents([.month, .day], from: parsed.wholeSecond)
+
+        #expect(day.month == 2)
+        #expect(day.day == 29)
     }
 
     @Test("A value with no offset reports none rather than the reader's own")

--- a/docs/customization/data-settings.mdx
+++ b/docs/customization/data-settings.mdx
@@ -17,7 +17,7 @@ The tab is app-wide, so these values apply to every connection you open; filters
 | Setting | Default | Notes |
 |---------|---------|-------|
 | Row height | Normal | Compact, Normal, Comfortable, Spacious |
-| Date format | ISO 8601 | ISO 8601, ISO Date, US Long, US Short, EU Long, EU Short. A UTC offset stored with the value is printed wherever the format renders a time, as the server wrote it: `2024-12-31 23:59:59+07`. A value stored without one, such as a MySQL `DATETIME`, never gains one |
+| Date format | ISO 8601 | ISO 8601, ISO Date, US Long, US Short, EU Long, EU Short. Sub-second digits and a UTC offset stored with the value are printed wherever the format renders a time, as the server wrote them: `2024-12-31 23:59:59.123456+07`. A value stored without an offset, such as a MySQL `DATETIME`, never gains one, and a fraction of nothing but zeros is not printed |
 | NULL display | `NULL` | Text shown for NULL cells, up to 20 characters |
 | Show alternate row backgrounds | On | |
 | Show row numbers | On | |


### PR DESCRIPTION
The five collateral defects the #2702 investigation found and reported, now fixed. #2703 shipped the reported bug alone; this is the register that came with it. Relates to #2702.

## 1. A zone-less timestamp is read in GMT

`DatabaseDateParser` resolved a value with no offset in the reader's own zone. A wall clock inside a daylight-saving gap does not exist there, so `Calendar` legally moved it: MySQL's `2024-03-10 02:30:00` drew as `03:30:00` in New York, and opening the picker to change the **date alone** wrote `03:30:00` back over the stored time. Worse where a zone skipped a whole day: Samoa has no 2011-12-30, so a value stored on that date failed to parse at all and rendered as raw text with no picker.

GMT is the only zone in which every wall clock exists exactly once and never twice, so display, the picker and the write-back now cancel exactly rather than accidentally. The answer no longer depends on the reader's Mac, which is the property the new tests guard.

Two things follow from it, both found by review rather than by me:

- **The chart.** `ResultChartProjector` was the one consumer reading `parsed.date` without `parsed.timeZone`, and Swift Charts labels a date axis in the reader's zone while ignoring `EnvironmentValues.timeZone` (measured). `ParsedTemporalValue.plottableDate` hands it the instant whose reader-zone wall clock is the text the grid prints, so the chart is unchanged.
- **The picker's today ring.** Its calendar is now GMT for a naive value, so each day cell is a GMT midnight. Asking `isDateInToday` about that instant answers for the previous local day west of Greenwich, so the ring is drawn by comparing calendar fields instead. A value that carries its own offset keeps its own zone's today: a `Z` suffix and no suffix both resolve to GMT, so only `layout.timeZoneSuffix` can tell them apart.

## 2. Sub-second precision is printed

None of the six format patterns contained an `S`, so `09:30:00.123456` and `09:30:00.789012` drew the same string and the column's value filter merged them into one entry with count 2.

Rendering the digits through `DateFormatter` is not possible, measured twice: it keeps three significant places and zero-pads the rest, so `SSSSSS` turns `.789012` into `.789000`, and `Date` is a `Double` whose resolution at 2024 is about 119ns, so `.000001` reads back as 953ns. The digits are therefore spliced from `layout.fractionalSeconds` into a quoted `U+0001` slot the pattern carries immediately after the seconds. That placement matters: `MM/dd/yyyy hh:mm:ss a` has to read `11:59:59.123456 PM`, and an append would give `11:59:59 PM.123456`. The slotted pattern is derived from the plain one by replacing the last `ss`, so a seventh format option cannot place it wrong, and a test asserts the two patterns differ by exactly one slot and that the marker never reaches a cell.

A fraction of nothing but zeros is dropped. MySQL pads a `DATETIME(6)` to its declared precision on every row where PostgreSQL trims at the server, so printing it would widen every row of such a column for nothing, and two rows both `.000000` are equal at the precision the value carries.

`ParsedTemporalValue` gains `wholeSecond` for this. A fraction near one second rounds the `Double` up, so `2024-02-29 23:59:59.9999999999` landed on 1 March: `keepsItsDay` then refused it as not a date, and the picker would have opened a day past the cell. Display and the picker both read the whole second; the chart keeps the instant.

## 3. The grid follows a system time zone change

Nothing in the app observed `NSSystemTimeZoneDidChange`, and a captured `TimeZone.current` never follows one: measured, a `DateFormatter` holding it renders the old zone for the life of the process. A column set to Unix Timestamp kept its old text while `Cmd+C` on the same cell copied the new one, because the copy path has no cache.

`format(_ date:)` now has its own formatter holding `.autoupdatingCurrent`, which follows the zone with no reassignment, and `updateFormat` keeps its pattern in sync so the column still tracks the chosen date format. The mounted grid redraws off `AppEvents.systemTimeZoneChanged`, mirroring `observeThemeChanges`; an unmounted tab is covered by a generation on `DataGridDisplayIdentity`, so its cache is replaced rather than repaired the next time it is shown. The notification documents no posting thread and this app has shipped a crash from assuming one, so the observer names the main queue and hops explicitly.

`format(dateString:columnType:)` is untouched: it parses and formats in the same zone, so it was already zone-independent and its cache needs neither a clear nor a zone key.

## 4. Oracle timestamp styles nothing produces

`TimestampStyle.zoned` never had a producer, and `.utc` lost its last one in #2703. Both still had passing tests, which is what made them look alive. Removed with their formatters and their tests. No behaviour changes: the only two call sites already named `.naive` and `.local`.

## 5. CI runs the TableProOracle package tests

`Packages/TableProOracle` has an eight-file test target that no job ran, which is why a dead enum case could keep a green test for a year. It is now a step in the existing `packages` job, gated on its own narrow path filter because it resolves a second dependency graph, and pinned to the tracked `Package.resolved`.

## Verified

- `verify.sh test`: `DateFormattingServiceTests`, `DateFormattingServiceTimeZoneTests`, `DatabaseDateParserTests`, `DateEditingServiceTests`, `TemporalEditingConsistencyTests`, `CellDisplayFormatterTests`, `ResultChartProjectorTests`, `MainContentCoordinatorDisplayStateTests`: 123 executed, 123 passed.
- `verify.sh lint` over `TablePro`, both test targets and the Oracle package: 0 violations.
- `docs/scripts/check-writing-style.sh` and `check-docs-against-source.py`: both clean.
- `actionlint` on the edited workflow: clean. The path detector was run by hand for both the match and the no-match case.
- Driven by hand against a sandboxed Debug build seeded with one row per fixed case. The grid printed `2024-03-10 02:30:00`, `2011-12-30 12:00:00`, `.123456` and `.789012` as distinct values, no fraction for `.000000`, and `2024-12-31 23:59:59.5+07`.
- The Oracle formatter compiled standalone under `swiftc -swift-version 6`, since the pinned `oracle-nio` fork's `@TaskLocal` macro fails on Xcode 27 locally. The new CI step is the real gate on it.

`GridTimeZoneOffsetUITests` passed on this code before the last two review fixes, which touch the date picker and not the grid's rendered text. It could not be re-run afterwards: XCUITest refuses to start while another TablePro is running, and the installed app was open. CI runs it.

## Not fixed, and why

A value filter on a Unix Timestamp column stores the rendered strings, so a zone change leaves it holding terms that match nothing. The same hole is already open on the date-format path, which has shipped that way; the real fix is for the filter to key on raw values, which is a change to the filter rather than to this. Reported rather than papered over.

`plottableDate` reproduces today's chart instant exactly, which means a naive value inside a gap is still plotted an hour out on the axis. One hour, one value a year, on a surface with no round-trip and no edit.


https://claude.ai/code/session_01P6WcfBSJ9Xa2heWLSQGP8m
