### PR TITLE
fix(settings): keep UI-test settings in the sandbox suite

### DIFF
--- a/TablePro/Core/Storage/AppSettingsStorage.swift
+++ b/TablePro/Core/Storage/AppSettingsStorage.swift
@@ -38,7 +38,12 @@ final class AppSettingsStorage: Sendable {
         static let legacyJsonFieldHeight = "rightSidebar.jsonFieldHeight"
     }
 
-    init(userDefaults: UserDefaults = .standard) {
+    /// The storage environment's defaults, not `.standard`. A UI test runs against a per-sandbox
+    /// suite, and reading the standard domain here put every setting, the onboarding flag among
+    /// them, in the machine's real preferences: a developer who had finished onboarding never saw
+    /// it under test, a fresh runner saw it until the first case skipped it, and every case after
+    /// that inherited the skip.
+    init(userDefaults: UserDefaults = AppStorageEnvironment.shared.defaults) {
         self.defaults = userDefaults
     }
 

--- a/TableProUITests/ConnectionWindowChromeUITests.swift
+++ b/TableProUITests/ConnectionWindowChromeUITests.swift
@@ -123,10 +123,10 @@ final class ConnectionWindowChromeUITests: UITestCase {
         save.click()
         XCTAssertTrue(waitForPredicate(timeout: 15) { !form.exists }, "Save should close the form")
 
-        /// Found by what it says rather than by its role: the row combines its children into one
-        /// element, and a list row's role is not the same on every macOS build the suite runs on.
-        let row = app.windows["welcome"].descendants(matching: .any)
-            .matching(NSPredicate(format: "label BEGINSWITH %@", "Probe"))
+        /// The row combines its children into one static text whose value carries the name and the
+        /// host, `Probe, 192.0.2.1`, and no label; the runner's element tree shows it that way.
+        let row = app.windows["welcome"].staticTexts
+            .matching(NSPredicate(format: "value BEGINSWITH %@", "Probe"))
             .firstMatch
         XCTAssertTrue(row.waitToExist(timeout: 15), "The saved connection must be listed on the welcome window")
         XCTAssertTrue(waitUntilHittable(row, timeout: 10))


### PR DESCRIPTION
Finishes the UI half of #2713, which merged before this commit. Main's `UI tests 1/3` is still red on `testTheDetailPaneNeverDrawsNothingWhileConnecting`; this is the fix.

## The settings store that escaped the sandbox

`testTheDetailPaneNeverDrawsNothingWhileConnecting` failed at `list.outlineRows.count > 0` after saving the probe connection. The element tree captured at teardown shows the `welcome` window holding Skip, three page dots and Continue: it was still on onboarding, so the saved connection had no list to appear in.

#2713 skipped onboarding first, and its CI run showed that was not enough. The first attempt saw onboarding, skipped it, and found the row. The retry saw **no** onboarding and an empty "No Connections" list: connections had been reset for the new sandbox, but the onboarding flag had not.

`AppSettingsStorage.shared` is built with `init(userDefaults: UserDefaults = .standard)`, so it never used the per-sandbox suite `AppStorageEnvironment` provides. Under UI tests every setting, the onboarding flag included, lived in the machine's real `com.TablePro` domain. That is why the test passed on a developer Mac (onboarding long since completed there), why a fresh runner showed onboarding until the first case in a shard skipped it, and why every case after that inherited the skip. `AppSettingsStorage` now defaults to `AppStorageEnvironment.shared.defaults`, which resolves to `.standard` in production and under unit tests and to the sandbox suite under UI tests. `AppStorageEnvironment.bootstrap()` runs in `main.swift` before the delegate exists, so nothing reads settings before the environment resolves.

With the store fixed, `dismissOnboarding(in:)` from #2713 holds on every launch, because "a fresh sandbox opens on onboarding" is now actually true.

The saved row is now found by its value rather than its label. The runner publishes it as `OutlineRow > Cell > StaticText` with `value: Probe, 192.0.2.1` and no label, which is why #2713's first attempt skipped onboarding, had the row on screen, and still failed.

None of the other bare-launch UI suites depend on the welcome list: they use the menus, the chooser sheet or the window's existence, and the CI logs already show `ConnectionFormTransportUITests` passing with onboarding on screen.

## Not fixed here

The lint rule meant to stop this, `storage_environment_defaults`, matches `UserDefaults\.standard` and so never sees the shorthand default argument `UserDefaults = .standard`. 23 other stores use that shorthand and bypass the UI-test sandbox the same way (`ConnectionStorage`, `GroupStorage`, `FavoriteTablesStorage`, `ColumnLayoutPersister`, `MCPApprovalStore`, `PluginManager`, `RegistryClient` and more). Some, like `ManagedPolicy` reading MDM-managed preferences, legitimately need the standard domain, so each one is a decision, and tightening the rule turns all 23 into lint errors at once. That belongs in its own PR rather than in a fix for red CI.

## Verified

- Unit suites that own or construct the store, run together: `AppSettingsStorageMigrationTests`, `AppSettingsStorageResetTests`, `AppStorageEnvironmentTests`, `SettingsWindowTitleTests`, the audit and tunnel suites that construct the store, `HealthMonitorOptOutParityTests`, `ExportTreeBuilderTests` and `DatabaseManagerSchemaChangeRoutingTests`: 84 executed, 84 passed.
- `swiftlint` over the changed files: clean apart from two pre-existing `UserDefaults.standard` calls in `UITestCase.swift`, untouched here and outside CI's lint scope.
- The UI test target compiles.
- The UI suites were **not** run locally: XCUITest will not start while another TablePro is running, and the installed app was open. This PR's CI run is the check.

No CHANGELOG entry: nothing a user sees changes.
