### PR TITLE
fix(editor): let the SQL editor narrow again and keep line starts clear of the gutter (#2709)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Window rebuilding its own layout three times while a connection opens.
 - Connecting screen naming the wrong step for the first half second of a connect.
 - Spinner flash in the object browser on Oracle, Snowflake, BigQuery, Trino and Dameng.
+- Start of every line hidden in the SQL editor after a long line was removed. (#2709)
+- Start of a line hidden under the line numbers after moving to it in a horizontally scrolled editor.
+- Editor jumping sideways on each keystroke in a long line while scrolled horizontally.
+- Cursor left off screen after pasting a long line.
+- Line number column keeping a stale width after the line count drops below 1,000 or the font size changes.
 
 ## [0.73.0] - 2026-09-09
 

--- a/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/Controller/TextViewController+GutterViewDelegate.swift
+++ b/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/Controller/TextViewController+GutterViewDelegate.swift
@@ -9,6 +9,6 @@ import Foundation
 
 extension TextViewController: GutterViewDelegate {
     public func gutterViewWidthDidUpdate() {
-        updateTextInsets()
+        updateFloatingSubviewInsets()
     }
 }

--- a/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/Controller/TextViewController+IndentLines.swift
+++ b/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/Controller/TextViewController+IndentLines.swift
@@ -82,6 +82,8 @@ extension TextViewController {
             selectionIndex += 1
         }
         textView.undoManager?.endUndoGrouping()
+        // Each line's edit skips revealing the selection, which is only final once every line is done.
+        textView.scrollSelectionToVisible()
     }
 
     private func updateSelection(

--- a/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/Controller/TextViewController+Lifecycle.swift
+++ b/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/Controller/TextViewController+Lifecycle.swift
@@ -13,7 +13,7 @@ extension TextViewController {
     override public func viewWillAppear() {
         super.viewWillAppear()
         // The calculation this causes cannot be done until the view knows it's final position
-        updateTextInsets()
+        updateFloatingSubviewInsets()
         minimapView.layout()
     }
 
@@ -30,7 +30,7 @@ extension TextViewController {
     override public func loadView() {
         super.loadView()
 
-        scrollView = NSScrollView()
+        scrollView = SourceEditorScrollView()
         scrollView.documentView = textView
 
         gutterView = GutterView(
@@ -132,7 +132,7 @@ extension TextViewController {
         ) { [weak self] _ in
             self?.gutterView.needsDisplay = true
             self?.emphasisManager?.removeEmphases(for: EmphasisGroup.brackets)
-            self?.updateTextInsets()
+            self?.updateFloatingSubviewInsets()
             NotificationCenter.default.post(name: Self.scrollPositionDidUpdateNotification, object: self)
         }
     }

--- a/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/Controller/TextViewController+StyleViews.swift
+++ b/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/Controller/TextViewController+StyleViews.swift
@@ -82,6 +82,10 @@ extension TextViewController {
         // Update scrollview tiling
         scrollView.reflectScrolledClipView(scrollView.contentView)
         minimapView.scrollView.reflectScrolledClipView(minimapView.scrollView.contentView)
+
+        // The host's insets change the width the text has to fill, and a change on the trailing side alone reaches the
+        // text view through no other route.
+        textView.updateFrameIfNeeded()
     }
 
     /// Reserves the gutter's and the minimap's widths on the scroll view. See ``floatingSubviewInsets``.

--- a/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/Controller/TextViewController+StyleViews.swift
+++ b/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/Controller/TextViewController+StyleViews.swift
@@ -44,7 +44,7 @@ extension TextViewController {
 
     /// Updates all relevant content insets including the find panel, scroll view, minimap and gutter position.
     package func updateContentInsets() {
-        updateTextInsets()
+        updateFloatingSubviewInsets()
 
         scrollView.contentView.postsBoundsChangedNotifications = true
         if let contentInsets = configuration.layout.contentInsets {
@@ -84,12 +84,17 @@ extension TextViewController {
         minimapView.scrollView.reflectScrolledClipView(minimapView.scrollView.contentView)
     }
 
-    /// Updates the text view's text insets. See ``textViewInsets`` for calculation.
-    func updateTextInsets() {
+    /// Reserves the gutter's and the minimap's widths on the scroll view. See ``floatingSubviewInsets``.
+    ///
+    /// The reservation changes the width the text has to fill, which the text view does not hear about on its own when
+    /// only the trailing side moves, so its frame is brought up to date here.
+    func updateFloatingSubviewInsets() {
         // Allow this method to be called before ``loadView()``
-        guard textView != nil, minimapView != nil else { return }
-        if textView.textInsets != textViewInsets {
-            textView.textInsets = textViewInsets
-        }
+        guard scrollView != nil, textView != nil, gutterView != nil, minimapView != nil else { return }
+        let insets = floatingSubviewInsets
+        guard scrollView.floatingSubviewInsets != insets else { return }
+        scrollView.floatingSubviewInsets = insets
+        textView.updateFrameIfNeeded()
+        reformattingGuideView?.updatePosition(in: self)
     }
 }

--- a/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/Controller/TextViewController.swift
+++ b/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/Controller/TextViewController.swift
@@ -229,6 +229,11 @@ public class TextViewController: NSViewController {
             return CGPoint(x: origin.x + scrollView.floatingSubviewInsets.left, y: origin.y)
         }
         set {
+            // The document is only as wide as the lines laid out so far, so the lines at the new vertical position are
+            // laid out before the horizontal position is applied, or it would be clamped to a width they have not
+            // reported yet.
+            textView.scroll(CGPoint(x: scrollView.contentView.bounds.minX, y: newValue.y))
+            textView.layoutManager.layoutLines()
             textView.scroll(CGPoint(x: newValue.x - scrollView.floatingSubviewInsets.left, y: newValue.y))
             scrollView.reflectScrolledClipView(scrollView.contentView)
         }

--- a/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/Controller/TextViewController.swift
+++ b/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/Controller/TextViewController.swift
@@ -26,7 +26,7 @@ public class TextViewController: NSViewController {
 
     weak var findViewController: FindViewController?
 
-    internal(set) public var scrollView: NSScrollView!
+    internal(set) public var scrollView: SourceEditorScrollView!
     internal(set) public var textView: TextView!
     var gutterView: GutterView!
     var minimapView: MinimapView!
@@ -68,6 +68,11 @@ public class TextViewController: NSViewController {
         didSet {
             highlighter?.setLanguage(language: language)
             setUpTextFormation()
+            // Another grammar highlights the text with other bold and italic runs, so the widths measured under the
+            // old one no longer hold.
+            if oldValue.id != language.id {
+                textView?.layoutManager?.invalidateLineWidths()
+            }
         }
     }
 
@@ -204,18 +209,29 @@ public class TextViewController: NSViewController {
 
     var cancellables = Set<AnyCancellable>()
 
-    /// The trailing inset for the editor. Grows when line wrapping is disabled or when the minimap is shown.
-    var textViewTrailingInset: CGFloat {
-        // See https://github.com/CodeEditApp/CodeEditTextView/issues/66
-        // wrapLines ? 1 : 48
-        (minimapView?.isHidden ?? false) ? 0 : (minimapView?.frame.width ?? 0.0)
-    }
-
-    var textViewInsets: HorizontalEdgeInsets {
+    /// The widths of the views floating along the editor's edges: the gutter on the leading side, and the minimap on
+    /// the trailing side while it is shown. ``SourceEditorScrollView`` reserves them so the text scrolls clear of both.
+    var floatingSubviewInsets: HorizontalEdgeInsets {
         HorizontalEdgeInsets(
             left: showGutter ? gutterView.frame.width : 0.0,
-            right: textViewTrailingInset
+            right: (minimapView?.isHidden ?? false) ? 0 : (minimapView?.frame.width ?? 0.0)
         )
+    }
+
+    /// Where the editor is scrolled, measured horizontally from where the text starts rather than from the gutter.
+    ///
+    /// The gutter's width is reserved on the clip view, so the clip view's own origin moves whenever the gutter shows,
+    /// hides or gains a digit. This is the position ``SourceEditorState`` records and restores, so a saved position
+    /// means the same text regardless.
+    var scrollPosition: CGPoint {
+        get {
+            let origin = scrollView.contentView.bounds.origin
+            return CGPoint(x: origin.x + scrollView.floatingSubviewInsets.left, y: origin.y)
+        }
+        set {
+            textView.scroll(CGPoint(x: newValue.x - scrollView.floatingSubviewInsets.left, y: newValue.y))
+            scrollView.reflectScrolledClipView(scrollView.contentView)
+        }
     }
 
     // MARK: Init

--- a/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/Gutter/GutterView.swift
+++ b/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/Gutter/GutterView.swift
@@ -14,22 +14,20 @@ public protocol GutterViewDelegate: AnyObject {
 }
 
 /// The gutter view displays line numbers that match the text view's line indexes.
-/// This view is used as a scroll view's ruler view. It sits on top of the text view so text scrolls underneath the
-/// gutter if line wrapping is disabled.
+/// This view floats over the leading edge of the scroll view, so text scrolls underneath it when line wrapping is
+/// disabled. Its width is reserved on the clip view's content insets (see ``SourceEditorScrollView``), which is what
+/// keeps the start of each line, and a caret revealed there, clear of it.
 ///
-/// If the gutter needs more space (when the number of digits in the numbers increases eg. adding a line after line 99),
-/// it will notify it's delegate via the ``GutterViewDelegate/gutterViewWidthDidUpdate(newWidth:)`` method. In
-/// `SourceEditor`, this notifies the ``TextViewController``, which in turn updates the textview's edge insets
-/// to adjust for the new leading inset.
+/// If the gutter needs a different width (when the number of digits in the numbers changes eg. adding a line after
+/// line 99), it will notify it's delegate via the ``GutterViewDelegate/gutterViewWidthDidUpdate()`` method. In
+/// `SourceEditor`, this notifies the ``TextViewController``, which in turn updates the width the scroll view reserves.
 ///
 /// This view also listens for selection updates, and draws a selected background on selected lines to keep the illusion
 /// that the gutter's line numbers are inline with the line itself.
 ///
 /// The gutter view has insets of it's own that are relative to the widest line index. By default, these insets are 20px
-/// leading, and 12px trailing. However, this view also has a ``GutterView/backgroundEdgeInsets`` property, that pads
-/// the rect that has a background drawn. This allows the text to be scrolled under the gutter view for 8px before being
-/// overlapped by the gutter. It should help the textview keep the cursor visible if the user types while the cursor is
-/// off the leading edge of the editor.
+/// leading, and 12px trailing. It paints its background across its whole width, the folding ribbon included: nothing
+/// it covers is meant to be read, since the text it floats over is scrolled clear of it whenever it matters.
 ///
 public class GutterView: NSView {
     struct EdgeInsets: Equatable, Hashable {
@@ -48,6 +46,8 @@ public class GutterView: NSView {
     var font: NSFont = .systemFont(ofSize: 13) {
         didSet {
             updateFontLineHeight()
+            lineNumberDigits = 0
+            updateWidthIfNeeded()
         }
     }
 
@@ -76,14 +76,11 @@ public class GutterView: NSView {
                 leading: fitsContent ? 0 : GutterView.windowEdgeLeadingInset,
                 trailing: edgeInsets.trailing
             )
-            maxLineNumberWidth = 0
-            maxLineLength = 0
+            lineNumberWidth = 0
+            lineNumberDigits = 0
             updateWidthIfNeeded()
         }
     }
-
-    @Invalidating(.display)
-    var backgroundEdgeInsets: EdgeInsets = EdgeInsets(leading: 0, trailing: 8)
 
     /// The leading padding for the folding ribbon from the line numbers.
     @Invalidating(.display)
@@ -138,9 +135,10 @@ public class GutterView: NSView {
 
     private weak var textView: TextView?
     private weak var delegate: GutterViewDelegate?
-    private var maxLineNumberWidth: CGFloat = 0
-    /// The maximum number of digits found for a line number.
-    private var maxLineLength: Int = 0
+    /// The width of the widest number the gutter has room for, measured for ``lineNumberDigits`` digits.
+    private var lineNumberWidth: CGFloat = 0
+    /// The number of digits ``lineNumberWidth`` was measured for, or zero when it has to be measured again.
+    private var lineNumberDigits: Int = 0
 
     private var fontLineHeight = 1.0
 
@@ -187,7 +185,7 @@ public class GutterView: NSView {
     }
 
     private var numberAreaWidth: CGFloat {
-        showLineNumbers ? maxLineNumberWidth : 0
+        showLineNumbers ? lineNumberWidth : 0
     }
 
     /// Syntax helper for determining the required space for the folding ribbon.
@@ -357,14 +355,12 @@ public class GutterView: NSView {
             ? documentDigits
             : max(GutterView.growingDocumentDigits, documentDigits)
 
-        if maxLineLength < lineStorageDigits {
-            // Update the max width
-            let maxCtLine = CTLineCreateWithAttributedString(
+        if lineNumberDigits != lineStorageDigits {
+            let widestNumber = CTLineCreateWithAttributedString(
                 NSAttributedString(string: String(repeating: "0", count: lineStorageDigits), attributes: attributes)
             )
-            let width = CTLineGetTypographicBounds(maxCtLine, nil, nil, nil)
-            maxLineNumberWidth = max(maxLineNumberWidth, width)
-            maxLineLength = lineStorageDigits
+            lineNumberWidth = CTLineGetTypographicBounds(widestNumber, nil, nil, nil)
+            lineNumberDigits = lineStorageDigits
         }
 
         let newWidth = numberAreaWidth + horizontalInsets + foldingRibbonWidth
@@ -380,13 +376,9 @@ public class GutterView: NSView {
     ///   - dirtyRect: A rect to draw in, received from ``draw(_:)``.
     private func drawBackground(_ context: CGContext, dirtyRect: NSRect) {
         guard let backgroundColor else { return }
-        let minX = max(backgroundEdgeInsets.leading, dirtyRect.minX)
-        let maxX = min(frame.width - backgroundEdgeInsets.trailing - foldingRibbonWidth, dirtyRect.maxX)
-        let width = maxX - minX
-
         context.saveGState()
         context.setFillColor(backgroundColor.safeCGColor)
-        context.fill(CGRect(x: minX, y: dirtyRect.minY, width: width, height: dirtyRect.height))
+        context.fill(bounds.intersection(dirtyRect))
         context.restoreGState()
     }
 
@@ -405,10 +397,10 @@ public class GutterView: NSView {
         var highlightedLines: Set<UUID> = []
         context.setFillColor(selectedLineColor.safeCGColor)
 
-        let xPos = backgroundEdgeInsets.leading
-        // Stops where the gutter background stops. The folding ribbon sits over the text view, so painting the
-        // selection under it would stack this colour on top of the text view's own line highlight.
-        let width = frame.width - backgroundEdgeInsets.trailing - foldingRibbonWidth
+        // Spans the whole gutter, the folding ribbon included, so the band meets the text view's own line highlight
+        // at the gutter's trailing edge.
+        let xPos: CGFloat = 0
+        let width = frame.width
 
         for selection in selectionManager.textSelections where selection.range.isEmpty {
             guard let line = textView.layoutManager.textLineForOffset(selection.range.location),

--- a/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/ReformattingGuide/ReformattingGuideView.swift
+++ b/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/ReformattingGuide/ReformattingGuideView.swift
@@ -55,34 +55,27 @@ class ReformattingGuideView: NSView {
             NSColor.black.withAlphaComponent(0.025) :
             NSColor.white.withAlphaComponent(0.025)
 
-        // Draw the vertical line (accounting for inverted Y coordinate system)
+        // Draw the vertical line along the view's leading edge. The view's frame already stands on the column, so
+        // drawing is done in bounds: using the frame's origin here would offset the line by the column a second time.
         lineColor.setStroke()
         let linePath = NSBezierPath()
-        linePath.move(to: NSPoint(x: frame.minX, y: frame.maxY))  // Start at top
-        linePath.line(to: NSPoint(x: frame.minX, y: frame.minY))  // Draw down to bottom
+        let lineX = bounds.minX + 0.5
+        linePath.move(to: NSPoint(x: lineX, y: bounds.maxY))
+        linePath.line(to: NSPoint(x: lineX, y: bounds.minY))
         linePath.lineWidth = 1.0
         linePath.stroke()
 
         // Draw the shaded area to the right of the line
         shadedColor.setFill()
-        let shadedRect = NSRect(
-            x: frame.minX,
-            y: frame.minY,
-            width: frame.width,
-            height: frame.height
-        )
-        shadedRect.fill()
+        bounds.fill()
     }
 
     func updatePosition(in controller: TextViewController) {
-        // Calculate the x position based on the font's character width and column number
-        let xPosition = (
-            CGFloat(column) * (controller.font.charWidth / 2) // Divide by 2 to account for coordinate system
-            + (controller.textViewInsets.left / 2)
-        )
-
-        // Get the scroll view's content size
-        guard let scrollView = controller.scrollView else { return }
+        // The column's x in the text view, converted into the floating container this view is drawn in, so the guide
+        // lands on the column however that container is offset from the document.
+        guard let scrollView = controller.scrollView, let container = superview else { return }
+        let columnX = controller.textView.layoutManager.edgeInsets.left + CGFloat(column) * controller.font.charWidth
+        let xPosition = container.convert(NSPoint(x: columnX, y: 0), from: controller.textView).x
         let contentSize = scrollView.documentVisibleRect.size
 
         // Ensure we don't create an invalid frame

--- a/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/SourceEditor/SourceEditor+Coordinator.swift
+++ b/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/SourceEditor/SourceEditor+Coordinator.swift
@@ -168,7 +168,7 @@ extension SourceEditor {
             guard let controller = notification.object as? TextViewController else {
                 return
             }
-            let currentPosition = controller.scrollView.contentView.bounds.origin
+            let currentPosition = controller.scrollPosition
             if editorState.scrollPosition != currentPosition {
                 updateState { $0.scrollPosition = currentPosition }
             }

--- a/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/SourceEditor/SourceEditor.swift
+++ b/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/SourceEditor/SourceEditor.swift
@@ -195,10 +195,9 @@ public struct SourceEditor: NSViewControllerRepresentable {
             controller.setCursorPositions(cursorPositions)
         }
 
-        let scrollView = controller.scrollView
-        if let scrollPosition = state.scrollPosition, scrollPosition != scrollView?.contentView.bounds.origin {
-            controller.scrollView.scroll(controller.scrollView.contentView, to: scrollPosition)
-            controller.scrollView.reflectScrolledClipView(controller.scrollView.contentView)
+        if let scrollPosition = state.scrollPosition, controller.scrollView != nil,
+           scrollPosition != controller.scrollPosition {
+            controller.scrollPosition = scrollPosition
             controller.gutterView.needsDisplay = true
             NotificationCenter.default.post(name: NSView.frameDidChangeNotification, object: controller.textView)
         }

--- a/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/SourceEditorConfiguration/SourceEditorConfiguration+Appearance.swift
+++ b/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/SourceEditorConfiguration/SourceEditorConfiguration+Appearance.swift
@@ -109,7 +109,7 @@ extension SourceEditorConfiguration {
                 controller.textView.layoutManager.wrapLines = wrapLines
                 controller.minimapView.layoutManager?.wrapLines = wrapLines
                 controller.scrollView.hasHorizontalScroller = !wrapLines
-                controller.updateTextInsets()
+                controller.updateFloatingSubviewInsets()
             }
 
             // useThemeBackground isn't needed
@@ -117,6 +117,15 @@ extension SourceEditorConfiguration {
             if oldConfig?.letterSpacing != letterSpacing {
                 controller.textView.letterSpacing = letterSpacing
                 needsHighlighterInvalidation = true
+            }
+
+            // A new font, letter spacing or theme restyles the whole document, a theme through the bold and italic
+            // traits it gives the highlighted text, so every width measured under the old one is wrong, including those
+            // of lines that are off screen and will not be laid out again soon. Reapplying the same configuration,
+            // which is what `reloadUI` does, leaves them alone.
+            if let oldConfig,
+               oldConfig.font != font || oldConfig.letterSpacing != letterSpacing || oldConfig.theme != theme {
+                controller.textView.layoutManager.invalidateLineWidths()
             }
 
             if oldConfig?.bracketPairEmphasis != bracketPairEmphasis {

--- a/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/SourceEditorConfiguration/SourceEditorConfiguration+Peripherals.swift
+++ b/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/SourceEditorConfiguration/SourceEditorConfiguration+Peripherals.swift
@@ -119,7 +119,7 @@ extension SourceEditorConfiguration {
 
             if shouldUpdateInsets && controller.scrollView != nil { // Check for view existence
                 controller.updateContentInsets()
-                controller.updateTextInsets()
+                controller.updateFloatingSubviewInsets()
             }
         }
     }

--- a/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/SupportingViews/SourceEditorScrollView.swift
+++ b/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/SupportingViews/SourceEditorScrollView.swift
@@ -1,0 +1,85 @@
+//
+//  SourceEditorScrollView.swift
+//  CodeEditSourceEditor
+//
+
+import AppKit
+import CodeEditTextView
+
+/// The editor's scroll view, which keeps the text clear of the views floating along its leading and trailing edges.
+///
+/// The gutter and the minimap are floating subviews. They sit over the clip view rather than beside it, so on its own
+/// AppKit treats the whole clip view as showing the document. Their widths are reserved on the clip view's content
+/// insets, the channel AppKit itself uses to make room for a ruler or a table header. Revealing a range, clamping the
+/// scroll position, autoscrolling during a drag and re-clamping after the document narrows then all stop at the edge
+/// of the chrome, instead of carrying the start of each line underneath the gutter.
+///
+/// The reservation is added in ``tile()``, on top of the insets AppKit works out for the clip view on that same tile:
+/// the scroll view's own ``contentInsets`` and title bar, and the room a ruler, a header or a legacy scroller takes.
+/// The clip view computes those only while it adjusts its insets automatically, so it does so for the length of
+/// `super.tile()` and stops before the reservation is written, or the next tile would drop it.
+public final class SourceEditorScrollView: NSScrollView {
+    /// Where the clip view sits horizontally before a tile, so it can be put back afterwards.
+    private enum HorizontalPlacement {
+        case leadingEdge
+        case trailingEdge
+        case offset(CGFloat)
+    }
+
+    /// AppKit aligns the clip view's origin to the backing store's pixels, and a gutter's width is fractional, so an
+    /// edge is only ever reached to within a fraction of a point.
+    private static let edgeTolerance: CGFloat = 0.5
+
+    /// The widths of the views floating along the leading and trailing edges.
+    public internal(set) var floatingSubviewInsets: HorizontalEdgeInsets = .zero {
+        didSet {
+            guard floatingSubviewInsets != oldValue else { return }
+            tile()
+        }
+    }
+
+    override public func tile() {
+        let placement = horizontalPlacement()
+
+        contentView.automaticallyAdjustsContentInsets = true
+        super.tile()
+        let computed = contentView.contentInsets
+        contentView.automaticallyAdjustsContentInsets = false
+        contentView.contentInsets = NSEdgeInsets(
+            top: computed.top,
+            left: computed.left + floatingSubviewInsets.left,
+            bottom: computed.bottom,
+            right: computed.right + floatingSubviewInsets.right
+        )
+
+        restore(placement)
+    }
+
+    /// A clip view that shows the start of the document, even partly under the leading reservation, is at the leading
+    /// edge and stays there, so a gutter that gains a digit moves the text over rather than covering the start of
+    /// every line. One showing the end of the widest line stays at the trailing edge, so a minimap appearing does not
+    /// cover it. Anywhere else keeps its offset.
+    private func horizontalPlacement() -> HorizontalPlacement {
+        let bounds = contentView.bounds
+        if bounds.minX <= Self.edgeTolerance {
+            return .leadingEdge
+        }
+        let furthest = NSRect(origin: NSPoint(x: documentView?.frame.maxX ?? bounds.minX, y: bounds.minY), size: bounds.size)
+        let trailingEdge = contentView.constrainBoundsRect(furthest).minX
+        return bounds.minX >= trailingEdge - Self.edgeTolerance ? .trailingEdge : .offset(bounds.minX)
+    }
+
+    private func restore(_ placement: HorizontalPlacement) {
+        guard let documentView else { return }
+        let x = switch placement {
+        case .leadingEdge:
+            -contentView.contentInsets.left
+        case .trailingEdge:
+            documentView.frame.maxX
+        case .offset(let offset):
+            offset
+        }
+        documentView.scroll(NSPoint(x: x, y: contentView.bounds.minY))
+        reflectScrolledClipView(contentView)
+    }
+}

--- a/LocalPackages/CodeEditSourceEditor/Tests/CodeEditSourceEditorTests/Controller/TextViewControllerFloatingInsetsTests.swift
+++ b/LocalPackages/CodeEditSourceEditor/Tests/CodeEditSourceEditorTests/Controller/TextViewControllerFloatingInsetsTests.swift
@@ -229,6 +229,32 @@ struct TextViewControllerFloatingInsetsTests {
         #expect(isAtLeadingEdge, "Restoring the start left the view at \(origin)")
     }
 
+    @Test("Restoring a position on a long line that has not been laid out yet keeps its horizontal offset")
+    func restoringAPositionOnAnUnmeasuredLine() throws {
+        let lines = Array(repeating: "SELECT 1", count: 150) + [longLine] + Array(repeating: "SELECT 2", count: 50)
+        load(lines.joined(separator: "\n"))
+        let longLineY = try #require(controller.textView.layoutManager.lineStorage.getLine(atIndex: 150)).yPos
+
+        controller.scrollPosition = CGPoint(x: 600, y: longLineY)
+
+        #expect(abs(controller.scrollPosition.x - 600) <= 0.5, "Restored to \(controller.scrollPosition.x)")
+    }
+
+    @Test("Changing only the host's trailing inset resizes the text to the width left for it")
+    func trailingHostInsetResizesTheText() {
+        load("SELECT 1")
+        let before = controller.textView.frame.width
+
+        controller.configuration.layout.contentInsets = NSEdgeInsets(
+            top: hostInsets.top,
+            left: hostInsets.left,
+            bottom: hostInsets.bottom,
+            right: hostInsets.right + 38
+        )
+
+        #expect(controller.textView.frame.width == before - 38)
+    }
+
     @Test("Reloading the same configuration keeps the widths already measured")
     func reloadingKeepsWidths() {
         load(longLine)

--- a/LocalPackages/CodeEditSourceEditor/Tests/CodeEditSourceEditorTests/Controller/TextViewControllerFloatingInsetsTests.swift
+++ b/LocalPackages/CodeEditSourceEditor/Tests/CodeEditSourceEditorTests/Controller/TextViewControllerFloatingInsetsTests.swift
@@ -1,0 +1,241 @@
+//
+//  TextViewControllerFloatingInsetsTests.swift
+//  CodeEditSourceEditor
+//
+
+import AppKit
+@testable import CodeEditSourceEditor
+import CodeEditTextView
+import Testing
+
+/// The editor keeps the start of every line clear of the gutter, whatever the document's width does (#2709).
+///
+/// The editor is the real controller in a window, with line numbers on and wrapping off, the SQL editor's defaults.
+@MainActor
+struct TextViewControllerFloatingInsetsTests {
+    private let hostInsets = NSEdgeInsets(top: 0, left: 4, bottom: 8, right: 2)
+    private let longLine = String(repeating: "2056705 20260908142922 ", count: 40)
+
+    private let window: NSWindow
+    private let controller: TextViewController
+
+    init() {
+        (window, controller) = Mock.windowedTextViewController(theme: Mock.theme())
+        controller.configuration.appearance.wrapLines = false
+        controller.configuration.peripherals.showMinimap = false
+        controller.configuration.layout.contentInsets = hostInsets
+        controller.reloadUI()
+        window.layoutIfNeeded()
+        controller.gutterView.updateWidthIfNeeded()
+    }
+
+    private var clip: NSClipView {
+        controller.scrollView.contentView
+    }
+
+    private var origin: CGFloat {
+        clip.bounds.origin.x
+    }
+
+    private var leadingEdge: CGFloat {
+        -(hostInsets.left + controller.gutterView.frame.width)
+    }
+
+    /// Whether the view rests at the leading edge. AppKit aligns the clip view's origin to the backing store's pixels
+    /// and the gutter's width is fractional, so the two only agree to half a point.
+    private var isAtLeadingEdge: Bool {
+        abs(origin - leadingEdge) <= 0.5
+    }
+
+    private func load(_ string: String) {
+        controller.textView.string = string
+        controller.textView.updateFrameIfNeeded()
+        controller.textView.layoutManager.layoutLines()
+        controller.gutterView.updateWidthIfNeeded()
+        controller.textView.scroll(NSPoint(x: -1_000_000, y: 0))
+    }
+
+    /// Where the character at `offset` is drawn, against where the gutter ends, both in window coordinates.
+    private func clearanceFromGutter(at offset: Int) throws -> CGFloat {
+        let character = try #require(controller.textView.layoutManager.rectForOffset(offset))
+        let characterX = controller.textView.convert(character.origin, to: nil).x
+        let gutter = try #require(controller.gutterView)
+        let gutterMaxX = gutter.convert(NSPoint(x: gutter.bounds.maxX, y: 0), to: nil).x
+        return characterX - gutterMaxX
+    }
+
+    @Test("The gutter's width is reserved on the clip view rather than pushed into the text")
+    func gutterIsReservedOnTheClipView() {
+        load("SELECT 1")
+
+        #expect(controller.gutterView.frame.width > 0)
+        #expect(controller.textView.textInsets == .zero)
+        #expect(clip.contentInsets.left == hostInsets.left + controller.gutterView.frame.width)
+        #expect(clip.contentInsets.right == hostInsets.right)
+        #expect(isAtLeadingEdge, "Resting at \(origin), the leading edge is \(leadingEdge)")
+    }
+
+    @Test("Undoing a long paste brings the start of every line back beside the gutter (#2709)")
+    func undoingALongPasteBringsTheLineStartsBack() throws {
+        let query = "SELECT * FROM pay_order\nORDER BY orderId desc\n"
+        let end = (query as NSString).length
+        load(query)
+
+        controller.textView.selectionManager.setSelectedRange(NSRange(location: end, length: 0))
+        controller.textView.replaceCharacters(in: NSRange(location: end, length: 0), with: longLine)
+        controller.textView.layoutManager.layoutLines()
+        try #require(origin > 0, "Pasting follows the caret out to the end of the long line")
+
+        controller.textView.undoManager?.undo()
+        controller.textView.layoutManager.layoutLines()
+
+        #expect(controller.textView.string == query)
+        #expect(isAtLeadingEdge, "Left at \(origin), the leading edge is \(leadingEdge)")
+        #expect(try clearanceFromGutter(at: 0) >= -0.5, "The S of SELECT is under the gutter")
+    }
+
+    @Test("Moving to the start of a line from far right puts it beside the gutter, not under it")
+    func movingToALineStartClearsTheGutter() throws {
+        load(longLine + "\nORDER BY orderId desc")
+        controller.textView.scroll(NSPoint(x: 1_000_000, y: 0))
+
+        let lineStart = (longLine as NSString).length + 1
+        controller.setCursorPositions(
+            [CursorPosition(range: NSRange(location: lineStart, length: 0))],
+            scrollToVisible: true
+        )
+
+        #expect(isAtLeadingEdge, "Left at \(origin), the leading edge is \(leadingEdge)")
+        #expect(try clearanceFromGutter(at: lineStart) >= -0.5)
+    }
+
+    @Test("The gutter narrows again once the document drops back below a thousand lines")
+    func gutterNarrowsWithTheLineCount() {
+        load("SELECT 1\nSELECT 2")
+        let threeDigits = controller.gutterView.frame.width
+
+        load((1...1_200).map { "SELECT \($0)" }.joined(separator: "\n"))
+        let fourDigits = controller.gutterView.frame.width
+        #expect(fourDigits > threeDigits)
+
+        load("SELECT 1\nSELECT 2")
+
+        #expect(controller.gutterView.frame.width == threeDigits)
+        #expect(clip.contentInsets.left == hostInsets.left + threeDigits)
+        #expect(isAtLeadingEdge, "Left at \(origin), the leading edge is \(leadingEdge)")
+    }
+
+    @Test("A larger or smaller font measures the gutter's numbers again")
+    func fontChangeMeasuresTheNumbersAgain() {
+        load("SELECT 1")
+        let regular = controller.gutterView.frame.width
+
+        controller.gutterView.font = .monospacedSystemFont(ofSize: 24, weight: .regular)
+        let large = controller.gutterView.frame.width
+        #expect(large > regular)
+
+        controller.gutterView.font = .monospacedSystemFont(ofSize: 11, weight: .medium).rulerFont
+
+        #expect(controller.gutterView.frame.width == regular)
+    }
+
+    @Test("The gutter paints its whole width, the folding ribbon included")
+    func gutterPaintsItsWholeWidth() throws {
+        load("SELECT 1\nSELECT 2")
+        let gutter = try #require(controller.gutterView)
+        let bounds = CGRect(x: 0, y: 0, width: gutter.frame.width, height: 20)
+        let rep = try #require(gutter.bitmapImageRepForCachingDisplay(in: bounds))
+        gutter.cacheDisplay(in: bounds, to: rep)
+
+        let ribbonMidX = gutter.foldingRibbon.frame.midX / bounds.width * CGFloat(rep.pixelsWide)
+        let color = try #require(rep.colorAt(x: Int(ribbonMidX), y: rep.pixelsHigh / 2))
+        #expect(color.alphaComponent == 1, "The strip under the folding ribbon is left unpainted")
+    }
+
+    @Test("The reformatting guide stands on its column, and stays there as the text scrolls sideways")
+    func reformattingGuideStandsOnItsColumn() throws {
+        controller.configuration.peripherals.showReformattingGuide = true
+        controller.configuration.behavior.reformatAtColumn = 20
+        load(longLine)
+        controller.reformattingGuideView.updatePosition(in: controller)
+        let guide = try #require(controller.reformattingGuideView)
+
+        func offsetFromColumn() throws -> CGFloat {
+            controller.textView.layoutManager.layoutLines()
+            let guideX = try #require(guide.superview).convert(guide.frame.origin, to: nil).x
+            let column = try #require(controller.textView.layoutManager.rectForOffset(20))
+            return guideX - controller.textView.convert(column.origin, to: nil).x
+        }
+
+        let atRest = try offsetFromColumn()
+        #expect(abs(atRest) < 1, "The guide stands \(atRest)pt from column 20")
+
+        controller.textView.scroll(NSPoint(x: 100, y: 0))
+        let scrolled = try offsetFromColumn()
+        #expect(abs(scrolled) < 1, "Scrolled, the guide stands \(scrolled)pt from column 20")
+
+        let bounds = CGRect(x: 0, y: 0, width: min(guide.bounds.width, 40), height: 20)
+        let rep = try #require(guide.bitmapImageRepForCachingDisplay(in: bounds))
+        guide.cacheDisplay(in: bounds, to: rep)
+        let firstInked = (0..<rep.pixelsWide).first { column in
+            (rep.colorAt(x: column, y: rep.pixelsHigh / 2)?.alphaComponent ?? 0) > 0.05
+        }
+        #expect(firstInked == 0 || firstInked == 1, "The guide draws its line \(String(describing: firstInked))px in")
+    }
+
+    @Test("Changing the editor font forgets the widths lines measured at the old size")
+    func changingTheFontForgetsWidths() {
+        load(longLine)
+        #expect(controller.textView.layoutManager.lineStorage.maxWidth > 0)
+
+        controller.configuration.appearance.font = .monospacedSystemFont(ofSize: 9, weight: .regular)
+
+        #expect(controller.textView.layoutManager.lineStorage.maxWidth == 0)
+    }
+
+    @Test("Changing the theme forgets the widths measured under the old one")
+    func changingTheThemeForgetsWidths() {
+        load(longLine)
+        var theme = controller.configuration.appearance.theme
+        theme.background = .systemRed
+
+        controller.configuration.appearance.theme = theme
+
+        #expect(controller.textView.layoutManager.lineStorage.maxWidth == 0)
+    }
+
+    @Test("Changing the language forgets the widths measured under the old one")
+    func changingTheLanguageForgetsWidths() {
+        load(longLine)
+
+        controller.language = .sql
+
+        #expect(controller.textView.layoutManager.lineStorage.maxWidth == 0)
+    }
+
+    @Test("The recorded scroll position is measured from the text, so it survives the gutter changing width")
+    func scrollPositionIsMeasuredFromTheText() {
+        load(longLine)
+        #expect(abs(controller.scrollPosition.x - -hostInsets.left) <= 0.5, "At rest \(controller.scrollPosition.x)")
+
+        controller.textView.scroll(NSPoint(x: 400, y: 0))
+        let saved = controller.scrollPosition
+        load((1...1_200).map { _ in longLine }.joined(separator: "\n"))
+
+        controller.scrollPosition = saved
+        #expect(abs(controller.scrollPosition.x - saved.x) <= 0.5, "Restored to \(controller.scrollPosition.x)")
+
+        controller.scrollPosition = CGPoint(x: -hostInsets.left, y: 0)
+        #expect(isAtLeadingEdge, "Restoring the start left the view at \(origin)")
+    }
+
+    @Test("Reloading the same configuration keeps the widths already measured")
+    func reloadingKeepsWidths() {
+        load(longLine)
+        let wide = controller.textView.layoutManager.lineStorage.maxWidth
+
+        controller.reloadUI()
+
+        #expect(controller.textView.layoutManager.lineStorage.maxWidth == wide)
+    }
+}

--- a/LocalPackages/CodeEditSourceEditor/Tests/CodeEditSourceEditorTests/Controller/TextViewControllerTests.swift
+++ b/LocalPackages/CodeEditSourceEditor/Tests/CodeEditSourceEditorTests/Controller/TextViewControllerTests.swift
@@ -466,16 +466,16 @@ final class TextViewControllerTests: XCTestCase {
     func test_minimapToggle() {
         XCTAssertFalse(controller.minimapView.isHidden)
         XCTAssertEqual(controller.minimapView.frame.width, MinimapView.maxWidth)
-        XCTAssertEqual(controller.textViewInsets.right, MinimapView.maxWidth)
+        XCTAssertEqual(controller.floatingSubviewInsets.right, MinimapView.maxWidth)
 
         controller.configuration.peripherals.showMinimap = false
         XCTAssertTrue(controller.minimapView.isHidden)
-        XCTAssertEqual(controller.textViewInsets.right, 0)
+        XCTAssertEqual(controller.floatingSubviewInsets.right, 0)
 
         controller.configuration.peripherals.showMinimap = true
         XCTAssertFalse(controller.minimapView.isHidden)
         XCTAssertEqual(controller.minimapView.frame.width, MinimapView.maxWidth)
-        XCTAssertEqual(controller.textViewInsets.right, MinimapView.maxWidth)
+        XCTAssertEqual(controller.floatingSubviewInsets.right, MinimapView.maxWidth)
     }
 
     // MARK: Folding Ribbon

--- a/LocalPackages/CodeEditSourceEditor/Tests/CodeEditSourceEditorTests/LineFoldingTests/LineFoldChunkBoundaryTests.swift
+++ b/LocalPackages/CodeEditSourceEditor/Tests/CodeEditSourceEditorTests/LineFoldingTests/LineFoldChunkBoundaryTests.swift
@@ -47,7 +47,12 @@ struct LineFoldChunkBoundaryTests {
         controller.foldProvider = provider
         let model = LineFoldModel(controller: controller, foldView: NSView())
 
-        try await Task.sleep(for: .milliseconds(200))
+        // The calculation runs on the main actor, which other suites share, so wait for it to reach the last line
+        // rather than for a fixed time.
+        let deadline = ContinuousClock.now + .seconds(5)
+        while provider.previousDepths[100] == nil, ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(10))
+        }
         _ = model
 
         #expect(provider.previousDepths[49] == 1)

--- a/LocalPackages/CodeEditSourceEditor/Tests/CodeEditSourceEditorTests/SourceEditorScrollViewTests.swift
+++ b/LocalPackages/CodeEditSourceEditor/Tests/CodeEditSourceEditorTests/SourceEditorScrollViewTests.swift
@@ -1,0 +1,195 @@
+//
+//  SourceEditorScrollViewTests.swift
+//  CodeEditSourceEditor
+//
+
+import AppKit
+@testable import CodeEditSourceEditor
+import CodeEditTextView
+import Testing
+
+/// The editor's scroll view reserves the room its floating views take on the clip view (#2709).
+///
+/// Positions are read off the real `NSClipView`, so what these check is that AppKit's own reveal and clamping stop at
+/// the reserved edge once it is there.
+@MainActor
+struct SourceEditorScrollViewTests {
+    private final class Document: NSView {
+        override var isFlipped: Bool { true }
+    }
+
+    private let scrollView = SourceEditorScrollView(frame: NSRect(x: 0, y: 0, width: 600, height: 300))
+    private let document = Document(frame: NSRect(x: 0, y: 0, width: 2_000, height: 1_000))
+
+    init() {
+        scrollView.scrollerStyle = .overlay
+        scrollView.hasHorizontalScroller = true
+        scrollView.hasVerticalScroller = true
+        scrollView.automaticallyAdjustsContentInsets = false
+        scrollView.documentView = document
+        scrollView.tile()
+    }
+
+    private var clip: NSClipView {
+        scrollView.contentView
+    }
+
+    private var origin: CGFloat {
+        clip.bounds.origin.x
+    }
+
+    @Test("The floating views' widths go on top of the scroll view's own insets")
+    func reservationAddsToTheScrollViewsInsets() {
+        scrollView.contentInsets = NSEdgeInsets(top: 10, left: 4, bottom: 8, right: 2)
+        scrollView.floatingSubviewInsets = HorizontalEdgeInsets(left: 70, right: 40)
+
+        let insets = clip.contentInsets
+        #expect(insets.top == 10)
+        #expect(insets.left == 74)
+        #expect(insets.bottom == 8)
+        #expect(insets.right == 42)
+    }
+
+    @Test("An inset added to the scroll view later is kept alongside the reservation")
+    func laterScrollViewInsetsKeepTheReservation() {
+        scrollView.floatingSubviewInsets = HorizontalEdgeInsets(left: 70, right: 0)
+
+        scrollView.contentInsets.top = 30
+
+        #expect(clip.contentInsets.top == 30)
+        #expect(clip.contentInsets.left == 70)
+    }
+
+    @Test("A view at the top stays clear of a top inset added later, such as the find panel")
+    func topInsetKeepsTheFirstLineClear() {
+        scrollView.floatingSubviewInsets = HorizontalEdgeInsets(left: 70, right: 0)
+        document.scroll(NSPoint(x: -10_000, y: -10_000))
+        #expect(clip.bounds.minY == 0)
+
+        scrollView.contentInsets.top = 30
+
+        #expect(clip.bounds.minY == -30)
+        #expect(origin == -70)
+    }
+
+    @Test("Laying the scroll view out again keeps the reservation and the position")
+    func retilingKeepsTheReservation() {
+        scrollView.floatingSubviewInsets = HorizontalEdgeInsets(left: 70, right: 40)
+
+        scrollView.setFrameSize(NSSize(width: 700, height: 320))
+        scrollView.tile()
+
+        #expect(clip.contentInsets.left == 70)
+        #expect(clip.contentInsets.right == 40)
+        #expect(origin == -70)
+    }
+
+    @Test("A view at the leading edge stays there as the gutter grows and shrinks")
+    func leadingEdgeFollowsTheReservation() {
+        scrollView.floatingSubviewInsets = HorizontalEdgeInsets(left: 70, right: 0)
+        #expect(origin == -70)
+
+        scrollView.floatingSubviewInsets = HorizontalEdgeInsets(left: 78, right: 0)
+        #expect(origin == -78)
+
+        scrollView.floatingSubviewInsets = HorizontalEdgeInsets(left: 62, right: 0)
+        #expect(origin == -62)
+    }
+
+    @Test("A view that has never scrolled stays at the leading edge as a fractional gutter widens")
+    func fractionalGutterKeepsTheLeadingEdge() {
+        scrollView.floatingSubviewInsets = HorizontalEdgeInsets(left: 51.41, right: 0)
+        scrollView.floatingSubviewInsets = HorizontalEdgeInsets(left: 69.41, right: 0)
+
+        #expect(abs(origin - -69.41) <= 0.5, "Left at \(origin)")
+    }
+
+    @Test("A view at the trailing edge stays there when the trailing reservation grows")
+    func trailingEdgeFollowsTheReservation() {
+        document.scroll(NSPoint(x: 10_000, y: 0))
+
+        scrollView.floatingSubviewInsets = HorizontalEdgeInsets(left: 0, right: 140)
+
+        let trailingEdge = document.frame.width - (clip.bounds.width - 140)
+        #expect(abs(origin - trailingEdge) <= 0.5, "Left at \(origin), the trailing edge is \(trailingEdge)")
+    }
+
+    @Test("Room AppKit reserves for legacy scrollers stays under the reservation")
+    func legacyScrollerRoomIsKept() throws {
+        scrollView.contentInsets = NSEdgeInsets(top: 0, left: 4, bottom: 8, right: 2)
+        scrollView.scrollerStyle = .legacy
+        scrollView.tile()
+        let computed = clip.contentInsets
+        try #require(computed.right > 2, "AppKit reserves the legacy scroller through the clip view's insets")
+
+        scrollView.floatingSubviewInsets = HorizontalEdgeInsets(left: 70, right: 40)
+
+        #expect(clip.contentInsets.left == computed.left + 70)
+        #expect(clip.contentInsets.right == computed.right + 40)
+        #expect(clip.contentInsets.bottom == computed.bottom)
+    }
+
+    @Test("Room AppKit reserves for a ruler stays under the reservation")
+    func rulerRoomIsKept() throws {
+        scrollView.hasVerticalRuler = true
+        scrollView.rulersVisible = true
+        scrollView.tile()
+        let rulerRoom = clip.contentInsets.left
+        try #require(rulerRoom > 0, "AppKit reserves the ruler through the clip view's insets")
+
+        scrollView.floatingSubviewInsets = HorizontalEdgeInsets(left: 70, right: 0)
+
+        #expect(clip.contentInsets.left == rulerRoom + 70)
+    }
+
+    @Test("A scrolled view keeps its position when the gutter's width changes")
+    func scrolledViewKeepsItsPosition() {
+        scrollView.floatingSubviewInsets = HorizontalEdgeInsets(left: 70, right: 0)
+        document.scroll(NSPoint(x: 500, y: 0))
+
+        scrollView.floatingSubviewInsets = HorizontalEdgeInsets(left: 78, right: 0)
+
+        #expect(origin == 500)
+    }
+
+    @Test("Revealing the start of the document stops beside the gutter")
+    func revealStopsAtTheReservation() {
+        scrollView.floatingSubviewInsets = HorizontalEdgeInsets(left: 70, right: 40)
+        document.scroll(NSPoint(x: 1_000, y: 0))
+
+        document.scrollToVisible(NSRect(x: 0, y: 0, width: 1, height: 10))
+
+        #expect(origin == -70)
+    }
+
+    @Test("Scrolling stops at the reserved edges on both sides")
+    func scrollingIsClampedToTheReservation() {
+        scrollView.floatingSubviewInsets = HorizontalEdgeInsets(left: 70, right: 40)
+
+        document.scroll(NSPoint(x: -10_000, y: 0))
+        #expect(origin == -70)
+
+        document.scroll(NSPoint(x: 10_000, y: 0))
+        #expect(origin == document.frame.width - (clip.bounds.width - 40))
+    }
+
+    @Test("A document that narrows pulls the view back to the reserved leading edge")
+    func narrowingReturnsToTheReservedEdge() {
+        scrollView.floatingSubviewInsets = HorizontalEdgeInsets(left: 70, right: 0)
+        document.scroll(NSPoint(x: 1_000, y: 0))
+
+        document.setFrameSize(NSSize(width: 300, height: 1_000))
+
+        #expect(origin == -70)
+    }
+
+    @Test("A floating view over the reserved edge still takes clicks")
+    func floatingViewStillTakesClicks() {
+        let gutter = Document(frame: NSRect(x: 0, y: 0, width: 70, height: 1_000))
+        scrollView.addFloatingSubview(gutter, for: .horizontal)
+
+        scrollView.floatingSubviewInsets = HorizontalEdgeInsets(left: 70, right: 0)
+
+        #expect(scrollView.hitTest(NSPoint(x: 35, y: 150)) === gutter)
+    }
+}

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextLayoutManager/TextAttachments/TextAttachmentManager.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextLayoutManager/TextAttachments/TextAttachmentManager.swift
@@ -54,6 +54,13 @@ public final class TextAttachmentManager {
             layoutManager?.lineStorage.update(atOffset: range.max, delta: 0, deltaHeight: -trailingLine.height)
         }
 
+        // The lines the attachment covers are no longer drawn, or are drawn as part of its first line, so none of their
+        // measured widths describe what is on screen any more.
+        layoutManager?.forgetWidths(ofLinesIn: range)
+        if getNextOne, let trailingLine = layoutManager?.lineStorage.getLine(atOffset: range.max) {
+            layoutManager?.lineStorage.setWidth(0, forLineAt: trailingLine.index)
+        }
+
         layoutManager?.setNeedsLayout()
 
         delegate?.textAttachmentDidAdd(attachment.attachment, for: range)
@@ -67,6 +74,9 @@ public final class TextAttachmentManager {
         guard !orderedAttachments.isEmpty else { return }
         let removed = orderedAttachments
         orderedAttachments.removeAll()
+        for attachment in removed {
+            layoutManager?.forgetWidths(ofLinesIn: attachment.range)
+        }
         layoutManager?.setNeedsLayout()
         for attachment in removed {
             delegate?.textAttachmentDidRemove(attachment.attachment, for: attachment.range)
@@ -85,6 +95,7 @@ public final class TextAttachmentManager {
         }
 
         let attachment = orderedAttachments.remove(at: index)
+        layoutManager?.forgetWidths(ofLinesIn: attachment.range)
         layoutManager?.invalidateLayoutForRange(attachment.range)
 
         delegate?.textAttachmentDidRemove(attachment.attachment, for: attachment.range)

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextLayoutManager/TextAttachments/TextAttachmentManager.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextLayoutManager/TextAttachments/TextAttachmentManager.swift
@@ -75,7 +75,7 @@ public final class TextAttachmentManager {
         let removed = orderedAttachments
         orderedAttachments.removeAll()
         for attachment in removed {
-            layoutManager?.forgetWidths(ofLinesIn: attachment.range)
+            forgetWidthOfFirstLine(of: attachment)
         }
         layoutManager?.setNeedsLayout()
         for attachment in removed {
@@ -95,12 +95,24 @@ public final class TextAttachmentManager {
         }
 
         let attachment = orderedAttachments.remove(at: index)
-        layoutManager?.forgetWidths(ofLinesIn: attachment.range)
+        forgetWidthOfFirstLine(of: attachment)
         layoutManager?.invalidateLayoutForRange(attachment.range)
 
         delegate?.textAttachmentDidRemove(attachment.attachment, for: attachment.range)
 
         return attachment
+    }
+
+    /// Forgets the width the attachment's first line measured with the attachment drawn in it.
+    ///
+    /// The lines the attachment covered were forgotten when it was added and have not been laid out since, so the
+    /// first line is the only one whose width still describes the attachment rather than the text.
+    private func forgetWidthOfFirstLine(of attachment: AnyTextAttachment) {
+        guard let layoutManager,
+              let firstLine = layoutManager.lineStorage.getLine(atOffset: attachment.range.location) else {
+            return
+        }
+        layoutManager.lineStorage.setWidth(0, forLineAt: firstLine.index)
     }
 
     /// Finds attachments starting in the given line range, and returns them as an array.

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextLayoutManager/TextLayoutManager+Edits.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextLayoutManager/TextLayoutManager+Edits.swift
@@ -46,6 +46,7 @@ extension TextLayoutManager: NSTextStorageDelegate {
         let insertedStringRange = NSRange(location: editedRange.location, length: editedRange.length - delta)
         removeLayoutLinesIn(range: insertedStringRange)
         insertNewLines(for: editedRange)
+        forgetWidths(ofLinesIn: editedRange)
 
         attachments.textUpdated(atOffset: editedRange.location, delta: delta)
 
@@ -74,6 +75,24 @@ extension TextLayoutManager: NSTextStorageDelegate {
             } else {
                 lineStorage.update(atOffset: linePosition.range.location, delta: -intersection.length, deltaHeight: 0)
             }
+        }
+    }
+
+    /// Forgets the measured width of every line an edit or an attachment touched.
+    ///
+    /// Each one is measured again when it is next laid out. Without this, text replaced off screen, as a Find and
+    /// Replace across the document does, would leave the document as wide as the text that is gone, and a folded line
+    /// would go on counting at the width it had before the fold hid it.
+    /// - Parameter range: The range of the edit, after it was applied.
+    func forgetWidths(ofLinesIn range: NSRange) {
+        for linePosition in lineStorage.linesInRange(range) {
+            lineStorage.setWidth(0, forLineAt: linePosition.index)
+        }
+
+        // Deleting from the very end of the document finds no line in the range, the same case
+        // `invalidateLayoutForRange` handles, so the last line is forgotten by hand.
+        if range.location == textStorage?.length, let lastLine = lineStorage.last {
+            lineStorage.setWidth(0, forLineAt: lastLine.index)
         }
     }
 

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextLayoutManager/TextLayoutManager+Invalidation.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextLayoutManager/TextLayoutManager+Invalidation.swift
@@ -34,6 +34,16 @@ extension TextLayoutManager {
         layoutView?.needsLayout = true
     }
 
+    /// Forgets the measured width of every line and lays them out again.
+    ///
+    /// Call this when something changes how wide every line is, such as the font or the letter spacing. Without it the
+    /// document keeps the width its lines measured before the change until each one is laid out again, and a line that
+    /// stays off screen never is.
+    public func invalidateLineWidths() {
+        lineStorage.resetWidths()
+        setNeedsLayout()
+    }
+
     public func setNeedsLayout() {
         needsLayout = true
         visibleLineIds.removeAll(keepingCapacity: true)

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextLayoutManager/TextLayoutManager+Layout.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextLayoutManager/TextLayoutManager+Layout.swift
@@ -83,7 +83,6 @@ extension TextLayoutManager {
         var didLayoutChange = false
         var newVisibleLines: Set<TextLine.ID> = []
         var yContentAdjustment: CGFloat = 0
-        var maxFoundLineWidth = maxLineWidth
 
         // The vertical span this pass laid out. The layout view draws its own decorations into a backing store
         // nothing else invalidates when the viewport moves, so a band drawn before its lines were laid out would
@@ -110,8 +109,7 @@ extension TextLayoutManager {
                     linePosition,
                     usedFragmentIDs: &usedFragmentIDs,
                     textStorage: textStorage,
-                    yRange: minY..<maxY,
-                    maxFoundLineWidth: &maxFoundLineWidth
+                    yRange: minY..<maxY
                 )
                 yContentAdjustment += yAdjustment
                 relaidOutMinY = min(relaidOutMinY, linePosition.yPos)
@@ -163,8 +161,8 @@ extension TextLayoutManager {
         layoutLock.unlock()
         CATransaction.commit()
 
-        if maxFoundLineWidth > maxLineWidth {
-            maxLineWidth = maxFoundLineWidth
+        if maxLineWidth != lineStorage.maxWidth {
+            maxLineWidth = lineStorage.maxWidth
         }
 
         if yContentAdjustment != 0 {
@@ -202,8 +200,7 @@ extension TextLayoutManager {
         _ linePosition: TextLineStorage<TextLine>.TextLinePosition,
         usedFragmentIDs: inout Set<LineFragment.ID>,
         textStorage: NSTextStorage,
-        yRange: Range<CGFloat>,
-        maxFoundLineWidth: inout CGFloat
+        yRange: Range<CGFloat>
     ) -> (CGFloat, wasLineHeightChanged: Bool) {
         let lineSize = layoutLineViews(
             linePosition,
@@ -226,9 +223,7 @@ extension TextLayoutManager {
                 yContentAdjustment += lineSize.height - linePosition.height
             }
         }
-        if maxFoundLineWidth < lineSize.width {
-            maxFoundLineWidth = lineSize.width
-        }
+        lineStorage.setWidth(lineSize.width, forLineAt: linePosition.index)
 
         return (yContentAdjustment, wasLineHeightChanged)
     }

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextLayoutManager/TextLayoutManager.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextLayoutManager/TextLayoutManager.swift
@@ -20,7 +20,8 @@ public class TextLayoutManager: NSObject {
     }
     public var wrapLines: Bool {
         didSet {
-            setNeedsLayout()
+            guard wrapLines != oldValue else { return }
+            invalidateLineWidths()
         }
     }
     public var detectedLineEnding: LineEnding = .lineFeed
@@ -100,9 +101,12 @@ public class TextLayoutManager: NSObject {
 
     weak var layoutView: NSView?
 
-    /// The calculated maximum width of all laid out lines.
-    /// - Note: This does not indicate *the* maximum width of the text view if all lines have not been laid out.
-    ///         This will be updated if it comes across a wider line.
+    /// The width of the widest line laid out so far.
+    ///
+    /// Published from ``TextLineStorage/maxWidth`` when a layout pass finishes, so it falls when the widest line is
+    /// deleted or narrowed as well as rising when a wider one is laid out.
+    /// - Note: A line that has never been laid out counts as zero wide, so this is not *the* maximum width of the
+    ///         document until every line has been laid out.
     var maxLineWidth: CGFloat = 0 {
         didSet {
             delegate?.layoutManagerMaxWidthDidChange(newWidth: maxLineWidth + edgeInsets.horizontal)

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextLineStorage/TextLineStorage+Node.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextLineStorage/TextLineStorage+Node.swift
@@ -63,6 +63,10 @@ extension TextLineStorage {
         var leftSubtreeHeight: CGFloat
         // The number of nodes in the left subtree
         var leftSubtreeCount: Int
+        // The measured width of this line, zero until the line is laid out
+        var width: CGFloat = 0
+        // The widest measured line in this node's subtree, this node included
+        var subtreeWidth: CGFloat = 0
 
         var left: Node<NodeData>?
         var right: Node<NodeData>?
@@ -103,6 +107,20 @@ extension TextLineStorage {
                 height: height,
                 color: .black
             )
+        }
+
+        /// Recomputes ``subtreeWidth`` from this node's own width and the aggregates of its children.
+        ///
+        /// A maximum cannot be maintained by passing deltas up the tree the way the sums are: removing the widest line
+        /// does not say how wide the next widest one is. It is recomputed from the children instead, which only holds
+        /// while every child's aggregate is already correct, so callers work from the bottom of a change upwards.
+        /// - Returns: Whether the aggregate changed.
+        @discardableResult
+        func updateSubtreeWidth() -> Bool {
+            let newValue = Swift.max(width, left?.subtreeWidth ?? 0, right?.subtreeWidth ?? 0)
+            guard newValue != subtreeWidth else { return false }
+            subtreeWidth = newValue
+            return true
         }
 
         func sibling() -> Node<NodeData>? {

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextLineStorage/TextLineStorage.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextLineStorage/TextLineStorage.swift
@@ -41,6 +41,11 @@ public final class TextLineStorage<Data: Identifiable> {
 
     public var height: CGFloat = 0
 
+    /// The width of the widest line measured so far. A line that has never been laid out counts as zero wide.
+    public var maxWidth: CGFloat {
+        root?.subtreeWidth ?? 0
+    }
+
     public var first: TextLinePosition? {
         guard count > 0, let position = search(forIndex: 0) else { return nil }
         return TextLinePosition(position: position)
@@ -257,6 +262,37 @@ public final class TextLineStorage<Data: Identifiable> {
         height = 0
     }
 
+    /// Records the measured width of the line at the given index, keeping ``maxWidth`` current.
+    /// - Complexity: `O(log n)`
+    /// - Parameters:
+    ///   - width: The width the line measured when it was laid out, or zero to forget it.
+    ///   - index: The index of the line.
+    public func setWidth(_ width: CGFloat, forLineAt index: Int) {
+        guard let node = search(forIndex: index)?.node, node.width != width else { return }
+        node.width = width
+        var current: Node<Data>? = node
+        while let node = current, node.updateSubtreeWidth() {
+            current = node.parent
+        }
+    }
+
+    /// Forgets every measured width, as if no line had been laid out yet.
+    /// - Complexity: `O(m)` where `m` is the number of lines with a width recorded.
+    public func resetWidths() {
+        var pending: [Node<Data>] = root.map { [$0] } ?? []
+        while let node = pending.popLast() {
+            guard node.subtreeWidth > 0 else { continue }
+            node.width = 0
+            node.subtreeWidth = 0
+            if let left = node.left {
+                pending.append(left)
+            }
+            if let right = node.right {
+                pending.append(right)
+            }
+        }
+    }
+
     /// Efficiently builds the tree from the given array of lines.
     /// - Note: Calls ``TextLineStorage/removeAll()`` before building.
     /// - Parameter lines: The lines to use to build the tree.
@@ -398,12 +434,16 @@ private extension TextLineStorage {
         var nodeY = nodeZ
         var nodeX: Node<Data>?
         var originalColor = nodeY.color
+        // The lowest node whose children change. Every width aggregate from there to the root has to be recomputed.
+        let lowestChangedNode: Node<Data>?
 
         if nodeZ.left == nil || nodeZ.right == nil {
+            lowestChangedNode = nodeZ.parent
             nodeX = nodeZ.right ?? nodeZ.left
             transplant(nodeZ, with: nodeX)
         } else {
             nodeY = nodeZ.right!.minimum()
+            lowestChangedNode = nodeY.parent === nodeZ ? nodeY : nodeY.parent
 
             // Delete nodeY from it's original place in the tree.
             metaFixup(startingAt: nodeY, delta: -nodeY.length, deltaHeight: -nodeY.height, nodeAction: .deleted)
@@ -433,6 +473,8 @@ private extension TextLineStorage {
             // We've inserted nodeY again into a new spot. Update tree meta
             metaFixup(startingAt: nodeY, delta: nodeY.length, deltaHeight: nodeY.height, nodeAction: .inserted)
         }
+
+        updateSubtreeWidths(upFrom: lowestChangedNode)
 
         if originalColor == .black, let nodeX {
             deleteFixup(node: nodeX)
@@ -540,6 +582,18 @@ private extension TextLineStorage {
         nodeX?.color = .black
     }
 
+    /// Recomputes the width aggregate of every node from `node` to the root.
+    ///
+    /// Unlike ``TextLineStorage/setWidth(_:forLineAt:)`` this never stops early: after a node is removed, a node
+    /// higher up may hold an aggregate that still counts it even where the nodes below have not changed.
+    func updateSubtreeWidths(upFrom node: Node<Data>?) {
+        var current = node
+        while let node = current {
+            node.updateSubtreeWidth()
+            current = node.parent
+        }
+    }
+
     /// Walk up the tree, updating any `leftSubtree` metadata.
     private func metaFixup(
         startingAt node: borrowing Node<Data>,
@@ -623,6 +677,10 @@ private extension TextLineStorage {
             node.leftSubtreeCount = metadata.count
         }
         node.parent = nodeY
+
+        // A rotation keeps each subtree's set of lines, so only the two nodes that swapped places need recomputing.
+        node.updateSubtreeWidth()
+        nodeY?.updateSubtreeWidth()
     }
 
     /// Finds the correct subtree metadata starting at a node.

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextView/TextView+Layout.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextView/TextView+Layout.swift
@@ -38,14 +38,32 @@ extension TextView {
         true
     }
 
+    /// The part of the document the clip view shows, less anything the scroll view reserves over its leading and
+    /// trailing edges, such as a gutter or a minimap floating there.
+    ///
+    /// `documentVisibleRect` includes the area under the clip view's content insets, so without this a caret sitting
+    /// under the gutter counts as visible and is never scrolled out from under it.
     override public var visibleRect: NSRect {
-        if let scrollView {
-            var rect = scrollView.documentVisibleRect
-            rect.origin.y += scrollView.contentInsets.top
-            return rect.pixelAligned
-        } else {
-            return super.visibleRect
-        }
+        guard let scrollView else { return super.visibleRect }
+        let insets = scrollView.contentView.contentInsets
+        var rect = scrollView.documentVisibleRect
+        rect.origin.x += insets.left
+        rect.origin.y += insets.top
+        rect.size.width = max(rect.width - insets.left - insets.right, 0)
+        return rect.pixelAligned
+    }
+
+    /// The size of the scroll view's content area that its content insets leave uncovered.
+    ///
+    /// `NSScrollView.contentSize` does not subtract the content insets, so anything reserved over the edges of the clip
+    /// view, a gutter on the leading side or a find panel along the top, is taken off here.
+    var unobscuredContentSize: CGSize {
+        guard let scrollView else { return .zero }
+        let insets = scrollView.contentView.contentInsets
+        return CGSize(
+            width: max(scrollView.contentSize.width - insets.left - insets.right, 0),
+            height: max(scrollView.contentSize.height - insets.top - insets.bottom, 0)
+        )
     }
 
     public var visibleTextRange: NSRange? {
@@ -63,8 +81,7 @@ extension TextView {
     /// - Returns: Whether or not the view was updated.
     @discardableResult
     public func updateFrameIfNeeded() -> Bool {
-        var availableSize = scrollView?.contentSize ?? .zero
-        availableSize.height -= (scrollView?.contentInsets.top ?? 0) + (scrollView?.contentInsets.bottom ?? 0)
+        let availableSize = unobscuredContentSize
 
         let extraHeight = availableSize.height * overscrollAmount
         let newHeight = max(layoutManager.estimatedHeight() + extraHeight, availableSize.height, 0)

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextView/TextView+ReplaceCharacters.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextView/TextView+ReplaceCharacters.swift
@@ -58,6 +58,10 @@ extension TextView {
         // visible and left the caret off the trailing edge, and typing in a long line scrolled horizontally read as
         // hidden and moved the view on every keystroke. `scrollSelectionToVisible` lays the line out first, and it
         // leaves the view alone when the caret is already showing.
+        //
+        // A caller that skips the selection update is applying one step of a batch, an indent or a grouped undo, whose
+        // selection still describes the text before the edit. It reveals the final selection once the batch is done.
+        guard !skipUpdateSelection else { return }
         scrollSelectionToVisible()
     }
 

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextView/TextView+ReplaceCharacters.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextView/TextView+ReplaceCharacters.swift
@@ -53,13 +53,12 @@ extension TextView {
         }
         NotificationCenter.default.post(name: Self.textDidChangeNotification, object: self)
 
-        // `scrollSelectionToVisible` is a little expensive to call every time. Instead we just check if the caret
-        // the edit left behind is visible. `.contains` checks that all points in the rect are inside.
-        if let selection = selectionManager.textSelections.first,
-           let caretRect = layoutManager.rectForOffset(selection.range.max),
-           !visibleRect.contains(caretRect) {
-            scrollSelectionToVisible()
-        }
+        // Whether the caret is still in view cannot be read off `rectForOffset` here: the edit left the caret's line
+        // waiting to be laid out, and until it is, the rect is the line's start. Pasting a long line then read as
+        // visible and left the caret off the trailing edge, and typing in a long line scrolled horizontally read as
+        // hidden and moved the view on every keystroke. `scrollSelectionToVisible` lays the line out first, and it
+        // leaves the view alone when the caret is already showing.
+        scrollSelectionToVisible()
     }
 
     /// Replace the characters in a range with a new string.

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextView/TextView+ScrollToVisible.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextView/TextView+ScrollToVisible.swift
@@ -25,14 +25,17 @@ extension TextView {
 
         // Laying out changes line heights, which moves the offset we are scrolling to, so converge instead of
         // scrolling to the first estimate. `rectForOffset` answers a not-yet-laid-out line from the line storage's
-        // estimated heights, which can be off by whole screens in a wrapped document.
+        // estimated heights, which can be off by whole screens in a wrapped document, and answers a line an edit has
+        // just invalidated with the line's start. So each pass lays out before it reads the rect: scrolling to an
+        // edited line's start first would carry a view that was already showing the caret away from it.
         let offset = offsetNotPivot(selection)
         var lastFrame: CGRect = .zero
         let deadline = Date().addingTimeInterval(0.5)
 
-        while let rect = layoutManager.rectForOffset(offset), lastFrame != rect, Date() < deadline {
-            lastFrame = rect
+        while Date() < deadline {
             layoutManager.layoutLines()
+            guard let rect = layoutManager.rectForOffset(offset), rect != lastFrame else { break }
+            lastFrame = rect
             selectionManager.updateSelectionViews()
             scrollView.contentView.scrollToVisible(rect)
             scrollView.reflectScrolledClipView(scrollView.contentView)
@@ -48,57 +51,38 @@ extension TextView {
     /// If `center` is `true`, the range will be centered in the visible area.
     /// If `center` is `false`, the range will be aligned at the top-left of the view.
     public func scrollToRange(_ range: NSRange, center: Bool = true) {
-        guard let scrollView else { return }
+        guard let scrollView, let boundingRect = layoutManager.rectForOffset(range.location) else { return }
 
-        guard let boundingRect = layoutManager.rectForOffset(range.location) else { return }
-
-        // Check if the range is already visible
         if visibleRect.contains(boundingRect) {
-            return // No scrolling needed
+            return
         }
 
-        // Calculate the target offset based on the center flag
-        let targetOffset: CGPoint
-        if center {
-            targetOffset = CGPoint(
-                x: max(boundingRect.midX - visibleRect.width / 2, 0),
-                y: max(boundingRect.midY - visibleRect.height / 2, 0)
-            )
-        } else {
-            targetOffset = CGPoint(
-                x: max(boundingRect.origin.x, 0),
-                y: max(boundingRect.origin.y, 0)
-            )
-        }
-
+        // Laying out changes line heights, which moves the offset we are scrolling to, so converge first.
         var lastFrame: CGRect = .zero
-
-        // Set a timeout to avoid an infinite loop
-        let timeout: TimeInterval = 0.5
-        let startTime = Date()
-
-        // Adjust layout until stable
-        while let newRect = layoutManager.rectForOffset(range.location),
-              lastFrame != newRect,
-              Date().timeIntervalSince(startTime) < timeout {
+        let deadline = Date().addingTimeInterval(0.5)
+        while let newRect = layoutManager.rectForOffset(range.location), lastFrame != newRect, Date() < deadline {
             lastFrame = newRect
             layoutManager.layoutLines()
             selectionManager.updateSelectionViews()
         }
+        guard lastFrame != .zero else { return }
 
-        // Scroll to make the range appear at the desired position
-        if lastFrame != .zero {
-            let animated = false // feature flag
-            if animated {
-                NSAnimationContext.runAnimationGroup { context in
-                    context.duration = 0.15 // Adjust duration as needed
-                    context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
-                    scrollView.contentView.animator().setBoundsOrigin(targetOffset)
-                }
-            } else {
-                scrollView.contentView.scroll(to: targetOffset)
-            }
+        // A rect the size of the unobscured viewport, placed where the range should end up. `scrollToVisible` then
+        // moves the clip view just far enough to show all of it, which lands the range in place, and it stops at the
+        // clip view's content insets and the document's edges, both of which a computed `scroll(to:)` ignores.
+        let viewport = unobscuredContentSize
+        let target = if center {
+            CGRect(
+                x: lastFrame.midX - viewport.width / 2,
+                y: lastFrame.midY - viewport.height / 2,
+                width: viewport.width,
+                height: viewport.height
+            )
+        } else {
+            CGRect(origin: lastFrame.origin, size: viewport)
         }
+        scrollView.contentView.scrollToVisible(target)
+        scrollView.reflectScrolledClipView(scrollView.contentView)
     }
 
     /// Get the selection that should be scrolled to visible for the current text selection.

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextView/TextView+TextLayoutManagerDelegate.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextView/TextView+TextLayoutManagerDelegate.swift
@@ -21,13 +21,10 @@ extension TextView: TextLayoutManagerDelegate {
     }
 
     public func textViewportSize() -> CGSize {
-        if let scrollView = scrollView {
-            var size = scrollView.contentSize
-            size.height -= scrollView.contentInsets.top + scrollView.contentInsets.bottom
-            return size
-        } else {
+        guard scrollView != nil else {
             return CGSize(width: CGFloat.infinity, height: CGFloat.infinity)
         }
+        return unobscuredContentSize
     }
 
     public func layoutManagerYAdjustment(_ yAdjustment: CGFloat) {

--- a/LocalPackages/CodeEditTextView/Tests/CodeEditTextViewTests/LayoutManager/TextLayoutManagerLineWidthTests.swift
+++ b/LocalPackages/CodeEditTextView/Tests/CodeEditTextViewTests/LayoutManager/TextLayoutManagerLineWidthTests.swift
@@ -169,6 +169,20 @@ struct TextLayoutManagerLineWidthTests {
         #expect(widthOf(textView) == wide)
     }
 
+    @Test("Removing every fold at once lets the folded lines count again once they are laid out")
+    func removingEveryFoldRestoresTheWidths() {
+        let textView = makeTextView(["SELECT 1", longLine, "SELECT 2"].joined(separator: "\n"))
+        let wide = widthOf(textView)
+        let foldStart = ("SELECT 1" as NSString).length
+        textView.layoutManager.attachments.add(DemoTextAttachment(), for: NSRange(location: foldStart, length: 401))
+        textView.layoutManager.layoutLines(in: everything)
+
+        textView.layoutManager.attachments.removeAll()
+        textView.layoutManager.layoutLines(in: everything)
+
+        #expect(widthOf(textView) == wide)
+    }
+
     @Test("Scrolling a line out of the layout window keeps its width")
     func layingOutElsewhereKeepsMeasuredWidths() {
         let textView = makeTextView(([longLine] + Array(repeating: "short", count: 300)).joined(separator: "\n"))

--- a/LocalPackages/CodeEditTextView/Tests/CodeEditTextViewTests/LayoutManager/TextLayoutManagerLineWidthTests.swift
+++ b/LocalPackages/CodeEditTextView/Tests/CodeEditTextViewTests/LayoutManager/TextLayoutManagerLineWidthTests.swift
@@ -1,0 +1,181 @@
+import AppKit
+@testable import CodeEditTextView
+import Testing
+
+/// The document is as wide as the widest line it still has, in both directions (#2709).
+///
+/// Every case edits through the text storage, the path an undo, a paste and a Find and Replace all take, and reads the
+/// result back off `maxLineWidth` and the text view's frame, which is what the scroll view sizes its content from.
+@Suite
+@MainActor
+struct TextLayoutManagerLineWidthTests {
+    private let everything = NSRect(x: 0, y: 0, width: 1_000, height: 100_000)
+    private let topOfDocument = NSRect(x: 0, y: 0, width: 1_000, height: 300)
+    private let farDown = NSRect(x: 0, y: 3_000, width: 1_000, height: 300)
+    private let longLine = String(repeating: "x", count: 400)
+
+    private func makeTextView(_ string: String) -> TextView {
+        let textView = TextView(string: string, wrapLines: false)
+        textView.frame = NSRect(x: 0, y: 0, width: 300, height: 300)
+        textView.layoutManager.layoutLines(in: everything)
+        return textView
+    }
+
+    private func widthOf(_ textView: TextView) -> CGFloat {
+        textView.layoutManager.maxLineWidth
+    }
+
+    @Test("Removing the widest line narrows the document back to the widest line left")
+    func removingTheWidestLineNarrowsTheDocument() {
+        let query = "SELECT * FROM pay_order\nORDER BY orderId desc\n"
+        let end = (query as NSString).length
+        let pasted = String(repeating: "2056705 20260908142922 ", count: 30)
+        let textView = makeTextView(query)
+        let narrow = widthOf(textView)
+        let narrowFrame = textView.frame.width
+
+        textView.textStorage.replaceCharacters(in: NSRange(location: end, length: 0), with: pasted)
+        textView.layoutManager.layoutLines(in: everything)
+        #expect(widthOf(textView) > narrow * 5)
+        #expect(textView.frame.width > narrowFrame * 5)
+
+        textView.textStorage.replaceCharacters(in: NSRange(location: end, length: (pasted as NSString).length), with: "")
+        textView.layoutManager.layoutLines(in: everything)
+
+        #expect(widthOf(textView) == narrow)
+        #expect(textView.frame.width == narrowFrame)
+    }
+
+    @Test("Undoing a long paste narrows the document again")
+    func undoingALongPasteNarrowsTheDocument() {
+        let textView = makeTextView("SELECT 1\n")
+        let narrow = widthOf(textView)
+
+        textView.replaceCharacters(in: NSRange(location: 9, length: 0), with: longLine)
+        textView.layoutManager.layoutLines(in: everything)
+        #expect(widthOf(textView) > narrow)
+
+        textView.undo(nil)
+        textView.layoutManager.layoutLines(in: everything)
+
+        #expect(widthOf(textView) == narrow)
+    }
+
+    @Test("A line shortened while it is off screen stops counting as soon as the edit lands")
+    func lineShortenedOffScreenStopsCounting() {
+        let textView = makeTextView(([longLine] + Array(repeating: "short", count: 300)).joined(separator: "\n"))
+        let wide = widthOf(textView)
+
+        textView.textStorage.replaceCharacters(in: NSRange(location: 0, length: 400), with: "y")
+        textView.layoutManager.layoutLines(in: farDown)
+
+        #expect(widthOf(textView) < wide / 10)
+    }
+
+    @Test("Deleting the end of the last line forgets its width, even while it is off screen")
+    func deletingTheEndOfTheDocumentForgetsTheLastLine() {
+        let textView = makeTextView((Array(repeating: "short", count: 300) + [longLine]).joined(separator: "\n"))
+        let wide = widthOf(textView)
+        let length = textView.textStorage.length
+
+        textView.textStorage.replaceCharacters(in: NSRange(location: length - 399, length: 399), with: "")
+        textView.layoutManager.layoutLines(in: topOfDocument)
+
+        #expect(widthOf(textView) < wide / 10)
+    }
+
+    @Test("Typing in a line that is not the widest leaves the width and the frame alone")
+    func typingInANarrowLineLeavesTheWidthAlone() {
+        let textView = makeTextView("short\n" + longLine)
+        let wide = widthOf(textView)
+        let frameWidth = textView.frame.width
+
+        textView.textStorage.replaceCharacters(in: NSRange(location: 2, length: 0), with: "abc")
+        textView.layoutManager.layoutLines(in: everything)
+
+        #expect(widthOf(textView) == wide)
+        #expect(textView.frame.width == frameWidth)
+    }
+
+    @Test("The width follows the widest line as it grows and shrinks")
+    func widthFollowsTheWidestLine() {
+        let textView = makeTextView("short\n" + String(repeating: "x", count: 100))
+        let original = widthOf(textView)
+        let end = textView.textStorage.length
+
+        textView.textStorage.replaceCharacters(in: NSRange(location: end, length: 0), with: "xxxxxxxxxx")
+        textView.layoutManager.layoutLines(in: everything)
+        #expect(widthOf(textView) > original)
+
+        textView.textStorage.replaceCharacters(in: NSRange(location: end, length: 10), with: "")
+        textView.layoutManager.layoutLines(in: everything)
+        #expect(widthOf(textView) == original)
+    }
+
+    @Test("Invalidating line widths forgets them, off screen included")
+    func invalidatingLineWidthsForgetsOffScreenWidths() {
+        let textView = makeTextView(([longLine] + Array(repeating: "short", count: 300)).joined(separator: "\n"))
+        let wide = widthOf(textView)
+
+        textView.layoutManager.invalidateLineWidths()
+        textView.layoutManager.layoutLines(in: farDown)
+
+        #expect(widthOf(textView) < wide / 10)
+    }
+
+    @Test("Setting the typing font keeps the widths of the text already there")
+    func typingFontKeepsMeasuredWidths() {
+        let textView = makeTextView(([longLine] + Array(repeating: "short", count: 300)).joined(separator: "\n"))
+        let wide = widthOf(textView)
+
+        textView.font = .monospacedSystemFont(ofSize: 6, weight: .regular)
+        textView.letterSpacing = 0.5
+        textView.layoutManager.layoutLines(in: farDown)
+
+        #expect(widthOf(textView) == wide)
+    }
+
+    @Test("Turning wrapping on forgets the widths lines measured without it")
+    func turningWrappingOnForgetsWidths() {
+        let textView = makeTextView(([longLine] + Array(repeating: "short", count: 300)).joined(separator: "\n"))
+
+        textView.layoutManager.wrapLines = true
+
+        #expect(textView.layoutManager.lineStorage.maxWidth == 0)
+    }
+
+    @Test("Setting wrapping to the value it already has keeps the widths")
+    func reassigningWrappingKeepsWidths() {
+        let textView = makeTextView(([longLine] + Array(repeating: "short", count: 300)).joined(separator: "\n"))
+        let wide = widthOf(textView)
+
+        textView.layoutManager.wrapLines = false
+
+        #expect(textView.layoutManager.lineStorage.maxWidth == wide)
+    }
+
+    @Test("Folding the widest line away narrows the document, and unfolding it widens it again")
+    func foldingTheWidestLineNarrowsTheDocument() {
+        let textView = makeTextView(["SELECT 1", longLine, "SELECT 2"].joined(separator: "\n"))
+        let wide = widthOf(textView)
+        let foldStart = ("SELECT 1" as NSString).length
+
+        textView.layoutManager.attachments.add(DemoTextAttachment(), for: NSRange(location: foldStart, length: 401))
+        textView.layoutManager.layoutLines(in: everything)
+        #expect(widthOf(textView) < wide / 5, "The folded line still counts at \(widthOf(textView))")
+
+        textView.layoutManager.attachments.remove(atOffset: foldStart)
+        textView.layoutManager.layoutLines(in: everything)
+        #expect(widthOf(textView) == wide)
+    }
+
+    @Test("Scrolling a line out of the layout window keeps its width")
+    func layingOutElsewhereKeepsMeasuredWidths() {
+        let textView = makeTextView(([longLine] + Array(repeating: "short", count: 300)).joined(separator: "\n"))
+        let wide = widthOf(textView)
+
+        textView.layoutManager.layoutLines(in: farDown)
+
+        #expect(widthOf(textView) == wide)
+    }
+}

--- a/LocalPackages/CodeEditTextView/Tests/CodeEditTextViewTests/TextLayoutLineStorageTests.swift
+++ b/LocalPackages/CodeEditTextView/Tests/CodeEditTextViewTests/TextLayoutLineStorageTests.swift
@@ -29,13 +29,14 @@ final class TextLayoutLineStorageTests: XCTestCase { // swiftlint:disable:this t
         let length: Int
         let count: Int
         let height: CGFloat
+        let maxWidth: CGFloat
     }
 
     /// Recursively checks that the given tree has the correct metadata everywhere.
     /// - Parameter tree: The tree to check.
     fileprivate func assertTreeMetadataCorrect<T: Identifiable>(_ tree: TextLineStorage<T>) throws {
         func checkChildren(_ node: TextLineStorage<T>.Node<T>?) -> ChildData {
-            guard let node else { return ChildData(length: 0, count: 0, height: 0.0) }
+            guard let node else { return ChildData(length: 0, count: 0, height: 0.0, maxWidth: 0.0) }
             let leftSubtreeData = checkChildren(node.left)
             let rightSubtreeData = checkChildren(node.right)
 
@@ -43,10 +44,14 @@ final class TextLayoutLineStorageTests: XCTestCase { // swiftlint:disable:this t
             XCTAssert(leftSubtreeData.count == node.leftSubtreeCount, "Left subtree node count incorrect")
             XCTAssert(leftSubtreeData.height.approxEqual(node.leftSubtreeHeight), "Left subtree height incorrect")
 
+            let subtreeWidth = max(node.width, leftSubtreeData.maxWidth, rightSubtreeData.maxWidth)
+            XCTAssertEqual(node.subtreeWidth, subtreeWidth, "Subtree width incorrect")
+
             return ChildData(
                 length: node.length + leftSubtreeData.length + rightSubtreeData.length,
                 count: 1 + leftSubtreeData.count + rightSubtreeData.count,
-                height: node.height + leftSubtreeData.height + rightSubtreeData.height
+                height: node.height + leftSubtreeData.height + rightSubtreeData.height,
+                maxWidth: subtreeWidth
             )
         }
 
@@ -55,6 +60,7 @@ final class TextLayoutLineStorageTests: XCTestCase { // swiftlint:disable:this t
         XCTAssert(rootData.count == tree.count, "Node count incorrect")
         XCTAssert(rootData.length == tree.length, "Length incorrect")
         XCTAssert(rootData.height.approxEqual(tree.height), "Height incorrect")
+        XCTAssertEqual(rootData.maxWidth, tree.maxWidth, "Max width incorrect")
 
         var lastIdx = -1
         for line in tree {
@@ -221,6 +227,110 @@ final class TextLayoutLineStorageTests: XCTestCase { // swiftlint:disable:this t
         }
     }
 
+    /// A balanced tree whose line at index `i` is `i + 1` characters long and `widths[i]` wide.
+    fileprivate func createMeasuredTree(widths: [CGFloat]) -> TextLineStorage<TextLine> {
+        let tree = TextLineStorage<TextLine>()
+        tree.build(
+            from: widths.indices.map { .init(data: TextLine(), length: $0 + 1, height: 1.0) },
+            estimatedLineHeight: 1.0
+        )
+        for (index, width) in widths.enumerated() {
+            tree.setWidth(width, forLineAt: index)
+        }
+        return tree
+    }
+
+    fileprivate func lineStart(ofLineAt index: Int, in tree: TextLineStorage<TextLine>) throws -> Int {
+        try XCTUnwrap(tree.getLine(atIndex: index)).range.location
+    }
+
+    func test_maxWidthIsTheWidestMeasuredLine() throws {
+        let tree = createMeasuredTree(widths: [10, 40, 25, 5, 30])
+        XCTAssertEqual(tree.maxWidth, 40)
+        try assertTreeMetadataCorrect(tree)
+
+        XCTAssertEqual(TextLineStorage<TextLine>().maxWidth, 0, "An empty tree has no width")
+    }
+
+    func test_narrowingTheWidestLineLowersMaxWidth() throws {
+        let tree = createMeasuredTree(widths: [10, 40, 25, 5, 30])
+
+        tree.setWidth(12, forLineAt: 1)
+        XCTAssertEqual(tree.maxWidth, 30, "The next widest line takes over")
+        try assertTreeMetadataCorrect(tree)
+
+        tree.setWidth(0, forLineAt: 4)
+        XCTAssertEqual(tree.maxWidth, 25, "A forgotten width counts as zero")
+        try assertTreeMetadataCorrect(tree)
+    }
+
+    func test_deletingTheWidestLineLowersMaxWidth() throws {
+        for index in 0..<15 {
+            var widths = (0..<15).map { CGFloat($0 + 1) }
+            widths[index] = 1_000
+            let tree = createMeasuredTree(widths: widths)
+            XCTAssertEqual(tree.maxWidth, 1_000)
+
+            tree.delete(lineAt: try lineStart(ofLineAt: index, in: tree))
+
+            widths.remove(at: index)
+            XCTAssertEqual(tree.maxWidth, widths.max(), "Deleting line \(index) left a stale width")
+            try assertTreeMetadataCorrect(tree)
+        }
+    }
+
+    func test_resetWidthsForgetsEveryWidth() throws {
+        let tree = createMeasuredTree(widths: [10, 40, 25, 5, 30])
+
+        tree.resetWidths()
+
+        XCTAssertEqual(tree.maxWidth, 0)
+        try assertTreeMetadataCorrect(tree)
+        tree.setWidth(7, forLineAt: 2)
+        XCTAssertEqual(tree.maxWidth, 7, "Widths recorded after a reset count again")
+    }
+
+    /// Runs a long, reproducible sequence of inserts, deletes, length changes and width changes against a plain array,
+    /// checking after every step that the tree's width aggregate and its per-node invariant agree with the array.
+    ///
+    /// Rotations and the two-child delete are where a width aggregate goes wrong, and a hand-written case reaches only
+    /// the few shapes it was written for.
+    func test_widthAggregateMatchesAModelThroughRandomEdits() throws {
+        var generator = SeededGenerator(seed: 2709)
+        let tree = TextLineStorage<TextLine>()
+        var model: [(length: Int, width: CGFloat)] = []
+
+        for _ in 0..<4_000 {
+            let operation = model.isEmpty ? 0 : Int.random(in: 0..<4, using: &generator)
+            switch operation {
+            case 0:
+                let index = Int.random(in: 0...model.count, using: &generator)
+                let offset = model[..<index].reduce(0) { $0 + $1.length }
+                let length = Int.random(in: 1...20, using: &generator)
+                tree.insert(line: TextLine(), atOffset: offset, length: length, height: 1.0)
+                model.insert((length, 0), at: index)
+            case 1:
+                let index = Int.random(in: 0..<model.count, using: &generator)
+                tree.delete(lineAt: try lineStart(ofLineAt: index, in: tree))
+                model.remove(at: index)
+            case 2:
+                let index = Int.random(in: 0..<model.count, using: &generator)
+                let delta = Int.random(in: 1...5, using: &generator)
+                tree.update(atOffset: try lineStart(ofLineAt: index, in: tree), delta: delta, deltaHeight: 0)
+                model[index].length += delta
+            default:
+                let index = Int.random(in: 0..<model.count, using: &generator)
+                let width = CGFloat(Int.random(in: 0...500, using: &generator))
+                tree.setWidth(width, forLineAt: index)
+                model[index].width = width
+            }
+
+            XCTAssertEqual(tree.maxWidth, model.map(\.width).max() ?? 0)
+            XCTAssertEqual(tree.map(\.range.length), model.map(\.length), "Lines out of order")
+            try assertTreeMetadataCorrect(tree)
+        }
+    }
+
     func test_insertPerformance() {
         let tree = TextLineStorage<TextLine>()
         var lines: [TextLineStorage<TextLine>.BuildItem] = []
@@ -383,5 +493,22 @@ final class TextLayoutLineStorageTests: XCTestCase { // swiftlint:disable:this t
         storage.delete(lineAt: 7) // Delete the root
 
         try assertTreeMetadataCorrect(storage)
+    }
+}
+
+/// A small deterministic generator, so a failing random sequence can be replayed exactly.
+private struct SeededGenerator: RandomNumberGenerator {
+    private var state: UInt64
+
+    init(seed: UInt64) {
+        state = seed
+    }
+
+    mutating func next() -> UInt64 {
+        state &+= 0x9E37_79B9_7F4A_7C15
+        var value = state
+        value = (value ^ (value >> 30)) &* 0xBF58_476D_1CE4_E5B9
+        value = (value ^ (value >> 27)) &* 0x94D0_49BB_1331_11EB
+        return value ^ (value >> 31)
     }
 }

--- a/LocalPackages/CodeEditTextView/Tests/CodeEditTextViewTests/TextViewScrollInsetsTests.swift
+++ b/LocalPackages/CodeEditTextView/Tests/CodeEditTextViewTests/TextViewScrollInsetsTests.swift
@@ -180,6 +180,18 @@ struct TextViewScrollInsetsTests {
         #expect(origin == 1_000)
     }
 
+    @Test("One step of a batch edit, which skips the selection update, leaves the view where it is")
+    func batchEditStepDoesNotScroll() {
+        load(longLine + "\n" + longLine)
+        textView.scroll(NSPoint(x: 300, y: 0))
+        textView.selectionManager.setSelectedRange(NSRange(location: 0, length: 0))
+
+        let secondLine = (longLine as NSString).length + 1
+        textView.replaceCharacters(in: NSRange(location: secondLine, length: 0), with: "    ", skipUpdateSelection: true)
+
+        #expect(origin == 300)
+    }
+
     @Test("Pasting a long line follows the caret to the end of it")
     func pastingALongLineRevealsTheCaret() throws {
         load("SELECT 1\n")

--- a/LocalPackages/CodeEditTextView/Tests/CodeEditTextViewTests/TextViewScrollInsetsTests.swift
+++ b/LocalPackages/CodeEditTextView/Tests/CodeEditTextViewTests/TextViewScrollInsetsTests.swift
@@ -1,0 +1,238 @@
+import AppKit
+@testable import CodeEditTextView
+import Testing
+
+/// A text view keeps its text out from under whatever its scroll view reserves over the leading and trailing edges
+/// (#2709).
+///
+/// The clip view here reserves 50pt on the leading side and 30pt on the trailing side through its content insets, the
+/// way the source editor reserves its gutter and its minimap. Positions are read off the real `NSClipView`, so the
+/// clamping under test is AppKit's own.
+@Suite
+@MainActor
+struct TextViewScrollInsetsTests {
+    private let leading: CGFloat = 50
+    private let trailing: CGFloat = 30
+    private let longLine = String(repeating: "2056705 20260908142922 ", count: 40)
+
+    private let scrollView: NSScrollView
+    private let textView: TextView
+
+    init() {
+        scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 400, height: 300))
+        scrollView.scrollerStyle = .overlay
+        scrollView.hasHorizontalScroller = true
+        scrollView.hasVerticalScroller = true
+        textView = TextView(string: "", wrapLines: false)
+        scrollView.documentView = textView
+        scrollView.contentView.automaticallyAdjustsContentInsets = false
+        scrollView.contentView.contentInsets = NSEdgeInsets(top: 0, left: leading, bottom: 0, right: trailing)
+        scrollView.tile()
+    }
+
+    private var clip: NSClipView {
+        scrollView.contentView
+    }
+
+    private var origin: CGFloat {
+        clip.bounds.origin.x
+    }
+
+    private var uncoveredWidth: CGFloat {
+        scrollView.contentSize.width - leading - trailing
+    }
+
+    /// The furthest right the view can scroll: the document's width less the part of the clip view left uncovered.
+    private var trailingEdge: CGFloat {
+        textView.frame.width - (clip.bounds.width - trailing)
+    }
+
+    /// AppKit aligns the clip view's origin to the backing store's pixels, so a position is only exact to half a point.
+    private func isSamePosition(_ lhs: CGFloat, _ rhs: CGFloat) -> Bool {
+        abs(lhs - rhs) <= 0.5
+    }
+
+    private func load(_ string: String) {
+        textView.setText(string)
+        textView.updateFrameIfNeeded()
+        textView.layoutManager.layoutLines()
+        textView.scroll(NSPoint(x: -1_000_000, y: 0))
+    }
+
+    private func scrollToTrailingEdge() {
+        textView.scroll(NSPoint(x: 1_000_000, y: 0))
+        textView.layoutManager.layoutLines()
+    }
+
+    @Test("At rest the view sits at the leading edge, with the text starting beside the leading inset")
+    func restsAtTheLeadingEdge() {
+        load("SELECT 1")
+
+        #expect(origin == -leading)
+        #expect(textView.visibleRect.minX == 0)
+    }
+
+    @Test("Without wrapping, the document is at least as wide as the area the insets leave uncovered")
+    func documentFillsTheUncoveredWidth() {
+        load("SELECT 1")
+
+        #expect(textView.frame.width == uncoveredWidth)
+    }
+
+    @Test("Wrapped text wraps at the width the insets leave uncovered")
+    func wrapsAtTheUncoveredWidth() {
+        textView.wrapLines = true
+        load(longLine)
+
+        #expect(textView.textViewportSize().width == uncoveredWidth)
+        #expect(textView.frame.width == uncoveredWidth)
+    }
+
+    @Test("The visible rect leaves out what the insets cover")
+    func visibleRectLeavesOutTheInsets() {
+        load(longLine)
+        scrollToTrailingEdge()
+
+        #expect(isSamePosition(textView.visibleRect.minX, origin + leading))
+        #expect(isSamePosition(textView.visibleRect.width, uncoveredWidth))
+    }
+
+    @Test("Removing a long pasted line brings the start of every line back into view (#2709)")
+    func undoingALongPasteBringsTheLineStartsBack() throws {
+        let query = "SELECT * FROM pay_order\nORDER BY orderId desc\n"
+        let end = (query as NSString).length
+        load(query)
+
+        textView.selectionManager.setSelectedRange(NSRange(location: end, length: 0))
+        textView.replaceCharacters(in: NSRange(location: end, length: 0), with: longLine)
+        textView.layoutManager.layoutLines()
+        try #require(origin > 0, "Pasting follows the caret out to the end of the long line")
+
+        textView.undo(nil)
+        textView.layoutManager.layoutLines()
+
+        #expect(textView.string == query)
+        #expect(textView.frame.width == uncoveredWidth)
+        #expect(origin == -leading)
+    }
+
+    @Test("A document that narrows but still overflows keeps the view as far right as it now reaches")
+    func narrowingClampsToTheNewTrailingEdge() {
+        load(String(repeating: "x", count: 600) + "\n" + String(repeating: "y", count: 200))
+        scrollToTrailingEdge()
+
+        textView.textStorage.replaceCharacters(in: NSRange(location: 0, length: 600), with: "")
+        textView.layoutManager.layoutLines()
+
+        #expect(textView.frame.width > uncoveredWidth)
+        #expect(isSamePosition(origin, trailingEdge))
+    }
+
+    @Test("Moving to the start of a line from far right lands it beside the leading inset, not under it")
+    func revealingALineStartClearsTheLeadingInset() {
+        load(longLine + "\nORDER BY orderId desc")
+        scrollToTrailingEdge()
+
+        textView.selectionManager.setSelectedRange(NSRange(location: (longLine as NSString).length + 1, length: 0))
+        textView.scrollSelectionToVisible()
+
+        #expect(origin == -leading)
+    }
+
+    @Test("Moving to the end of a long line stops short of the trailing inset")
+    func revealingALineEndClearsTheTrailingInset() throws {
+        load(longLine + "\nshort")
+        let end = (longLine as NSString).length
+
+        textView.selectionManager.setSelectedRange(NSRange(location: end, length: 0))
+        textView.scrollSelectionToVisible()
+
+        let caret = try #require(textView.layoutManager.rectForOffset(end))
+        #expect(caret.maxX - origin <= clip.bounds.width - trailing + 0.5)
+        #expect(caret.minX - origin >= leading - 0.5)
+    }
+
+    @Test("Typing at the start of a line half hidden under the leading inset scrolls the caret clear of it")
+    func typingUnderTheLeadingInsetRevealsTheCaret() throws {
+        load(longLine + "\nshort")
+        textView.scroll(NSPoint(x: -leading + 20, y: 0))
+
+        let lineStart = (longLine as NSString).length + 1
+        textView.selectionManager.setSelectedRange(NSRange(location: lineStart, length: 0))
+        textView.replaceCharacters(in: NSRange(location: lineStart, length: 0), with: "a")
+
+        let caret = try #require(textView.layoutManager.rectForOffset(lineStart + 1))
+        #expect(origin < -leading + 20, "The view did not move")
+        #expect(caret.minX - origin >= leading - 0.5, "The caret is still under the leading inset")
+    }
+
+    @Test("Typing in the middle of a long line while scrolled leaves the view where it is")
+    func typingInViewKeepsThePosition() throws {
+        load(String(repeating: "abcdefghij", count: 100) + "\nshort")
+        textView.scroll(NSPoint(x: 1_000, y: 0))
+        textView.layoutManager.layoutLines()
+        let offset = 150
+        try #require(textView.visibleRect.contains(try #require(textView.layoutManager.rectForOffset(offset))))
+
+        textView.selectionManager.setSelectedRange(NSRange(location: offset, length: 0))
+        textView.replaceCharacters(in: NSRange(location: offset, length: 0), with: "Z")
+
+        #expect(origin == 1_000)
+    }
+
+    @Test("Pasting a long line follows the caret to the end of it")
+    func pastingALongLineRevealsTheCaret() throws {
+        load("SELECT 1\n")
+
+        textView.selectionManager.setSelectedRange(NSRange(location: 9, length: 0))
+        textView.replaceCharacters(in: NSRange(location: 9, length: 0), with: longLine)
+
+        let caret = try #require(textView.layoutManager.rectForOffset(9 + (longLine as NSString).length))
+        #expect(textView.visibleRect.contains(caret))
+        #expect(origin > 0)
+    }
+
+    @Test("Scrolling a range to the top left stops at the leading inset")
+    func scrollToRangeWithoutCenteringClearsTheInset() {
+        load(longLine)
+        scrollToTrailingEdge()
+
+        textView.scrollToRange(NSRange(location: 0, length: 0), center: false)
+
+        #expect(origin == -leading)
+    }
+
+    @Test("Centering a range centres it in the area the insets leave uncovered")
+    func scrollToRangeCentresInTheUncoveredArea() throws {
+        load(longLine)
+        let target = 300
+
+        textView.scrollToRange(NSRange(location: target, length: 0))
+
+        let rect = try #require(textView.layoutManager.rectForOffset(target))
+        let centre = leading + uncoveredWidth / 2
+        #expect(abs((rect.midX - origin) - centre) < 1)
+    }
+
+    @Test("Centering a range near the end of a line stops at the document's trailing edge")
+    func scrollToRangeNearTheEndIsClamped() {
+        load(longLine)
+        let end = (longLine as NSString).length
+
+        textView.scrollToRange(NSRange(location: end, length: 0))
+
+        #expect(isSamePosition(origin, trailingEdge))
+    }
+
+    @Test("Scrolling to a range that is already in view leaves the view where it is")
+    func scrollToRangeInViewDoesNothing() throws {
+        load(longLine)
+        textView.scroll(NSPoint(x: 100, y: 0))
+        let inView = 40
+        try #require(textView.visibleRect.contains(try #require(textView.layoutManager.rectForOffset(inView))))
+
+        textView.scrollToRange(NSRange(location: inView, length: 0))
+
+        #expect(origin == 100)
+    }
+}

--- a/TableProTests/Views/Editor/FoldCommandBehaviourTests.swift
+++ b/TableProTests/Views/Editor/FoldCommandBehaviourTests.swift
@@ -66,7 +66,7 @@ struct FoldCommandBehaviourTests {
         )
         try await waitForFolds(controller)
 
-        #expect(controller.textView.textInsets.left == 0, "No gutter means no reserved rail beside the code")
+        #expect(controller.scrollView.floatingSubviewInsets.left == 0, "No gutter means no reserved rail beside the code")
         #expect(!controller.foldRanges.isEmpty, "Folds are still calculated with nothing drawing them")
 
         controller.foldAll()

--- a/TableProTests/Views/Editor/FoldGutterLayoutTests.swift
+++ b/TableProTests/Views/Editor/FoldGutterLayoutTests.swift
@@ -15,7 +15,8 @@ import Testing
 @MainActor
 struct FoldGutterLayoutTests {
 
-    /// The text view is inset by the gutter's width, so the inset is the gutter width as the reader sees it.
+    /// The scroll view reserves the gutter's width over its leading edge, so the reservation is the gutter width as the
+    /// reader sees it.
     private func gutterInset(showLineNumbers: Bool, showFoldingRibbon: Bool) -> CGFloat {
         gutterInset(
             peripherals: .init(
@@ -46,7 +47,7 @@ struct FoldGutterLayoutTests {
         controller.loadView()
         controller.textView.frame = NSRect(x: 0, y: 0, width: 800, height: 600)
         controller.textView.updatedViewport(NSRect(x: 0, y: 0, width: 800, height: 600))
-        return controller.textView.textInsets.left
+        return controller.scrollView.floatingSubviewInsets.left
     }
 
     @Test("An editor showing only the ribbon keeps a thin gutter")

--- a/TableProTests/Views/Editor/SQLEditorLongLineScrollTests.swift
+++ b/TableProTests/Views/Editor/SQLEditorLongLineScrollTests.swift
@@ -1,0 +1,52 @@
+//
+//  SQLEditorLongLineScrollTests.swift
+//  TableProTests
+//
+
+import AppKit
+@testable import CodeEditSourceEditor
+import CodeEditTextView
+import Testing
+
+/// Pasting a long line into the query editor and taking it back out leaves the start of every line in view (#2709).
+@Suite("Long line scroll")
+@MainActor
+struct SQLEditorLongLineScrollTests {
+    private let query = "SELECT * FROM pay_order\nORDER BY orderId desc\n"
+    private let pastedRow = String(repeating: "2056705 20260908142922 0.01 2026-09-15 14:29:40 ", count: 20)
+
+    @Test("Undoing a long paste narrows the editor and brings back the start of every line")
+    func undoingALongPasteReturnsToTheLineStarts() throws {
+        let controller = EditorControllerFixture.make(string: query)
+        let end = (query as NSString).length
+        let narrowWidth = controller.textView.frame.width
+
+        controller.textView.selectionManager.setSelectedRange(NSRange(location: end, length: 0))
+        controller.textView.replaceCharacters(in: NSRange(location: end, length: 0), with: pastedRow)
+        controller.textView.layoutManager.layoutLines()
+        try #require(controller.scrollPosition.x > 0, "Pasting follows the caret out to the end of the long line")
+
+        controller.textView.undoManager?.undo()
+        controller.textView.layoutManager.layoutLines()
+
+        #expect(controller.textView.string == query)
+        #expect(controller.textView.frame.width == narrowWidth)
+        #expect(abs(controller.scrollPosition.x) <= 0.5, "The start of each line is scrolled away by \(controller.scrollPosition.x)")
+    }
+
+    @Test("The start of a line is never left under the gutter")
+    func lineStartClearsTheGutter() throws {
+        let controller = EditorControllerFixture.make(string: pastedRow + "\n" + query)
+        controller.textView.scroll(NSPoint(x: 1_000_000, y: 0))
+
+        let lineStart = (pastedRow as NSString).length + 1
+        controller.textView.selectionManager.setSelectedRange(NSRange(location: lineStart, length: 0))
+        controller.textView.scrollSelectionToVisible()
+
+        let character = try #require(controller.textView.layoutManager.rectForOffset(lineStart))
+        let gutter = try #require(controller.gutterView)
+        let characterX = controller.textView.convert(character.origin, to: nil).x
+        let gutterMaxX = gutter.convert(NSPoint(x: gutter.bounds.maxX, y: 0), to: nil).x
+        #expect(characterX >= gutterMaxX - 0.5, "The line starts \(gutterMaxX - characterX)pt under the gutter")
+    }
+}


### PR DESCRIPTION
Fixes #2709

## What was wrong

After pasting a long line into the SQL editor and undoing it, the editor stayed scrolled sideways, and the first six or seven characters of every line sat under the line numbers ("* FROM pay_order" for "SELECT * FROM pay_order"). Two defects together produced it.

1. **The document never got narrower.** `TextLayoutManager.maxLineWidth` was a running maximum: a layout pass could raise it but nothing could lower it, and no line kept its own measured width, so once the widest line was gone there was nothing to recompute the width from. The text view's frame, and so the scrollable area, stayed as wide as the pasted line. Measured in the package's own test target: 170pt before the paste, 2967pt with it, still 2967pt after removing it.
2. **Revealing the caret scrolled it under the gutter.** The gutter and the minimap float over the scroll view, and they reserved their width inside the text view's document coordinates (`textInsets`). AppKit's own scroll machinery therefore treated the whole clip view as showing text, and `scrollToVisible` put a line-start caret at clip x = 0, under the opaque gutter. Undo reveals the caret, so the view ended exactly one gutter width to the right.

## The fix

**The width follows the widest line in both directions.** Each line's measured width now lives in `TextLineStorage`'s red-black tree next to its length and height, with a subtree maximum kept on every node (the textbook augmented red-black tree). A rotation recomputes the two nodes it swaps, a delete recomputes the path from the lowest node whose children changed, and a width update walks up until the maximum stops changing: `O(log n)` throughout. `maxLineWidth` is published from the tree's root at the end of each layout pass and compared with the last value published, so a line removed during an edit, before the pass, is still caught. A line's width is forgotten when its text changes, including when that happens off screen, as a Find and Replace does, and when a fold hides it or shows it again, so folding the widest line away narrows the document too. Every width is forgotten when the editor's font, letter spacing, theme or language changes, or when wrapping is turned on or off. Reapplying the same configuration, which `reloadUI` does, keeps them. Attribute-only edits, which syntax highlighting makes constantly, keep widths too, so the scroller does not twitch while you read.

**AppKit does the clamping.** Once the document can narrow, nothing else is needed for the scroll position. Narrowing the document view re-clamps the clip view synchronously, to `newWidth - clipWidth`: the smallest movement, reaching the start only when the text fits. Measured, not assumed.

**The gutter and minimap reserve their room where AppKit looks for it.** A new `SourceEditorScrollView` adds their widths to `NSClipView.contentInsets`, the channel AppKit itself uses to reserve room for a ruler or a table header, from `tile()`, its documented layout hook. It adds them on top of the insets AppKit computes for the clip view on that same tile, so the room a legacy scroller, a ruler, a header or the title bar takes is kept (measured: a legacy scroller's 17pt and a ruler's 17pt both survive). A view resting at either edge stays at that edge when the reservation changes, which a fractional gutter width needs, since AppKit pixel-aligns the origin. That keeps the floating views clickable. `NSScrollView.contentInsets` was measured and rejected: it shrinks the floating-subview container, so the gutter still draws but stops taking clicks, and the scrollers move. `NSRulerView` was measured and rejected too: on this system it reserves through the same clip insets, its subviews do not follow vertical scrolling, and it has nothing for the minimap. With the reservation on the clip view, AppKit's `scrollToVisible`, `NSView.scroll(_:)`, `constrainBoundsRect`, drag autoscroll and the narrow-reclamp all stop at the gutter's edge on their own, so no reveal arithmetic was written. The text view reads the clip view's insets for its viewport width, its minimum frame width and its visible rect. `scrollToRange`, which used the unclamped `NSClipView.scroll(to:)`, now builds a rect the size of the uncovered viewport and hands it to `scrollToVisible`.

Knock-on changes in the same subsystem:

- **Caret check after an edit.** An edit leaves the caret's line waiting for layout, and until then `rectForOffset` answers with the line's start. The post-edit check read that rect, so pasting a long line left the caret off the trailing edge. Typing in a long line while scrolled sideways moved the view on every keystroke; measured, one character moved it 242pt. `scrollSelectionToVisible` now lays out before it reads the rect, and the post-edit check goes through it. One step of a batch (indenting several lines, a grouped undo) skips the reveal, since its selection still describes the text before the edit, and the batch reveals its final selection once.
- **Host insets.** The text view's frame is recomputed after the host's content insets are applied, since a change on the trailing side alone reaches it no other way.
- **Gutter background.** The gutter paints its full width. The 8pt "let text scroll under the gutter" allowance existed to paper over the reveal bug and is gone.
- **Line-number width.** It is measured for the current digit count, so it narrows again below 1,000 lines (still floored at three digits) and is re-measured when the font changes.
- **Reformatting guide.** Its position is now converted from the text view instead of derived from the old document-space gutter inset. It also draws in its own bounds: it used to draw at its frame's origin, which offset the line by the column a second time, and a `/ 2` on the position was compensating for that.
- **Scroll position.** `SourceEditorState.scrollPosition` is recorded and restored measured from where the text starts rather than from the gutter, so the clip view's origin moving by the gutter's width does not change what a saved position means. Restoring clamps, after laying out the lines at the new vertical position so a long line not measured yet is not clamped away.

## Tests

`CodeEditTextView`, which CI runs (`swift test --package-path LocalPackages/CodeEditTextView`):

- `TextLayoutLineStorageTests`: the per-node width invariant is checked in `assertTreeMetadataCorrect`, so every existing insert, update, delete and transplant case now checks it too. Added: deleting the widest line from each of 15 positions, narrowing, resetting, and a 4,000-step seeded random sequence of inserts, deletes, length changes and width changes against a plain array.
- `TextLayoutManagerLineWidthTests` (new): removing, undoing, shortening off screen, deleting from the end of the document, typing in a narrower line, growing and shrinking the widest line, invalidating, wrap changes. Setting only the typing font keeps widths, and so does reassigning the current wrap mode.
- `TextViewScrollInsetsTests` (new, against a real `NSClipView` with 50/30pt insets): the reported undo, line start and line end reveals, typing half under the inset, typing mid-line while scrolled, pasting a long line, `scrollToRange` in both modes and near the end, and a narrowing that still overflows.

`CodeEditSourceEditor`:

- `SourceEditorScrollViewTests` (new): the reservation adds to the scroll view's insets, survives retiling and later insets, a top inset added later (the find panel) keeps the first line clear, the leading edge follows a gutter that grows or shrinks, a scrolled view keeps its place, reveal and clamping stop at the reservation, and the floating gutter still takes clicks.
- `TextViewControllerFloatingInsetsTests` (new, the real controller in a window): the reported paste and undo, moving to a line start from far right, the gutter narrowing below 1,000 lines, font re-measure, full-width paint, the reformatting guide on its column at rest and scrolled and drawn at its leading edge, a font change forgetting widths and `reloadUI` keeping them.

`TableProTests` (CI): `SQLEditorLongLineScrollTests` (new) runs the reported paste and undo through the app's own editor fixture, plus a line start never landing under the gutter. `FoldGutterLayoutTests` and `FoldCommandBehaviourTests` read the gutter's width from where it is reserved now.

`CodeEditSourceEditor`'s tests do not run in CI; `.github/workflows/macos-tests.yml` explains why. I ran them locally. Failures in `HighlighterTests`, `TagEditingTests`, `TreeSitterClientTests`, `TextViewControllerTests.test_foldingRibbonToggle` and `GutterNumberOffsetTests` ("A window's gutter keeps its margin") are the same on `HEAD`. `LineFoldChunkBoundaryTests` waited a fixed 200ms for work on the main actor, which the new suites share, so it now waits for the calculation to reach its last line (5s deadline). What it checks is unchanged.

No UI test: the editor's horizontal scroll position and the characters under the gutter are not exposed through accessibility, so XCUITest cannot observe the defect. The package tests drive the real `TextView`, `NSScrollView` and `TextViewController`.

## Verification

- `swift test --package-path LocalPackages/CodeEditTextView`: 219 Swift Testing cases and 52 XCTest cases pass.
- `swift test --package-path LocalPackages/CodeEditSourceEditor`: 92 Swift Testing cases, one failure (`GutterNumberOffsetTests`, "A window's gutter keeps its margin"), which fails the same way on `HEAD` on this machine because it rasterises the gutter in dark mode. XCTest failures are the nine that also fail on `HEAD`: `HighlighterTests` 1, `TagEditingTests` 5, `TreeSitterClientTests` 2 and `test_foldingRibbonToggle`, which still expects a 7pt folding ribbon.
- `xcodebuild -scheme TablePro` Debug build: passes.
- `TableProTests`, every suite that builds a real editor (19 suites, including the three fold and minimap suites and the fold, statement-run and Vim performance guards): 120 cases, all pass.
- `swiftlint` over every changed file: nothing new against the `HEAD` versions of the same files, and the new files are clean.
- Tree benchmarks, `HEAD` vs branch: insert 250,000 lines 0.335s vs 0.345s (within the test's own 8% deviation), fast insert 0.074s vs 0.074s, iteration 0.122s vs 0.123s.
- AppKit behaviour the design relies on was measured with standalone probes on macOS 27: the narrowing re-clamp, clip-view insets keeping a floating subview clickable where scroll-view insets do not, `scrollToVisible` and `NSView.scroll(_:)` respecting clip insets, and `NSClipView.scroll(to:)` not clamping. Nothing here was measured on macOS 14 or 15. `NSClipView.contentInsets` has been available since 10.10, and the CI runner will exercise the package tests on its own macOS.

## Before / After

The real editor, rendered off-screen from `TextViewController` in a window: paste a long line after `SELECT * FROM pay_order` / `ORDER BY orderId desc`, undo it, and capture. The same harness ran against `main` and against this branch.

**Before (`main`):** clip origin 70.5pt. The first lines read "* FROM pay_order" and "BY orderId desc", the same as the reporter's third screenshot.

![Before: after undoing the paste on main, the start of both lines is hidden under the line numbers](https://github.com/user-attachments/assets/fb80e9c8-2ac8-466a-bb81-75eb87474b89)

**After:** clip origin -69.5pt, the leading edge. Both lines show in full beside the line numbers.

![After: after undoing the paste on this branch, both lines show in full](https://github.com/user-attachments/assets/925db2a9-02db-4f74-aab4-fe17b5bc561f)
