### PR TITLE
fix(editor): route Vim Control and Option chords to the engine instead of the text view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Invisible control characters typed into a query by an input method or a Control-key chord such as Ctrl+Option+H. (#2717)
 - Statement with a NUL character running only up to it on SQLite and PostgreSQL, dropping its WHERE clause. (#2717)
 - Vim Replace mode writing an invisible character for Backspace and keypad Enter. (#2717)
+- Option and Control chords editing text in Vim Normal and Visual mode, and Vim's Ctrl commands never running. (#2717)
 - Line and paragraph separators (U+2028, U+2029) shown as line breaks the database does not see. (#2717)
 
 ## [0.73.0] - 2026-09-09

--- a/TablePro/Core/Vim/VimEngine+Controls.swift
+++ b/TablePro/Core/Vim/VimEngine+Controls.swift
@@ -13,32 +13,98 @@ struct VimNumberMatch {
     var hexUppercase: Bool
 }
 
-extension VimEngine {
-    func handleNormalControl(_ char: Character, in buffer: VimTextBuffer) -> Bool? {
-        switch char {
-        case "\u{01}":
-            adjustNumberOnLine(by: consumeCount(), in: buffer)
-            return true
-        case "\u{18}":
-            adjustNumberOnLine(by: -consumeCount(), in: buffer)
-            return true
-        case "\u{04}":
-            scrollByLines(halfVisibleLineCount(in: buffer), in: buffer)
-            return true
-        case "\u{15}":
-            scrollByLines(-halfVisibleLineCount(in: buffer), in: buffer)
-            return true
-        case "\u{06}":
-            scrollByLines(visibleLineSpan(in: buffer), in: buffer)
-            return true
-        case "\u{02}":
-            scrollByLines(-visibleLineSpan(in: buffer), in: buffer)
-            return true
-        case "\u{05}", "\u{19}":
-            return true
-        default:
-            return nil
+enum VimNormalControl: Character {
+    case incrementNumber = "\u{01}"
+    case scrollPageUp = "\u{02}"
+    case scrollHalfPageDown = "\u{04}"
+    case scrollLineDown = "\u{05}"
+    case scrollPageDown = "\u{06}"
+    case redo = "\u{12}"
+    case scrollHalfPageUp = "\u{15}"
+    case decrementNumber = "\u{18}"
+    case scrollLineUp = "\u{19}"
+}
+
+enum VimControlMotion: Character {
+    case left = "\u{08}"
+    case down = "\u{0E}"
+    case up = "\u{10}"
+
+    var motionKey: Character {
+        switch self {
+        case .left: return "h"
+        case .down: return "j"
+        case .up: return "k"
         }
+    }
+}
+
+extension VimEngine {
+    func handleNormalControl(_ char: Character, in buffer: VimTextBuffer) -> Bool {
+        if let motion = VimControlMotion(rawValue: char) {
+            _ = processNormal(motion.motionKey, shift: false)
+            return true
+        }
+        guard let control = VimNormalControl(rawValue: char) else { return false }
+        guard pendingOperator == nil else {
+            pendingOperator = nil
+            countPrefix = 0
+            operatorCount = 0
+            return true
+        }
+        performNormalControl(control, in: buffer)
+        return true
+    }
+
+    func handleVisualControl(_ char: Character, linewise: Bool, in buffer: VimTextBuffer) -> Bool {
+        if let motion = VimControlMotion(rawValue: char) {
+            _ = processVisual(motion.motionKey, shift: false)
+            return true
+        }
+        guard let control = VimNormalControl(rawValue: char) else { return false }
+        switch control {
+        case .scrollHalfPageDown:
+            moveVisualCursor(byLines: halfVisibleLineCount(in: buffer), linewise: linewise, in: buffer)
+        case .scrollHalfPageUp:
+            moveVisualCursor(byLines: -halfVisibleLineCount(in: buffer), linewise: linewise, in: buffer)
+        case .scrollPageDown:
+            moveVisualCursor(byLines: visibleLineSpan(in: buffer), linewise: linewise, in: buffer)
+        case .scrollPageUp:
+            moveVisualCursor(byLines: -visibleLineSpan(in: buffer), linewise: linewise, in: buffer)
+        case .scrollLineDown, .scrollLineUp, .incrementNumber, .decrementNumber, .redo:
+            break
+        }
+        return true
+    }
+
+    private func performNormalControl(_ control: VimNormalControl, in buffer: VimTextBuffer) {
+        let hasExplicitCount = countPrefix > 0
+        let count = consumeCount()
+        switch control {
+        case .incrementNumber:
+            adjustNumberOnLine(by: count, in: buffer)
+        case .decrementNumber:
+            adjustNumberOnLine(by: -count, in: buffer)
+        case .scrollHalfPageDown:
+            scrollByLines(hasExplicitCount ? count : halfVisibleLineCount(in: buffer), in: buffer)
+        case .scrollHalfPageUp:
+            scrollByLines(-(hasExplicitCount ? count : halfVisibleLineCount(in: buffer)), in: buffer)
+        case .scrollPageDown:
+            scrollByLines(visibleLineSpan(in: buffer) * count, in: buffer)
+        case .scrollPageUp:
+            scrollByLines(-visibleLineSpan(in: buffer) * count, in: buffer)
+        case .redo:
+            for _ in 0..<count { buffer.redo() }
+        case .scrollLineDown, .scrollLineUp:
+            break
+        }
+    }
+
+    private func moveVisualCursor(byLines delta: Int, linewise: Bool, in buffer: VimTextBuffer) {
+        let (line, column) = buffer.lineAndColumn(forOffset: visualCursorEnd(buffer: buffer))
+        let targetLine = max(0, min(buffer.lineCount - 1, line + delta))
+        let target = buffer.offset(forLine: targetLine, column: column)
+        updateVisualSelection(cursorPos: target, linewise: linewise, in: buffer)
     }
 
     func halfVisibleLineCount(in buffer: VimTextBuffer) -> Int {

--- a/TablePro/Core/Vim/VimEngine+InsertReplace.swift
+++ b/TablePro/Core/Vim/VimEngine+InsertReplace.swift
@@ -6,7 +6,16 @@
 import CodeEditTextView
 import Foundation
 
+enum VimInsertControl: Character {
+    case outdentLine = "\u{04}"
+    case indentLine = "\u{14}"
+    case deleteToLineStart = "\u{15}"
+    case deleteWordBackward = "\u{17}"
+}
+
 extension VimEngine {
+    nonisolated static let backspaceCharacters: Set<Character> = ["\u{08}", "\u{7F}"]
+
     func processInsert(_ char: Character) -> Bool {
         if char == "\u{1B}" {
             lastInsertOffset = buffer?.selectedRange().location
@@ -20,10 +29,9 @@ extension VimEngine {
             }
             return true
         }
-        if let buffer, handleInsertModeControl(char, in: buffer) {
-            return true
-        }
-        return false
+        guard let buffer, let control = VimInsertControl(rawValue: char) else { return false }
+        performInsertControl(control, in: buffer)
+        return true
     }
 
     func processReplace(_ char: Character) -> Bool {
@@ -37,11 +45,15 @@ extension VimEngine {
             }
             return true
         }
-        if handleInsertModeControl(char, in: buffer) { return true }
+        if let control = VimInsertControl(rawValue: char) {
+            replaceModeEdits.removeAll()
+            performInsertControl(control, in: buffer)
+            return true
+        }
         if char == "\r" || char == "\n" {
             return false
         }
-        if char == "\u{7F}" {
+        if Self.backspaceCharacters.contains(char) {
             backspaceInReplace(in: buffer)
             return true
         }
@@ -75,7 +87,7 @@ extension VimEngine {
         buffer.setSelectedRange(NSRange(location: pos - 1, length: 0))
     }
 
-    static func isUnwritableControl(_ char: Character) -> Bool {
+    nonisolated static func isUnwritableControl(_ char: Character) -> Bool {
         guard char.unicodeScalars.count == 1, let scalar = char.unicodeScalars.first else { return false }
         return SpecialCharacter.isTextInputControl(scalar)
     }
@@ -97,7 +109,7 @@ extension VimEngine {
                 onCommand?(body)
             }
             return true
-        case "\u{7F}":
+        case "\u{7F}", "\u{08}":
             if (commandBuffer as NSString).length > 1 {
                 setMode(.commandLine(buffer: String(commandBuffer.dropLast())))
             } else {
@@ -105,58 +117,41 @@ extension VimEngine {
             }
             return true
         default:
+            guard !Self.isUnwritableControl(char) else { return true }
             setMode(.commandLine(buffer: commandBuffer + String(char)))
             return true
         }
     }
 
-    func handleInsertModeControl(_ char: Character, in buffer: VimTextBuffer) -> Bool {
-        switch char {
-        case "\u{17}":
-            deleteWordBackwardInInsert(in: buffer)
-            return true
-        case "\u{15}":
-            deleteToLineStartInInsert(in: buffer)
-            return true
-        case "\u{08}":
-            backspaceInInsert(in: buffer)
-            return true
-        case "\u{14}":
+    func performInsertControl(_ control: VimInsertControl, in buffer: VimTextBuffer) {
+        switch control {
+        case .deleteWordBackward:
+            deleteBackwardInInsert(to: wordStartBeforeCaret(in: buffer), in: buffer)
+        case .deleteToLineStart:
+            deleteBackwardInInsert(to: lineStartBeforeCaret(in: buffer), in: buffer)
+        case .indentLine:
             indentLineInInsert(outdent: false, in: buffer)
-            return true
-        case "\u{04}":
+        case .outdentLine:
             indentLineInInsert(outdent: true, in: buffer)
-            return true
-        default:
-            return false
         }
     }
 
-    func deleteWordBackwardInInsert(in buffer: VimTextBuffer) {
+    func wordStartBeforeCaret(in buffer: VimTextBuffer) -> Int {
         let pos = buffer.selectedRange().location
-        guard pos > 0 else { return }
-        let lineStart = buffer.lineRange(forOffset: pos).location
-        guard pos > lineStart else { return }
-        let target = max(lineStart, buffer.wordBoundary(forward: false, from: pos))
-        let range = NSRange(location: target, length: pos - target)
-        buffer.replaceCharacters(in: range, with: "")
+        let lineStart = lineStartBeforeCaret(in: buffer)
+        guard pos > lineStart else { return pos }
+        return max(lineStart, buffer.wordBoundary(forward: false, from: pos))
+    }
+
+    func lineStartBeforeCaret(in buffer: VimTextBuffer) -> Int {
+        buffer.lineRange(forOffset: buffer.selectedRange().location).location
+    }
+
+    func deleteBackwardInInsert(to target: Int, in buffer: VimTextBuffer) {
+        let pos = buffer.selectedRange().location
+        guard pos > target else { return }
+        buffer.replaceCharacters(in: NSRange(location: target, length: pos - target), with: "")
         buffer.setSelectedRange(NSRange(location: target, length: 0))
-    }
-
-    func deleteToLineStartInInsert(in buffer: VimTextBuffer) {
-        let pos = buffer.selectedRange().location
-        let lineStart = buffer.lineRange(forOffset: pos).location
-        guard pos > lineStart else { return }
-        let range = NSRange(location: lineStart, length: pos - lineStart)
-        buffer.replaceCharacters(in: range, with: "")
-        buffer.setSelectedRange(NSRange(location: lineStart, length: 0))
-    }
-
-    func backspaceInInsert(in buffer: VimTextBuffer) {
-        let pos = buffer.selectedRange().location
-        guard pos > 0 else { return }
-        buffer.replaceCharacters(in: NSRange(location: pos - 1, length: 1), with: "")
-        buffer.setSelectedRange(NSRange(location: pos - 1, length: 0))
     }
 
     func indentLineInInsert(outdent: Bool, in buffer: VimTextBuffer) {

--- a/TablePro/Core/Vim/VimEngine+NormalMode.swift
+++ b/TablePro/Core/Vim/VimEngine+NormalMode.swift
@@ -9,10 +9,6 @@ extension VimEngine {
     func processNormal(_ char: Character, shift: Bool) -> Bool { // swiftlint:disable:this function_body_length cyclomatic_complexity
         guard let buffer else { return false }
 
-        if let consumed = handleNormalControl(char, in: buffer) {
-            return consumed
-        }
-
         if let req = pendingFindChar {
             pendingFindChar = nil
             if char == "\u{1B}" { return true }
@@ -81,6 +77,10 @@ extension VimEngine {
         if pendingG {
             pendingG = false
             return handlePendingG(char, in: buffer)
+        }
+
+        if handleNormalControl(char, in: buffer) {
+            return true
         }
 
         switch char {

--- a/TablePro/Core/Vim/VimEngine+VisualMode.swift
+++ b/TablePro/Core/Vim/VimEngine+VisualMode.swift
@@ -37,6 +37,10 @@ extension VimEngine {
             return true
         }
 
+        if handleVisualControl(char, linewise: isLinewise, in: buffer) {
+            return true
+        }
+
         switch char {
         case "\u{1B}":
             recordVisualSelection(linewise: isLinewise, in: buffer)

--- a/TablePro/Core/Vim/VimEngine.swift
+++ b/TablePro/Core/Vim/VimEngine.swift
@@ -134,10 +134,6 @@ final class VimEngine {
         return consumed
     }
 
-    func redo() {
-        buffer?.redo()
-    }
-
     func invalidateLineCache() {
         buffer?.invalidateLineCache()
     }

--- a/TablePro/Core/Vim/VimKeyInterceptor.swift
+++ b/TablePro/Core/Vim/VimKeyInterceptor.swift
@@ -194,14 +194,6 @@ final class VimKeyInterceptor {
         }
     }
 
-    /// Arrow key Unicode scalars → Vim motion characters
-    private static let arrowToVimKey: [UInt32: Character] = [
-        0xF700: "k", // Up
-        0xF701: "j", // Down
-        0xF702: "h", // Left
-        0xF703: "l"  // Right
-    ]
-
     // MARK: - Event Handling
 
     private func handleKeyEvent(_ event: NSEvent) -> NSEvent? {
@@ -237,48 +229,28 @@ final class VimKeyInterceptor {
             return event
         }
 
-        // Pass through all events with Cmd or Option modifiers
-        // (system shortcuts like Cmd+C, Cmd+V, Cmd+Z, etc.)
-        let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-        if modifiers.contains(.command) || modifiers.contains(.option) {
+        let keystroke = VimKeystroke(
+            characters: event.characters ?? "",
+            charactersIgnoringModifiers: event.charactersIgnoringModifiers ?? "",
+            modifiers: event.modifierFlags,
+            isKeypadEnter: event.semanticKeyCode == .enter
+        )
+        switch VimKeyRouteResolver.route(keystroke, in: engine.mode) {
+        case .textView:
             return event
+        case .discard:
+            return nil
+        case .engine(let character):
+            return process(character, shift: keystroke.modifiers.contains(.shift)) ? nil : event
         }
+    }
 
-        // Ctrl+R in Normal mode → redo (Vim convention)
-        if modifiers.contains(.control) {
-            if !engine.mode.isInsert && event.keyCode == 15 { // keyCode 15 = R
-                engine.redo()
-                return nil
-            }
-            return event // Pass through other Ctrl combinations
-        }
-
-        guard let characters = event.characters, let typed = characters.first else {
-            return event
-        }
-        let char: Character = event.semanticKeyCode == .enter ? "\r" : typed
-
-        // In non-insert modes, translate arrow keys to h/j/k/l so the Vim engine
-        // handles them (critical for visual mode selection to work with arrows).
-        if let scalar = char.unicodeScalars.first, scalar.value >= 0xF700 {
-            if !engine.mode.isInsert, let vimChar = Self.arrowToVimKey[scalar.value] {
-                let consumed = engine.process(vimChar, shift: modifiers.contains(.shift))
-                return consumed ? nil : event
-            }
-            return event // Pass through non-arrow function keys and insert-mode arrows
-        }
-
-        // In non-normal modes, Escape should exit to Normal mode.
-        // Also dismiss any active inline suggestion and close autocomplete popup.
-        if engine.mode != .normal && char == "\u{1B}" {
+    private func process(_ character: Character, shift: Bool) -> Bool {
+        if character == "\u{1B}", engine.mode != .normal {
             inlineSuggestionManager?.dismissSuggestion()
             closeSuggestionPopup()
         }
-
-        let shift = modifiers.contains(.shift)
-        let consumed = engine.process(char, shift: shift)
-
-        return consumed ? nil : event
+        return engine.process(character, shift: shift)
     }
 
     private func closeSuggestionPopup() {

--- a/TablePro/Core/Vim/VimKeyRouteResolver.swift
+++ b/TablePro/Core/Vim/VimKeyRouteResolver.swift
@@ -1,0 +1,100 @@
+//
+//  VimKeyRouteResolver.swift
+//  TablePro
+//
+
+import AppKit
+
+enum VimKeyRoute: Equatable {
+    case textView
+    case engine(Character)
+    case discard
+}
+
+struct VimKeystroke {
+    let characters: String
+    let charactersIgnoringModifiers: String
+    let modifiers: NSEvent.ModifierFlags
+    let isKeypadEnter: Bool
+}
+
+enum VimKeyRouteResolver {
+    private static let escape: Character = "\u{1B}"
+    private static let backtab: Character = "\u{19}"
+    private static let keysControlLeavesToTheTextView: Set<Character> = ["\t", backtab, " "]
+    private static let forwardDelete: UInt32 = 0xF728
+    private static let functionKeyRange: ClosedRange<UInt32> = 0xF700...0xF8FF
+    private static let arrowMotions: [UInt32: Character] = [
+        0xF700: "k",
+        0xF701: "j",
+        0xF702: "h",
+        0xF703: "l"
+    ]
+
+    static func route(_ keystroke: VimKeystroke, in mode: VimMode) -> VimKeyRoute {
+        let modifiers = keystroke.modifiers.intersection(.deviceIndependentFlagsMask)
+        guard !modifiers.contains(.command) else { return .textView }
+        guard let typed = keystroke.characters.first else {
+            return mode.isInsert ? .textView : .discard
+        }
+        let character: Character = keystroke.isKeypadEnter ? "\r" : typed
+        if let functionKey = functionKeyValue(of: character) {
+            return routeFunctionKey(functionKey, modifiers: modifiers, in: mode)
+        }
+        let key = keystroke.charactersIgnoringModifiers.first
+        if let key, isPlainControlChord(modifiers), keysControlLeavesToTheTextView.contains(key) {
+            return .textView
+        }
+        if key == backtab {
+            return mode == .insert ? .textView : .discard
+        }
+        if modifiers.contains(.control) {
+            return routeControlChord(character, modifiers: modifiers, in: mode)
+        }
+        if modifiers.contains(.option), mode == .insert {
+            return .textView
+        }
+        return .engine(character)
+    }
+
+    private static func isPlainControlChord(_ modifiers: NSEvent.ModifierFlags) -> Bool {
+        modifiers.contains(.control) && !modifiers.contains(.option)
+    }
+
+    private static func routeFunctionKey(
+        _ functionKey: UInt32,
+        modifiers: NSEvent.ModifierFlags,
+        in mode: VimMode
+    ) -> VimKeyRoute {
+        guard !mode.isInsert else { return .textView }
+        let isChord = modifiers.contains(.option) || modifiers.contains(.control)
+        if functionKey == forwardDelete {
+            return isChord || mode.isCommandLine ? .discard : .engine("x")
+        }
+        guard let motion = arrowMotions[functionKey], !isChord else { return .textView }
+        return mode.isCommandLine ? .discard : .engine(motion)
+    }
+
+    private static func routeControlChord(
+        _ character: Character,
+        modifiers: NSEvent.ModifierFlags,
+        in mode: VimMode
+    ) -> VimKeyRoute {
+        if mode.isInsert {
+            let claimed = isClaimedInInsertModes(character, in: mode)
+            return claimed && !modifiers.contains(.option) ? .engine(character) : .textView
+        }
+        let producesInput = modifiers.contains(.option) || VimEngine.isUnwritableControl(character)
+        return producesInput ? .engine(character) : .textView
+    }
+
+    private static func isClaimedInInsertModes(_ character: Character, in mode: VimMode) -> Bool {
+        if character == escape || VimInsertControl(rawValue: character) != nil { return true }
+        return mode == .replace && VimEngine.backspaceCharacters.contains(character)
+    }
+
+    private static func functionKeyValue(of character: Character) -> UInt32? {
+        guard character.unicodeScalars.count == 1, let scalar = character.unicodeScalars.first else { return nil }
+        return functionKeyRange.contains(scalar.value) ? scalar.value : nil
+    }
+}

--- a/TablePro/Core/Vim/VimMode.swift
+++ b/TablePro/Core/Vim/VimMode.swift
@@ -37,4 +37,9 @@ enum VimMode: Equatable {
         if case .visual = self { return true }
         return false
     }
+
+    var isCommandLine: Bool {
+        if case .commandLine = self { return true }
+        return false
+    }
 }

--- a/TablePro/Views/Settings/EditorSettingsView.swift
+++ b/TablePro/Views/Settings/EditorSettingsView.swift
@@ -26,6 +26,7 @@ struct EditorSettingsView: View {
                 Toggle("Auto-uppercase keywords", isOn: $settings.uppercaseKeywords)
                 Toggle("Query parameters (:name syntax)", isOn: $settings.queryParametersEnabled)
                 Toggle("Vim mode", isOn: $settings.vimModeEnabled)
+                    .accessibilityIdentifier("vim-mode-toggle")
             }
         }
         .formStyle(.grouped)

--- a/TableProTests/Core/Vim/VimEngineControlKeyTests.swift
+++ b/TableProTests/Core/Vim/VimEngineControlKeyTests.swift
@@ -1,0 +1,213 @@
+//
+//  VimEngineControlKeyTests.swift
+//  TableProTests
+//
+
+@testable import TablePro
+import XCTest
+
+@MainActor
+final class VimEngineControlKeyTests: XCTestCase {
+    private var engine: VimEngine!
+    private var buffer: VimTextBufferMock!
+
+    override func setUp() {
+        super.setUp()
+        let lines = (0..<30).map { "line\($0) text" }
+        buffer = VimTextBufferMock(text: lines.joined(separator: "\n") + "\n")
+        engine = VimEngine(buffer: buffer)
+    }
+
+    override func tearDown() {
+        engine = nil
+        buffer = nil
+        super.tearDown()
+    }
+
+    private func useText(_ text: String) {
+        buffer = VimTextBufferMock(text: text)
+        engine = VimEngine(buffer: buffer)
+    }
+
+    private func keys(_ chars: String) {
+        for char in chars { _ = engine.process(char, shift: false) }
+    }
+
+    @discardableResult
+    private func control(_ letter: Character) -> Bool {
+        let code = (letter.asciiValue ?? 0) & 0x1F
+        return engine.process(Character(UnicodeScalar(code)), shift: false)
+    }
+
+    private var pos: Int { buffer.selectedRange().location }
+
+    private var line: Int { buffer.lineAndColumn(forOffset: pos).line }
+
+    private func caret(atLine line: Int, column: Int = 0) {
+        buffer.setSelectedRange(NSRange(location: buffer.offset(forLine: line, column: column), length: 0))
+    }
+
+    // MARK: - Normal mode
+
+    func testControlRRedoesThroughTheEngine() {
+        XCTAssertTrue(control("r"))
+        XCTAssertEqual(buffer.redoCallCount, 1)
+    }
+
+    func testControlRTakesACount() {
+        keys("3")
+        control("r")
+        XCTAssertEqual(buffer.redoCallCount, 3)
+    }
+
+    func testControlHMovesLeftLikeH() {
+        caret(atLine: 0, column: 5)
+        let original = buffer.text
+        XCTAssertTrue(control("h"))
+        XCTAssertEqual(pos, 4)
+        XCTAssertEqual(buffer.text, original, "Ctrl+H must move the caret in Normal mode, never delete")
+    }
+
+    func testControlHTakesACount() {
+        caret(atLine: 0, column: 5)
+        keys("3")
+        control("h")
+        XCTAssertEqual(pos, 2)
+    }
+
+    func testControlNAndControlPMoveBetweenLines() {
+        caret(atLine: 4, column: 2)
+        control("n")
+        XCTAssertEqual(line, 5)
+        control("p")
+        control("p")
+        XCTAssertEqual(line, 3)
+    }
+
+    func testControlNCompletesAPendingOperatorLikeJ() {
+        useText("one\ntwo\nthree\n")
+        keys("d")
+        control("n")
+        XCTAssertEqual(buffer.text, "three\n", "d followed by Ctrl+N deletes two lines, as dj does")
+    }
+
+    func testScrollControlCancelsAPendingOperator() {
+        useText("one two three\n")
+        keys("d")
+        control("d")
+        keys("w")
+        XCTAssertEqual(buffer.text, "one two three\n", "Ctrl+D is no motion, so it abandons the pending d")
+        XCTAssertNil(engine.pendingOperator)
+    }
+
+    func testScrollControlUsesAndConsumesItsCount() {
+        caret(atLine: 0)
+        keys("4")
+        control("d")
+        XCTAssertEqual(line, 4, "A count sets how many lines Ctrl+D moves")
+        keys("j")
+        XCTAssertEqual(line, 5, "The count must not carry over to the next command")
+    }
+
+    func testUnboundControlCharacterDoesNotEditInNormalMode() {
+        caret(atLine: 0, column: 3)
+        let original = buffer.text
+        XCTAssertTrue(control("k"))
+        XCTAssertTrue(control("o"))
+        XCTAssertTrue(control("t"))
+        XCTAssertEqual(buffer.text, original)
+        XCTAssertEqual(engine.mode, .normal)
+    }
+
+    func testOptionTypedCharactersDoNotEditInNormalMode() {
+        caret(atLine: 0, column: 3)
+        let original = buffer.text
+        XCTAssertTrue(engine.process("\u{02D9}", shift: false))
+        XCTAssertTrue(engine.process("\u{00A0}", shift: false))
+        XCTAssertEqual(buffer.text, original)
+    }
+
+    func testReplaceCharConsumesAControlCharacterWithoutWritingIt() {
+        useText("hello\n")
+        keys("r")
+        control("d")
+        keys("x")
+        XCTAssertEqual(buffer.text, "ello\n", "r takes Ctrl+D as its argument, so the next x deletes")
+    }
+
+    // MARK: - Visual mode
+
+    func testControlDExtendsTheVisualSelection() {
+        caret(atLine: 0)
+        keys("v")
+        control("d")
+        let selection = buffer.selectedRange()
+        XCTAssertEqual(selection.location, 0)
+        XCTAssertEqual(
+            buffer.lineAndColumn(forOffset: selection.location + selection.length - 1).line,
+            15,
+            "Ctrl+D moves the visual cursor half the visible lines down"
+        )
+        XCTAssertEqual(engine.mode, .visual(linewise: false))
+    }
+
+    func testControlHMovesTheVisualCursor() {
+        caret(atLine: 0)
+        keys("vll")
+        control("h")
+        XCTAssertEqual(buffer.selectedRange(), NSRange(location: 0, length: 2))
+    }
+
+    func testUnboundControlCharacterLeavesTheVisualSelection() {
+        caret(atLine: 0)
+        keys("vl")
+        let original = buffer.text
+        control("k")
+        XCTAssertEqual(buffer.text, original)
+        XCTAssertEqual(buffer.selectedRange(), NSRange(location: 0, length: 2))
+        XCTAssertEqual(engine.mode, .visual(linewise: false))
+    }
+
+    // MARK: - Insert and Replace mode
+
+    func testControlHInInsertModeIsLeftToTheTextView() {
+        useText("a\u{1F600}b\n")
+        buffer.setSelectedRange(NSRange(location: 3, length: 0))
+        keys("i")
+        XCTAssertFalse(control("h"), "Insert mode Ctrl+H is the text view's deleteBackward, as Delete is")
+        XCTAssertEqual(buffer.text, "a\u{1F600}b\n")
+        XCTAssertEqual(engine.mode, .insert)
+    }
+
+    func testControlHInReplaceModeRestoresLikeBackspace() {
+        useText("hello\n")
+        _ = engine.process("R", shift: true)
+        _ = engine.process("X", shift: true)
+        _ = engine.process("Y", shift: true)
+        control("h")
+        XCTAssertEqual(buffer.text, "Xello\n")
+        XCTAssertEqual(pos, 1)
+    }
+
+    func testOptionTypedCharacterOverwritesInReplaceMode() {
+        useText("hello\n")
+        _ = engine.process("R", shift: true)
+        _ = engine.process("\u{00E9}", shift: false)
+        XCTAssertEqual(buffer.text, "\u{00E9}ello\n")
+    }
+
+    // MARK: - Command line
+
+    func testControlHErasesInTheCommandLine() {
+        keys(":ab")
+        control("h")
+        XCTAssertEqual(engine.mode, .commandLine(buffer: ":a"))
+    }
+
+    func testControlCharacterIsNotAppendedToTheCommandLine() {
+        keys(":")
+        control("d")
+        control("k")
+        XCTAssertEqual(engine.mode, .commandLine(buffer: ":"))
+    }
+}

--- a/TableProTests/Core/Vim/VimEngineInsertModeEditTests.swift
+++ b/TableProTests/Core/Vim/VimEngineInsertModeEditTests.swift
@@ -3,8 +3,8 @@
 //  TableProTests
 //
 //  Spec for editing shortcuts available inside Insert mode: Ctrl+W (delete previous
-//  word), Ctrl+U (delete to line start), Ctrl+H (backspace), Ctrl+T (indent), Ctrl+D
-//  (outdent), Ctrl+J (newline), Ctrl+M (carriage return → newline).
+//  word), Ctrl+U (delete to line start), Ctrl+T (indent), Ctrl+D (outdent). Ctrl+H is
+//  left to the text view, whose deleteBackward it is.
 //
 
 import XCTest
@@ -89,11 +89,14 @@ final class VimEngineInsertModeEditTests: XCTestCase {
 
     // MARK: - Ctrl+H: Backspace
 
-    func testCtrlHDeletesPreviousChar() {
+    func testCtrlHIsLeftToTheTextViewBackspace() {
         enterInsert(at: 5)
-        _ = engine.process("\u{08}", shift: false) // Ctrl+H
-        XCTAssertEqual(buffer.text, "hell world\n",
-            "Ctrl+H should delete the char before the cursor")
+        let consumed = engine.process("\u{08}", shift: false) // Ctrl+H
+        XCTAssertFalse(
+            consumed,
+            "Ctrl+H in insert mode is the text view's deleteBackward, which handles selections and every cursor"
+        )
+        XCTAssertEqual(buffer.text, "hello world\n")
     }
 
     // MARK: - Ctrl+T / Ctrl+D: Indent / Outdent

--- a/TableProTests/Core/Vim/VimEngineScrollTests.swift
+++ b/TableProTests/Core/Vim/VimEngineScrollTests.swift
@@ -36,8 +36,6 @@ final class VimEngineScrollTests: XCTestCase {
     }
 
     private func ctrl(_ char: Character) -> Bool {
-        // Ctrl is handled at the interceptor layer, but for these engine-level tests
-        // we use the equivalent ASCII control code so the engine path can interpret it.
         let raw = char.asciiValue.map { UInt8($0 & 0x1F) } ?? 0
         let scalar = UnicodeScalar(raw)
         return engine.process(Character(scalar), shift: false)

--- a/TableProTests/Core/Vim/VimEngineUndoRepeatTests.swift
+++ b/TableProTests/Core/Vim/VimEngineUndoRepeatTests.swift
@@ -2,7 +2,7 @@
 //  VimEngineUndoRepeatTests.swift
 //  TableProTests
 //
-//  Specification tests for undo (u), redo (Ctrl+R via engine.redo()),
+//  Specification tests for undo (u), redo (Ctrl+R),
 //  the repeat command (.), and the line undo (U).
 //
 
@@ -56,14 +56,14 @@ final class VimEngineUndoRepeatTests: XCTestCase {
 
     func testRedoCallsBufferRedo() {
         XCTAssertEqual(buffer.redoCallCount, 0)
-        engine.redo()
+        key("\u{12}")
         XCTAssertEqual(buffer.redoCallCount, 1)
     }
 
     func testMultipleRedoCalls() {
-        engine.redo()
-        engine.redo()
-        engine.redo()
+        key("\u{12}")
+        key("\u{12}")
+        key("\u{12}")
         XCTAssertEqual(buffer.redoCallCount, 3)
     }
 

--- a/TableProTests/Core/Vim/VimKeyRouteResolverTests.swift
+++ b/TableProTests/Core/Vim/VimKeyRouteResolverTests.swift
@@ -1,0 +1,262 @@
+//
+//  VimKeyRouteResolverTests.swift
+//  TableProTests
+//
+
+import AppKit
+@testable import TablePro
+import Testing
+
+@Suite("VimKeyRouteResolver")
+struct VimKeyRouteResolverTests {
+    private static let outsideInsertModes: [VimMode] = [
+        .normal,
+        .visual(linewise: false),
+        .visual(linewise: true),
+        .commandLine(buffer: ":")
+    ]
+    private static let normalAndVisualModes: [VimMode] = [.normal, .visual(linewise: false), .visual(linewise: true)]
+    private static let insertModes: [VimMode] = [.insert, .replace]
+    private static let everyMode: [VimMode] = outsideInsertModes + insertModes
+
+    private static let controlLetters: [(characters: String, key: String)] = [
+        ("\u{01}", "a"), ("\u{03}", "c"), ("\u{04}", "d"), ("\u{08}", "h"), ("\u{0B}", "k"), ("\u{0E}", "n"),
+        ("\u{0F}", "o"), ("\u{10}", "p"), ("\u{12}", "r"), ("\u{14}", "t"), ("\u{15}", "u"), ("\u{18}", "x"),
+        ("\u{19}", "y")
+    ]
+
+    private func route(
+        _ characters: String,
+        key: String? = nil,
+        _ modifiers: NSEvent.ModifierFlags = [],
+        in mode: VimMode,
+        keypadEnter: Bool = false
+    ) -> VimKeyRoute {
+        let keystroke = VimKeystroke(
+            characters: characters,
+            charactersIgnoringModifiers: key ?? characters,
+            modifiers: modifiers,
+            isKeypadEnter: keypadEnter
+        )
+        return VimKeyRouteResolver.route(keystroke, in: mode)
+    }
+
+    @Test("Ctrl+D reaches the engine in Normal mode instead of deleting forward")
+    func controlDReachesTheEngine() {
+        #expect(route("\u{04}", key: "d", .control, in: .normal) == .engine("\u{04}"))
+    }
+
+    @Test("Every Control chord that edits in AppKit reaches the engine outside Insert mode")
+    func editingControlChordsReachTheEngine() {
+        for mode in Self.outsideInsertModes {
+            for (control, key) in Self.controlLetters {
+                #expect(route(control, key: key, .control, in: mode) == .engine(Character(control)))
+                #expect(route(control, key: key.uppercased(), [.control, .shift], in: mode) == .engine(Character(control)))
+            }
+            #expect(route("\u{7F}", .control, in: mode) == .engine("\u{7F}"))
+        }
+    }
+
+    @Test("Control chords that type no character stay with the menus outside Insert mode")
+    func nonTypingControlChordsStayWithTheTextView() {
+        let chords: [(characters: String, key: String)] = [
+            ("1", "1"), ("/", "/"), ("\r", "\r"), ("\t", "i"), ("\r", "m"), ("\n", "j")
+        ]
+        for mode in Self.outsideInsertModes {
+            for (characters, key) in chords {
+                #expect(route(characters, key: key, .control, in: mode) == .textView)
+            }
+        }
+    }
+
+    @Test("Ctrl+Space, Ctrl+Tab and Ctrl+Shift+Tab stay with the text view in every mode")
+    func controlSpaceAndTabStayWithTheTextView() {
+        for mode in Self.everyMode {
+            #expect(route("\u{00}", key: " ", .control, in: mode) == .textView)
+            #expect(route("\t", key: "\t", .control, in: mode) == .textView)
+            #expect(route("\u{19}", key: "\u{19}", [.control, .shift], in: mode) == .textView)
+        }
+    }
+
+    @Test("Ctrl+Y and Ctrl+Shift+Tab share a character but only Ctrl+Y reaches the engine")
+    func controlYIsNotControlShiftTab() {
+        for mode in Self.outsideInsertModes {
+            #expect(route("\u{19}", key: "y", .control, in: mode) == .engine("\u{19}"))
+            #expect(route("\u{19}", key: "\u{19}", [.control, .shift], in: mode) == .textView)
+        }
+    }
+
+    @Test("Shift+Tab is never read as Ctrl+Y")
+    func shiftTabIsNotControlY() {
+        for mode in Self.outsideInsertModes + [.replace] {
+            #expect(route("\u{19}", key: "\u{19}", .shift, in: mode) == .discard)
+            #expect(route("\u{19}", key: "\u{19}", [.control, .option, .shift], in: mode) == .discard)
+        }
+        #expect(route("\u{19}", key: "\u{19}", .shift, in: .insert) == .textView)
+    }
+
+    @Test("Ctrl+Option+Space and Ctrl+Option+Tab type a character, so the text view never gets them outside Insert")
+    func controlOptionSpaceAndTabReachTheEngine() {
+        for mode in Self.outsideInsertModes {
+            #expect(route("\u{00}", key: " ", [.control, .option], in: mode) == .engine("\u{00}"))
+            #expect(route("\t", key: "\t", [.control, .option], in: mode) == .engine("\t"))
+        }
+    }
+
+    @Test("Option chords that type text reach the engine outside Insert mode")
+    func optionTextReachesTheEngine() {
+        let chords: [(characters: String, key: String)] = [
+            ("\u{02D9}", "h"), ("\u{00A0}", " "), ("[", "5"), ("@", "l"), ("~", "n"), ("\u{7F}", "\u{7F}")
+        ]
+        for mode in Self.outsideInsertModes {
+            for (characters, key) in chords {
+                #expect(route(characters, key: key, .option, in: mode) == .engine(Character(characters)))
+            }
+            #expect(route("\u{2021}", key: "7", [.option, .shift], in: mode) == .engine("\u{2021}"))
+        }
+    }
+
+    @Test("Control+Option chords that type text reach the engine outside Insert mode")
+    func controlOptionTextReachesTheEngine() {
+        for mode in Self.outsideInsertModes {
+            #expect(route("\u{2202}", key: "d", [.control, .option], in: mode) == .engine("\u{2202}"))
+            #expect(route("\u{04}", key: "d", [.control, .option], in: mode) == .engine("\u{04}"))
+        }
+    }
+
+    @Test("A dead key never starts a composition outside Insert mode")
+    func deadKeyIsDiscardedOutsideInsertMode() {
+        for mode in Self.outsideInsertModes {
+            #expect(route("", .option, in: mode) == .discard)
+            #expect(route("", [], in: mode) == .discard)
+        }
+        for mode in Self.insertModes {
+            #expect(route("", .option, in: mode) == .textView)
+        }
+    }
+
+    @Test("Command shortcuts always reach the text view")
+    func commandShortcutsStayWithTheTextView() {
+        for mode in Self.everyMode {
+            #expect(route("c", .command, in: mode) == .textView)
+            #expect(route("v", [.command, .shift], in: mode) == .textView)
+            #expect(route("\u{06}", key: "f", [.command, .control], in: mode) == .textView)
+            #expect(route("\u{0192}", [.command, .option], in: mode) == .textView)
+        }
+    }
+
+    @Test("Arrow keys become hjkl motions in Normal and Visual mode")
+    func arrowsBecomeMotions() {
+        let arrows: [(String, Character)] = [("\u{F700}", "k"), ("\u{F701}", "j"), ("\u{F702}", "h"), ("\u{F703}", "l")]
+        for mode in Self.normalAndVisualModes {
+            for (arrow, motion) in arrows {
+                #expect(route(arrow, [.function, .numericPad], in: mode) == .engine(motion))
+                #expect(route(arrow, [.function, .numericPad, .shift], in: mode) == .engine(motion))
+            }
+        }
+    }
+
+    @Test("Option and Control arrows stay native navigation")
+    func modifiedArrowsStayWithTheTextView() {
+        for mode in Self.normalAndVisualModes {
+            #expect(route("\u{F702}", [.function, .numericPad, .option], in: mode) == .textView)
+            #expect(route("\u{F703}", [.function, .numericPad, .control], in: mode) == .textView)
+        }
+    }
+
+    @Test("Forward Delete deletes like x in Normal and Visual mode")
+    func forwardDeleteBecomesX() {
+        for mode in Self.normalAndVisualModes {
+            #expect(route("\u{F728}", .function, in: mode) == .engine("x"))
+        }
+    }
+
+    @Test("A modified Forward Delete never edits outside Insert mode")
+    func modifiedForwardDeleteIsDiscarded() {
+        for mode in Self.outsideInsertModes {
+            #expect(route("\u{F728}", [.function, .option], in: mode) == .discard)
+            #expect(route("\u{F728}", [.function, .control], in: mode) == .discard)
+        }
+    }
+
+    @Test("The command line takes no arrow or Forward Delete")
+    func commandLineDiscardsEditingFunctionKeys() {
+        let mode = VimMode.commandLine(buffer: ":")
+        #expect(route("\u{F700}", [.function, .numericPad], in: mode) == .discard)
+        #expect(route("\u{F728}", .function, in: mode) == .discard)
+    }
+
+    @Test("Other function keys stay with the text view")
+    func otherFunctionKeysStayWithTheTextView() {
+        for mode in Self.everyMode {
+            for key in ["\u{F729}", "\u{F72B}", "\u{F72C}", "\u{F708}"] {
+                #expect(route(key, .function, in: mode) == .textView)
+            }
+        }
+    }
+
+    @Test("Keypad Enter reaches the engine as Return, apart from Ctrl+C that shares its character")
+    func keypadEnterIsReturn() {
+        #expect(route("\u{03}", .numericPad, in: .normal, keypadEnter: true) == .engine("\r"))
+        #expect(route("\u{03}", key: "c", .control, in: .normal) == .engine("\u{03}"))
+    }
+
+    @Test("Insert and Replace mode send the Vim insert controls to the engine")
+    func insertControlsReachTheEngine() {
+        let controls: [(characters: String, key: String)] = [
+            ("\u{17}", "w"), ("\u{15}", "u"), ("\u{14}", "t"), ("\u{04}", "d"), ("\u{1B}", "[")
+        ]
+        for mode in Self.insertModes {
+            for (control, key) in controls {
+                #expect(route(control, key: key, .control, in: mode) == .engine(Character(control)))
+            }
+        }
+    }
+
+    @Test("Insert mode leaves Ctrl+H and Ctrl+Delete to the text view, which deletes every selection")
+    func insertModeBackspaceChordsStayWithTheTextView() {
+        #expect(route("\u{08}", key: "h", .control, in: .insert) == .textView)
+        #expect(route("\u{7F}", .control, in: .insert) == .textView)
+    }
+
+    @Test("Replace mode sends Ctrl+H and Ctrl+Delete to the engine, which restores the overwritten text")
+    func replaceModeBackspaceChordsReachTheEngine() {
+        #expect(route("\u{08}", key: "h", .control, in: .replace) == .engine("\u{08}"))
+        #expect(route("\u{7F}", .control, in: .replace) == .engine("\u{7F}"))
+    }
+
+    @Test("Insert and Replace mode leave every other Control chord to the text view")
+    func otherControlChordsStayWithTheTextViewInInsertMode() {
+        let chords: [(characters: String, key: String)] = [
+            ("\u{01}", "a"), ("\u{05}", "e"), ("\u{0B}", "k"), ("\u{12}", "r"), ("\u{00}", " "), ("\t", "\t")
+        ]
+        for mode in Self.insertModes {
+            for (characters, key) in chords {
+                #expect(route(characters, key: key, .control, in: mode) == .textView)
+            }
+            #expect(route("\u{04}", key: "d", [.control, .option], in: mode) == .textView)
+        }
+    }
+
+    @Test("Option chords type text in Insert mode and overwrite in Replace mode")
+    func optionTextInInsertModes() {
+        #expect(route("\u{02D9}", .option, in: .insert) == .textView)
+        #expect(route("\u{02D9}", .option, in: .replace) == .engine("\u{02D9}"))
+    }
+
+    @Test("Function keys stay native in Insert and Replace mode")
+    func functionKeysStayNativeInInsertModes() {
+        for mode in Self.insertModes {
+            #expect(route("\u{F700}", [.function, .numericPad], in: mode) == .textView)
+            #expect(route("\u{F728}", .function, in: mode) == .textView)
+        }
+    }
+
+    @Test("Plain keys reach the engine in every mode")
+    func plainKeysReachTheEngine() {
+        for mode in Self.everyMode {
+            #expect(route("j", in: mode) == .engine("j"))
+            #expect(route("J", .shift, in: mode) == .engine("J"))
+        }
+    }
+}

--- a/TableProUITests/VimNormalModeChordUITests.swift
+++ b/TableProUITests/VimNormalModeChordUITests.swift
@@ -1,0 +1,104 @@
+import XCTest
+
+final class VimNormalModeChordUITests: UITestCase {
+    private var appWithVimMode: XCUIApplication?
+
+    override func tearDownWithError() throws {
+        continueAfterFailure = true
+        if let appWithVimMode {
+            setVimMode(false, in: appWithVimMode)
+        }
+        appWithVimMode = nil
+        try super.tearDownWithError()
+    }
+
+    func testNormalModeChordsNeverTypeIntoTheQuery() throws {
+        let app = try launchWithSampleDatabase()
+        enableVimModeUntilTearDown(in: app)
+        let editor = openQueryTab(in: app)
+
+        app.typeText("iSELECT 1")
+        app.typeKey(XCUIKeyboardKey.escape, modifierFlags: [])
+        app.typeKey("h", modifierFlags: .option)
+        app.typeKey(" ", modifierFlags: .option)
+        app.typeKey("d", modifierFlags: .control)
+        app.typeText("A AS a")
+
+        XCTAssertTrue(
+            waitForValue("SELECT 1 AS a", in: editor),
+            "Option+H, Option+Space and Ctrl+D must not edit the query in Normal mode; editor holds "
+                + "'\(debugValue(of: editor))'"
+        )
+    }
+
+    func testInsertModeControlHDeletesTheSelection() throws {
+        let app = try launchWithSampleDatabase()
+        enableVimModeUntilTearDown(in: app)
+        let editor = openQueryTab(in: app)
+
+        app.typeText("i1 + 23")
+        app.typeKey(XCUIKeyboardKey.leftArrow, modifierFlags: .shift)
+        app.typeKey(XCUIKeyboardKey.leftArrow, modifierFlags: .shift)
+        app.typeKey("h", modifierFlags: .control)
+
+        XCTAssertTrue(
+            waitForValue("1 + ", in: editor),
+            "Ctrl+H in Insert mode must delete the selection, as Delete does; editor holds "
+                + "'\(debugValue(of: editor))'"
+        )
+    }
+
+    private func enableVimModeUntilTearDown(in app: XCUIApplication) {
+        appWithVimMode = app
+        setVimMode(true, in: app)
+    }
+
+    private func setVimMode(_ enabled: Bool, in app: XCUIApplication) {
+        let menuBar = app.menuBars.firstMatch
+        XCTAssertTrue(menuBar.waitToExist(timeout: 20), "The app must publish its menu bar")
+        menuBar.menuItems["Settings…"].click()
+
+        let settings = app.children(matching: .window).matching(identifier: "settings").firstMatch
+        XCTAssertTrue(settings.waitToExist(timeout: 10), "Settings must open")
+        let editorPane = settings.toolbars.buttons["Editor"]
+        XCTAssertTrue(editorPane.waitToExist(timeout: 10))
+        editorPane.click()
+
+        let vimToggle = settings.descendants(matching: .any).matching(identifier: "vim-mode-toggle").firstMatch
+        XCTAssertTrue(waitUntilHittable(vimToggle, timeout: 10), "The Editor pane must offer Vim mode")
+        if isOn(vimToggle) != enabled {
+            vimToggle.click()
+        }
+        XCTAssertTrue(
+            waitForPredicate(timeout: 5) { self.isOn(vimToggle) == enabled },
+            "Vim mode must be \(enabled ? "on" : "off") after the click"
+        )
+
+        app.typeKey("w", modifierFlags: .command)
+        XCTAssertTrue(waitForPredicate(timeout: 10) { !settings.exists }, "Settings must close")
+    }
+
+    private func openQueryTab(in app: XCUIApplication) -> XCUIElement {
+        app.typeKey("t", modifierFlags: .command)
+        let editor = editorTextView(in: app)
+        XCTAssertTrue(editor.waitToExist(timeout: 10))
+        XCTAssertTrue(waitForValue("", in: editor), "A new tab starts with an empty editor")
+        return editor
+    }
+
+    private func isOn(_ toggle: XCUIElement) -> Bool {
+        if let number = toggle.value as? Int { return number == 1 }
+        return (toggle.value as? String) == "1"
+    }
+
+    private func waitForValue(_ expected: String, in element: XCUIElement) -> Bool {
+        waitForPredicate(timeout: 10) { (element.value as? String) == expected }
+    }
+
+    private func debugValue(of element: XCUIElement) -> String {
+        let value = (element.value as? String) ?? "nil"
+        return value.unicodeScalars.map { scalar in
+            scalar.isASCII && scalar.value >= 0x20 ? String(scalar) : String(format: "<U+%04X>", scalar.value)
+        }.joined()
+    }
+}

--- a/docs/features/vim-mode.mdx
+++ b/docs/features/vim-mode.mdx
@@ -3,7 +3,7 @@ title: Vim Mode
 description: Vim motions, text objects, registers, marks, and search inside the SQL editor
 ---
 
-Vim mode is scoped to the SQL editor. The data grid, the find field and every other control in the window keep their own keys, and a `Cmd` or `Option` chord passes through in any mode, so `Cmd+Enter` still runs the query.
+Vim mode is scoped to the SQL editor. The data grid, the find field and every other control in the window keep their own keys, and a `Cmd` chord passes through in any mode, so `Cmd+Enter` still runs the query.
 
 Turn it on in **Settings > Editor > Vim mode**, which is also the only way to turn it off: there is no `:set`. A badge next to the editor shows the current mode.
 
@@ -24,7 +24,7 @@ Turn it on in **Settings > Editor > Vim mode**, which is also the only way to tu
 
 | Mode | How to enter |
 |------|--------------|
-| Normal | `Esc` |
+| Normal | `Esc`, `Ctrl+[` |
 | Insert | `i`, `I`, `a`, `A`, `o`, `O`, `s`, `S`, `c`, `C`, `gi` |
 | Replace | `R` |
 | Visual | `v` |
@@ -39,7 +39,7 @@ Turn it on in **Settings > Editor > Vim mode**, which is also the only way to tu
 
 | Key | Goes to |
 |-----|---------|
-| `h` `j` `k` `l` | Left, down, up, right |
+| `h` `j` `k` `l` | Left, down, up, right. The arrow keys do the same |
 | `0` | Start of line |
 | `^` `_` | First non-blank on line |
 | `$` | End of line |
@@ -92,7 +92,7 @@ Counts work: `3w` moves three words, `5j` moves five lines down.
 | `y{m}` | Yank |
 | `dd` `cc` `yy` | Same on the whole line |
 | `D` `C` `Y` | Same as `d$`, `c$`, `yy` |
-| `x` `X` | Delete one char under, one before cursor |
+| `x` `X` | Delete one char under, one before cursor. `Forward Delete` is `x` |
 | `s` `S` | Replace one char or whole line, then insert |
 | `r{c}` | Replace one char with `{c}`, stay in normal |
 | `~` | Toggle case under cursor |
@@ -197,15 +197,34 @@ A macro that calls itself stops after 50 rounds.
 
 ## Control keys
 
-`Ctrl+R` in normal mode is the only control combination vim mode intercepts, and it redoes. Every other one reaches the editor and gets the editor's own binding, so these vim meanings are not available:
+Outside insert mode, a `Ctrl` letter goes to vim, never to the editor's own binding:
 
-| Keys | What you do not get |
-|------|---------------------|
-| `Ctrl+D` `Ctrl+U` `Ctrl+F` `Ctrl+B` `Ctrl+E` `Ctrl+Y` | Scrolling. `Ctrl+D` deletes the character after the cursor and `Ctrl+E` goes to the end of the paragraph instead |
-| `Ctrl+A` `Ctrl+X` | Increment and decrement the number under the cursor. `Ctrl+A` goes to the start of the paragraph instead |
-| `Ctrl+W` `Ctrl+U` `Ctrl+T` `Ctrl+D` | Insert-mode delete word, delete to line start, indent, outdent. `Ctrl+H` still backspaces, through the editor's binding rather than vim's |
+| Keys | Normal mode | Visual mode |
+|------|-------------|-------------|
+| `Ctrl+D` `Ctrl+U` | Down, up half the visible lines. With a count, that many lines | Moves the end of the selection half the visible lines |
+| `Ctrl+F` `Ctrl+B` | Down, up one screen | Moves the end of the selection one screen |
+| `Ctrl+A` `Ctrl+X` | Add, subtract 1 from the number under or after the cursor. `5 Ctrl+A` adds 5 | Nothing |
+| `Ctrl+R` | Redo | Nothing |
+| `Ctrl+H` `Ctrl+N` `Ctrl+P` | Same as `h`, `j`, `k` | Same as `h`, `j`, `k` |
 
-`zt`, `zz` and `zb` are read and discarded, so there is no way to move the viewport from the keyboard at all.
+Any other `Ctrl` letter does nothing. That includes `Ctrl+E` and `Ctrl+Y`, which like `zt`, `zz` and `zb` are read and discarded: the view scrolls only to follow the cursor. `Ctrl+Space` still opens completions, and `Ctrl+Tab` and `Ctrl+Shift+Tab` still move focus to the next and previous control. A shortcut of `Ctrl` and a letter assigned in **Settings > Keyboard** does not fire from the SQL editor outside insert mode.
+
+In insert and replace mode, vim takes these and leaves every other `Ctrl` combination to the editor:
+
+| Keys | Action |
+|------|--------|
+| `Esc` `Ctrl+[` | Back to normal mode |
+| `Ctrl+W` | Delete the word before the cursor |
+| `Ctrl+U` | Delete back to the start of the line |
+| `Ctrl+T` `Ctrl+D` | Indent, outdent the line |
+
+`Ctrl+H` is the editor's own backspace in insert mode, so it deletes a selection the way `Delete` does. In replace mode vim takes it, and like `Delete` it restores the character you overwrote.
+
+## Option keys
+
+An `Option` chord outside insert mode is read as the character it types. On a keyboard layout where `Option` types `[` or `@`, such as German, those work as vim commands, and a character vim has no use for, such as the non-breaking space from `Option+Space`, does nothing. A dead key such as `Option+E` on the US layout does nothing outside insert mode.
+
+In insert mode, `Option` types as usual. In replace mode, the character it types overwrites the one under the cursor.
 
 ## Visual mode
 
@@ -227,7 +246,7 @@ Indent and outdent work in normal mode only (`>>`, `<<`, `>{m}`, `<{m}`).
 
 ## Insert mode
 
-`Esc` goes back to normal mode. Nothing else is intercepted while you type; see [Control keys](#control-keys).
+`Esc` or `Ctrl+[` goes back to normal mode. Apart from the insert-mode [control keys](#control-keys), what you type goes to the editor as usual.
 
 ## Command line
 
@@ -237,3 +256,5 @@ Indent and outdent work in normal mode only (`>>`, `<<`, `>{m}`, `<{m}`).
 | `:q` | Close the tab |
 
 `/` and `?` are search. Every other `:` command is parsed and ignored, `:wq`, `:x` and `:set` among them. `:10` does not jump to line 10 either; use `10G` or `10gg`.
+
+`Delete` and `Ctrl+H` erase the last character of the command. The arrow keys and the other `Ctrl` letters do nothing while you type one.


### PR DESCRIPTION
Found while investigating #2717 (PR #2724).

## Root cause

`VimKeyInterceptor.handleKeyEvent` returned every `Option` chord and every `Control` chord except `Ctrl+R` to the text view, whatever the Vim mode. Three things followed:

- In Normal and Visual mode an `Option` chord typed its character into the query: `Option+H` wrote `˙`, `Option+Space` wrote a non-breaking space. After #2724 drops typed control characters, the remaining `Option` output was still ordinary text landing in a mode that should never edit.
- A `Control` letter got the text view's Emacs binding instead of Vim's. `Ctrl+D` in Normal mode deleted the character after the cursor, `Ctrl+E` jumped to the end of the paragraph, `Ctrl+A` to its start.
- The engine already had handlers for `Ctrl+D`/`U`/`F`/`B`, `Ctrl+A`/`X` and the insert-mode `Ctrl+W`/`U`/`T`/`D`, but the interceptor never delivered those characters, so none of them ever ran. `Ctrl+R` worked only because the interceptor special-cased its key code and called `VimEngine.redo()` directly, bypassing counts and pending operators.

The decision of where a key goes was spread across ad hoc checks in the interceptor, keyed off `event.characters` alone, which cannot tell `Ctrl+Shift+Tab` (U+0019) from `Ctrl+Y`, or `Ctrl+Space` (U+0000) from any other unwritable control.

## What changed

- New `VimKeyRouteResolver`: a pure function from a keystroke (`characters`, `charactersIgnoringModifiers`, modifiers, keypad Enter) and the Vim mode to one of three routes: text view, engine, or discard. The interceptor now builds the keystroke and follows the route.
  - `Cmd` chords still pass through in every mode.
  - Outside insert mode, `Control` and `Option` chords go to the engine; anything the engine has no use for is consumed instead of typed.
  - `Ctrl+Tab`, `Ctrl+Shift+Tab` and `Ctrl+Space` stay with the text view (focus moves, completions), decided from `charactersIgnoringModifiers`.
  - Arrow keys map to `h`/`j`/`k`/`l` outside insert mode as before, and `Forward Delete` is `x`. In the command line both are discarded.
  - In insert and replace mode, only `Esc`/`Ctrl+[` and the Vim insert controls reach the engine; replace mode also takes the backspace characters so an overwritten character is restored.
- `VimEngine`: control characters are typed enums (`VimNormalControl`, `VimControlMotion`, `VimInsertControl`) instead of string switches.
  - Normal mode: `Ctrl+D`/`U` honour a count, `Ctrl+F`/`B` take a count, `Ctrl+R` redoes through `process()` and takes a count, and a scroll, number or redo control cancels a pending operator. `Ctrl+H`/`N`/`P` are `h`/`j`/`k`, including as operator targets.
  - Visual mode: `Ctrl+D`/`U`/`F`/`B` move the selection end; `Ctrl+H`/`N`/`P` move it too.
  - Insert mode: `Ctrl+H` is left to AppKit's `deleteBackward:`, so it respects selections and multiple cursors.
  - Command line: `Ctrl+H` erases like `Delete`; other unwritable controls are dropped instead of appended to the command.
  - `VimEngine.redo()` had no caller left and is removed.
- Settings: the Vim mode toggle gets an accessibility identifier for the UI test.
- Docs: `docs/features/vim-mode.mdx` gains Control keys and Option keys sections that match the new routing.
- CHANGELOG: one Fixed entry.

## Verification

Wrapper logs are under `.analysis/fix-vim-normal-mode-chords/logs/` in the worktree.

- Build: `verify.sh build` passed (`build-TablePro-161247.log`).
- Unit tests, final source: all 26 Vim suites (`VimKeyRouteResolverTests`, `VimEngineControlKeyTests`, `VimEngineInsertModeEditTests`, `VimEngineScrollTests`, `VimEngineUndoRepeatTests`, `VimKeyInterceptorFocusTests` and the other 20 `VimEngine*Tests`), 554 cases passed, 0 failed (`test-VimKeyRouteResolverTests-161941.log`). After the last test edit, `VimEngineInsertModeEditTests` and `VimKeyRouteResolverTests` re-ran: 36 passed, 0 failed (`test-VimEngineInsertModeEditTests-162226.log`).
- Tests fail without the fix: with the engine changes reverted, `VimEngineControlKeyTests` failed 16 of 20 (`test-VimEngineControlKeyTests-152556.log`). With the resolver and insert/replace changes reverted, 7 cases failed across `VimKeyRouteResolverTests` and `VimEngineInsertModeEditTests` (`test-VimKeyRouteResolverTests-161723.log`).
- UI tests: `VimNormalModeChordUITests`, 2 of 2 passed (`test-VimNormalModeChordUITests-163451.log`). `testNormalModeChordsNeverTypeIntoTheQuery` types `Option+H`, `Option+Space` and `Ctrl+D` in Normal mode and checks the query is untouched. `testInsertModeControlHDeletesTheSelection` checks `Ctrl+H` deletes a selection in Insert mode.
- Package tests: not applicable, nothing under `LocalPackages/` changed.
- SwiftLint `--strict` on the changed Swift files: no violations on lines this PR adds. The 18 reported in `VimEngineInsertModeEditTests`, `VimEngineScrollTests` and `VimEngineUndoRepeatTests` (`sorted_imports`, `vertical_parameter_alignment_on_call`) all predate this change (blame: 2d540e9fa).
- `main` has moved one commit ahead (#2727, CodeEditTextView word navigation); the branch merges into it without conflicts.

## Notes

Codex review was unavailable (usage limit), so an adversarial reviewer agent read the diff instead. Its findings:

1. The UI test left Vim mode on in the shared `com.TablePro.uitest` defaults. Fixed: the test clicks the toggle only when it is off and turns it back off in teardown. Declined the reviewer's suggested alternative, a launch variable forcing Vim mode: under `@Observable` even an init assignment runs the `didSet` that saves settings, so it would still write to defaults unless all three settings reads were rerouted. The runner not clearing that defaults domain is an existing harness issue, not this PR's.
2. Routing looked only at `event.characters` (`Ctrl+Shift+Tab` is U+0019, `Ctrl+Space` is U+0000). Fixed: the keystroke carries `charactersIgnoringModifiers`, and `Control` on Tab, backtab or Space goes to the text view. Checked against real `CGEvent`-built key events with small probe programs, and the docs line was corrected.
3. Insert-mode `Ctrl+H` ignored selections and multiple cursors. Fixed: it is left to AppKit's `deleteBackward:`; `backspaceInInsert` was removed and its test rewritten.
4. `VimEngine.redo()` had no production caller. Fixed: removed, and the tests press `^R` through `process()`.

No finding was dismissed.

https://claude.ai/code/session_011THKc9TRHE8xjcxXidDHXP
