### PR TITLE
fix(editor): treat invisible characters around a statement as blank on the run path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Connecting silently switching a disabled plugin back on.
 - Plugin install error replaced by "not installed" when connecting.
 - Test Connection doing nothing after installing the plugin it asked for.
+- Safe Mode and run buttons misreading statements beside invisible characters, CRLF or MySQL conditional comments.
 - Connecting removing a plugin that failed to load, and its settings, when no replacement could be downloaded.
 - Disabled plugin's code loaded when a connection looked up its driver.
 - Failed connect from an opened file or URL titled "Disconnected", with Reconnect as its only fix.

--- a/TablePro/Core/Coordinators/QueryExecutionCoordinator.swift
+++ b/TablePro/Core/Coordinators/QueryExecutionCoordinator.swift
@@ -20,11 +20,8 @@ final class QueryExecutionCoordinator {
               !parent.tabExecution.isExecuting(tab.id),
               tab.tabType == .query else { return }
 
-        let fullQuery = tab.content.query
-        guard !fullQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
-
         let statements = QueryStatementScanner.executableStatements(
-            in: fullQuery, model: parent.statementModel, dialect: parent.sqlDialect
+            in: tab.content.query, model: parent.statementModel, dialect: parent.sqlDialect
         )
         guard !statements.isEmpty else { return }
 

--- a/TablePro/Core/Database/Access/DatabaseAccessBridge.swift
+++ b/TablePro/Core/Database/Access/DatabaseAccessBridge.swift
@@ -174,8 +174,11 @@ internal actor DatabaseAccessBridge {
         timeoutSeconds: Int,
         cancellation: (any StatementCancellationSignal)?
     ) async throws -> StatementOutcome {
-        let databaseType = try await ensureConnected(scope.connectionId)
         let normalizedQuery = Self.stripTrailingSemicolons(query)
+        guard !normalizedQuery.isEmpty else {
+            throw DatabaseAccessError.invalidArgument(String(localized: "The query is empty."))
+        }
+        let databaseType = try await ensureConnected(scope.connectionId)
         let classification = QueryClassifier.classify(normalizedQuery, databaseType: databaseType)
         let hasReturning = normalizedQuery.range(
             of: #"\bRETURNING\b"#,
@@ -236,10 +239,9 @@ internal actor DatabaseAccessBridge {
     }
 
     internal static func stripTrailingSemicolons(_ query: String) -> String {
-        var result = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        var result = StatementBlank.trimming(query)
         while result.hasSuffix(";") {
-            result = String(result.dropLast())
-                .trimmingCharacters(in: .whitespacesAndNewlines)
+            result = StatementBlank.trimming(String(result.dropLast()))
         }
         return result
     }

--- a/TablePro/Core/Utilities/JavaScript/JavaScriptStatementScanner.swift
+++ b/TablePro/Core/Utilities/JavaScript/JavaScriptStatementScanner.swift
@@ -32,9 +32,7 @@ enum JavaScriptStatementScanner {
         /// statement to the scanner and nothing at all to the engine, so counting it adds an empty
         /// result and a gutter control that runs nothing.
         var hasContent: Bool {
-            !JavaScriptStatementScanner.strippingComments(text)
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-                .isEmpty
+            StatementBlank.hasContent(JavaScriptStatementScanner.strippingComments(text))
         }
     }
 

--- a/TablePro/Core/Utilities/SQL/QueryClassifier.swift
+++ b/TablePro/Core/Utilities/SQL/QueryClassifier.swift
@@ -32,6 +32,13 @@ struct QueryClassification: Sendable, Equatable {
         )
     }
 
+    func escalated(with other: QueryClassification) -> QueryClassification {
+        QueryClassification(
+            tier: QueryClassification.worse(tier, other.tier),
+            reachesFilesystemOrExecutesCode: reachesFilesystemOrExecutesCode || other.reachesFilesystemOrExecutesCode
+        )
+    }
+
     static func worse(_ lhs: QueryTier, _ rhs: QueryTier) -> QueryTier {
         if lhs == .destructive || rhs == .destructive { return .destructive }
         if lhs == .write || rhs == .write { return .write }
@@ -41,7 +48,7 @@ struct QueryClassification: Sendable, Equatable {
 
 enum QueryClassifier {
     static func classify(_ sql: String, databaseType: DatabaseType) -> QueryClassification {
-        let trimmed = strippingLeadingComments(sql).trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmed = StatementBlank.trimming(strippingLeadingComments(sql))
         guard !trimmed.isEmpty else { return .safe }
         if let redis = redisClassification(trimmed, databaseType: databaseType) { return redis }
         if let document = documentStoreClassification(trimmed, databaseType: databaseType) { return document }
@@ -56,7 +63,7 @@ enum QueryClassifier {
         let classification = classify(sql, databaseType: databaseType)
         if classification.tier == .destructive { return true }
         guard databaseType != .redis else { return false }
-        let trimmed = strippingLeadingComments(sql).trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmed = StatementBlank.trimming(strippingLeadingComments(sql))
         guard leadingKeyword(of: trimmed) == "DELETE" else { return false }
         return !hasWhereClause(trimmed)
     }
@@ -88,7 +95,7 @@ enum QueryClassifier {
     }
 
     static func explainedStatement(in sql: String) -> String? {
-        let trimmed = strippingLeadingComments(sql).trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmed = StatementBlank.trimming(strippingLeadingComments(sql))
         let keyword = leadingKeyword(of: trimmed)
         guard explainPrefixes.contains(keyword) else { return nil }
         return explainInnerStatement(trimmed, keyword: keyword)?.statement
@@ -101,7 +108,7 @@ enum QueryClassifier {
     static func leadingKeyword(of sql: String) -> String {
         var remaining = strippingLeadingComments(sql)[...]
         while remaining.first == "(" {
-            remaining = remaining.dropFirst().drop { $0.isWhitespace }
+            remaining = StatementBlank.trimmingLeading(remaining.dropFirst())
             guard remaining.hasPrefix("--") || remaining.hasPrefix("/*") else { continue }
             remaining = strippingLeadingComments(String(remaining))[...]
         }
@@ -111,11 +118,11 @@ enum QueryClassifier {
     static func strippingLeadingComments(_ sql: String) -> String {
         var remaining = sql[...]
         while true {
-            let trimmed = remaining.drop { $0.isWhitespace }
+            let trimmed = StatementBlank.trimmingLeading(remaining)
             if trimmed.hasPrefix("--") {
-                guard let newline = trimmed.firstIndex(of: "\n") else { return "" }
-                remaining = trimmed[trimmed.index(after: newline)...]
-            } else if trimmed.hasPrefix("/*") {
+                guard let lineBreak = trimmed.firstIndex(where: endsLineComment) else { return "" }
+                remaining = trimmed[trimmed.index(after: lineBreak)...]
+            } else if trimmed.hasPrefix("/*"), !startsConditionalComment(trimmed) {
                 guard let close = trimmed.range(of: "*/") else { return "" }
                 remaining = trimmed[close.upperBound...]
             } else {
@@ -124,7 +131,7 @@ enum QueryClassifier {
         }
     }
 
-    static func strippingStringLiterals(_ sql: String) -> String {
+    static func strippingStringLiterals(_ sql: String, revealingConditionalComments: Bool = false) -> String {
         var output = ""
         output.reserveCapacity(sql.count)
         var characters = Array(sql)
@@ -141,10 +148,11 @@ enum QueryClassifier {
                 continue
             }
             if character == "-", index + 1 < characters.count, characters[index + 1] == "-" {
-                while index < characters.count, characters[index] != "\n" { index += 1 }
+                while index < characters.count, !endsLineComment(characters[index]) { index += 1 }
                 continue
             }
-            if character == "/", index + 1 < characters.count, characters[index + 1] == "*" {
+            if character == "/", index + 1 < characters.count, characters[index + 1] == "*",
+               !(revealingConditionalComments && startsConditionalComment(characters, at: index)) {
                 index += 2
                 while index + 1 < characters.count, !(characters[index] == "*" && characters[index + 1] == "/") {
                     index += 1
@@ -215,6 +223,10 @@ private extension QueryClassifier {
 
     static let destructiveKeywords: Set<String> = ["DROP", "TRUNCATE"]
 
+    static let conditionalCommentOpeners: [String] = ["/*!", "/*M!"]
+
+    static let lineCommentTerminators: Set<Character> = ["\n", "\r", "\r\n"]
+
     static let filesystemOrCodeKeywords: Set<String> = [
         "COPY", "ATTACH", "DETACH", "DO", "LOAD", "INSTALL", "IMPORT", "EXPORT",
         "BACKUP", "RESTORE", "DUMP", "SOURCE", "UNLOAD"
@@ -259,7 +271,35 @@ private extension QueryClassifier {
         let body = strippingStringLiterals(trimmed).uppercased()
         let touchesUnsafeSurface = filesystemMarkers.contains { body.contains($0) }
         let base = keywordClassification(trimmed, body: body)
-        return touchesUnsafeSurface ? base.markingUnsafeSurface() : base
+        let classification = touchesUnsafeSurface ? base.markingUnsafeSurface() : base
+        guard let conditional = conditionalCommentClassification(trimmed) else { return classification }
+        return classification.escalated(with: conditional)
+    }
+
+    static func conditionalCommentClassification(_ trimmed: String) -> QueryClassification? {
+        guard conditionalCommentOpeners.contains(where: { trimmed.contains($0) }) else { return nil }
+        let revealed = strippingStringLiterals(trimmed, revealingConditionalComments: true).uppercased()
+        guard conditionalCommentOpeners.contains(where: { revealed.contains($0) }) else { return nil }
+        let dropsData = destructiveKeywords.contains { containsWord(revealed, $0) }
+        let reachesFilesystemOrExecutesCode = filesystemMarkers.contains { revealed.contains($0) }
+            || filesystemOrCodeKeywords.contains { containsWord(revealed, $0) }
+        return QueryClassification(
+            tier: dropsData ? .destructive : .write,
+            reachesFilesystemOrExecutesCode: reachesFilesystemOrExecutesCode
+        )
+    }
+
+    static func startsConditionalComment(_ text: Substring) -> Bool {
+        conditionalCommentOpeners.contains { text.hasPrefix($0) }
+    }
+
+    static func startsConditionalComment(_ characters: [Character], at index: Int) -> Bool {
+        let end = min(index + 4, characters.count)
+        return startsConditionalComment(Substring(String(characters[index..<end])))
+    }
+
+    static func endsLineComment(_ character: Character) -> Bool {
+        lineCommentTerminators.contains(character)
     }
 
     static func keywordClassification(_ trimmed: String, body: String) -> QueryClassification {
@@ -343,8 +383,8 @@ private extension QueryClassifier {
             guard let first = remainder.first else { return nil }
             if remainder.hasPrefix("--") {
                 statementTriviaStart = statementTriviaStart ?? remainder.startIndex
-                guard let newline = remainder.firstIndex(where: { $0 == "\n" || $0 == "\r" }) else { return nil }
-                remainder = remainder[remainder.index(after: newline)...]
+                guard let lineBreak = remainder.firstIndex(where: endsLineComment) else { return nil }
+                remainder = remainder[remainder.index(after: lineBreak)...]
                 continue
             }
             if remainder.hasPrefix("/*") {

--- a/TablePro/Core/Utilities/SQL/SQLStatementScanner.swift
+++ b/TablePro/Core/Utilities/SQL/SQLStatementScanner.swift
@@ -29,16 +29,8 @@ enum SQLStatementScanner {
         /// lands on the newline that ended the previous line. A decoration or a gutter anchor placed from ``range``
         /// therefore starts a line early, and uses this instead.
         var contentRange: NSRange {
-            let text = sql as NSString
-            var start = 0
-            var end = text.length
-            while start < end, SqlLexer.isWhitespace(text.character(at: start)) {
-                start += 1
-            }
-            while end > start, SqlLexer.isWhitespace(text.character(at: end - 1)) {
-                end -= 1
-            }
-            return NSRange(location: offset + start, length: end - start)
+            let content = StatementBlank.contentRange(of: sql)
+            return NSRange(location: offset + content.location, length: content.length)
         }
     }
 
@@ -155,11 +147,8 @@ enum SQLStatementScanner {
     /// The same statements ``allStatements(in:dialect:)`` returns, each with its span in the document.
     ///
     /// One enumeration produces both, because the alternative is two filters that have to agree and that nothing
-    /// checks. ``navigableStatements(in:dialect:)`` is deliberately not that second filter: it trims only
-    /// ``SqlLexer/isWhitespace`` and keeps the terminating semicolon, while execution trims the wider
-    /// `.whitespacesAndNewlines` and strips one semicolon, so a segment can survive one and not the other. Pointing
-    /// execution at the navigation filter would change which text reaches the driver, which is not a change a
-    /// feature about labelling results is allowed to make.
+    /// checks. ``navigableStatements(in:dialect:)`` is deliberately not that second filter: it keeps the terminating
+    /// semicolon, while execution strips one, so pointing execution at it would change which text reaches the driver.
     static func executableStatements(in sql: String, dialect: SqlDialect = .generic) -> [ExecutableStatement] {
         var results: [ExecutableStatement] = []
         scan(sql: sql, cursorPosition: nil, dialect: dialect) { rawSQL, offset, hasStatementContent in
@@ -172,43 +161,27 @@ enum SQLStatementScanner {
     }
 
     private static func executableStatement(rawSQL: String, offset: Int) -> ExecutableStatement? {
-        let text = rawSQL as NSString
-        guard var range = trimmedRange(in: text, range: NSRange(location: 0, length: text.length)) else { return nil }
-
-        if text.character(at: range.upperBound - 1) == semicolon {
-            range.length -= 1
-            guard let withoutSemicolon = trimmedRange(in: text, range: range) else { return nil }
-            range = withoutSemicolon
+        var content = StatementBlank.trimming(rawSQL[...])
+        if content.last == ";" {
+            content = StatementBlank.trimming(content.dropLast())
         }
+        guard !content.isEmpty else { return nil }
 
+        let range = NSRange(content.startIndex..<content.endIndex, in: rawSQL)
         return ExecutableStatement(
-            sql: text.substring(with: range),
+            sql: String(content),
             range: NSRange(location: offset + range.location, length: range.length)
         )
     }
-
-    /// The span of `range` with `.whitespacesAndNewlines` trimmed off both ends, or `nil` when nothing is left.
-    ///
-    /// Matches what `String.trimmingCharacters(in:)` would produce, but in UTF-16 offsets, so the text and the span
-    /// handed to a caller describe the same characters by construction rather than by two separate calculations.
-    private static func trimmedRange(in text: NSString, range: NSRange) -> NSRange? {
-        let content = CharacterSet.whitespacesAndNewlines.inverted
-        let first = text.rangeOfCharacter(from: content, options: [], range: range)
-        guard first.location != NSNotFound else { return nil }
-        let last = text.rangeOfCharacter(from: content, options: .backwards, range: range)
-        return NSRange(location: first.location, length: last.upperBound - first.location)
-    }
-
-    private static let semicolon: unichar = 59
 
     /// Returns statements preserving trailing semicolons, for display/history/favorites.
     static func allStatementsPreservingSemicolons(in sql: String) -> [String] {
         var results: [String] = []
         scan(sql: sql, cursorPosition: nil) { rawSQL, _, hasStatementContent in
             guard hasStatementContent else { return true }
-            let trimmed = rawSQL.trimmingCharacters(in: .whitespacesAndNewlines)
+            let trimmed = StatementBlank.trimming(rawSQL)
             let withoutSemicolon = trimmed.hasSuffix(";")
-                ? String(trimmed.dropLast()).trimmingCharacters(in: .whitespacesAndNewlines)
+                ? StatementBlank.trimming(String(trimmed.dropLast()))
                 : trimmed
             if !withoutSemicolon.isEmpty {
                 results.append(trimmed)
@@ -219,12 +192,11 @@ enum SQLStatementScanner {
     }
 
     static func statementAtCursor(in sql: String, cursorPosition: Int, dialect: SqlDialect = .generic) -> String {
-        var result = locatedStatementAtCursor(in: sql, cursorPosition: cursorPosition, dialect: dialect)
-            .sql
-            .trimmingCharacters(in: .whitespacesAndNewlines)
+        var result = StatementBlank.trimming(
+            locatedStatementAtCursor(in: sql, cursorPosition: cursorPosition, dialect: dialect).sql
+        )
         if result.hasSuffix(";") {
-            result = String(result.dropLast())
-                .trimmingCharacters(in: .whitespacesAndNewlines)
+            result = StatementBlank.trimming(String(result.dropLast()))
         }
         return result
     }
@@ -396,7 +368,12 @@ enum SQLStatementScanner {
                 sawStatementKeyword = false
                 opensRoutineDefinition = false
                 blockDepth = 0
-            } else if !SqlLexer.isWhitespace(ch) {
+            } else if !hasStatementContent {
+                let blankLength = StatementBlank.blankLength(in: nsQuery, at: i)
+                guard blankLength == 0 else {
+                    i += blankLength
+                    continue
+                }
                 hasStatementContent = true
             }
 

--- a/TablePro/Core/Utilities/SQL/StatementBlank.swift
+++ b/TablePro/Core/Utilities/SQL/StatementBlank.swift
@@ -1,0 +1,64 @@
+//
+//  StatementBlank.swift
+//  TablePro
+//
+
+import Foundation
+
+internal enum StatementBlank {
+    private static let interlinearAnnotations: ClosedRange<UInt32> = 0xFFF9...0xFFFB
+    private static let asciiDelete: UInt32 = 0x7F
+    private static let asciiSpace: UInt32 = 0x20
+
+    static func isBlank(_ scalar: Unicode.Scalar) -> Bool {
+        guard !scalar.isASCII else { return scalar.value <= asciiSpace || scalar.value == asciiDelete }
+        let properties = scalar.properties
+        guard !properties.isAlphabetic else { return false }
+        return properties.isWhitespace
+            || properties.generalCategory == .control
+            || properties.isDefaultIgnorableCodePoint
+            || interlinearAnnotations.contains(scalar.value)
+    }
+
+    static func isBlank(_ character: Character) -> Bool {
+        character.unicodeScalars.allSatisfy { isBlank($0) }
+    }
+
+    static func hasContent(_ text: String) -> Bool {
+        text.contains { !isBlank($0) }
+    }
+
+    static func blankLength(in text: NSString, at offset: Int) -> Int {
+        guard let scalar = scalar(in: text, at: offset), isBlank(scalar) else { return 0 }
+        return scalar.utf16.count
+    }
+
+    static func trimming(_ text: String) -> String {
+        String(trimming(text[...]))
+    }
+
+    static func trimming(_ text: Substring) -> Substring {
+        let leading = trimmingLeading(text)
+        guard let last = leading.lastIndex(where: { !isBlank($0) }) else { return leading[leading.endIndex...] }
+        return leading[...last]
+    }
+
+    static func trimmingLeading(_ text: Substring) -> Substring {
+        text.drop { isBlank($0) }
+    }
+
+    static func contentRange(of text: String) -> NSRange {
+        let content = trimming(text[...])
+        return NSRange(content.startIndex..<content.endIndex, in: text)
+    }
+
+    private static func scalar(in text: NSString, at offset: Int) -> Unicode.Scalar? {
+        guard offset >= 0, offset < text.length else { return nil }
+        let unit = text.character(at: offset)
+        guard UTF16.isLeadSurrogate(unit) else { return Unicode.Scalar(unit) }
+        guard offset + 1 < text.length else { return nil }
+        let trail = text.character(at: offset + 1)
+        guard UTF16.isTrailSurrogate(trail) else { return nil }
+        return Unicode.Scalar(0x10000 + ((UInt32(unit) - 0xD800) << 10) + (UInt32(trail) - 0xDC00))
+    }
+}

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -1124,10 +1124,6 @@ final class MainContentCoordinator {
         bypassRowLimit: Bool,
         sourceOffset: Int? = nil
     ) -> Bool {
-        guard !sql.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            return false
-        }
-
         let anchored = { (statements: [SQLStatementScanner.ExecutableStatement]) in
             guard let sourceOffset else { return statements }
             return statements.map { $0.offset(by: sourceOffset) }

--- a/TableProTests/Core/Database/DatabaseAccessBridgeStatementTests.swift
+++ b/TableProTests/Core/Database/DatabaseAccessBridgeStatementTests.swift
@@ -1,0 +1,60 @@
+//
+//  DatabaseAccessBridgeStatementTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import TableProPluginKit
+import Testing
+
+@Suite("Database access bridge statement text")
+struct DatabaseAccessBridgeStatementTests {
+    @Test(
+        "Invisible characters and trailing semicolons come off an external statement",
+        arguments: ["\u{FEFF}\u{0008}SELECT 1;\u{00A0};\u{200B}", "\u{3000}SELECT 1\u{2028}", " SELECT 1 ; "]
+    )
+    func trimsInvisibleCharacters(sql: String) {
+        #expect(DatabaseAccessBridge.stripTrailingSemicolons(sql) == "SELECT 1")
+    }
+
+    @Test("A statement of nothing but invisible characters is empty")
+    func invisibleOnlyStatementIsEmpty() {
+        #expect(DatabaseAccessBridge.stripTrailingSemicolons("\u{FEFF}\u{0008};\u{200B}").isEmpty)
+    }
+
+    @Test(
+        "A statement that trims to nothing is refused before it reaches a connection",
+        arguments: ["\u{FEFF}", ";", "\u{0008} ;\u{200B}"]
+    )
+    func emptyStatementIsRefused(sql: String) async {
+        let bridge = DatabaseAccessBridge()
+        let scope = DatabaseScope(connectionId: UUID(), database: "", schema: nil)
+        let error = await #expect(throws: DatabaseAccessError.self) {
+            try await bridge.runStatement(scope: scope, query: sql, maxRows: 1, timeoutSeconds: 1, cancellation: nil)
+        }
+        guard case .invalidArgument(let detail)? = error else {
+            Issue.record("Expected an invalid argument, got \(String(describing: error))")
+            return
+        }
+        #expect(detail == String(localized: "The query is empty."))
+    }
+
+    @Test("The text an external client sends is the text that was classified")
+    func sentTextMatchesClassifiedText() {
+        let sent = DatabaseAccessBridge.stripTrailingSemicolons("\u{0008}SELECT 1;")
+        #expect(sent == "SELECT 1")
+        #expect(QueryClassifier.classifyTier(sent, databaseType: .postgresql) == .safe)
+    }
+
+    @Test("An explain behind an invisible character is not wrapped in a second explain")
+    func explainBehindInvisibleCharacterIsNotWrapped() throws {
+        let statement = try MCPConnectionBridge.explainStatement(
+            for: "\u{FEFF}EXPLAIN SELECT 1;",
+            databaseType: .postgresql,
+            variantId: nil,
+            analyze: false
+        )
+        #expect(statement == "EXPLAIN SELECT 1")
+    }
+}

--- a/TableProTests/Core/Execution/ExternalStatementGateTests.swift
+++ b/TableProTests/Core/Execution/ExternalStatementGateTests.swift
@@ -84,6 +84,20 @@ struct ExternalStatementGateTests {
         #expect(refusal(statement("SELECT 1", externalAccess: access)) == nil)
     }
 
+    @Test(
+        "A write hidden from the classifier by a comment is still refused on a read-only connection",
+        arguments: [
+            ("-- note\r\nDROP TABLE users", DatabaseType.postgresql),
+            ("-- note\rDROP TABLE users", DatabaseType.postgresql),
+            ("/*!50000 DROP TABLE users */", DatabaseType.mysql),
+            ("/*M!100000 DROP TABLE users */", DatabaseType.mariadb),
+        ]
+    )
+    func commentedWriteRefusedOnReadOnlyConnection(sql: String, databaseType: DatabaseType) {
+        let refused = refusal(statement(sql, databaseType: databaseType, externalAccess: .readOnly))
+        #expect(refused == .denied(String(localized: "This connection is read only for external clients.")))
+    }
+
     @Test("A destructive statement is refused when the caller may not run one")
     func destructiveRefusedWithoutPermission() {
         let refused = refusal(statement("DROP TABLE users", allowsDestructive: false))

--- a/TableProTests/Core/Services/Execution/ExecutionGateTests.swift
+++ b/TableProTests/Core/Services/Execution/ExecutionGateTests.swift
@@ -179,6 +179,19 @@ struct ExecutionGateTests {
         #expect(auth.callCount == 0)
     }
 
+    @Test("Silent still confirms a destructive statement that an invisible character precedes")
+    func silentConfirmsDestructiveBehindInvisibleCharacter() async {
+        let confirm = StubConfirming(answer: true)
+        let auth = StubAuthenticating(answer: true)
+        let gate = makeGate(level: .silent, confirm: confirm, auth: auth)
+
+        let decision = await gate.authorize(makeRequest(sql: "\u{FEFF}DROP TABLE t", kind: .readQuery))
+
+        #expect(decision.isAuthorized)
+        #expect(confirm.callCount == 1)
+        #expect(confirm.lastDestructive)
+    }
+
     @Test("Silent destructive denied when user cancels")
     func silentDestructiveCancelled() async {
         let confirm = StubConfirming(answer: false)
@@ -237,6 +250,18 @@ struct ExecutionGateTests {
 
         #expect(read.isAuthorized)
         #expect(write.deniedReason?.contains("read-only") == true)
+        #expect(confirm.callCount == 0)
+    }
+
+    @Test("Read-only runs a read that an invisible character precedes")
+    func readOnlyAllowsReadBehindInvisibleCharacter() async {
+        let confirm = StubConfirming(answer: true)
+        let auth = StubAuthenticating(answer: true)
+        let gate = makeGate(level: .readOnly, confirm: confirm, auth: auth)
+
+        let decision = await gate.authorize(makeRequest(sql: "\u{0008}SELECT 1", kind: .readQuery))
+
+        #expect(decision.isAuthorized)
         #expect(confirm.callCount == 0)
     }
 
@@ -453,6 +478,19 @@ struct ExecutionGateTests {
 
         let decision = await gate.authorize(
             makeRequest(sql: "SELECT 1; -- note", kind: .readQuery, capabilities: [.mayWrite])
+        )
+
+        #expect(decision.isAuthorized)
+    }
+
+    @Test("An invisible character after the semicolon is not denied as multi-statement")
+    func trailingInvisibleCharacterNotDeniedAsMultiStatement() async {
+        let confirm = StubConfirming(answer: true)
+        let auth = StubAuthenticating(answer: true)
+        let gate = makeGate(level: .silent, confirm: confirm, auth: auth)
+
+        let decision = await gate.authorize(
+            makeRequest(sql: "SELECT 1;\n\u{FEFF}\u{0008}", kind: .readQuery, capabilities: [.mayWrite])
         )
 
         #expect(decision.isAuthorized)

--- a/TableProTests/Core/Utilities/QueryStatementModelTests.swift
+++ b/TableProTests/Core/Utilities/QueryStatementModelTests.swift
@@ -72,4 +72,16 @@ struct QueryStatementModelTests {
         let end = QueryStatementScanner.statementSelectionEnd(after: 14, in: script, model: .javascript)
         #expect(end == (script as NSString).length)
     }
+
+    @Test("A trailing line of invisible characters is not a statement under the JavaScript model")
+    func javaScriptInvisibleTrailingLine() {
+        let script = "db.a.find();\n\u{FEFF}\u{0008}"
+        let located = QueryStatementScanner.locatedStatementAtCursor(
+            in: script, cursorPosition: (script as NSString).length, model: .javascript
+        )
+
+        #expect(located.sql.contains("db.a.find()"))
+        #expect(QueryStatementScanner.navigableStatements(in: script, model: .javascript).count == 1)
+        #expect(QueryStatementScanner.executableStatements(in: script, model: .javascript).count == 1)
+    }
 }

--- a/TableProTests/Core/Utilities/SQL/QueryClassifierHardeningTests.swift
+++ b/TableProTests/Core/Utilities/SQL/QueryClassifierHardeningTests.swift
@@ -252,6 +252,96 @@ struct QueryClassifierFailClosedTests {
     }
 }
 
+@Suite("QueryClassifier comment boundaries")
+struct QueryClassifierCommentBoundaryTests {
+    @Test(
+        "A line comment ends at a carriage return as well as a line feed",
+        arguments: ["-- note\r\nDROP TABLE users", "-- note\rDROP TABLE users", "/* a */ -- b\r\nDROP TABLE users"]
+    )
+    func lineCommentEndsAtAnyLineBreak(sql: String) {
+        #expect(QueryClassifier.classifyTier(sql, databaseType: .postgresql) == .destructive)
+    }
+
+    @Test("A DELETE after a CRLF comment is still an unqualified delete")
+    func deleteAfterCRLFCommentIsDangerous() {
+        #expect(QueryClassifier.isDangerousQuery("-- note\r\nDELETE FROM users", databaseType: .mysql))
+    }
+
+    @Test("A CRLF comment inside a statement does not hide what follows it")
+    func crlfCommentDoesNotSwallowTheBody() {
+        #expect(
+            QueryClassifier.classifyTier(
+                "WITH x AS (SELECT 1) -- note\r\nDELETE FROM users",
+                databaseType: .postgresql
+            ) == .write
+        )
+        #expect(
+            QueryClassifier.reachesFilesystemOrExecutesCode(
+                "SELECT * FROM users -- note\r\nINTO OUTFILE '/tmp/users.csv'",
+                databaseType: .mysql
+            )
+        )
+    }
+
+    @Test("A CRLF comment between EXPLAIN and ANALYZE does not hide the write it runs")
+    func explainAnalyzeAfterCRLFComment() {
+        #expect(
+            QueryClassifier.isWriteQuery("EXPLAIN -- options\r\nANALYZE DELETE FROM users", databaseType: .postgresql)
+        )
+    }
+
+    @Test(
+        "A conditional comment that drops data is destructive",
+        arguments: [
+            "/*!50000 DROP TABLE users */",
+            "/*M!100000 DROP TABLE users */",
+            "/*!99999 SELECT 1 */ /*!1 TRUNCATE users */",
+        ]
+    )
+    func conditionalCommentDropIsDestructive(sql: String) {
+        #expect(QueryClassifier.classifyTier(sql, databaseType: .mysql) == .destructive)
+    }
+
+    @Test(
+        "A conditional comment may or may not run, so a statement carrying one is never safe",
+        arguments: [
+            "/*!99999 SELECT 1 */ /*!1 DELETE FROM users */",
+            "/*!99999 SELECT 1 */ DELETE FROM users",
+            "SELECT /*!40001 SQL_NO_CACHE */ * FROM users",
+        ]
+    )
+    func conditionalCommentIsNeverSafe(sql: String) {
+        #expect(QueryClassifier.classifyTier(sql, databaseType: .mysql) == .write)
+    }
+
+    @Test(
+        "A file or code surface inside a conditional comment is flagged",
+        arguments: [
+            "SELECT * FROM users /*!50000 INTO OUTFILE '/tmp/users.csv' */",
+            "/*!40000 LOAD DATA INFILE '/etc/passwd' INTO TABLE t */",
+        ]
+    )
+    func conditionalCommentFilesystemIsFlagged(sql: String) {
+        #expect(QueryClassifier.reachesFilesystemOrExecutesCode(sql, databaseType: .mysql))
+        #expect(QueryClassifier.isWriteQuery(sql, databaseType: .mysql))
+    }
+
+    @Test("A WHERE inside a conditional comment does not qualify the DELETE")
+    func conditionalWhereDoesNotQualifyDelete() {
+        #expect(
+            QueryClassifier.isDangerousQuery("DELETE FROM users /*!99999 WHERE id = 1 */", databaseType: .mysql)
+        )
+    }
+
+    @Test(
+        "The conditional comment opener only counts where a comment could start",
+        arguments: ["SELECT '/*! DROP TABLE users */' AS note", "/* see /*! */ SELECT 1", "-- /*! DROP\nSELECT 1"]
+    )
+    func conditionalOpenerInsideLiteralOrCommentIsInert(sql: String) {
+        #expect(QueryClassifier.classifyTier(sql, databaseType: .mysql) == .safe)
+    }
+}
+
 @Suite("QueryClassifier non-SQL engines")
 struct QueryClassifierNonSqlTests {
     @Test("MongoDB read methods stay safe and writes never look like reads")

--- a/TableProTests/Core/Utilities/SQL/QueryClassifierInvisibleCharacterTests.swift
+++ b/TableProTests/Core/Utilities/SQL/QueryClassifierInvisibleCharacterTests.swift
@@ -1,0 +1,78 @@
+//
+//  QueryClassifierInvisibleCharacterTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("QueryClassifier with invisible characters")
+struct QueryClassifierInvisibleCharacterTests {
+    @Test(
+        "A read behind a leading invisible character is still a read",
+        arguments: [
+            "\u{0008}SELECT 1",
+            "\u{FEFF}SELECT 1",
+            "\u{200B}SELECT 1",
+            "\u{00A0}SELECT 1",
+            "\u{3000}SELECT 1",
+            "\u{200E}\u{2060}SELECT 1",
+            "\u{E0020}SELECT 1",
+            "\u{FE0F}SELECT 1",
+            "-- note\n\u{FEFF}SELECT 1",
+            "/* note */\u{0008}SELECT 1",
+            "(\u{200B}SELECT 1)",
+        ]
+    )
+    func leadingInvisibleRead(sql: String) {
+        #expect(QueryClassifier.classifyTier(sql, databaseType: .postgresql) == .safe)
+    }
+
+    @Test(
+        "A destructive statement behind a leading invisible character is still destructive",
+        arguments: ["\u{FEFF}DROP TABLE users", "\u{0008}TRUNCATE users", "\u{200B}DELETE FROM users"]
+    )
+    func leadingInvisibleDestructive(sql: String) {
+        #expect(QueryClassifier.isDangerousQuery(sql, databaseType: .postgresql))
+    }
+
+    @Test("A write behind a leading invisible character is still a write")
+    func leadingInvisibleWrite() {
+        #expect(QueryClassifier.classifyTier("\u{FEFF}UPDATE t SET a = 1", databaseType: .mysql) == .write)
+        #expect(QueryClassifier.classifyTier("\u{0008}INSERT INTO t VALUES (1)", databaseType: .mysql) == .write)
+    }
+
+    @Test(
+        "An invisible character inside the keyword hides it, so the statement stays a write",
+        arguments: ["SEL\u{200B}ECT 1", "SEL\u{FEFF}ECT 1", "\u{FEFF}SEL\u{0008}ECT 1", "(SEL\u{00A0}ECT 1)"]
+    )
+    func invisibleInsideTheKeyword(sql: String) {
+        #expect(QueryClassifier.classifyTier(sql, databaseType: .postgresql) == .write)
+    }
+
+    @Test(
+        "A filler that is a letter belongs to the word after it",
+        arguments: ["\u{3164}SELECT 1", "\u{115F}SELECT 1", "\u{FFA0}SELECT 1"]
+    )
+    func letterFillerIsNotSkipped(sql: String) {
+        #expect(QueryClassifier.classifyTier(sql, databaseType: .mssql) == .write)
+    }
+
+    @Test("A visible mark on a leading blank is content, so the statement stays a write")
+    func markedBlankIsNotSkipped() {
+        #expect(QueryClassifier.classifyTier("\u{00A0}\u{0301}SELECT 1", databaseType: .postgresql) == .write)
+    }
+
+    @Test("A Redis command behind a leading invisible character keeps its tier")
+    func redisCommandBehindInvisibleCharacter() {
+        #expect(QueryClassifier.classifyTier("\u{FEFF}FLUSHALL", databaseType: .redis) == .destructive)
+        #expect(QueryClassifier.classifyTier("\u{0008}GET key", databaseType: .redis) == .safe)
+    }
+
+    @Test("A leading invisible character does not hide an EXPLAIN")
+    func explainBehindInvisibleCharacter() {
+        #expect(QueryClassifier.isExplainStatement("\u{FEFF}EXPLAIN SELECT 1"))
+        #expect(QueryClassifier.explainedStatement(in: "\u{0008}EXPLAIN SELECT 1") == "SELECT 1")
+    }
+}

--- a/TableProTests/Core/Utilities/SQL/SQLExecutableStatementTests.swift
+++ b/TableProTests/Core/Utilities/SQL/SQLExecutableStatementTests.swift
@@ -78,6 +78,61 @@ struct SQLExecutableStatementTests {
         #expect(shifted.sql == only.sql)
     }
 
+    @Test(
+        "Invisible characters around a statement are not sent to the driver",
+        arguments: [
+            "\u{0008}SELECT 1",
+            "\u{FEFF}SELECT 1;",
+            "\u{200B}\u{00A0}SELECT 1\u{3000};\u{2028}",
+            "SELECT 1\u{200E};",
+            "\u{E0020}SELECT 1;\u{E0020}",
+            "\u{2060}\u{0000}SELECT 1\u{00AD}\u{FFF9};",
+        ]
+    )
+    func invisibleEdgesAreTrimmed(sql: String) {
+        #expect(SQLStatementScanner.allStatements(in: sql) == ["SELECT 1"])
+    }
+
+    @Test(
+        "An invisible character that belongs to the last visible one reaches the driver with it",
+        arguments: [
+            "SET k \u{2764}\u{FE0F}",
+            "SET flag \u{1F3F4}\u{E0067}\u{E0062}\u{E0073}\u{E0063}\u{E0074}\u{E007F}",
+            "SET k \u{0645}\u{06CC}\u{200C}",
+        ]
+    )
+    func attachedInvisibleCharacterIsSent(sql: String) {
+        #expect(SQLStatementScanner.allStatements(in: "\u{FEFF}" + sql + ";\u{0008}") == [sql])
+    }
+
+    @Test(
+        "A segment of nothing but invisible characters runs nothing",
+        arguments: ["\u{0008}", "\u{FEFF};", "\u{00A0}\u{200B}\u{FEFF}\u{0008}\u{3000}", "\u{E0020};\u{2028};"]
+    )
+    func invisibleOnlySegmentsRunNothing(sql: String) {
+        #expect(SQLStatementScanner.executableStatements(in: sql).isEmpty)
+    }
+
+    @Test("An invisible segment between two statements is not a statement of its own")
+    func invisibleSegmentBetweenStatements() {
+        #expect(SQLStatementScanner.allStatements(in: "SELECT 1;\u{0008};SELECT 2") == ["SELECT 1", "SELECT 2"])
+    }
+
+    @Test("An invisible character inside a word stays in the text the driver receives")
+    func invisibleInsideAWordIsKept() {
+        #expect(SQLStatementScanner.allStatements(in: "\u{FEFF}SEL\u{200B}ECT 1") == ["SEL\u{200B}ECT 1"])
+    }
+
+    @Test("The span starts at the first visible character after an invisible one")
+    func spanSkipsInvisibleLeadingCharacters() throws {
+        let sql = "SELECT 1;\n\u{FEFF}\u{0008}SELECT 2;"
+        let second = try #require(SQLStatementScanner.executableStatements(in: sql).last)
+        let text = sql as NSString
+
+        #expect(second.range.location == text.range(of: "SELECT 2").location)
+        #expect(text.substring(with: second.range) == second.sql)
+    }
+
     @Test("Offsets are UTF-16, so text outside the BMP does not shift the span")
     func offsetsAreUTF16() throws {
         let sql = "SELECT '👍';\nSELECT 2;"

--- a/TableProTests/Core/Utilities/SQL/SQLStatementNavigationTests.swift
+++ b/TableProTests/Core/Utilities/SQL/SQLStatementNavigationTests.swift
@@ -99,6 +99,43 @@ struct SQLStatementNavigationTests {
         #expect(SQLStatementScanner.statementStart(after: 0, in: "SELECT 1;\n   \n") == nil)
     }
 
+    @Test(
+        "A line of invisible characters after the last statement is not a destination",
+        arguments: [
+            "\u{00A0}", "\u{3000}", "\u{FEFF}", "\u{0008}", "\u{200B}", "\u{2028}", "\u{E0020}", " \u{00A0}\t\u{200E}",
+        ]
+    )
+    func invisibleLineIsNotADestination(line: String) {
+        let sql = "SELECT 1;\n" + line
+        #expect(SQLStatementScanner.navigableStatements(in: sql).count == 1)
+        #expect(SQLStatementScanner.statementStart(after: 0, in: sql) == nil)
+    }
+
+    @Test("A statement starts at its keyword, not at an invisible character in front of it")
+    func invisibleLeadingCharactersAreNotTheStart() throws {
+        let sql = "SELECT 1;\n\u{FEFF}\u{00A0}\u{0008}SELECT 2;"
+        let second = try #require(SQLStatementScanner.navigableStatements(in: sql).last)
+        #expect(second.contentRange.location == (sql as NSString).range(of: "SELECT 2").location)
+    }
+
+    @Test(
+        "Every statement offered a run control is a statement that runs",
+        arguments: [
+            "SELECT 1;\n\u{00A0}",
+            "SELECT 1;\u{0008};SELECT 2",
+            "\u{FEFF}",
+            "-- note\n\u{3000}",
+            "SELECT 1; \u{200B} ; SELECT 2;",
+            "\u{E0020}SELECT 1;\u{2029}",
+        ]
+    )
+    func runControlsMatchExecution(sql: String) {
+        #expect(
+            SQLStatementScanner.navigableStatements(in: sql).count
+                == SQLStatementScanner.executableStatements(in: sql).count
+        )
+    }
+
     @Test("An empty document has nowhere to go")
     func emptyDocument() {
         #expect(SQLStatementScanner.statementStart(after: 0, in: "") == nil)

--- a/TableProTests/Core/Utilities/SQL/StatementBlankTests.swift
+++ b/TableProTests/Core/Utilities/SQL/StatementBlankTests.swift
@@ -1,0 +1,176 @@
+//
+//  StatementBlankTests.swift
+//  TableProTests
+//
+
+import CodeEditTextView
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("Statement blank characters")
+struct StatementBlankTests {
+    private static func label(_ value: UInt32) -> String {
+        String(format: "U+%04X", value)
+    }
+
+    @Test("Everything the run path used to trim as whitespace is still blank")
+    func coversEveryEarlierWhitespaceDefinition() {
+        for value in UInt32(0)...0xFFFF {
+            guard let scalar = Unicode.Scalar(value) else { continue }
+            let wasWhitespace = CharacterSet.whitespacesAndNewlines.contains(scalar)
+                || scalar.properties.isWhitespace
+                || value == UInt32(SqlLexer.space)
+                || value == UInt32(SqlLexer.tab)
+            guard wasWhitespace else { continue }
+            #expect(StatementBlank.isBlank(scalar), "\(Self.label(value))")
+        }
+    }
+
+    @Test("Every character the editor reveals is blank unless it is a letter")
+    func coversEveryCharacterTheEditorMarks() {
+        let supplementary: [ClosedRange<UInt32>] = [0x1BCA0...0x1BCA3, 0x1D173...0x1D17A, 0xE0000...0xE01EF]
+        let basic = (UInt32(0)...0xFFFF).filter { SpecialCharacter.mayBeSpecial(UInt16($0)) }
+        var marked = 0
+        for value in basic + supplementary.flatMap({ Array($0) }) {
+            guard let scalar = Unicode.Scalar(value) else { continue }
+            let text = String(Character(scalar)) as NSString
+            guard SpecialCharacter.classify(in: text, at: 0) != nil else { continue }
+            marked += 1
+            #expect(StatementBlank.isBlank(scalar) == !scalar.properties.isAlphabetic, "\(Self.label(value))")
+        }
+        #expect(marked > 100)
+    }
+
+    @Test("A filler that is a letter is content", arguments: [0x115F, 0x1160, 0x3164, 0xFFA0] as [UInt32])
+    func letterFillersAreContent(value: UInt32) throws {
+        let scalar = try #require(Unicode.Scalar(value))
+        #expect(!StatementBlank.isBlank(scalar))
+    }
+
+    @Test("Visible text is content")
+    func visibleTextIsContent() {
+        for scalar in "SELECT;()'\"`-_0#$@éß中😀".unicodeScalars {
+            #expect(!StatementBlank.isBlank(scalar), "\(Self.label(scalar.value))")
+        }
+    }
+
+    @Test(
+        "A character is blank only when every scalar in it is",
+        arguments: [
+            ("\r\n", true),
+            ("\u{00A0}\u{200D}", true),
+            ("\u{FE0F}", true),
+            ("\u{00A0}\u{0301}", false),
+            ("\u{2764}\u{FE0F}", false),
+            ("1\u{E0020}", false),
+        ] as [(String, Bool)]
+    )
+    func characterIsBlankOnlyWhenEveryScalarIs(text: String, isBlank: Bool) throws {
+        #expect(text.count == 1)
+        let character = try #require(text.first)
+        #expect(StatementBlank.isBlank(character) == isBlank)
+    }
+
+    @Test("A blank outside the BMP is measured as the two units it occupies")
+    func supplementaryBlankLength() {
+        let text = "\u{E0020}x" as NSString
+        #expect(StatementBlank.blankLength(in: text, at: 0) == 2)
+        #expect(StatementBlank.blankLength(in: text, at: 2) == 0)
+    }
+
+    @Test("Half of a surrogate pair is never blank")
+    func halfOfASurrogatePairIsNotBlank() {
+        let text = "\u{E0020}" as NSString
+        #expect(StatementBlank.blankLength(in: text, at: 1) == 0)
+    }
+
+    @Test("Every ASCII character is blank exactly when it is a space or a control character")
+    func asciiBlanksAreSpaceAndControls() throws {
+        for value in UInt32(0)...0x7F {
+            let scalar = try #require(Unicode.Scalar(value))
+            let expected = scalar.properties.isWhitespace || scalar.properties.generalCategory == .control
+            #expect(StatementBlank.isBlank(scalar) == expected, "\(Self.label(value))")
+        }
+    }
+
+    @Test("Offsets outside the text measure nothing")
+    func offsetsOutsideTheText() {
+        let text = " " as NSString
+        #expect(StatementBlank.blankLength(in: text, at: -1) == 0)
+        #expect(StatementBlank.blankLength(in: text, at: 1) == 0)
+    }
+
+    @Test("Trimming takes blanks off both ends and leaves the inside alone")
+    func trimsBothEnds() {
+        let text = "\u{FEFF}\u{0008}\u{00A0} SEL\u{200B}ECT 1 \u{3000}\u{E0020}\u{2028}"
+        #expect(StatementBlank.trimming(text) == "SEL\u{200B}ECT 1")
+    }
+
+    @Test("Text made only of blanks trims to nothing")
+    func allBlankTrimsToNothing() {
+        #expect(StatementBlank.trimming(" \u{00A0}\u{200B}\u{FEFF}\u{0008}\u{3000}\u{E0020}").isEmpty)
+    }
+
+    @Test(
+        "An invisible character attached to the last visible one stays with it",
+        arguments: [
+            "SET k \u{2764}\u{FE0F}",
+            "SET flag \u{1F3F4}\u{E0067}\u{E0062}\u{E0073}\u{E0063}\u{E0074}\u{E007F}",
+            "SET k \u{0915}\u{094D}\u{200D}",
+            "SET k \u{0645}\u{06CC}\u{200C}",
+            "SELECT 1\u{E0020}",
+        ]
+    )
+    func attachedInvisibleCharacterIsKept(text: String) {
+        #expect(StatementBlank.trimming(text) == text)
+        #expect(StatementBlank.trimming("\u{FEFF}" + text + "\u{0008}\n") == text)
+    }
+
+    @Test("A visible mark on a blank character makes it content")
+    func markOnABlankIsContent() {
+        let text = "\u{00A0}\u{0301}SELECT 1"
+        #expect(StatementBlank.trimming(text) == text)
+    }
+
+    @Test("Trimming a substring stays inside it")
+    func trimmingRespectsTheSubstring() {
+        let text = "x \u{00A0}SELECT 1\u{00A0} x"
+        let inner = text.dropFirst().dropLast()
+        #expect(StatementBlank.trimming(inner) == "SELECT 1")
+    }
+
+    @Test(
+        "The content range is the trimmed text measured in UTF-16 units",
+        arguments: [
+            ("\u{FEFF}\u{E0020} SELECT 1\u{00A0}\n", NSRange(location: 4, length: 8)),
+            ("\u{1F600} \u{2764}\u{FE0F}\u{200B}", NSRange(location: 0, length: 5)),
+            ("\u{00A0}\u{200B}", NSRange(location: 2, length: 0)),
+        ] as [(String, NSRange)]
+    )
+    func contentRangeIsMeasuredInUTF16(text: String, expected: NSRange) {
+        let range = StatementBlank.contentRange(of: text)
+        #expect(range == expected)
+        #expect((text as NSString).substring(with: range) == StatementBlank.trimming(text))
+    }
+
+    @Test("Text holds content when any character in it is visible")
+    func hasContent() {
+        #expect(StatementBlank.hasContent("\u{FEFF} x"))
+        #expect(StatementBlank.hasContent("\u{00A0}\u{0301}"))
+        #expect(!StatementBlank.hasContent("\u{FEFF}\u{0008}\u{200B} \n\u{E0020}"))
+        #expect(!StatementBlank.hasContent(""))
+    }
+
+    @Test("Leading blanks come off a substring and nothing after the first visible character does")
+    func trimmingLeadingStopsAtContent() {
+        let text = "\u{0008}\u{FEFF} \u{E0020}SEL\u{200B}ECT 1"
+        #expect(StatementBlank.trimmingLeading(text[...]) == "SEL\u{200B}ECT 1")
+    }
+
+    @Test("Leading trimming keeps a visible mark on a blank character")
+    func trimmingLeadingKeepsAMarkedBlank() {
+        let text = "\u{3000}\u{0301}SELECT"
+        #expect(StatementBlank.trimmingLeading(text[...]) == text[...])
+    }
+}

--- a/docs/features/safe-mode.mdx
+++ b/docs/features/safe-mode.mdx
@@ -26,9 +26,11 @@ Safe Mode sits in front of query execution, saving cell edits, structure and tab
 
 It does not sit in front of reading metadata. Loading the sidebar, opening a table's structure, and exporting data are never confirmed, which is why a backup stays available on a Read-Only connection.
 
-## Drivers without read-only support
+## What always counts as a write
 
 The Redis, MongoDB, and etcd drivers cannot open a read-only session, so Safe Mode treats every query on those connections as a write: the Alert and Safe Mode levels confirm everything, and Read-Only blocks everything. Every other driver classifies reads and writes normally.
+
+The server runs the text inside a MySQL conditional comment, `/*! ... */` or MariaDB's `/*M! ... */`, so a statement holding one counts as a write even when the rest of it only reads. Remove the comment to run the statement on a Read-Only connection.
 
 ## Changing the level while connected
 

--- a/docs/features/sql-editor.mdx
+++ b/docs/features/sql-editor.mdx
@@ -160,7 +160,7 @@ Control characters never arrive by typing. A stray backspace an input method sen
 
 Choose **Query > Remove Invisible Characters** to clean a query. With nothing selected, it removes marked characters outside string literals, quoted identifiers and comments. Special spaces, form feeds and vertical tabs become ordinary spaces, and a line or paragraph separator becomes a line break. Select text first to clean inside a literal as well. `Cmd+Z` undoes the whole change.
 
-A statement containing a NUL character is not sent to the database. Remove the character and run it again.
+Invisible characters around a statement, such as a byte order mark in front of `SELECT` or a non-breaking space on the line after it, are not sent with it, and a line holding nothing else gets no run button. A NUL character inside a statement stops it from being sent. Remove the character and run it again.
 
 To hide the marks in the editor, turn off **Show invisible characters** in **Settings > Editor**. Read-only views, such as the AI assistant's code blocks, always show them.
 


### PR DESCRIPTION
Found while investigating #2717 (PR #2724).

## Root cause

The run path used three different definitions of whitespace, and they disagreed:

- The scanner's content check and `contentRange` only knew space, tab, LF and CR.
- Execution trimmed `CharacterSet.whitespacesAndNewlines`, which includes U+00A0, U+3000 and U+200B but not U+FEFF or U+0008.
- `QueryClassifier` skipped `Character.isWhitespace`.

So a line holding only U+00A0 counted as a statement for the gutter but trimmed to nothing at run time: the run button showed and did nothing. And `"\u{0008}SELECT 1"` kept its U+0008, the leading keyword came out empty, the unknown-keyword arm answered "write", and Read-Only Safe Mode refused a plain `SELECT`. A leading BOM hid a `DROP` the same way, just in the other direction.

The review turned up two more ways the classifier could miss a write, in the same comment-skipping code this change edits:

- It compared `Character`s to `"\n"`. In Swift, CRLF is one `"\r\n"` Character, so `-- note\r\nDROP TABLE users` stripped to `""` and classified as safe. A bare CR did the same. That text reaches the classifier through MCP `execute_query` on a read-only external connection, or through a CRLF `.sql` file under Read-Only Safe Mode.
- It stripped MySQL `/*! ... */` and MariaDB `/*M! ... */` comments, which the server executes, so `/*!50000 DROP TABLE users */` also classified as safe.

## What changed

- New `StatementBlank` (`TablePro/Core/Utilities/SQL/StatementBlank.swift`) is the one definition of blank for the run path. A character is blank when every scalar in it is Unicode whitespace, a control character, a default-ignorable code point or U+FFF9 to U+FFFB, and is not a letter. ASCII skips the property lookups.
- Trimming works on Swift Characters from both ends, so an invisible scalar attached to a visible one stays with it: the VS16 in `❤️`, flag tag characters, a ZWJ after a virama, a ZWNJ ending a Persian word. An invisible character inside a word is never removed, so `SEL\u{200B}ECT 1` still reaches the server as written and stays a write.
- Callers now go through it: the scanner's content check and content range, executable-statement trimming, `statementAtCursor`, `allStatementsPreservingSemicolons`, the JavaScript scanner's `hasContent`, the classifier's comment and keyword skipping, and `DatabaseAccessBridge` (MCP and AppleScript). The text an external client has classified is the text that is sent.
- The two duplicate `.whitespacesAndNewlines` guards in `QueryExecutionCoordinator` and `MainContentCoordinator` are gone. The executable-statement list is the only gate, so the gutter's run controls and execution agree by construction.
- `QueryClassifier`: a line comment ends at LF, CR or CRLF in all three places that skip comments (`strippingLeadingComments`, `strippingStringLiterals`, the `EXPLAIN` inner-statement walk). A statement holding a conditional comment is never safe: at least a write, destructive when the revealed text has `DROP` or `TRUNCATE`, and flagged when it touches the filesystem or runs code. An opener inside a string literal or an ordinary comment stays inert.
- `DatabaseAccessBridge.runStatement` refuses a statement that trims to nothing ("The query is empty.", already in the catalog) before it opens a connection.
- Docs: `docs/features/sql-editor.mdx` says invisible characters around a statement are not sent and a line of them gets no run button. `docs/features/safe-mode.mdx` says a conditional comment makes a statement count as a write.

## Verification

- Build: `verify.sh build` passed, `.analysis/fix-run-path-invisible-whitespace/logs/build-TablePro-161542.log`.
- Tests with the fix: 481 cases executed, 481 passed, 0 failed across 32 suites: `StatementBlankTests`, ten `QueryClassifier*` suites (including the new `QueryClassifierCommentBoundaryTests` and `QueryClassifierInvisibleCharacterTests`), `SQLExecutableStatementTests`, `SQLStatementNavigationTests`, `SQLStatementScannerTests`, `SQLStatementBlockSplittingTests`, `SQLStatementRangeTests`, `SQLStatementScannerLocatedTests`, `StatementAnchorTests`, `StatementNavigationCommandTests`, `StatementRunPerformanceGuardTests`, `StatementRunControllerTests`, `JavaScriptStatementScannerTests`, `QueryStatementModelTests`, `DatabaseAccessBridgeStatementTests`, `ExternalStatementGateTests`, `ExecutionGateTests`, `MCPStatementGateConsentPolicyTests`, `MCPStatementGateRefusalTests`, `ConfirmDestructiveOperationToolTests`, `ExportDataToolStatementTests`, `ExplainResultRouterTests`, `StringCatalogIntegrityTests`. Log: `.analysis/fix-run-path-invisible-whitespace/logs/test-StatementBlankTests-161621.log`.
- Tests without the fix, with the source changes reverted in the worktree:
  - First round (invisible characters): 47 of 138 cases failed across the scanner, navigation, statement model, classifier, gate and bridge suites. Log: `test-SQLExecutableStatementTests-152352.log`.
  - Second round (CRLF comments, conditional comments, empty external statement, ZWNJ): 20 cases failed across `QueryClassifierCommentBoundaryTests`, `ExternalStatementGateTests`, `DatabaseAccessBridgeStatementTests` and `SQLExecutableStatementTests`. Log: `test-QueryClassifierCommentBoundaryTests-161227.log`.
- Performance, measured with a standalone copy of the trimming code: the content range of a statement wrapped in 4,000,000 ASCII spaces takes about 100 ms with the ASCII fast path, where the reviewer measured 199 ms for half that many before it. 2,000,000 non-ASCII blanks (U+00A0, U+3000) take 115 to 200 ms, and 20,000 ordinary statements take 7 ms in total. Only long blank runs cost anything, and they are rare in real scripts.
- SwiftLint `--strict` on the changed files: no violations on added lines. The two hits are on existing lines 12 and 16 of `SQLExecutableStatementTests.swift`.
- `scripts/localization.py verify`: ok. Docs `check-writing-style.sh` and `check-docs-against-source.py`: pass.
- Package tests: not applicable, `LocalPackages/CodeEditTextView` is untouched.
- UI tests: none. The behaviour is classification and text trimming, and the unit suites cover the gutter parity, the executed text and spans, the classifier tiers and the Safe Mode gate decisions. A UI test would have to put U+0008 or U+00A0 into the editor, but #2724 drops typed control characters and XCUITest cannot paste one reliably, so it would not run deterministically.

## Notes

Codex was unavailable, so an adversarial reviewer agent read the diff instead. It raised four findings:

1. CRLF and conditional comments hiding a `DROP` from the classifier (material, existing before this change). Fixed as described above.
2. Trimming split on NSString composed sequences, which do not attach a ZWNJ, so a ZWNJ ending a word was stripped. Fixed: trimming now works on Swift Characters, and a ZWNJ case is in the tests.
3. Run and Execute stay enabled for a tab holding only invisible characters, and pressing them now does nothing. Partly taken: the external bridge now refuses an empty statement. The enablement change was left out. Execute has no text gate and the menu only checks `isEmpty`, so a tab of only spaces or only comments already ran nothing through those controls before this change. Giving them a runnable-statement signal is a separate change to how those controls validate.
4. Four Unicode property lookups per blank character on the main thread. Fixed with the ASCII fast path.

Known trade-offs, all in the safe direction:

- `SELECT /*!40001 SQL_NO_CACHE */ * FROM t` is now a write, so Read-Only Safe Mode and read-only MCP connections refuse it. The Safe Mode page says so and tells the user to remove the comment.
- A bare CR now ends a line comment for the classifier on every engine. MySQL and SQLite end comments only at LF, so text after a bare CR there may be over-classified. It is never under-classified.
- A NUL at the very start or end of a statement is now trimmed and the statement runs. A NUL inside a statement is still refused, and the docs sentence says that.
- The Safe Mode section heading changed to "What always counts as a write". No page links to the old anchor.

https://claude.ai/code/session_011THKc9TRHE8xjcxXidDHXP
