### PR TITLE
fix(editor): leave keys to the input method while the SQL editor has marked text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Failed connect from an opened file or URL titled "Disconnected", with Reconnect as its only fix.
 - Connection Failed alert covering the window that already showed the same failure.
 - Invisible control characters typed into a query by an input method or a Control-key chord such as Ctrl+Option+H. (#2717)
+- Escape and Tab taken from an input method mid-composition in the SQL editor, and AI suggestions shown during it.
 - Statement with a NUL character running only up to it on SQLite and PostgreSQL, dropping its WHERE clause. (#2717)
 - Vim Replace mode writing an invisible character for Backspace and keypad Enter. (#2717)
 - Line and paragraph separators (U+2028, U+2029) shown as line breaks the database does not see. (#2717)

--- a/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/CodeSuggestion/Window/SuggestionController.swift
+++ b/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/CodeSuggestion/Window/SuggestionController.swift
@@ -6,6 +6,7 @@
 //
 
 import AppKit
+import Carbon.HIToolbox
 import CodeEditTextView
 import Combine
 import SwiftUI
@@ -269,31 +270,35 @@ public final class SuggestionController: NSWindowController {
         }
         localEventMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
             guard let self else { return event }
+            return self.handleKeyDown(event)
+        }
+    }
 
-            // Close if the active text view was removed from its window (e.g., tab closed)
-            if self.model.activeTextView == nil || self.model.activeTextView?.view.window == nil {
-                self.close()
-                return event
-            }
+    internal func handleKeyDown(_ event: NSEvent) -> NSEvent? {
+        guard let activeTextView = model.activeTextView, activeTextView.view.window != nil else {
+            close()
+            return event
+        }
 
-            switch event.keyCode {
-            case 53: // Escape
-                self.close()
-                return nil
-            case 125: // Down Arrow
-                self.model.moveDown()
-                return nil
-            case 126: // Up Arrow
-                self.model.moveUp()
-                return nil
-            case 36, 48: // Return, Tab
-                if let item = self.model.selectedItem {
-                    self.model.applySelectedItem(item: item)
-                }
-                return nil
-            default:
-                return event
+        guard !activeTextView.textView.hasMarkedText() else { return event }
+
+        switch Int(event.keyCode) {
+        case kVK_Escape:
+            close()
+            return nil
+        case kVK_DownArrow:
+            model.moveDown()
+            return nil
+        case kVK_UpArrow:
+            model.moveUp()
+            return nil
+        case kVK_Return, kVK_Tab:
+            if let item = model.selectedItem {
+                model.applySelectedItem(item: item)
             }
+            return nil
+        default:
+            return event
         }
     }
 

--- a/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/Controller/EditorKeyCommand.swift
+++ b/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/Controller/EditorKeyCommand.swift
@@ -1,0 +1,78 @@
+//
+//  EditorKeyCommand.swift
+//  CodeEditSourceEditor
+//
+
+import AppKit
+import Carbon.HIToolbox
+
+internal enum EditorKeyCommand: Equatable {
+    case toggleComment
+    case outdent
+    case indent
+    case duplicateLine
+    case deleteLine
+    case escape
+    case showCompletions
+    case jumpToDefinition
+    case moveLinesUp
+    case moveLinesDown
+
+    private static let command = NSEvent.ModifierFlags.command
+    private static let control = NSEvent.ModifierFlags.control
+    private static let option = NSEvent.ModifierFlags.option
+    private static let noModifiers = NSEvent.ModifierFlags()
+
+    internal init?(event: NSEvent, modifierFlags: NSEvent.ModifierFlags) {
+        let resolved = Self.characterCommand(modifierFlags: modifierFlags, characters: event.charactersIgnoringModifiers)
+            ?? Self.keyCodeCommand(modifierFlags: modifierFlags.subtracting(.numericPad), keyCode: Int(event.keyCode))
+        guard let resolved else { return nil }
+        self = resolved
+    }
+
+    internal var isCommandChord: Bool {
+        switch self {
+        case .toggleComment, .outdent, .indent, .duplicateLine, .deleteLine, .jumpToDefinition:
+            return true
+        case .escape, .showCompletions, .moveLinesUp, .moveLinesDown:
+            return false
+        }
+    }
+
+    private static func characterCommand(
+        modifierFlags: NSEvent.ModifierFlags,
+        characters: String?
+    ) -> EditorKeyCommand? {
+        switch (modifierFlags, characters) {
+        case (command, "/"):
+            return .toggleComment
+        case (command, "["):
+            return .outdent
+        case (command, "]"):
+            return .indent
+        case ([command, .shift], "D"):
+            return .duplicateLine
+        case ([command, .shift], "K"):
+            return .deleteLine
+        case (noModifiers, "\u{1b}"):
+            return .escape
+        case (control, " "):
+            return .showCompletions
+        case ([command, control], "j"):
+            return .jumpToDefinition
+        default:
+            return nil
+        }
+    }
+
+    private static func keyCodeCommand(modifierFlags: NSEvent.ModifierFlags, keyCode: Int) -> EditorKeyCommand? {
+        switch (modifierFlags, keyCode) {
+        case (option, kVK_UpArrow):
+            return .moveLinesUp
+        case (option, kVK_DownArrow):
+            return .moveLinesDown
+        default:
+            return nil
+        }
+    }
+}

--- a/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/Controller/TextViewController+Lifecycle.swift
+++ b/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/Controller/TextViewController+Lifecycle.swift
@@ -6,7 +6,6 @@
 //
 
 import AppKit
-import Carbon.HIToolbox
 import CodeEditTextView
 
 extension TextViewController {
@@ -210,6 +209,9 @@ extension TextViewController {
             .subtracting([.capsLock, .function])
         switch event.type {
         case .keyDown:
+            guard !textView.hasMarkedText() else {
+                return handleKeyDownDuringComposition(event: event, modifierFlags: modifierFlags)
+            }
             let tabKey: UInt16 = 0x30
 
             if event.keyCode == tabKey {
@@ -245,61 +247,49 @@ extension TextViewController {
         }
     }
 
-    func handleCommand(event: NSEvent, modifierFlags: NSEvent.ModifierFlags) -> NSEvent? {
-        let commandKey = NSEvent.ModifierFlags.command
-        let controlKey = NSEvent.ModifierFlags.control
-
-        switch (modifierFlags, event.charactersIgnoringModifiers) {
-        case (commandKey, "/"):
-            handleCommandSlash()
-            return nil
-        case (commandKey, "["):
-            handleIndent(inwards: true)
-            return nil
-        case (commandKey, "]"):
-            handleIndent()
-            return nil
-        case ([commandKey, .shift], "D"):
-            duplicateLine()
-            return nil
-        case ([commandKey, .shift], "K"):
-            deleteLine()
-            return nil
-        case (.init(rawValue: 0), "\u{1b}"): // Escape key
-            if findViewController?.viewModel.isShowingFindPanel == true {
-                self.findViewController?.hideFindPanel()
-                return nil
-            }
-            // Attempt to show completions otherwise
-            return handleShowCompletions(event)
-        case (controlKey, " "):
-            return handleShowCompletions(event)
-        case ([NSEvent.ModifierFlags.command, NSEvent.ModifierFlags.control], "j"):
-            guard let cursor = cursorPositions.first else {
-                return event
-            }
-            jumpToDefinitionModel.performJump(at: cursor.range)
-            return nil
-        case (_, _):
-            // Handle key-code-based shortcuts (arrow keys don't have stable characters)
-            return handleKeyCodeCommand(event: event, modifierFlags: modifierFlags)
-        }
-    }
-
-    private func handleKeyCodeCommand(event: NSEvent, modifierFlags: NSEvent.ModifierFlags) -> NSEvent? {
-        // Strip .numericPad — arrow keys include it on macOS
-        let flags = modifierFlags.subtracting(.numericPad)
-
-        switch (flags, Int(event.keyCode)) {
-        case (.option, kVK_UpArrow):
-            moveLinesUp()
-            return nil
-        case (.option, kVK_DownArrow):
-            moveLinesDown()
-            return nil
-        default:
+    private func handleKeyDownDuringComposition(event: NSEvent, modifierFlags: NSEvent.ModifierFlags) -> NSEvent? {
+        guard let command = EditorKeyCommand(event: event, modifierFlags: modifierFlags),
+              command.isCommandChord else {
             return event
         }
+        return nil
+    }
+
+    func handleCommand(event: NSEvent, modifierFlags: NSEvent.ModifierFlags) -> NSEvent? {
+        guard let command = EditorKeyCommand(event: event, modifierFlags: modifierFlags) else { return event }
+
+        switch command {
+        case .toggleComment:
+            handleCommandSlash()
+        case .outdent:
+            handleIndent(inwards: true)
+        case .indent:
+            handleIndent()
+        case .duplicateLine:
+            duplicateLine()
+        case .deleteLine:
+            deleteLine()
+        case .moveLinesUp:
+            moveLinesUp()
+        case .moveLinesDown:
+            moveLinesDown()
+        case .escape:
+            return handleEscape(event)
+        case .showCompletions:
+            return handleShowCompletions(event)
+        case .jumpToDefinition:
+            guard let cursor = cursorPositions.first else { return event }
+            jumpToDefinitionModel.performJump(at: cursor.range)
+        }
+        return nil
+    }
+
+    private func handleEscape(_ event: NSEvent) -> NSEvent? {
+        guard let findViewController, findViewController.viewModel.isShowingFindPanel else {
+            return handleShowCompletions(event)
+        }
+        findViewController.hideFindPanel()
+        return nil
     }
 
     /// Handles the tab key event.

--- a/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/Find/PanelView/FindPanelHostingView.swift
+++ b/LocalPackages/CodeEditSourceEditor/Sources/CodeEditSourceEditor/Find/PanelView/FindPanelHostingView.swift
@@ -5,9 +5,10 @@
 //  Created by Khan Winter on 3/10/25.
 //
 
-import SwiftUI
 import AppKit
+import Carbon.HIToolbox
 import Combine
+import SwiftUI
 
 /// A subclass of `NSHostingView` that hosts the SwiftUI `FindPanelView` in an 
 /// AppKit context.
@@ -55,12 +56,16 @@ final class FindPanelHostingView: NSHostingView<FindPanelView> {
     func addEventMonitor() {
         eventMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event -> NSEvent? in
             guard let self else { return event }
-            if event.keyCode == 53 { // if esc pressed
-                self.viewModel?.dismiss?()
-                return nil // do not play "beep" sound
-            }
-            return event
+            return self.handleKeyDown(event)
         }
+    }
+
+    internal func handleKeyDown(_ event: NSEvent) -> NSEvent? {
+        guard Int(event.keyCode) == kVK_Escape else { return event }
+        let firstResponder = event.window?.firstResponder as? NSTextInputClient
+        guard firstResponder?.hasMarkedText() != true else { return event }
+        viewModel?.dismiss?()
+        return nil
     }
 
     func removeEventMonitor() {

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextView/TextView+NSTextInput.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/TextView/TextView+NSTextInput.swift
@@ -159,6 +159,10 @@ extension TextView: NSTextInputClient {
             NSRange(location: $0.max, length: 0)
         }))
 
+        if insertString.isEmpty {
+            layoutManager.markedTextManager.removeAll()
+        }
+
         _undoManager?.enable()
     }
 

--- a/LocalPackages/CodeEditTextView/Tests/CodeEditTextViewTests/IMEInputTests.swift
+++ b/LocalPackages/CodeEditTextView/Tests/CodeEditTextViewTests/IMEInputTests.swift
@@ -91,6 +91,76 @@ struct IMEInputTests {
         #expect(textView.markedRange().location == NSNotFound)
     }
 
+    @Test("An input method that empties its composition ends it")
+    func emptiedCompositionEndsIt() throws {
+        let textView = makeLaidOutTextView("alpha")
+        textView.selectionManager.setSelectedRange(NSRange(location: 5, length: 0))
+
+        typeMarkedCeshi(on: textView)
+        textView.setMarkedText(
+            "",
+            selectedRange: NSRange(location: 0, length: 0),
+            replacementRange: NSRange(location: NSNotFound, length: 0)
+        )
+
+        #expect(textView.string == "alpha")
+        #expect(textView.hasMarkedText() == false)
+        #expect(textView.markedRange().location == NSNotFound)
+        let caret = try #require(textView.selectionManager.textSelections.first)
+        #expect(caret.range == NSRange(location: 5, length: 0))
+    }
+
+    @Test("A composition begun after an emptied one starts at the caret")
+    func compositionAfterEmptiedOneStartsAtCaret() throws {
+        let textView = makeLaidOutTextView("alpha")
+        textView.selectionManager.setSelectedRange(NSRange(location: 5, length: 0))
+
+        typeMarkedCeshi(on: textView)
+        textView.setMarkedText(
+            "",
+            selectedRange: NSRange(location: 0, length: 0),
+            replacementRange: NSRange(location: NSNotFound, length: 0)
+        )
+        textView.setMarkedText(
+            "c",
+            selectedRange: NSRange(location: 1, length: 0),
+            replacementRange: NSRange(location: NSNotFound, length: 0)
+        )
+        #expect(textView.markedRange() == NSRange(location: 5, length: 1))
+
+        textView.insertText("测", replacementRange: NSRange(location: NSNotFound, length: 0))
+
+        #expect(textView.string == "alpha测")
+        #expect(textView.hasMarkedText() == false)
+        let caret = try #require(textView.selectionManager.textSelections.first)
+        #expect(caret.range == NSRange(location: 6, length: 0))
+    }
+
+    @Test("Emptying a composition across several cursors ends it at every cursor")
+    func emptiedMultiCursorCompositionEndsIt() {
+        let textView = makeLaidOutTextView("ABC")
+        textView.selectionManager.setSelectedRanges([
+            NSRange(location: 1, length: 0),
+            NSRange(location: 2, length: 0)
+        ])
+
+        textView.setMarkedText(
+            "´",
+            selectedRange: NSRange(location: 1, length: 0),
+            replacementRange: NSRange(location: NSNotFound, length: 0)
+        )
+        textView.setMarkedText(
+            "",
+            selectedRange: NSRange(location: 0, length: 0),
+            replacementRange: NSRange(location: NSNotFound, length: 0)
+        )
+
+        #expect(textView.string == "ABC")
+        #expect(textView.hasMarkedText() == false)
+        let carets = textView.selectionManager.textSelections.map(\.range).sorted { $0.location < $1.location }
+        #expect(carets == [NSRange(location: 1, length: 0), NSRange(location: 2, length: 0)])
+    }
+
     @Test("Plain Latin insertText path is unaffected")
     func plainInsertTextIsUnaffected() {
         let textView = makeLaidOutTextView("alpha")

--- a/TablePro/Core/AI/InlineSuggestion/InlineSuggestionManager.swift
+++ b/TablePro/Core/AI/InlineSuggestion/InlineSuggestionManager.swift
@@ -111,6 +111,7 @@ final class InlineSuggestionManager {
         guard let controller else { return false }
         guard let textView = controller.textView else { return false }
         guard textView.window?.firstResponder === textView else { return false }
+        guard !textView.hasMarkedText() else { return false }
         guard let cursor = controller.cursorPositions.first,
               cursor.range.length == 0 else { return false }
 
@@ -122,7 +123,7 @@ final class InlineSuggestionManager {
 
     // MARK: - Request
 
-    private func requestSuggestion() {
+    internal func requestSuggestion() {
         guard isEnabled() else { return }
         guard let source = sourceResolver?() else { return }
         guard let controller, let textView = controller.textView else { return }
@@ -157,6 +158,7 @@ final class InlineSuggestionManager {
                 guard let activeIdentity = self.sourceResolver?()?.sourceIdentity,
                       activeIdentity == requestedFromIdentity else { return }
                 guard !suggestion.text.isEmpty else { return }
+                guard self.controller?.textView?.hasMarkedText() == false else { return }
 
                 self.currentSuggestion = suggestion
                 self.renderer.show(suggestion.text, at: cursorOffset)
@@ -210,32 +212,28 @@ final class InlineSuggestionManager {
         removeKeyEventMonitor()
         let monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] nsEvent in
             nonisolated(unsafe) let event = nsEvent
-            let acceptsSuggestion = MainActor.assumeIsolated { () -> Bool in
-                guard let self, self.isEditorFocused else { return false }
-
-                guard self.currentSuggestion != nil else { return false }
-
-                guard let textView = self.controller?.textView,
-                      event.window === textView.window,
-                      textView.window?.firstResponder === textView else { return false }
-
-                switch event.keyCode {
-                case 48:
-                    self.acceptSuggestion()
-                    return true
-
-                case 53:
-                    self.dismissSuggestion()
-                    return false
-
-                default:
-                    self.dismissSuggestion()
-                    return false
-                }
+            let consumed = MainActor.assumeIsolated { () -> Bool in
+                self?.consumesKeyDown(event) ?? false
             }
-            return acceptsSuggestion ? nil : nsEvent
+            return consumed ? nil : nsEvent
         }
         _keyEventMonitor.withLockUnchecked { $0 = monitor }
+    }
+
+    internal func consumesKeyDown(_ event: NSEvent) -> Bool {
+        guard isEditorFocused, currentSuggestion != nil else { return false }
+
+        guard let textView = controller?.textView,
+              event.window === textView.window,
+              textView.window?.firstResponder === textView else { return false }
+
+        guard event.keyCode == KeyCode.tab.rawValue, !textView.hasMarkedText() else {
+            dismissSuggestion()
+            return false
+        }
+
+        acceptSuggestion()
+        return true
     }
 
     private func removeKeyEventMonitor() {

--- a/TableProTests/Core/AI/InlineSuggestionManagerCompositionTests.swift
+++ b/TableProTests/Core/AI/InlineSuggestionManagerCompositionTests.swift
@@ -1,0 +1,180 @@
+//
+//  InlineSuggestionManagerCompositionTests.swift
+//  TableProTests
+//
+
+import AppKit
+import Carbon.HIToolbox
+import CodeEditSourceEditor
+import CodeEditTextView
+@testable import TablePro
+import Testing
+
+@MainActor
+private final class RecordingInlineSource: InlineSuggestionSource {
+    static let completion = "FROM users"
+
+    let isAvailable = true
+    var holdsReplies = false
+    private(set) var requests: [SuggestionContext] = []
+    private(set) var shown: [InlineSuggestion] = []
+    private(set) var accepted: [InlineSuggestion] = []
+    private(set) var dismissed: [InlineSuggestion] = []
+    private var heldReplies: [CheckedContinuation<Void, Never>] = []
+
+    var heldReplyCount: Int { heldReplies.count }
+
+    func requestSuggestion(context: SuggestionContext) async throws -> InlineSuggestion? {
+        requests.append(context)
+        if holdsReplies {
+            await withCheckedContinuation { continuation in
+                heldReplies.append(continuation)
+            }
+        }
+        return InlineSuggestion(text: Self.completion, replacementText: Self.completion)
+    }
+
+    func releaseReplies() {
+        let replies = heldReplies
+        heldReplies.removeAll()
+        replies.forEach { $0.resume() }
+    }
+
+    func didShowSuggestion(_ suggestion: InlineSuggestion) {
+        shown.append(suggestion)
+    }
+
+    func didAcceptSuggestion(_ suggestion: InlineSuggestion) {
+        accepted.append(suggestion)
+    }
+
+    func didDismissSuggestion(_ suggestion: InlineSuggestion) {
+        dismissed.append(suggestion)
+    }
+}
+
+@Suite("Inline suggestions during an input method composition")
+@MainActor
+internal struct InlineSuggestionManagerCompositionTests {
+    @MainActor
+    private struct Harness {
+        let window: NSWindow
+        let editor: TextViewController
+        let manager: InlineSuggestionManager
+        let source: RecordingInlineSource
+
+        func tab() -> NSEvent? {
+            EditorControllerFixture.keyDown(keyCode: kVK_Tab, characters: "\t", in: window)
+        }
+    }
+
+    private func makeHarness() -> Harness {
+        let (window, editor) = EditorControllerFixture.makeFocusedInWindow(string: "SELECT * ")
+        let source = RecordingInlineSource()
+        let manager = InlineSuggestionManager()
+        manager.install(controller: editor, sourceResolver: { source })
+        manager.editorDidFocus()
+        return Harness(window: window, editor: editor, manager: manager, source: source)
+    }
+
+    private func waitUntil(_ condition: () -> Bool) async {
+        var attempts = 0
+        while !condition(), attempts < 500 {
+            attempts += 1
+            await Task.yield()
+        }
+    }
+
+    private func drainMainActor() async {
+        for _ in 0..<50 {
+            await Task.yield()
+        }
+    }
+
+    @Test("A settled line requests and shows a suggestion")
+    func settledLineShowsSuggestion() async {
+        let harness = makeHarness()
+        defer { harness.manager.uninstall() }
+
+        harness.manager.requestSuggestion()
+        await waitUntil { !harness.source.shown.isEmpty }
+
+        #expect(harness.source.requests.count == 1)
+        #expect(harness.source.shown.count == 1)
+    }
+
+    @Test("No suggestion is requested while a composition is in progress")
+    func compositionRequestsNothing() async {
+        let harness = makeHarness()
+        defer { harness.manager.uninstall() }
+        EditorControllerFixture.beginComposition("le", in: harness.editor.textView)
+
+        harness.manager.requestSuggestion()
+        await drainMainActor()
+
+        #expect(harness.source.requests.isEmpty)
+        #expect(harness.source.shown.isEmpty)
+    }
+
+    @Test("A composition the input method empties no longer holds suggestions back")
+    func emptiedCompositionRequestsAgain() async {
+        let harness = makeHarness()
+        defer { harness.manager.uninstall() }
+        EditorControllerFixture.beginComposition("le", in: harness.editor.textView)
+        EditorControllerFixture.emptyComposition(in: harness.editor.textView)
+
+        harness.manager.requestSuggestion()
+        await waitUntil { !harness.source.shown.isEmpty }
+
+        #expect(harness.source.requests.count == 1)
+        #expect(harness.source.shown.count == 1)
+    }
+
+    @Test("A reply that arrives after a composition begins is not shown")
+    func replyDuringCompositionIsDropped() async {
+        let harness = makeHarness()
+        defer { harness.manager.uninstall() }
+        harness.source.holdsReplies = true
+
+        harness.manager.requestSuggestion()
+        await waitUntil { harness.source.heldReplyCount == 1 }
+        EditorControllerFixture.beginComposition("le", in: harness.editor.textView)
+        harness.source.releaseReplies()
+        await drainMainActor()
+
+        #expect(harness.source.requests.count == 1)
+        #expect(harness.source.shown.isEmpty)
+    }
+
+    @Test("Tab mid-composition goes to the input method and dismisses the suggestion unaccepted")
+    func tabDuringCompositionIsNotAccepted() async throws {
+        let harness = makeHarness()
+        defer { harness.manager.uninstall() }
+        harness.manager.requestSuggestion()
+        await waitUntil { !harness.source.shown.isEmpty }
+        try #require(harness.source.shown.count == 1)
+
+        EditorControllerFixture.beginComposition("le", in: harness.editor.textView)
+        let tab = try #require(harness.tab())
+
+        #expect(harness.manager.consumesKeyDown(tab) == false)
+        #expect(harness.editor.textView.string == "SELECT * le")
+        #expect(harness.editor.textView.hasMarkedText())
+        #expect(harness.source.accepted.isEmpty)
+        #expect(harness.source.dismissed.count == 1)
+    }
+
+    @Test("Tab accepts a shown suggestion when nothing is composing")
+    func tabAcceptsSettledSuggestion() async throws {
+        let harness = makeHarness()
+        defer { harness.manager.uninstall() }
+        harness.manager.requestSuggestion()
+        await waitUntil { !harness.source.shown.isEmpty }
+        try #require(harness.source.shown.count == 1)
+        let tab = try #require(harness.tab())
+
+        #expect(harness.manager.consumesKeyDown(tab))
+        #expect(harness.editor.textView.string == "SELECT * " + RecordingInlineSource.completion)
+        #expect(harness.source.accepted.count == 1)
+    }
+}

--- a/TableProTests/Views/Editor/EditorControllerFixture.swift
+++ b/TableProTests/Views/Editor/EditorControllerFixture.swift
@@ -31,6 +31,59 @@ internal enum EditorControllerFixture {
         return controller
     }
 
+    internal static func makeFocusedInWindow(string: String) -> (NSWindow, TextViewController) {
+        let controller = make(string: string)
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 1_000, height: 1_000),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        window.contentView = controller.view
+        controller.view.layoutSubtreeIfNeeded()
+        _ = window.makeFirstResponder(controller.textView)
+        let end = (string as NSString).length
+        controller.setCursorPositions([CursorPosition(range: NSRange(location: end, length: 0))])
+        return (window, controller)
+    }
+
+    internal static func beginComposition(_ markedText: String, in textView: TextView) {
+        textView.setMarkedText(
+            markedText,
+            selectedRange: NSRange(location: (markedText as NSString).length, length: 0),
+            replacementRange: NSRange(location: NSNotFound, length: 0)
+        )
+    }
+
+    internal static func emptyComposition(in textView: TextView) {
+        textView.setMarkedText(
+            "",
+            selectedRange: NSRange(location: 0, length: 0),
+            replacementRange: NSRange(location: NSNotFound, length: 0)
+        )
+    }
+
+    internal static func keyDown(
+        keyCode: Int,
+        characters: String,
+        modifiers: NSEvent.ModifierFlags = [],
+        in window: NSWindow?
+    ) -> NSEvent? {
+        NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: modifiers,
+            timestamp: 0,
+            windowNumber: window?.windowNumber ?? 0,
+            context: nil,
+            characters: characters,
+            charactersIgnoringModifiers: characters,
+            isARepeat: false,
+            keyCode: UInt16(keyCode)
+        )
+    }
+
     private static var configuration: SourceEditorConfiguration {
         SourceEditorConfiguration(
             appearance: .init(

--- a/TableProTests/Views/Editor/EditorKeyMonitorCompositionTests.swift
+++ b/TableProTests/Views/Editor/EditorKeyMonitorCompositionTests.swift
@@ -1,0 +1,246 @@
+//
+//  EditorKeyMonitorCompositionTests.swift
+//  TableProTests
+//
+
+import AppKit
+import Carbon.HIToolbox
+@testable import CodeEditSourceEditor
+import CodeEditTextView
+import SwiftUI
+import Testing
+
+internal struct EditorKeyChord: Sendable, CustomTestStringConvertible {
+    let name: String
+    let keyCode: Int
+    let characters: String
+    let modifiers: NSEvent.ModifierFlags
+
+    var testDescription: String { name }
+
+    static let inputMethodKeys: [EditorKeyChord] = [
+        EditorKeyChord(name: "Escape", keyCode: kVK_Escape, characters: "\u{1b}", modifiers: []),
+        EditorKeyChord(name: "Control-Space", keyCode: kVK_Space, characters: " ", modifiers: .control),
+        EditorKeyChord(name: "Shift-Tab", keyCode: kVK_Tab, characters: "\t", modifiers: .shift),
+        EditorKeyChord(name: "Option-Up", keyCode: kVK_UpArrow, characters: "\u{F700}", modifiers: .option),
+        EditorKeyChord(name: "Option-Down", keyCode: kVK_DownArrow, characters: "\u{F701}", modifiers: .option)
+    ]
+
+    static let commandChords: [EditorKeyChord] = [
+        EditorKeyChord(name: "Command-Slash", keyCode: kVK_ANSI_Slash, characters: "/", modifiers: .command),
+        EditorKeyChord(name: "Command-[", keyCode: kVK_ANSI_LeftBracket, characters: "[", modifiers: .command),
+        EditorKeyChord(name: "Command-]", keyCode: kVK_ANSI_RightBracket, characters: "]", modifiers: .command),
+        EditorKeyChord(name: "Command-Shift-D", keyCode: kVK_ANSI_D, characters: "D", modifiers: [.command, .shift]),
+        EditorKeyChord(name: "Command-Shift-K", keyCode: kVK_ANSI_K, characters: "K", modifiers: [.command, .shift]),
+        EditorKeyChord(
+            name: "Command-Control-J",
+            keyCode: kVK_ANSI_J,
+            characters: "j",
+            modifiers: [.command, .control]
+        )
+    ]
+
+    static let editorCommands: [EditorKeyChord] = inputMethodKeys + commandChords
+
+    static let foreignCommandChords: [EditorKeyChord] = [
+        EditorKeyChord(name: "Command-S", keyCode: kVK_ANSI_S, characters: "s", modifiers: .command),
+        EditorKeyChord(name: "Command-C", keyCode: kVK_ANSI_C, characters: "c", modifiers: .command),
+        EditorKeyChord(
+            name: "Command-Option-[",
+            keyCode: kVK_ANSI_LeftBracket,
+            characters: "[",
+            modifiers: [.command, .option]
+        )
+    ]
+
+    static let completionListKeys: [EditorKeyChord] = [
+        EditorKeyChord(name: "Escape", keyCode: kVK_Escape, characters: "\u{1b}", modifiers: []),
+        EditorKeyChord(name: "Down", keyCode: kVK_DownArrow, characters: "\u{F701}", modifiers: []),
+        EditorKeyChord(name: "Up", keyCode: kVK_UpArrow, characters: "\u{F700}", modifiers: []),
+        EditorKeyChord(name: "Return", keyCode: kVK_Return, characters: "\r", modifiers: []),
+        EditorKeyChord(name: "Tab", keyCode: kVK_Tab, characters: "\t", modifiers: [])
+    ]
+
+    @MainActor
+    func event(in window: NSWindow?) -> NSEvent? {
+        EditorControllerFixture.keyDown(keyCode: keyCode, characters: characters, modifiers: modifiers, in: window)
+    }
+}
+
+@MainActor
+private final class RecordingCompletionDelegate: CodeSuggestionDelegate {
+    private(set) var appliedLabels: [String] = []
+
+    func completionOnCursorMove(textView: TextViewController, cursorPosition: CursorPosition) -> [CodeSuggestionEntry]? {
+        nil
+    }
+
+    func completionWindowApplyCompletion(
+        item: CodeSuggestionEntry,
+        textView: TextViewController,
+        cursorPosition: CursorPosition?
+    ) {
+        appliedLabels.append(item.label)
+    }
+}
+
+private struct StubSuggestionEntry: CodeSuggestionEntry {
+    let label: String
+    let detail: String? = nil
+    let documentation: String? = nil
+    let pathComponents: [String]? = nil
+    let targetPosition: CursorPosition? = nil
+    let sourcePreview: String? = nil
+    let image = Image(systemName: "tablecells")
+    let imageColor = Color.accentColor
+    let deprecated = false
+}
+
+@Suite("Editor key monitors during an input method composition")
+@MainActor
+internal struct EditorKeyMonitorCompositionTests {
+    @Test("The editor leaves its plain keys to the input method mid-composition", arguments: EditorKeyChord.inputMethodKeys)
+    func editorKeysDeferToComposition(chord: EditorKeyChord) throws {
+        let (window, editor) = EditorControllerFixture.makeFocusedInWindow(string: "    SELECT 1\nFROM ")
+        let delegate = RecordingCompletionDelegate()
+        editor.completionDelegate = delegate
+        EditorControllerFixture.beginComposition("le", in: editor.textView)
+        let composed = editor.textView.string
+        let event = try #require(chord.event(in: window))
+
+        #expect(editor.handleEvent(event: event) === event)
+        #expect(editor.textView.string == composed)
+        #expect(editor.textView.hasMarkedText())
+    }
+
+    @Test("The editor keeps its Command chords from the menu bar mid-composition and runs none", arguments: EditorKeyChord.commandChords)
+    func editorCommandChordsWithheldDuringComposition(chord: EditorKeyChord) throws {
+        let (window, editor) = EditorControllerFixture.makeFocusedInWindow(string: "    SELECT 1\nFROM ")
+        let delegate = RecordingCompletionDelegate()
+        editor.completionDelegate = delegate
+        EditorControllerFixture.beginComposition("le", in: editor.textView)
+        let composed = editor.textView.string
+        let event = try #require(chord.event(in: window))
+
+        #expect(editor.handleEvent(event: event) == nil)
+        #expect(editor.textView.string == composed)
+        #expect(editor.textView.hasMarkedText())
+    }
+
+    @Test("A Command chord the editor does not own reaches the menu bar mid-composition", arguments: EditorKeyChord.foreignCommandChords)
+    func foreignCommandChordsPassDuringComposition(chord: EditorKeyChord) throws {
+        let (window, editor) = EditorControllerFixture.makeFocusedInWindow(string: "SELECT ")
+        EditorControllerFixture.beginComposition("le", in: editor.textView)
+        let event = try #require(chord.event(in: window))
+
+        #expect(editor.handleEvent(event: event) === event)
+        #expect(editor.textView.string == "SELECT le")
+    }
+
+    @Test("A composition the input method empties gives the editor its keys back", arguments: EditorKeyChord.editorCommands)
+    func emptiedCompositionReturnsKeysToEditor(chord: EditorKeyChord) throws {
+        let (window, editor) = EditorControllerFixture.makeFocusedInWindow(string: "    SELECT 1\nFROM ")
+        let delegate = RecordingCompletionDelegate()
+        editor.completionDelegate = delegate
+        EditorControllerFixture.beginComposition("le", in: editor.textView)
+        EditorControllerFixture.emptyComposition(in: editor.textView)
+        try #require(editor.textView.hasMarkedText() == false)
+        let event = try #require(chord.event(in: window))
+
+        #expect(editor.handleEvent(event: event) == nil)
+    }
+
+    @Test("The editor claims each of those keys when nothing is composing", arguments: EditorKeyChord.editorCommands)
+    func editorCommandsClaimSettledText(chord: EditorKeyChord) throws {
+        let (window, editor) = EditorControllerFixture.makeFocusedInWindow(string: "    SELECT 1\nFROM ")
+        let delegate = RecordingCompletionDelegate()
+        editor.completionDelegate = delegate
+        let event = try #require(chord.event(in: window))
+
+        #expect(editor.handleEvent(event: event) == nil)
+    }
+
+    @Test("The completion list leaves its keys to the input method mid-composition", arguments: EditorKeyChord.completionListKeys)
+    func completionListDefersToComposition(chord: EditorKeyChord) throws {
+        let (window, editor) = EditorControllerFixture.makeFocusedInWindow(string: "SELECT ")
+        let delegate = RecordingCompletionDelegate()
+        let panel = makeCompletionList(for: editor, delegate: delegate)
+        EditorControllerFixture.beginComposition("le", in: editor.textView)
+        let event = try #require(chord.event(in: window))
+
+        #expect(panel.handleKeyDown(event) === event)
+        #expect(delegate.appliedLabels.isEmpty)
+        #expect(editor.textView.string == "SELECT le")
+    }
+
+    @Test("The completion list claims its keys when nothing is composing", arguments: EditorKeyChord.completionListKeys)
+    func completionListClaimsSettledText(chord: EditorKeyChord) throws {
+        let (window, editor) = EditorControllerFixture.makeFocusedInWindow(string: "SELECT ")
+        let delegate = RecordingCompletionDelegate()
+        let panel = makeCompletionList(for: editor, delegate: delegate)
+        let event = try #require(chord.event(in: window))
+
+        #expect(panel.handleKeyDown(event) == nil)
+    }
+
+    @Test("Escape mid-composition in the editor leaves the find panel open")
+    func findPanelDefersToEditorComposition() throws {
+        let (window, editor) = EditorControllerFixture.makeFocusedInWindow(string: "SELECT ")
+        let finder = try #require(editor.findViewController)
+        finder.showFindPanel(animated: false)
+        defer { finder.hideFindPanel(animated: false) }
+        _ = window.makeFirstResponder(editor.textView)
+        EditorControllerFixture.beginComposition("le", in: editor.textView)
+        let escape = try #require(EditorControllerFixture.keyDown(keyCode: kVK_Escape, characters: "\u{1b}", in: window))
+
+        #expect(finder.findPanel.handleKeyDown(escape) === escape)
+        #expect(finder.viewModel.isShowingFindPanel)
+    }
+
+    @Test("Escape mid-composition in a text field leaves the find panel open")
+    func findPanelDefersToFieldComposition() throws {
+        let (window, editor) = EditorControllerFixture.makeFocusedInWindow(string: "SELECT ")
+        let finder = try #require(editor.findViewController)
+        finder.showFindPanel(animated: false)
+        defer { finder.hideFindPanel(animated: false) }
+        let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 200, height: 22))
+        window.contentView?.addSubview(field)
+        _ = window.makeFirstResponder(field)
+        let fieldEditor = try #require(window.firstResponder as? NSTextView)
+        fieldEditor.setMarkedText(
+            "le",
+            selectedRange: NSRange(location: 2, length: 0),
+            replacementRange: NSRange(location: NSNotFound, length: 0)
+        )
+        try #require(fieldEditor.hasMarkedText())
+        let escape = try #require(EditorControllerFixture.keyDown(keyCode: kVK_Escape, characters: "\u{1b}", in: window))
+
+        #expect(finder.findPanel.handleKeyDown(escape) === escape)
+        #expect(finder.viewModel.isShowingFindPanel)
+    }
+
+    @Test("Escape with nothing composing closes the find panel")
+    func findPanelClosesOnSettledEscape() throws {
+        let (window, editor) = EditorControllerFixture.makeFocusedInWindow(string: "SELECT ")
+        let finder = try #require(editor.findViewController)
+        finder.showFindPanel(animated: false)
+        defer { finder.hideFindPanel(animated: false) }
+        _ = window.makeFirstResponder(editor.textView)
+        let escape = try #require(EditorControllerFixture.keyDown(keyCode: kVK_Escape, characters: "\u{1b}", in: window))
+
+        #expect(finder.findPanel.handleKeyDown(escape) == nil)
+        #expect(finder.viewModel.isShowingFindPanel == false)
+    }
+
+    private func makeCompletionList(
+        for editor: TextViewController,
+        delegate: RecordingCompletionDelegate
+    ) -> SuggestionController {
+        let panel = SuggestionController()
+        panel.model.activeTextView = editor
+        panel.model.delegate = delegate
+        panel.model.items = [StubSuggestionEntry(label: "users"), StubSuggestionEntry(label: "user_roles")]
+        panel.model.selectedIndex = 0
+        return panel
+    }
+}


### PR DESCRIPTION
Found while investigating #2717 (PR #2724).

## Root cause

The SQL editor handles several keys in local `NSEvent` monitors. A local monitor sees a `keyDown` before the window hands it to the first responder, so it runs before `NSTextInputContext` gets a chance to give the key to the input method. None of the monitors asked whether a composition was in progress:

- `TextViewController.handleEvent` took Escape (show completions or close the find panel), Control-Space, Shift-Tab, Option-Up and Option-Down, and ran its Command chords (Command-/, Command-[, Command-], Command-Shift-D, Command-Shift-K, Command-Control-J) over the text around the marked range.
- The completion list (`SuggestionController`) took Escape, Up, Down, Return and Tab.
- The find panel (`FindPanelHostingView`) closed on Escape, even when a text field or the editor was composing.
- `InlineSuggestionManager` accepted the AI suggestion on Tab, and requested and showed suggestions while text was still marked.

So with Pinyin, Kana, Hangul or a dead key, Escape could not cancel a composition, Tab went to the editor or the AI suggestion, and with the completion list open, Return, Tab and the arrows moved or applied the list instead of the candidates. The editor acted on the key and the input method never saw it.

A second defect sat under the first. When an input method empties its composition (Backspace over the last marked character, or Escape), it calls `setMarkedText("")`. `CodeEditTextView.TextView` kept a zero-length marked range after that call, so `hasMarkedText()` stayed `true`. `NSTextView` ends the composition instead; measured with a probe on this machine:

```
after le: true {7, 2} "SELECT le"
after empty: false {7, 0} "SELECT " {7, 0}
```

Left alone, that stale range would have made the new guards withhold the editor's keys until the next committed character.

## What changed

- Every editor key monitor now returns the event untouched while the text view has marked text, so the input method gets Escape, Tab, Return, the arrows and Control-Space.
- The editor's own Command chords are consumed and run nothing mid-composition. They are not passed on, because Command-[ and Command-] are also Previous Page and Next Page in the Query menu, and letting them through would page the grid while the user is composing. Command chords the editor does not own (Command-S, Command-C, Command-Option-[) still reach the menu bar.
- The editor's chord table moved into `EditorKeyCommand`, so the normal path and the composition path read one list instead of two copies that could drift.
- The find panel's Escape monitor leaves the key alone when the first responder is composing, whether that is the editor or the panel's own search field.
- `InlineSuggestionManager` requests nothing while text is marked, drops a reply that arrives after a composition began, and on Tab mid-composition dismisses the suggestion unaccepted and lets the input method have the key.
- `TextView.setMarkedText` with an empty string now clears the marked text at every cursor, matching `NSTextView`.

## Verification

TableProTests, through `verify.sh --no-wait --root <worktree>`:

- Build: `.analysis/fix-ime-composition-key-monitors/logs/build-TablePro-161007.log`, BUILD SUCCEEDED.
- Final run on the committed tree: `.analysis/fix-ime-composition-key-monitors/logs/test-EditorKeyMonitorCompositionTests-161741.log`, 55 cases passed, 0 failed (`EditorKeyMonitorCompositionTests` 49, `InlineSuggestionManagerCompositionTests` 6).
- Neighbouring suites: `test-EditorKeyMonitorCompositionTests-161600.log`, 68 cases passed, 0 failed, adding `InlineSuggestionManagerFocusTests` 6 and `CellOverlayEditorMovementTests` 7.
- The tests fail without the fix. With the first-round changes reverted (`test-EditorKeyMonitorCompositionTests-152650.log`), 16 cases failed across 7 tests while the settled-text controls passed. With the second-round changes reverted (`test-EditorKeyMonitorCompositionTests-161444.log`), 19 cases failed: the 6 withheld Command chords, 11 emptied-composition cases, plus the inline suggestion's re-request after an emptied composition and its Tab mid-composition.

The editor tests drive the real `TextViewController`, `SuggestionController` and `FindPanelHostingView` in a window: they begin a composition with `setMarkedText` and send real `keyDown` events through each monitor's handler, then check the event's fate, the text and the marked range. Each key is also checked with nothing composing, to prove the editor still claims it.

Packages:

- `swift test --package-path LocalPackages/CodeEditTextView` (the CI gate): 260 tests in 25 suites and 52 XCTest cases passed, including the 3 new `IMEInputTests` cases for an emptied composition (single cursor, a composition begun after an emptied one, and several cursors).
- `swift test --package-path LocalPackages/CodeEditSourceEditor --filter` over the four suggestion suites (`SuggestionApplyTests`, `SuggestionControllerPlacementTests`, `SuggestionPanelFocusTests`, `TextViewControllerSuggestionsTests`): 17 tests, 1 skipped, 0 failures.

SwiftLint `--strict` on every changed Swift file: no violation on an added line. The ones it reports in the vendored packages (`implicit_return`, `identifier_name` on `MAX_VISIBLE_ROWS`, `sorted_imports` in `IMEInputTests`) are on lines this PR does not touch.

UI tests: none. A composition needs a system input source selected, and switching the input source from the test runner changes the keyboard state of the whole machine, so it cannot run deterministically on CI. The unit tests drive the same `NSTextInputClient` calls an input method makes.

## Notes

Codex was unavailable (usage limit), so an adversarial reviewer agent read the diff instead. It raised two defects in the first version, both fixed here:

- An emptied composition left `hasMarkedText()` true for good, so the new guards would have withheld Escape and Tab until the next committed character. Fixed in `CodeEditTextView` itself rather than worked around in each monitor.
- The first version passed the editor's Command chords on mid-composition, which let Command-[ and Command-] fire Previous Page and Next Page. They are now consumed.

The SwiftLint findings above are left as they are: they sit in the vendored forks, which stay close to upstream so they can take its changes.

https://claude.ai/code/session_011THKc9TRHE8xjcxXidDHXP
