### PR TITLE
test: read the curated health-monitor table and skip onboarding before listing a connection

### DIFF
--- a/TablePro/Core/Plugins/PluginMetadataRegistry.swift
+++ b/TablePro/Core/Plugins/PluginMetadataRegistry.swift
@@ -350,9 +350,17 @@ final class PluginMetadataRegistry: @unchecked Sendable {
         registerBuiltInDefaults()
     }
 
+    /// The curated table the app ships, before any plugin or test registers over it.
+    ///
+    /// The live snapshots are not that table: a loaded plugin replaces its entry, and a test can
+    /// register a synthetic engine into the same shared registry. Anything that means to check the
+    /// table itself reads this instead of iterating `allRegisteredTypeIds()`.
+    func builtInDefaults() -> [(typeId: String, snapshot: PluginMetadataSnapshot)] {
+        Self.curatedDefaults() + registryPluginDefaults()
+    }
+
     private func registerBuiltInDefaults() {
-        let allDefaults = Self.curatedDefaults() + registryPluginDefaults()
-        for entry in allDefaults {
+        for entry in builtInDefaults() {
             snapshots[entry.typeId] = entry.snapshot
             defaultSnapshots[entry.typeId] = entry.snapshot
             for scheme in entry.snapshot.urlSchemes {

--- a/TableProTests/Core/Plugins/HealthMonitorOptOutParityTests.swift
+++ b/TableProTests/Core/Plugins/HealthMonitorOptOutParityTests.swift
@@ -15,22 +15,25 @@ import Testing
 
 @Suite("Health monitor opt-out parity")
 struct HealthMonitorOptOutParityTests {
+    /// Reads the curated table, not the live registry. Other suites register synthetic engines
+    /// into the same shared registry, several with the monitor off, and none of them has a plugin
+    /// source to find: reading the live snapshots made this fail or pass by suite order.
     @Test("every type curated as health-monitor-free says so on its plugin too")
     func curatedOptOutsAreDeclaredOnTheirPlugins() throws {
-        let optedOut = DatabaseType.allKnownTypes.filter { type in
-            PluginMetadataRegistry.shared.snapshot(for: type)?.supportsHealthMonitor == false
-        }
+        let optedOut = PluginMetadataRegistry.shared.builtInDefaults()
+            .filter { $0.snapshot.supportsHealthMonitor == false }
+            .map(\.typeId)
         #expect(!optedOut.isEmpty, "The curated table opts at least SQLite and DuckDB out")
 
         let sources = try Self.pluginSources()
         var missing: [String] = []
-        for type in optedOut {
-            guard let source = sources.first(where: { $0.declaresTypeId(type.rawValue) }) else {
-                missing.append("\(type.rawValue) (no plugin source declares this type id)")
+        for typeId in optedOut {
+            guard let source = sources.first(where: { $0.declaresTypeId(typeId) }) else {
+                missing.append("\(typeId) (no plugin source declares this type id)")
                 continue
             }
             if !source.text.contains("static let supportsHealthMonitor = false") {
-                missing.append("\(type.rawValue) (\(source.url.lastPathComponent))")
+                missing.append("\(typeId) (\(source.url.lastPathComponent))")
             }
         }
 

--- a/TableProUITests/ConnectionWindowChromeUITests.swift
+++ b/TableProUITests/ConnectionWindowChromeUITests.swift
@@ -59,6 +59,7 @@ final class ConnectionWindowChromeUITests: UITestCase {
     func testTheDetailPaneNeverDrawsNothingWhileConnecting() throws {
         let app = try launchApp()
         XCTAssertTrue(app.windows.firstMatch.waitToExist(timeout: 20))
+        dismissOnboarding(in: app)
 
         try openProbeConnection(in: app)
 
@@ -122,11 +123,14 @@ final class ConnectionWindowChromeUITests: UITestCase {
         save.click()
         XCTAssertTrue(waitForPredicate(timeout: 15) { !form.exists }, "Save should close the form")
 
-        let list = app.windows.firstMatch.outlines.firstMatch
-        XCTAssertTrue(waitForPredicate(timeout: 15) { list.outlineRows.count > 0 })
-        list.outlineRows.element(boundBy: 0)
-            .coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
-            .doubleClick()
+        /// Found by what it says rather than by its role: the row combines its children into one
+        /// element, and a list row's role is not the same on every macOS build the suite runs on.
+        let row = app.windows["welcome"].descendants(matching: .any)
+            .matching(NSPredicate(format: "label BEGINSWITH %@", "Probe"))
+            .firstMatch
+        XCTAssertTrue(row.waitToExist(timeout: 15), "The saved connection must be listed on the welcome window")
+        XCTAssertTrue(waitUntilHittable(row, timeout: 10))
+        row.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).doubleClick()
     }
 
     private func disconnect(in app: XCUIApplication) {

--- a/TableProUITests/Support/UITestCase.swift
+++ b/TableProUITests/Support/UITestCase.swift
@@ -182,6 +182,23 @@ internal class UITestCase: XCTestCase {
         waitForPredicate(timeout: timeout) { element.exists && element.isHittable }
     }
 
+    /// Every case gets a fresh sandbox, and a sandbox that has never completed onboarding opens the
+    /// welcome window on `OnboardingContentView`. The window carries the `welcome` identifier
+    /// either way, so a test that only waits for the window is satisfied by a screen holding
+    /// nothing but Skip, three page dots and Continue, and a test that then looks for the
+    /// connection list finds none: a saved connection has nowhere to be listed.
+    ///
+    /// The defaults suite is per-sandbox, so seeding `hasCompletedOnboarding` through a launch
+    /// argument cannot work: `NSArgumentDomain` reaches the standard domain alone, and an override
+    /// aimed at a suite opened by name is an ordinary argument nothing reads. Skip is the supported
+    /// way past it and costs one click.
+    internal func dismissOnboarding(in app: XCUIApplication) {
+        let skip = app.windows["welcome"].links["Skip"]
+        XCTAssertTrue(skip.waitToExist(timeout: 10), "A fresh sandbox must open the welcome window on onboarding")
+        XCTAssertTrue(waitUntilHittable(skip, timeout: 5))
+        skip.click()
+    }
+
     /// Switches the result to its Structure editor, through **View > Result View > Structure**
     /// rather than the `Structure` segment of the results status bar.
     ///

--- a/TableProUITests/SupportWindowUITests.swift
+++ b/TableProUITests/SupportWindowUITests.swift
@@ -13,22 +13,6 @@ final class SupportWindowUITests: UITestCase {
         return app
     }
 
-    /// Every case gets a fresh sandbox, and a sandbox that has never completed onboarding opens the
-    /// welcome window on `OnboardingContentView`. The window carries the `welcome` identifier
-    /// either way, so a test that only waits for the window is satisfied by a screen holding
-    /// nothing but Skip, three page dots and Continue.
-    ///
-    /// The defaults suite is per-sandbox, so seeding `hasCompletedOnboarding` through a launch
-    /// argument cannot work: `NSArgumentDomain` reaches the standard domain alone, and an override
-    /// aimed at a suite opened by name is an ordinary argument nothing reads. Skip is the supported
-    /// way past it and costs one click.
-    private func dismissOnboarding(in app: XCUIApplication) {
-        let skip = app.windows["welcome"].links["Skip"]
-        XCTAssertTrue(skip.waitToExist(timeout: 10), "A fresh sandbox must open the welcome window on onboarding")
-        XCTAssertTrue(waitUntilHittable(skip, timeout: 5))
-        skip.click()
-    }
-
     private func openSupportWindow(in app: XCUIApplication) -> XCUIElement {
         let item = app.menuBars.menuItems["Support TablePro"]
         XCTAssertTrue(item.waitToExist(timeout: 10), "Support TablePro must be in the Help menu")


### PR DESCRIPTION
`macOS Tests` had been red on main since #2707 with two failures. This PR fixes one outright and starts on the other; the rest of the UI fix follows in a separate PR, because this one merged before it landed.

## Health monitor opt-out parity (unit) - fixed

The test says it checks every type the *curated table* opts out of the health monitor, but it enumerated the live registry through `DatabaseType.allKnownTypes`. `ExportTreeBuilderTests` and `DatabaseManagerSchemaChangeRoutingTests` register synthetic engines into that same shared registry with `supportsHealthMonitor: false`, and none has a plugin source to find, so the result depended on suite order.

`PluginMetadataRegistry.builtInDefaults()` now returns the curated table the app ships, `registerBuiltInDefaults` builds from it, and the test reads it. The unit job is green on this PR's CI run.

## Connection window chrome (UI) - partly fixed

`testTheDetailPaneNeverDrawsNothingWhileConnecting` failed because the welcome window was still on onboarding after the probe connection was saved, so there was no list for it to appear in. `dismissOnboarding(in:)` moves from `SupportWindowUITests` into `UITestCase`, and this test calls it after launch.

That was not sufficient. This PR's own CI run showed the retry opening with no onboarding at all, because `AppSettingsStorage` reads the machine's real defaults domain rather than the per-sandbox suite, so the first attempt's Skip leaked into the retry. The row predicate here also matches `label`, while the runner publishes the row's text as `value`. Both are fixed in the follow-up.
