### PR TITLE
fix(editor): keep word delete and move on whole characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Start of a line hidden under the line numbers after moving to it in a horizontally scrolled editor.
 - Editor jumping sideways on each keystroke in a long line while scrolled horizontally.
 - Cursor left off screen after pasting a long line.
+- Option+Delete and Option+Arrow splitting an emoji or accented letter in the SQL and JSON editors.
 - Line number column keeping a stale width after the line count drops below 1,000 or the font size changes.
 - Line after the data grid's row numbers drawn twice as thick as the other column lines.
 - `#` heading in the data grid darker and dimmer than the headings beside it.

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextSelectionManager/SelectionManipulation/SelectionManipulation+Horizontal.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextSelectionManager/SelectionManipulation/SelectionManipulation+Horizontal.swift
@@ -70,14 +70,32 @@ package extension TextSelectionManager {
         delta: Int,
         decomposeCharacters: Bool
     ) -> NSRange {
-        let range = delta > 0 ? NSRange(location: offset, length: 1) : NSRange(location: offset - 1, length: 1)
         if delta > 0 && offset == string.length {
             return NSRange(location: offset, length: 0)
         } else if delta < 0 && offset == 0 {
             return NSRange(location: 0, length: 0)
         }
 
-        return decomposeCharacters ? range : string.rangeOfComposedCharacterSequences(for: range)
+        let index = delta > 0 ? offset : offset - 1
+        guard decomposeCharacters else {
+            return string.rangeOfComposedCharacterSequence(at: index)
+        }
+        return rangeOfUnicodeScalar(in: string, at: index)
+    }
+
+    private func rangeOfUnicodeScalar(in string: NSString, at index: Int) -> NSRange {
+        let unit = string.character(at: index)
+        if UTF16.isLeadSurrogate(unit),
+           index + 1 < string.length,
+           UTF16.isTrailSurrogate(string.character(at: index + 1)) {
+            return NSRange(location: index, length: 2)
+        }
+        if UTF16.isTrailSurrogate(unit),
+           index > 0,
+           UTF16.isLeadSurrogate(string.character(at: index - 1)) {
+            return NSRange(location: index - 1, length: 2)
+        }
+        return NSRange(location: index, length: 1)
     }
 
     /// Extends the selection by one "word".
