### PR TITLE
fix(editor): recheck query diagnostics whenever the document is replaced and show their messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Connecting screen naming the wrong step for the first half second of a connect.
 - Spinner flash in the object browser on Oracle, Snowflake, BigQuery, Trino and Dameng.
 - Start of every line hidden in the SQL editor after a long line was removed. (#2709)
+- Query error underlines on the wrong text or missing after a tab switch or loaded query, with no way to read them.
 - Start of a line hidden under the line numbers after moving to it in a horizontally scrolled editor.
 - Editor jumping sideways on each keystroke in a long line while scrolled horizontally.
 - Cursor left off screen after pasting a long line.

--- a/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/Controller/TextViewController.swift
+++ b/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/Controller/TextViewController.swift
@@ -311,6 +311,9 @@ public class TextViewController: NSViewController {
         self.foldModel?.documentDidReplace()
         self.setUpHighlighter()
         self.gutterView.setNeedsDisplay(self.gutterView.frame)
+        for coordinator in textCoordinators.values() {
+            coordinator.textViewDidReplaceDocument(controller: self)
+        }
     }
 
     /// Release the caches an editor can rebuild (tree-sitter, highlighter, coordinators, observers)

--- a/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/TextViewCoordinator/TextViewCoordinator.swift
+++ b/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/TextViewCoordinator/TextViewCoordinator.swift
@@ -39,6 +39,8 @@ public protocol TextViewCoordinator: AnyObject {
     /// - Parameter controller: The text controller.
     func textViewDidChangeText(controller: TextViewController)
 
+    func textViewDidReplaceDocument(controller: TextViewController)
+
     /// Called after the text view updated it's cursor positions.
     /// - Parameter newPositions: The new positions of the cursors.
     func textViewDidChangeSelection(controller: TextViewController, newPositions: [CursorPosition])
@@ -62,6 +64,7 @@ public extension TextViewCoordinator {
     func controllerDidAppear(controller: TextViewController) { }
     func controllerDidDisappear(controller: TextViewController) { }
     func textViewDidChangeText(controller: TextViewController) { }
+    func textViewDidReplaceDocument(controller: TextViewController) { }
     func textViewDidChangeSelection(controller: TextViewController, newPositions: [CursorPosition]) { }
     func textViewDidChangeHoveredFold(controller: TextViewController, hit: CollapsedFoldHit?) { }
     func destroy() { }

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/EmphasisManager/Emphasis.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/EmphasisManager/Emphasis.swift
@@ -31,17 +31,21 @@ public struct Emphasis: Equatable {
     /// this object's ``Emphasis/range`` value.
     public let selectInDocument: Bool
 
+    public let toolTip: String?
+
     public init(
         range: NSRange,
         style: EmphasisStyle = .standard,
         flash: Bool = false,
         inactive: Bool = false,
-        selectInDocument: Bool = false
+        selectInDocument: Bool = false,
+        toolTip: String? = nil
     ) {
         self.range = range
         self.style = style
         self.flash = flash
         self.inactive = inactive
         self.selectInDocument = selectInDocument
+        self.toolTip = toolTip
     }
 }

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/EmphasisManager/EmphasisManager.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/EmphasisManager/EmphasisManager.swift
@@ -20,10 +20,26 @@ import AppKit
 /// each outside object without knowledge of the other's state.
 public final class EmphasisManager {
     /// Internal representation of a emphasis layer with its associated text layer
-    private struct EmphasisLayer: Equatable {
+    private final class EmphasisLayer: Equatable {
         let emphasis: Emphasis
         let layer: CAShapeLayer
-        let textLayer: CATextLayer?
+        private(set) var textLayer: CATextLayer?
+
+        init(emphasis: Emphasis, layer: CAShapeLayer) {
+            self.emphasis = emphasis
+            self.layer = layer
+        }
+
+        var isAttached: Bool {
+            layer.superlayer != nil
+        }
+
+        func attach(to hostLayer: CALayer, textLayer: CATextLayer?) {
+            hostLayer.insertSublayer(layer, at: 1)
+            guard let textLayer else { return }
+            hostLayer.addSublayer(textLayer)
+            self.textLayer = textLayer
+        }
 
         func removeLayers() {
             layer.removeAllAnimations()
@@ -31,12 +47,17 @@ public final class EmphasisManager {
             textLayer?.removeAllAnimations()
             textLayer?.removeFromSuperlayer()
         }
+
+        static func == (lhs: EmphasisLayer, rhs: EmphasisLayer) -> Bool {
+            lhs === rhs
+        }
     }
 
     private var emphasisGroups: [String: [EmphasisLayer]] = [:]
     private let activeColor: NSColor = .findHighlightColor
     private let inactiveColor: NSColor = NSColor.lightGray.withAlphaComponent(0.4)
     private var originalSelectionColor: NSColor?
+    let toolTips = EmphasisToolTips()
 
     weak var textView: TextView?
 
@@ -66,6 +87,7 @@ public final class EmphasisManager {
 
         let layers = emphases.map { createEmphasisLayer(for: $0) }
         emphasisGroups[id, default: []].append(contentsOf: layers)
+        layers.forEach { registerToolTip(for: $0) }
         // Handle selections
         handleSelections(for: emphases)
 
@@ -81,6 +103,7 @@ public final class EmphasisManager {
                         return
                     }
 
+                    self.toolTips.unregister(flashingLayer.layer, in: self.textView)
                     self.emphasisGroups[id, default: []][emphasisIdx].removeLayers()
                     self.emphasisGroups[id, default: []].remove(at: emphasisIdx)
 
@@ -115,6 +138,7 @@ public final class EmphasisManager {
     /// - Parameter id: The group identifier
     public func removeEmphases(for id: String) {
         emphasisGroups[id]?.forEach { emphasis in
+            toolTips.unregister(emphasis.layer, in: textView)
             emphasis.removeLayers()
         }
         emphasisGroups[id] = nil
@@ -141,6 +165,24 @@ public final class EmphasisManager {
         emphasisGroups[id, default: []].map(\.emphasis)
     }
 
+    private func registerToolTip(for emphasisLayer: EmphasisLayer) {
+        guard emphasisLayer.emphasis.toolTip != nil, emphasisLayer.isAttached else { return }
+        toolTips.register(
+            emphasisLayer.emphasis.toolTip,
+            rects: toolTipRects(for: emphasisLayer.emphasis.range),
+            for: emphasisLayer.layer,
+            in: textView
+        )
+    }
+
+    private func toolTipRects(for range: NSRange) -> [CGRect] {
+        guard let textView,
+              range.resolved(inDocumentOfLength: textView.textStorage.length) == range else {
+            return []
+        }
+        return textView.layoutManager.rectsFor(range: range)
+    }
+
     // MARK: - Drawing Layers
 
     /// Updates the positions and bounds of all emphasis layers to match the current text layout.
@@ -156,21 +198,14 @@ public final class EmphasisManager {
                 // shape come back when the range lays out again.
                 emphasis.layer.isHidden = true
                 emphasis.textLayer?.isHidden = true
+                toolTips.unregister(emphasis.layer, in: textView)
                 continue
             }
             emphasis.layer.isHidden = false
             emphasis.textLayer?.isHidden = false
-            if #available(macOS 14.0, *) {
-                emphasis.layer.path = shapePath.cgPath
-            } else {
-                emphasis.layer.path = shapePath.cgPathFallback
-            }
-
-            // Update bounds and position
-            if let cgPath = emphasis.layer.path {
-                let boundingBox = cgPath.boundingBox
-                emphasis.layer.bounds = boundingBox
-                emphasis.layer.position = CGPoint(x: boundingBox.midX, y: boundingBox.midY)
+            draw(shapePath, on: emphasis.layer)
+            if !emphasis.isAttached {
+                attach(emphasis)
             }
 
             // Update text layer if it exists
@@ -178,27 +213,44 @@ public final class EmphasisManager {
                 bounds.origin.y += 1 // Move down by 1 pixel
                 textLayer.frame = bounds
             }
+            registerToolTip(for: emphasis)
         }
     }
 
     private func createEmphasisLayer(for emphasis: Emphasis) -> EmphasisLayer {
+        let emphasisLayer = EmphasisLayer(emphasis: emphasis, layer: createShapeLayer(for: emphasis))
         guard let shapePath = makeShapePath(forStyle: emphasis.style, range: emphasis.range) else {
-            return EmphasisLayer(emphasis: emphasis, layer: CAShapeLayer(), textLayer: nil)
+            return emphasisLayer
         }
 
-        let layer = createShapeLayer(shapePath: shapePath, emphasis: emphasis)
-        textView?.layer?.insertSublayer(layer, at: 1)
-
-        let textLayer = createTextLayer(for: emphasis)
-        if let textLayer = textLayer {
-            textView?.layer?.addSublayer(textLayer)
-        }
+        draw(shapePath, on: emphasisLayer.layer)
+        attach(emphasisLayer)
 
         if emphasis.inactive == false && emphasis.style == .standard {
-            applyPopAnimation(to: layer)
+            applyPopAnimation(to: emphasisLayer.layer)
         }
 
-        return EmphasisLayer(emphasis: emphasis, layer: layer, textLayer: textLayer)
+        return emphasisLayer
+    }
+
+    private func attach(_ emphasisLayer: EmphasisLayer) {
+        guard let hostLayer = textView?.layer else { return }
+        emphasisLayer.attach(to: hostLayer, textLayer: createTextLayer(for: emphasisLayer.emphasis))
+    }
+
+    private func draw(_ shapePath: NSBezierPath, on layer: CAShapeLayer) {
+        if #available(macOS 14.0, *) {
+            layer.path = shapePath.cgPath
+        } else {
+            layer.path = shapePath.cgPathFallback
+        }
+
+        // Set bounds of the layer; needed for the scale animation
+        if let cgPath = layer.path {
+            let boundingBox = cgPath.boundingBox
+            layer.bounds = boundingBox
+            layer.position = CGPoint(x: boundingBox.midX, y: boundingBox.midY)
+        }
     }
 
     private func makeShapePath(forStyle emphasisStyle: EmphasisStyle, range: NSRange) -> NSBezierPath? {
@@ -229,7 +281,7 @@ public final class EmphasisManager {
         }
     }
 
-    private func createShapeLayer(shapePath: NSBezierPath, emphasis: Emphasis) -> CAShapeLayer {
+    private func createShapeLayer(for emphasis: Emphasis) -> CAShapeLayer {
         let layer = CAShapeLayer()
 
         switch emphasis.style {
@@ -256,19 +308,6 @@ public final class EmphasisManager {
             layer.fillColor = shouldFill ? color.safeCGColor : nil
             layer.opacity = emphasis.flash ? 0.0 : 1.0
             layer.zPosition = 1
-        }
-
-        if #available(macOS 14.0, *) {
-            layer.path = shapePath.cgPath
-        } else {
-            layer.path = shapePath.cgPathFallback
-        }
-
-        // Set bounds of the layer; needed for the scale animation
-        if let cgPath = layer.path {
-            let boundingBox = cgPath.boundingBox
-            layer.bounds = boundingBox
-            layer.position = CGPoint(x: boundingBox.midX, y: boundingBox.midY)
         }
 
         return layer

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/EmphasisManager/EmphasisToolTips.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/EmphasisManager/EmphasisToolTips.swift
@@ -1,0 +1,44 @@
+//
+//  EmphasisToolTips.swift
+//  CodeEditTextView
+//
+
+import AppKit
+
+final class EmphasisToolTips: NSObject, NSViewToolTipOwner {
+    private struct Registration {
+        let text: String
+        let rects: [CGRect]
+        let tags: [NSView.ToolTipTag]
+    }
+
+    private var registrations: [ObjectIdentifier: Registration] = [:]
+
+    func register(_ text: String?, rects: [CGRect], for layer: CALayer, in view: NSView?) {
+        let key = ObjectIdentifier(layer)
+        if let existing = registrations[key], existing.text == text, existing.rects == rects {
+            return
+        }
+        unregister(layer, in: view)
+        guard let view, let text, !text.isEmpty, !rects.isEmpty else { return }
+
+        let tags = rects.map { view.addToolTip($0, owner: self, userData: nil) }
+        registrations[key] = Registration(text: text, rects: rects, tags: tags)
+    }
+
+    func unregister(_ layer: CALayer, in view: NSView?) {
+        guard let registration = registrations.removeValue(forKey: ObjectIdentifier(layer)) else { return }
+        registration.tags.forEach { view?.removeToolTip($0) }
+    }
+
+    func view(
+        _ view: NSView,
+        stringForToolTip tag: NSView.ToolTipTag,
+        point: NSPoint,
+        userData data: UnsafeMutableRawPointer?
+    ) -> String {
+        registrations.values.first { registration in
+            registration.rects.contains { $0.contains(point) }
+        }?.text ?? ""
+    }
+}

--- a/LocalPackages/CodeEditTextView/Tests/CodeEditTextViewTests/EmphasisManagerTests.swift
+++ b/LocalPackages/CodeEditTextView/Tests/CodeEditTextViewTests/EmphasisManagerTests.swift
@@ -1,6 +1,7 @@
-import Testing
-import Foundation
+import AppKit
 @testable import CodeEditTextView
+import Foundation
+import Testing
 
 @Suite()
 struct EmphasisManagerTests {
@@ -118,11 +119,127 @@ struct EmphasisManagerTests {
         #expect(textView.layer?.sublayers?.contains(where: \.isHidden) == false)
     }
 
+    @Test()
+    @MainActor
+    func anEmphasisToolTipCoversItsText() throws {
+        let textView = makeLaidOutTextView()
+        let manager = try #require(textView.emphasisManager)
+
+        manager.addEmphasis(
+            Emphasis(range: NSRange(location: 6, length: 5), style: .underline(color: .red), toolTip: "Ipsum"),
+            for: "e"
+        )
+
+        #expect(manager.toolTip(at: try center(of: NSRange(location: 6, length: 5), in: textView)) == "Ipsum")
+        #expect(manager.toolTip(at: try center(of: NSRange(location: 0, length: 5), in: textView)) == nil)
+    }
+
+    @Test()
+    @MainActor
+    func anEmphasisWithoutAToolTipRegistersNone() throws {
+        let textView = makeLaidOutTextView()
+        let manager = try #require(textView.emphasisManager)
+
+        manager.addEmphasis(Emphasis(range: NSRange(location: 0, length: 5), style: .underline(color: .red)), for: "e")
+
+        #expect(manager.toolTip(at: try center(of: NSRange(location: 0, length: 5), in: textView)) == nil)
+    }
+
+    @Test()
+    @MainActor
+    func removingAGroupRemovesItsToolTips() throws {
+        let textView = makeLaidOutTextView()
+        let manager = try #require(textView.emphasisManager)
+        let point = try center(of: NSRange(location: 0, length: 5), in: textView)
+
+        manager.addEmphasis(Emphasis(range: NSRange(location: 0, length: 5), toolTip: "Lorem"), for: "e")
+        manager.removeEmphases(for: "e")
+
+        #expect(manager.toolTip(at: point) == nil)
+    }
+
+    @Test()
+    @MainActor
+    func anEmphasisWhoseTextIsGoneLosesItsToolTip() throws {
+        let textView = makeLaidOutTextView()
+        let manager = try #require(textView.emphasisManager)
+        let point = try center(of: NSRange(location: 6, length: 5), in: textView)
+        manager.addEmphasis(Emphasis(range: NSRange(location: 6, length: 5), toolTip: "Ipsum"), for: "e")
+
+        textView.textStorage.replaceCharacters(in: NSRange(location: 5, length: 6), with: "")
+        textView.layoutManager.layoutLines(in: CGRect(origin: .zero, size: CGSize(width: 1_000, height: 100)))
+        manager.updateLayerBackgrounds()
+
+        #expect(manager.toolTip(at: point) == nil)
+    }
+
+    @Test()
+    @MainActor
+    func aToolTipFollowsItsTextWhenTheLayoutMoves() throws {
+        let textView = TextView(string: "Lorem\nIpsum")
+        textView.frame = NSRect(x: 0, y: 0, width: 1_000, height: 200)
+        textView.layoutManager.layoutLines(in: CGRect(origin: .zero, size: CGSize(width: 1_000, height: 200)))
+        let manager = try #require(textView.emphasisManager)
+        let range = NSRange(location: 6, length: 5)
+        manager.addEmphasis(Emphasis(range: range, style: .underline(color: .red), toolTip: "Ipsum"), for: "e")
+        let before = try center(of: range, in: textView)
+
+        textView.layoutManager.lineHeightMultiplier = 3
+        textView.layoutManager.layoutLines(in: CGRect(origin: .zero, size: CGSize(width: 1_000, height: 200)))
+        manager.updateLayerBackgrounds()
+        let after = try center(of: range, in: textView)
+
+        #expect(after.y > before.y)
+        #expect(manager.toolTip(at: after) == "Ipsum")
+    }
+
+    @Test()
+    @MainActor
+    func anUnderlineOnALineNotYetLaidOutIsDrawnOnceItIs() throws {
+        let textView = TextView(string: "")
+        textView.frame = NSRect(x: 0, y: 0, width: 1_000, height: 10_000)
+        textView.setText((1...200).map { "line \($0)" }.joined(separator: "\n"))
+        textView.layoutManager.layoutLines(in: CGRect(origin: .zero, size: CGSize(width: 1_000, height: 100)))
+        let manager = try #require(textView.emphasisManager)
+        let range = (textView.string as NSString).range(of: "line 150")
+        let sublayersBefore = textView.layer?.sublayers?.count ?? 0
+        #expect(textView.layoutManager.rectsFor(range: range).isEmpty)
+
+        manager.addEmphasis(Emphasis(range: range, style: .underline(color: .red), toolTip: "Line"), for: "e")
+        #expect((textView.layer?.sublayers?.count ?? 0) == sublayersBefore)
+
+        textView.layoutManager.layoutLines(in: CGRect(origin: .zero, size: CGSize(width: 1_000, height: 10_000)))
+        manager.updateLayerBackgrounds()
+
+        let underline = try #require(textView.layer?.sublayers?.compactMap { $0 as? CAShapeLayer }.first)
+        #expect(textView.layer?.sublayers?.count == sublayersBefore + 2)
+        #expect(underline.path != nil)
+        #expect(underline.lineWidth == 1)
+        #expect(underline.strokeColor != nil)
+        #expect(underline.isHidden == false)
+        #expect(manager.toolTip(at: try center(of: range, in: textView)) == "Line")
+    }
+
+    @MainActor
+    private func center(of range: NSRange, in textView: TextView) throws -> CGPoint {
+        let rect = try #require(textView.layoutManager.rectsFor(range: range).first)
+        return CGPoint(x: rect.midX, y: rect.midY)
+    }
+
     @MainActor
     private func makeLaidOutTextView() -> TextView {
         let textView = TextView(string: "Lorem Ipsum")
         textView.frame = NSRect(x: 0, y: 0, width: 1_000, height: 100)
         textView.layoutManager.layoutLines(in: CGRect(origin: .zero, size: CGSize(width: 1_000, height: 100)))
         return textView
+    }
+}
+
+private extension EmphasisManager {
+    @MainActor
+    func toolTip(at point: CGPoint) -> String? {
+        guard let textView else { return nil }
+        let text = toolTips.view(textView, stringForToolTip: 0, point: point, userData: nil)
+        return text.isEmpty ? nil : text
     }
 }

--- a/TablePro/Resources/Localizable.xcstrings
+++ b/TablePro/Resources/Localizable.xcstrings
@@ -933,6 +933,41 @@
         }
       }
     },
+    "Query Issues" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "쿼리 문제"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sorgu Sorunları"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sự cố truy vấn"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查询问题"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "查詢問題"
+          }
+        }
+      }
+    },
     "Remove Invisible Characters" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/TablePro/Views/Editor/QueryDiagnosticsController.swift
+++ b/TablePro/Views/Editor/QueryDiagnosticsController.swift
@@ -18,8 +18,11 @@ final class QueryDiagnosticsController {
     private var producer: QueryDiagnosticsProducing
     private var pendingTask: Task<Void, Never>?
     private(set) var diagnostics: [QueryDiagnostic] = []
+    private lazy var rotorSearch = QueryDiagnosticsRotorSearch { [weak self] in
+        self?.diagnostics ?? []
+    }
 
-    private let debounceNanoseconds: UInt64 = 500_000_000
+    private static let debounce: Duration = .milliseconds(500)
 
     nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "QueryDiagnostics")
 
@@ -32,6 +35,18 @@ final class QueryDiagnosticsController {
         diagnostics = []
     }
 
+    func install(on controller: TextViewController) {
+        guard let textView = controller.textView else { return }
+        rotorSearch.textView = textView
+        let rotors = textView.accessibilityCustomRotors()
+        guard !rotors.contains(where: { $0.itemSearchDelegate === rotorSearch }) else { return }
+        let rotor = NSAccessibilityCustomRotor(
+            label: QueryDiagnosticsRotorSearch.label,
+            itemSearchDelegate: rotorSearch
+        )
+        textView.setAccessibilityCustomRotors(rotors + [rotor])
+    }
+
     func scheduleRefresh(for controller: TextViewController?) {
         pendingTask?.cancel()
 
@@ -41,13 +56,12 @@ final class QueryDiagnosticsController {
         }
 
         pendingTask = Task { [weak self, weak controller] in
-            guard let self else { return }
             do {
-                try await Task.sleep(nanoseconds: self.debounceNanoseconds)
+                try await Task.sleep(for: Self.debounce)
             } catch {
                 return
             }
-            guard !Task.isCancelled, let controller else { return }
+            guard !Task.isCancelled, let self, let controller else { return }
             self.refresh(for: controller)
         }
     }
@@ -65,11 +79,9 @@ final class QueryDiagnosticsController {
         pendingTask?.cancel()
         pendingTask = nil
         diagnostics = []
-        controller?.textView.emphasisManager?.removeEmphases(for: Self.emphasisGroup)
-    }
-
-    func diagnostic(at offset: Int) -> QueryDiagnostic? {
-        diagnostics.first { NSLocationInRange(offset, $0.range) }
+        guard let manager = controller?.textView.emphasisManager,
+              !manager.getEmphases(for: Self.emphasisGroup).isEmpty else { return }
+        manager.removeEmphases(for: Self.emphasisGroup)
     }
 
     private func apply(_ produced: [QueryDiagnostic], in controller: TextViewController) {
@@ -79,7 +91,11 @@ final class QueryDiagnosticsController {
         let emphases = produced.compactMap { diagnostic -> Emphasis? in
             guard diagnostic.range.location >= 0,
                   NSMaxRange(diagnostic.range) <= length else { return nil }
-            return Emphasis(range: diagnostic.range, style: .underline(color: color(for: diagnostic.severity)))
+            return Emphasis(
+                range: diagnostic.range,
+                style: .underline(color: color(for: diagnostic.severity)),
+                toolTip: diagnostic.message
+            )
         }
 
         manager.replaceEmphases(emphases, for: Self.emphasisGroup)

--- a/TablePro/Views/Editor/QueryDiagnosticsRotorSearch.swift
+++ b/TablePro/Views/Editor/QueryDiagnosticsRotorSearch.swift
@@ -1,0 +1,44 @@
+//
+//  QueryDiagnosticsRotorSearch.swift
+//  TablePro
+//
+
+import AppKit
+
+@MainActor
+final class QueryDiagnosticsRotorSearch: NSObject, @MainActor NSAccessibilityCustomRotorItemSearchDelegate {
+    static var label: String {
+        String(localized: "Query Issues")
+    }
+
+    weak var textView: NSView?
+    private let diagnostics: () -> [QueryDiagnostic]
+
+    init(diagnostics: @escaping () -> [QueryDiagnostic]) {
+        self.diagnostics = diagnostics
+    }
+
+    func rotor(
+        _ rotor: NSAccessibilityCustomRotor,
+        resultFor searchParameters: NSAccessibilityCustomRotor.SearchParameters
+    ) -> NSAccessibilityCustomRotor.ItemResult? {
+        guard let textView else { return nil }
+        let candidates = matching(searchParameters.filterString)
+        let start = searchParameters.currentItem?.targetRange.location ?? NSNotFound
+        let found = searchParameters.searchDirection == .previous
+            ? candidates.last { start == NSNotFound || $0.range.location < start }
+            : candidates.first { start == NSNotFound || $0.range.location > start }
+        guard let found else { return nil }
+
+        let result = NSAccessibilityCustomRotor.ItemResult(targetElement: textView)
+        result.targetRange = found.range
+        result.customLabel = found.message
+        return result
+    }
+
+    private func matching(_ filter: String) -> [QueryDiagnostic] {
+        let sorted = diagnostics().sorted { $0.range.location < $1.range.location }
+        guard !filter.isEmpty else { return sorted }
+        return sorted.filter { $0.message.localizedCaseInsensitiveContains(filter) }
+    }
+}

--- a/TablePro/Views/Editor/SQLEditorCoordinator.swift
+++ b/TablePro/Views/Editor/SQLEditorCoordinator.swift
@@ -95,8 +95,6 @@ final class SQLEditorCoordinator: TextViewCoordinator, TextViewDelegate {
             foldRestorePending = ranges
             return
         }
-        statementRunController.refreshControls(in: controller)
-        statementRunController.refreshHighlight(in: controller)
         guard let ranges, !ranges.isEmpty else { return }
         controller.restoreCollapsedFolds(ranges)
     }
@@ -176,6 +174,7 @@ final class SQLEditorCoordinator: TextViewCoordinator, TextViewDelegate {
         installStatementRunControls(controller: controller)
         installInlineSuggestionManager(controller: controller)
         diagnosticsController.configure(databaseType: databaseType)
+        diagnosticsController.install(on: controller)
         diagnosticsController.scheduleRefresh(for: controller)
         installVimModeIfEnabled(controller: controller)
         installEditorSettingsObserver(controller: controller)
@@ -236,10 +235,26 @@ final class SQLEditorCoordinator: TextViewCoordinator, TextViewDelegate {
 
         uppercaseKeywordIfNeeded(textView: textView, range: range, string: string)
         statementRunController.scheduleControlsRefresh(in: controller)
+        refreshDiagnostics(in: controller, isLargeDocument: isLargeDocument)
+    }
 
-        if !isLargeDocument {
-            diagnosticsController.scheduleRefresh(for: controller)
+    func textViewDidReplaceDocument(controller: TextViewController) {
+        vimEngine?.invalidateLineCache()
+        foldPreview.dismiss()
+        inlineSuggestionManager?.dismissSuggestion()
+        statementRunController.refreshControls(in: controller)
+        statementRunController.refreshHighlight(in: controller)
+        diagnosticsController.clear(in: controller)
+        guard controller.textView.textStorage.length <= Self.languageServiceLengthLimit else { return }
+        diagnosticsController.scheduleRefresh(for: controller)
+    }
+
+    private func refreshDiagnostics(in controller: TextViewController?, isLargeDocument: Bool) {
+        guard !isLargeDocument else {
+            diagnosticsController.clear(in: controller)
+            return
         }
+        diagnosticsController.scheduleRefresh(for: controller)
     }
 
     func textViewDidChangeSelection(controller: TextViewController, newPositions: [CursorPosition]) {
@@ -289,6 +304,7 @@ final class SQLEditorCoordinator: TextViewCoordinator, TextViewDelegate {
         onRunStatement = nil
         statementRunController.onRun = nil
         statementRunController.clear(in: controller)
+        diagnosticsController.clear(in: controller)
         onAIExplain = nil
         onAIOptimize = nil
         onSaveAsFavorite = nil

--- a/TableProTests/Views/Editor/QueryDiagnosticsRefreshTests.swift
+++ b/TableProTests/Views/Editor/QueryDiagnosticsRefreshTests.swift
@@ -1,0 +1,269 @@
+//
+//  QueryDiagnosticsRefreshTests.swift
+//  TableProTests
+//
+
+import AppKit
+@testable import CodeEditSourceEditor
+@testable import CodeEditTextView
+import Foundation
+import SwiftUI
+@testable import TablePro
+import Testing
+
+@MainActor
+private final class DocumentReplacementRecorder: TextViewCoordinator {
+    private(set) var replacedDocuments: [String] = []
+
+    func prepareCoordinator(controller: TextViewController) {}
+
+    func textViewDidReplaceDocument(controller: TextViewController) {
+        replacedDocuments.append(controller.textView.string)
+    }
+}
+
+@MainActor
+@Suite("Query diagnostics refresh")
+struct QueryDiagnosticsRefreshTests {
+    private func makeEditor(_ text: String = "") -> (SQLEditorCoordinator, TextViewController) {
+        let coordinator = SQLEditorCoordinator()
+        coordinator.databaseType = .mysql
+        let controller = EditorControllerFixture.make(string: text, coordinators: [coordinator])
+        return (coordinator, controller)
+    }
+
+    private func underlines(in controller: TextViewController) -> [NSRange] {
+        controller.textView.emphasisManager?
+            .getEmphases(for: QueryDiagnosticsController.emphasisGroup)
+            .map(\.range) ?? []
+    }
+
+    private func waitForUnderlines(
+        in controller: TextViewController,
+        timeout: Duration = .seconds(5)
+    ) async -> [NSRange] {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while ContinuousClock.now < deadline {
+            let ranges = underlines(in: controller)
+            if !ranges.isEmpty { return ranges }
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+        return underlines(in: controller)
+    }
+
+    @Test("Replacing the document tells every coordinator, and an edit does not")
+    func setTextNotifiesCoordinators() {
+        let recorder = DocumentReplacementRecorder()
+        let controller = EditorControllerFixture.make(string: "SELECT 1", coordinators: [recorder])
+
+        controller.textView.replaceCharacters(in: NSRange(location: 8, length: 0), with: ";")
+        #expect(recorder.replacedDocuments.isEmpty)
+
+        controller.setText("SELECT 2")
+        #expect(recorder.replacedDocuments == ["SELECT 2"])
+    }
+
+    @Test("A replaced document is checked without a keystroke")
+    func replacedDocumentIsChecked() async {
+        let (coordinator, controller) = makeEditor("SELECT 1")
+        defer { coordinator.destroy() }
+
+        controller.setText("SELECT 2))")
+
+        #expect(await waitForUnderlines(in: controller) == [NSRange(location: 8, length: 1)])
+    }
+
+    @Test("The previous document's underline goes the moment the document is replaced")
+    func staleUnderlineIsDropped() async throws {
+        let (coordinator, controller) = makeEditor("SELECT 1")
+        defer { coordinator.destroy() }
+        controller.textView.replaceCharacters(in: NSRange(location: 8, length: 0), with: ")")
+        #expect(await waitForUnderlines(in: controller) == [NSRange(location: 8, length: 1)])
+
+        controller.setText("SELECT name FROM t")
+
+        #expect(underlines(in: controller).isEmpty)
+        try await Task.sleep(for: .milliseconds(800))
+        #expect(underlines(in: controller).isEmpty)
+    }
+
+    @Test("A tab switch pushed through the text binding re-checks the incoming tab")
+    func tabSwitchThroughBinding() async {
+        let (coordinator, controller) = makeEditor()
+        defer { coordinator.destroy() }
+        let sync = TextBindingSync(text: .binding(.constant("")), phase: RepresentableSyncPhase())
+        sync.applyRepresentableText("SELECT 1)", controller: controller)
+        #expect(await waitForUnderlines(in: controller) == [NSRange(location: 8, length: 1)])
+
+        sync.applyRepresentableText("SELECT name FROM t /* open", controller: controller)
+
+        #expect(underlines(in: controller).isEmpty)
+        #expect(await waitForUnderlines(in: controller) == [NSRange(location: 19, length: 2)])
+    }
+
+    @Test("An underline below the lines on screen is drawn once its line lays out")
+    func underlineBelowTheViewportIsDrawn() async throws {
+        let (coordinator, controller) = makeEditor("SELECT 1")
+        defer { coordinator.destroy() }
+        let statements = (1...200).map { "SELECT \($0);" } + ["SELECT 201)"]
+        controller.setText(statements.joined(separator: "\n"))
+        let range = try #require(await waitForUnderlines(in: controller).first)
+
+        let textView = try #require(controller.textView)
+        textView.layoutManager.layoutLines(in: CGRect(origin: .zero, size: CGSize(width: 1_000, height: 20_000)))
+        textView.emphasisManager?.updateLayerBackgrounds()
+
+        let line = try #require(textView.layoutManager.rectsFor(range: range).first)
+        let underlines = (textView.layer?.sublayers ?? []).compactMap { $0 as? CAShapeLayer }.filter { layer in
+            guard !layer.isHidden, let bounds = layer.path?.boundingBox else { return false }
+            return abs(bounds.minX - line.minX) < 1 && bounds.midY >= line.minY && bounds.midY <= line.maxY
+        }
+        #expect(underlines.count == 1)
+    }
+
+    @Test("The statement run controls follow a replaced document")
+    func runControlsFollowReplacedDocument() {
+        let (coordinator, controller) = makeEditor("SELECT 1;")
+        defer { coordinator.destroy() }
+
+        controller.setText("SELECT 1;\nSELECT 2;\nSELECT 3;")
+
+        #expect(controller.runnableStatements.count == 3)
+    }
+}
+
+@MainActor
+@Suite("Query diagnostic messages")
+struct QueryDiagnosticMessageTests {
+    private func makeChecked(_ text: String) -> (QueryDiagnosticsController, TextViewController) {
+        let controller = EditorControllerFixture.make(string: text)
+        let diagnostics = QueryDiagnosticsController(databaseType: .mysql)
+        diagnostics.install(on: controller)
+        diagnostics.refresh(for: controller)
+        controller.textView.emphasisManager?.updateLayerBackgrounds()
+        return (diagnostics, controller)
+    }
+
+    private func center(of range: NSRange, in controller: TextViewController) throws -> CGPoint {
+        let rect = try #require(controller.textView.layoutManager.rectsFor(range: range).first)
+        return CGPoint(x: rect.midX, y: rect.midY)
+    }
+
+    private func rotor(in controller: TextViewController) throws -> NSAccessibilityCustomRotor {
+        try #require(
+            controller.textView.accessibilityCustomRotors().first { $0.label == QueryDiagnosticsRotorSearch.label }
+        )
+    }
+
+    private func search(
+        _ rotor: NSAccessibilityCustomRotor,
+        in element: NSView,
+        from current: NSRange?,
+        direction: NSAccessibilityCustomRotor.SearchDirection = .next,
+        filter: String = ""
+    ) -> NSAccessibilityCustomRotor.ItemResult? {
+        let parameters = NSAccessibilityCustomRotor.SearchParameters()
+        parameters.searchDirection = direction
+        parameters.filterString = filter
+        if let current {
+            let item = NSAccessibilityCustomRotor.ItemResult(targetElement: element)
+            item.targetRange = current
+            parameters.currentItem = item
+        }
+        return rotor.itemSearchDelegate?.rotor(rotor, resultFor: parameters)
+    }
+
+    @Test("Resting the pointer on an underline shows its message")
+    func toolTipOverUnderline() throws {
+        let (_, controller) = makeChecked("SELECT 1)")
+        let manager = try #require(controller.textView.emphasisManager)
+
+        let underlined = try center(of: NSRange(location: 8, length: 1), in: controller)
+        let plain = try center(of: NSRange(location: 0, length: 6), in: controller)
+
+        #expect(manager.toolTip(at: underlined) == "No matching opening bracket")
+        #expect(manager.toolTip(at: plain) == nil)
+    }
+
+    @Test("A cleared diagnostic takes its message with it")
+    func clearedDiagnosticDropsToolTip() throws {
+        let (diagnostics, controller) = makeChecked("SELECT 1)")
+        let manager = try #require(controller.textView.emphasisManager)
+        let underlined = try center(of: NSRange(location: 8, length: 1), in: controller)
+
+        diagnostics.clear(in: controller)
+
+        #expect(manager.toolTip(at: underlined) == nil)
+    }
+
+    @Test("Clearing with nothing underlined leaves the editor's layout alone")
+    func clearWithoutUnderlinesDoesNotForceLayout() throws {
+        let controller = EditorControllerFixture.make(string: "SELECT 1")
+        let diagnostics = QueryDiagnosticsController(databaseType: .mysql)
+        let layer = try #require(controller.textView.layer)
+        layer.setNeedsLayout()
+
+        diagnostics.clear(in: controller)
+
+        #expect(layer.needsLayout())
+    }
+
+    @Test("The rotor walks every problem in document order with its message")
+    func rotorWalksProblems() throws {
+        let (diagnostics, controller) = makeChecked("SELECT 1) /* open")
+        let rotor = try rotor(in: controller)
+        #expect(diagnostics.diagnostics.count == 2)
+
+        let first = try #require(search(rotor, in: controller.textView, from: nil))
+        #expect(first.targetRange == NSRange(location: 8, length: 1))
+        #expect(first.customLabel == "No matching opening bracket")
+        #expect(first.targetElement === controller.textView)
+
+        let second = try #require(search(rotor, in: controller.textView, from: first.targetRange))
+        #expect(second.targetRange == NSRange(location: 10, length: 2))
+        #expect(second.customLabel == "Unterminated comment")
+
+        #expect(search(rotor, in: controller.textView, from: second.targetRange) == nil)
+        let previous = search(rotor, in: controller.textView, from: second.targetRange, direction: .previous)
+        #expect(previous?.targetRange == first.targetRange)
+    }
+
+    @Test("The rotor filters by message")
+    func rotorFiltersByMessage() throws {
+        let (diagnostics, controller) = makeChecked("SELECT 1) /* open")
+        let rotor = try rotor(in: controller)
+        #expect(diagnostics.diagnostics.count == 2)
+
+        let found = try #require(search(rotor, in: controller.textView, from: nil, filter: "comment"))
+
+        #expect(found.targetRange == NSRange(location: 10, length: 2))
+    }
+
+    @Test("A document with no problems gives the rotor nothing to find")
+    func rotorEmptyWithoutProblems() throws {
+        let (diagnostics, controller) = makeChecked("SELECT 1")
+        let rotor = try rotor(in: controller)
+
+        #expect(diagnostics.diagnostics.isEmpty)
+        #expect(search(rotor, in: controller.textView, from: nil) == nil)
+    }
+
+    @Test("Installing twice leaves one rotor")
+    func rotorInstalledOnce() {
+        let (diagnostics, controller) = makeChecked("SELECT 1")
+
+        diagnostics.install(on: controller)
+
+        let rotors = controller.textView.accessibilityCustomRotors()
+        #expect(rotors.filter { $0.label == QueryDiagnosticsRotorSearch.label }.count == 1)
+    }
+}
+
+private extension EmphasisManager {
+    @MainActor
+    func toolTip(at point: CGPoint) -> String? {
+        guard let textView else { return nil }
+        let text = toolTips.view(textView, stringForToolTip: 0, point: point, userData: nil)
+        return text.isEmpty ? nil : text
+    }
+}

--- a/docs/features/sql-editor.mdx
+++ b/docs/features/sql-editor.mdx
@@ -99,6 +99,8 @@ A structural mistake is underlined in red 500ms after you stop typing, and the u
 
 A half-written statement is never flagged. An opener you have not closed yet, a string you are still typing, and brackets inside a string or a comment are all left alone. Documents over 100,000 characters are not checked at all.
 
+Switching tabs or loading a query checks the new text the same way, without a keystroke. Rest the pointer on an underline to read its message. In VoiceOver, the rotor lists every underline under **Query Issues**, each read with its message.
+
 On MongoDB connections the query parser runs as well, so an unknown collection method or a query that does not start with `db.` is underlined with the reason. Where the parser names the method, the method name itself is what gets marked.
 
 ## Per-tab database picker


### PR DESCRIPTION
Found while investigating #2717 (PR #2724).

The SQL editor underlines structural mistakes (an unclosed bracket, a stray quote) 500ms after typing stops. Three things were wrong with those underlines:

- Switching query tabs left the previous tab's underlines in place, now sitting under unrelated text at the old offsets. The incoming text, or any query pushed into the editor through its text binding, was not checked at all until the first keystroke.
- An underline on a line below the visible area was never drawn, even after scrolling to it.
- An underline had no message anywhere. `QueryDiagnostic.message` was produced for every problem and never shown, and `QueryDiagnosticsController.diagnostic(at:)` had no caller.

## Root cause

**Refresh.** Diagnostics were scheduled only from `textView(_:didReplaceContentsIn:with:)`, which fires on edits. A tab switch or a loaded query replaces the whole document through `TextViewController.setText` (the app's only route, via `TextBindingSync`), and that method rebuilt the text storage, folds and highlighter without telling any `TextViewCoordinator`. So nothing re-ran the check and nothing removed the old emphasis layers, which live on the text view's layer and survive a storage swap. The statement run controls had the same gap and were only kept current because `repointFolds(to:)` happened to refresh them as a side effect.

**Drawing.** `EmphasisManager.createEmphasisLayer` built the shape layer only when the range already had line fragments. For a range on a line not yet laid out it returned a bare `CAShapeLayer()` that was never inserted into the view and had no stroke colour or line width. `updateLayerBackgrounds()` later gave that layer a path but never attached it, so the underline stayed invisible for good.

**Messages.** Nothing carried the message from the diagnostic to the view.

## What changed

- `TextViewCoordinator` gains `textViewDidReplaceDocument(controller:)` with an empty default, and `TextViewController.setText` calls it on every coordinator after the new document is in place. This is the vendored CodeEditSourceEditor, not PluginKit, so no ABI concern.
- `SQLEditorCoordinator.textViewDidReplaceDocument` drops the old underlines at once, schedules a check of the new text (skipped past the same 100,000 character limit edits use), refreshes the run controls and current-statement highlight, and resets the Vim line cache, fold preview and inline suggestion. The run-control refresh moved here out of `repointFolds(to:)`. A large document now also clears its underlines on edit instead of keeping stale ones, and teardown clears them too.
- `EmphasisManager`: the per-emphasis record is a class, so a layer that could not be drawn yet is created with its real style and attached on the first `updateLayerBackgrounds()` that finds its line fragments.
- `Emphasis` gains an optional `toolTip`. `EmphasisManager` registers native `NSView.addToolTip(_:owner:userData:)` rects for it through a new `EmphasisToolTips` owner, moves them when layout moves the text, and removes them when the emphasis is removed, flashed away, or its text is gone. Query diagnostics pass their message, so resting the pointer on an underline shows it.
- `QueryDiagnosticsRotorSearch` adds an `NSAccessibilityCustomRotor` named "Query Issues" to the editor's text view. VoiceOver walks the problems in document order, reads each message, and can filter by message text. `install(on:)` is idempotent.
- `QueryDiagnosticsController.clear(in:)` returns early when nothing is underlined, because `removeEmphases(for:)` forces a layer layout and clear now runs on every document replacement.
- New string "Query Issues" in the catalog with ko, tr, vi, zh-Hans and zh-Hant. `docs/features/sql-editor.mdx` describes the tab-switch check, the tooltip and the rotor. One CHANGELOG line under Fixed.

## Verification

- `verify.sh build`: succeeded (`.analysis/fix-query-diagnostics-refresh/logs/build-TablePro-154839.log`).
- `verify.sh test` over 13 suites (`QueryDiagnosticsRefreshTests`, `QueryDiagnosticMessageTests`, `SQLEditorCoordinatorTests`, `SQLEditorCoordinatorCleanupTests`, `SQLEditorCoordinatorEscapeMenuTests`, `EditorLifecycleTeardownTests`, `RemoveInvisibleCharactersCommandTests`, `StatementRunControllerTests`, `StatementNavigationCommandTests`, `GutterHighlightTests`, `StatementRunPerformanceGuardTests`, `QueryCompletionAdapterLifecycleTests`, `StringCatalogIntegrityTests`): 99 cases executed, 99 passed (`.analysis/fix-query-diagnostics-refresh/logs/test-QueryDiagnosticsRefreshTests-154956.log`).
- The two new suites on the final source: 13 cases (6 in `QueryDiagnosticsRefreshTests`, 7 in `QueryDiagnosticMessageTests`), all passed (`.analysis/fix-query-diagnostics-refresh/logs/test-QueryDiagnosticsRefreshTests-155454.log`).
- Fails without the fix: with the `setText` notification removed, all 5 refresh cases that existed then failed (`test-QueryDiagnosticsRefreshTests-145858.log`, `-145954.log`). With the lazy attach and the early-returning clear reverted, `underlineBelowTheViewportIsDrawn` and `clearWithoutUnderlinesDoesNotForceLayout` failed (`test-QueryDiagnosticsRefreshTests-155225.log`).
- `swift test --package-path LocalPackages/CodeEditTextView` (the CI gate), rerun on the committed HEAD: XCTest 52 tests, 0 failures; Swift Testing 263 tests in 25 suites, all passed. That includes 6 new `EmphasisManagerTests` cases: the tooltip covers its text and nothing else, no tooltip without text, removal drops it, a deleted range drops it, it follows a layout change, and an underline on a line not yet laid out is drawn with its stroke once the line lays out.
- `swiftlint lint --strict` on every changed Swift file: no violations on added lines. The 12 it reports in the vendored `LocalPackages` files are all on lines that predate this branch.
- `python3 scripts/localization.py verify` and the docs checks (`check-writing-style.sh`, `check-docs-against-source.py`) passed.
- UI tests: none added. A tooltip needs the pointer to rest over a point for the system hover delay, and the rotor needs VoiceOver, so neither runs deterministically under XCUITest. The unit tests drive the real `TextViewController.setText` and `TextBindingSync` paths and ask the tooltip owner and the rotor delegate directly.

## Notes

Codex review was unavailable (usage limit), so an adversarial reviewer agent read the diff before the commit. On a final read for this PR, these were left as they are:

- **Two problems at the same offset.** The rotor steps by start offset, so a second problem starting exactly where another starts is skipped by next and previous. This cannot happen today: the SQL producer emits at most an unmatched closer and an unterminated comment, which never start on the same character, and the MongoDB producer emits at most one diagnostic.
- **Overlapping underlines.** The tooltip owner answers with the first registration whose rect contains the point, so where two underlines overlap one message wins. The producers do not emit overlapping ranges, for the same reason.
- **`setTextStorage` path.** `TextView.setTextStorage` still does not notify coordinators. Nothing in the app replaces the storage that way; every document replacement goes through `TextViewController.setText`.
- **`EmphasisLayer` identity.** Changing it from a struct to a class makes `==` identity. The only comparison is the flash removal lookup, which already holds the same instance.

https://claude.ai/code/session_011THKc9TRHE8xjcxXidDHXP