@@ -95,13 +113,13 @@ package extension TextSelectionManager {
         if delta < 0 {
             enumerationOptions.formUnion(.reverse)
         }
-        var rangeToDelete = NSRange(location: offset, length: 0)
+        var wordRange = NSRange(location: offset, length: 0)
 
         var hasFoundValidWordChar = false
         string.enumerateSubstrings(
             in: NSRange(location: delta > 0 ? offset : 0, length: delta > 0 ? string.length - offset : offset),
             options: enumerationOptions
-        ) { substring, _, _, stop in
+        ) { substring, substringRange, _, stop in
             guard let substring = substring else {
                 stop.pointee = true
                 return
@@ -116,14 +134,10 @@ package extension TextSelectionManager {
             } else if CharacterSet.codeIdentifierCharacters.isSuperset(of: CharacterSet(charactersIn: substring)) {
                 hasFoundValidWordChar = true
             }
-            rangeToDelete.length += substring.count
-
-            if delta < 0 {
-                rangeToDelete.location -= substring.count
-            }
+            wordRange.formUnion(substringRange)
         }
 
-        return rangeToDelete
+        return wordRange
     }
 
     /// Extends the selection by one visual line in the direction specified (eg one line fragment).
@@ -221,13 +235,12 @@ package extension TextSelectionManager {
     /// - Returns: A new range to replace the given range for the line.
     private func findBeginningOfLineText(string: NSString, initialRange: NSRange) -> NSRange {
         var foundRange = initialRange
-        string.enumerateSubstrings(in: foundRange, options: .byCaretPositions) { substring, _, _, stop in
+        string.enumerateSubstrings(in: foundRange, options: .byCaretPositions) { substring, substringRange, _, stop in
             if let substring = substring as String? {
                 if CharacterSet
                     .whitespacesAndNewlines.subtracting(.newlines)
                     .isSuperset(of: CharacterSet(charactersIn: substring)) {
-                    foundRange.location += 1
-                    foundRange.length -= 1
+                    foundRange = NSRange(start: substringRange.max, end: initialRange.max)
                 } else {
                     stop.pointee = true
                 }

--- a/LocalPackages/CodeEditTextView/Tests/CodeEditTextViewTests/TextSelectionManagerTests.swift
+++ b/LocalPackages/CodeEditTextView/Tests/CodeEditTextViewTests/TextSelectionManagerTests.swift
@@ -25,7 +25,7 @@ final class TextSelectionManagerTests: XCTestCase {
     func test_updateSelectionLeft() {
         let selectionManager = selectionManager()
         let locations = [2, 0, 14, 14]
-        let expectedRanges = [(1, 1), (0, 0), (12, 2), (13, 1)]
+        let expectedRanges = [(1, 1), (0, 0), (12, 2), (12, 2)]
         let decomposeCharacters = [false, false, false, true]
 
         for idx in locations.indices {
@@ -50,7 +50,7 @@ final class TextSelectionManagerTests: XCTestCase {
     func test_updateSelectionRight() {
         let selectionManager = selectionManager()
         let locations = [2, 0, 14, 13, 12]
-        let expectedRanges = [(2, 1), (0, 1), (14, 0), (12, 2), (12, 1)]
+        let expectedRanges = [(2, 1), (0, 1), (14, 0), (12, 2), (12, 2)]
         let decomposeCharacters = [false, false, false, false, true]
 
         for idx in locations.indices {

--- a/LocalPackages/CodeEditTextView/Tests/CodeEditTextViewTests/WordNavigationUnicodeTests.swift
+++ b/LocalPackages/CodeEditTextView/Tests/CodeEditTextViewTests/WordNavigationUnicodeTests.swift
@@ -1,0 +1,266 @@
+import AppKit
+@testable import CodeEditTextView
+import Testing
+
+@Suite
+@MainActor
+struct WordNavigationUnicodeTests {
+    struct WordCase: CustomTestStringConvertible, Sendable {
+        let text: String
+        let caret: Int
+        let wordRanges: [NSRange]
+
+        var testDescription: String { text }
+
+        var expectedEdits: [TextEdit] {
+            wordRanges.map { range in
+                TextEdit(
+                    text: (text as NSString).replacingCharacters(in: range, with: ""),
+                    caret: NSRange(location: range.location, length: 0)
+                )
+            }
+        }
+
+        var expectedCarets: [NSRange] {
+            wordRanges.map { NSRange(location: $0.location, length: 0) }
+        }
+
+        var expectedForwardCarets: [NSRange] {
+            wordRanges.map { NSRange(location: $0.max, length: 0) }
+        }
+
+        static func backward(before: String, word: String) -> WordCase {
+            WordCase(
+                text: before + word,
+                caret: (before + word).utf16.count,
+                wordRanges: [NSRange(location: before.utf16.count, length: word.utf16.count)]
+            )
+        }
+
+        static func forward(word: String, after: String) -> WordCase {
+            WordCase(
+                text: word + after,
+                caret: 0,
+                wordRanges: [NSRange(location: 0, length: word.utf16.count)]
+            )
+        }
+
+        static func backward(before: String, emoji: String, identifier: String, after: String) -> WordCase {
+            let caret = (before + emoji + identifier).utf16.count
+            return WordCase(
+                text: before + emoji + identifier + after,
+                caret: caret,
+                wordRanges: [
+                    NSRange(location: caret - identifier.utf16.count, length: identifier.utf16.count),
+                    NSRange(location: before.utf16.count, length: (emoji + identifier).utf16.count)
+                ]
+            )
+        }
+
+        static func forward(before: String, identifier: String, emoji: String, after: String) -> WordCase {
+            let caret = before.utf16.count
+            return WordCase(
+                text: before + identifier + emoji + after,
+                caret: caret,
+                wordRanges: [
+                    NSRange(location: caret, length: identifier.utf16.count),
+                    NSRange(location: caret, length: (identifier + emoji).utf16.count)
+                ]
+            )
+        }
+    }
+
+    struct TextEdit: Equatable, Sendable {
+        let text: String
+        let caret: NSRange
+    }
+
+    static let backwardCases: [WordCase] = [
+        .backward(before: "SELECT '", word: "e\u{301}x"),
+        .backward(before: "x = ", word: "nai\u{308}ve"),
+        .backward(before: "SELECT '", word: "\u{10437}\u{1042F}x"),
+        .backward(before: "x = ", word: "\u{1D465}1"),
+        .backward(before: "WHERE ", word: "\u{10437}e\u{301}_1"),
+        .backward(before: "'", word: "\u{10437}\u{1042F}'"),
+        .backward(before: "WHERE name LIKE '%", emoji: "\u{1F600}", identifier: "abc", after: "'"),
+        .backward(before: "'", emoji: "\u{1F44D}\u{1F3FD}", identifier: "ok", after: "'"),
+        .backward(before: "", emoji: "\u{1F600}", identifier: "a", after: " b"),
+        .backward(before: "x = ", emoji: "\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}", identifier: "id", after: "")
+    ]
+
+    static let forwardCases: [WordCase] = [
+        .forward(word: "e\u{301}x", after: "' = 1"),
+        .forward(word: "nai\u{308}ve", after: " = 1"),
+        .forward(word: "\u{10437}\u{1042F}x", after: "' = 1"),
+        .forward(word: "\u{1D465}1", after: " + 2"),
+        .forward(word: "\u{10437}e\u{301}_1", after: " FROM"),
+        .forward(word: "\u{10437}\u{1042F}", after: "'"),
+        .forward(before: "WHERE name LIKE '%", identifier: "abc", emoji: "\u{1F600}", after: "'"),
+        .forward(before: "'", identifier: "ok", emoji: "\u{1F44D}\u{1F3FD}", after: "'"),
+        .forward(before: "", identifier: "a", emoji: "\u{1F600}", after: " b"),
+        .forward(before: "x = ", identifier: "id", emoji: "\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}", after: "")
+    ]
+
+    func makeTextView(_ text: String, caret: Int) -> TextView {
+        let textView = TextView(string: text)
+        textView.isEditable = true
+        textView.isSelectable = true
+        textView.frame = NSRect(x: 0, y: 0, width: 500, height: 100)
+        textView.layoutSubtreeIfNeeded()
+        textView.selectionManager.setSelectedRange(NSRange(location: caret, length: 0))
+        return textView
+    }
+
+    func caretRange(of textView: TextView) throws -> NSRange {
+        try #require(textView.selectionManager.textSelections.first).range
+    }
+
+    func edit(of textView: TextView) throws -> TextEdit {
+        let caret = try caretRange(of: textView)
+        return TextEdit(text: textView.string, caret: caret)
+    }
+
+    @Test(arguments: backwardCases)
+    func backwardWordRangeCoversWholeCharacters(_ wordCase: WordCase) {
+        let textView = makeTextView(wordCase.text, caret: wordCase.caret)
+
+        let range = textView.selectionManager.rangeOfSelection(
+            from: wordCase.caret,
+            direction: .backward,
+            destination: .word
+        )
+
+        #expect(wordCase.wordRanges.contains(range))
+    }
+
+    @Test(arguments: forwardCases)
+    func forwardWordRangeCoversWholeCharacters(_ wordCase: WordCase) {
+        let textView = makeTextView(wordCase.text, caret: wordCase.caret)
+
+        let range = textView.selectionManager.rangeOfSelection(
+            from: wordCase.caret,
+            direction: .forward,
+            destination: .word
+        )
+
+        #expect(wordCase.wordRanges.contains(range))
+    }
+
+    @Test(arguments: backwardCases)
+    func deleteWordBackwardRemovesTheWholeWord(_ wordCase: WordCase) throws {
+        let textView = makeTextView(wordCase.text, caret: wordCase.caret)
+
+        textView.deleteWordBackward(nil)
+
+        let result = try edit(of: textView)
+        #expect(wordCase.expectedEdits.contains(result))
+    }
+
+    @Test(arguments: forwardCases)
+    func deleteWordForwardRemovesTheWholeWord(_ wordCase: WordCase) throws {
+        let textView = makeTextView(wordCase.text, caret: wordCase.caret)
+
+        textView.deleteWordForward(nil)
+
+        let result = try edit(of: textView)
+        #expect(wordCase.expectedEdits.contains(result))
+    }
+
+    @Test(arguments: backwardCases)
+    func moveWordLeftLandsBeforeTheWord(_ wordCase: WordCase) throws {
+        let textView = makeTextView(wordCase.text, caret: wordCase.caret)
+
+        textView.moveWordLeft(nil)
+
+        let caret = try caretRange(of: textView)
+        #expect(textView.string == wordCase.text)
+        #expect(wordCase.expectedCarets.contains(caret))
+    }
+
+    @Test(arguments: forwardCases)
+    func moveWordRightLandsAfterTheWord(_ wordCase: WordCase) throws {
+        let textView = makeTextView(wordCase.text, caret: wordCase.caret)
+
+        textView.moveWordRight(nil)
+
+        let caret = try caretRange(of: textView)
+        #expect(textView.string == wordCase.text)
+        #expect(wordCase.expectedForwardCarets.contains(caret))
+    }
+
+    @Test(arguments: backwardCases)
+    func moveWordLeftAndModifySelectionSelectsTheWholeWord(_ wordCase: WordCase) throws {
+        let textView = makeTextView(wordCase.text, caret: wordCase.caret)
+
+        textView.moveWordLeftAndModifySelection(nil)
+
+        let selection = try caretRange(of: textView)
+        #expect(wordCase.wordRanges.contains(selection))
+    }
+
+    @Test(arguments: forwardCases)
+    func moveWordRightAndModifySelectionSelectsTheWholeWord(_ wordCase: WordCase) throws {
+        let textView = makeTextView(wordCase.text, caret: wordCase.caret)
+
+        textView.moveWordRightAndModifySelection(nil)
+
+        let selection = try caretRange(of: textView)
+        #expect(wordCase.wordRanges.contains(selection))
+    }
+
+    @Test
+    func decomposingBackwardKeepsASurrogatePairTogether() {
+        let textView = makeTextView("a😀", caret: 3)
+
+        let range = textView.selectionManager.rangeOfSelection(
+            from: 3,
+            direction: .backward,
+            destination: .character,
+            decomposeCharacters: true
+        )
+
+        #expect(range == NSRange(location: 1, length: 2))
+    }
+
+    @Test
+    func decomposingForwardKeepsASurrogatePairTogether() {
+        let textView = makeTextView("a😀", caret: 1)
+
+        let range = textView.selectionManager.rangeOfSelection(
+            from: 1,
+            direction: .forward,
+            destination: .character,
+            decomposeCharacters: true
+        )
+
+        #expect(range == NSRange(location: 1, length: 2))
+    }
+
+    @Test
+    func decomposingBackwardTakesOnlyTheLastScalarOfACluster() {
+        let textView = makeTextView("a👍🏽", caret: 5)
+
+        let range = textView.selectionManager.rangeOfSelection(
+            from: 5,
+            direction: .backward,
+            destination: .character,
+            decomposeCharacters: true
+        )
+
+        #expect(range == NSRange(location: 3, length: 2))
+    }
+
+    @Test
+    func decomposingBackwardSeparatesACombiningMark() {
+        let textView = makeTextView("e\u{301}", caret: 2)
+
+        let range = textView.selectionManager.rangeOfSelection(
+            from: 2,
+            direction: .backward,
+            destination: .character,
+            decomposeCharacters: true
+        )
+
+        #expect(range == NSRange(location: 1, length: 1))
+    }
+}


### PR DESCRIPTION
Found while investigating #2717 (PR #2724).

Option+Delete, Option+Forward Delete and Option+Left/Right in the SQL and JSON editors could split a character in two. Deleting the word `éx` (`e` + U+0301) left a lone combining accent. Deleting after `'%😀abc` removed `abc` plus half of the emoji, which left an unpaired surrogate that draws as a replacement box. Control+Delete on `💯` deleted one half of the pair. Each of these leaves exactly the kind of invisible or broken character #2717 was about.

## Root cause

`TextSelectionManager.extendSelectionWord` walks the text with `NSString.enumerateSubstrings(options: .byCaretPositions)`, which hands back one grapheme cluster per step, and grew an `NSRange` by `substring.count` on each step. `NSRange` counts UTF-16 code units, and `String.count` counts grapheme clusters. So every character wider than one UTF-16 unit (a combining sequence, anything outside the BMP, an emoji with a modifier or ZWJ, a flag) made the range one or more units short. Backward, the start landed inside the first character of the word. Forward, the end landed inside the last one. The same range drives word delete, word move and word select, so all six commands were off.

`extendSelectionCharacter` with `decomposeCharacters` (Control+Delete, `deleteBackwardByDecomposingPreviousCharacter:`) returned a single UTF-16 unit. That separates a combining mark correctly, but it also cut a surrogate pair in half. AppKit's `NSTextView` removes one Unicode scalar here: all of `😀`, only the skin tone modifier of `👍🏽`, only U+0301 of `é` (measured with a probe against `NSTextView.doCommand(by:)`).

## What changed

All in `LocalPackages/CodeEditTextView`, `SelectionManipulation+Horizontal.swift`:

- The word range is the union of the ranges the enumerator reports (`substringRange`), which are already in UTF-16 units. No counting.
- The decomposing character range takes one Unicode scalar: two units when the unit at the caret is half of a valid surrogate pair, one unit otherwise. The non-decomposing path asks `rangeOfComposedCharacterSequence(at:)` directly.
- `findBeginningOfLineText` stepped the same way (one unit per caret position). It now moves to the end of the enumerator's range instead. I found no input where the old stepping gave a wrong answer, since every horizontal whitespace character is a single unit, but it was the same unit mix.

`TextSelectionManagerTests` had two expectations that encoded the bug: on `"Loren Ipsum 💯"`, a decomposing step over `💯` expected `(13, 1)` and `(12, 1)`, which is half of the surrogate pair. They now expect `(12, 2)`, the whole scalar, matching `NSTextView`.

## Verification

- `swift test --package-path LocalPackages/CodeEditTextView` (the CI gate), on the committed HEAD: XCTest 52 tests, 0 failures; Swift Testing 269 tests in 26 suites, all passed. Log: `scratchpad/word-delete-surrogates-package-tests-publish.log`.
- New suite `WordNavigationUnicodeTests`: 12 tests, 84 cases. Eight parameterized tests run 10 strings each (combining marks, `naïve`, Deseret and math-italic letters outside the BMP, emoji with a skin tone, a ZWJ family, emoji before and after an identifier) through the real `TextView` responder methods: `deleteWordBackward(_:)`, `deleteWordForward(_:)`, `moveWordLeft(_:)`, `moveWordRight(_:)` and both `AndModifySelection` variants, plus the raw word range. Four cases cover the decomposing character step. All 84 pass.
- Baseline: the same tests against the pre-fix `SelectionManipulation+Horizontal.swift` fail with 83 issues across 11 of the 12 tests. The one that passes on both is `decomposingBackwardSeparatesACombiningMark`, which guards that the scalar fix still splits `é` the way AppKit does. `TextSelectionManagerTests` fails 3 assertions on the old code (`{13, 1}` and `{12, 1}`). Log: `scratchpad/word-delete-surrogates-baseline-publish.log`.
- App: `verify.sh build` succeeded (`.analysis/fix-word-delete-surrogate-pairs/logs/build-TablePro-154459.log`). `verify.sh test` over the editor suites `EditorContextMenuRoutingTests` and `StatementNavigationCommandTests`: 18 cases passed (`.analysis/fix-word-delete-surrogate-pairs/logs/test-EditorContextMenuRoutingTests-144530.log`).
- `swiftlint lint --strict`: clean on the changed source file and the new test file. `TextSelectionManagerTests.swift` reports 17 `xct_specific_matcher` violations, the same 17 as on `main`, none on the edited lines.
- UI tests: none added. The package tests call the same responder methods the key bindings dispatch to, on a real `TextView`, so a UI test would only add keyboard driving of astral-plane input.

## Notes

Codex review was unavailable (usage limit), so an adversarial reviewer agent read the diff and probed the old and new word logic side by side. What it raised and what I did with it:

- **Emoji next to an identifier.** After `😀abc`, Option+Delete now removes `😀abc`, while `NSTextView` removes only `abc`. The editor's word rule treats an emoji as part of a word because it is neither punctuation nor whitespace. That rule predates this change and is a policy question, not the defect: the old code removed `abc` and half of the emoji. The tests accept either range, so a later change to the word rule does not have to rewrite them.
- **Flags.** `🇻🇳abc` used to lose `abc` plus the trailing surrogate of the second regional indicator. It now goes with the word as a whole, by the same rule as above.
- **A caret already inside a character.** If the caret sits between `e` and U+0301, a forward step starts mid-cluster and still separates them. The editor's own movement commands never leave the caret there, so this is not reachable from the keyboard and is left alone.
- **CRLF.** `\r\n` is one caret position of two units; the reviewer confirmed the old and new ranges are identical for word moves across it.
- **Not fixed here, separate path:** double-clicking `❤️` (U+2764 U+FE0F) selects U+2764 alone and leaves the variation selector outside the selection. That is `findWordBoundary`, the double-click word selection, which this PR does not touch. Worth a follow-up since deleting that selection leaves an invisible U+FE0F behind.

https://claude.ai/code/session_011THKc9TRHE8xjcxXidDHXP
