### PR TITLE
fix(editor): mark invisible characters in database error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Connecting removing a plugin that failed to load, and its settings, when no replacement could be downloaded.
 - Disabled plugin's code loaded when a connection looked up its driver.
 - Failed connect from an opened file or URL titled "Disconnected", with Reconnect as its only fix.
+- Database error messages hiding invisible characters, such as a backspace quoted back from a query. (#2717)
 - Connection Failed alert covering the window that already showed the same failure.
 - Invisible control characters typed into a query by an input method or a Control-key chord such as Ctrl+Option+H. (#2717)
 - Statement with a NUL character running only up to it on SQLite and PostgreSQL, dropping its WHERE clause. (#2717)

--- a/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/SpecialCharacters/SpecialCharacter.swift
+++ b/LocalPackages/CodeEditTextView/Sources/CodeEditTextView/SpecialCharacters/SpecialCharacter.swift
@@ -16,6 +16,14 @@ public struct ClassifiedSpecialCharacter: Equatable, Sendable {
     public let scalar: Unicode.Scalar
 }
 
+public extension ClassifiedSpecialCharacter {
+    var name: String {
+        SpecialCharacter.controlName(for: scalar.value)
+            ?? scalar.properties.name?.lowercased()
+            ?? String(format: "U+%04X", scalar.value)
+    }
+}
+
 public extension SpecialCharacter {
     static func classify(in string: NSString, at index: Int) -> ClassifiedSpecialCharacter? {
         guard index >= 0, index < string.length else { return nil }
@@ -73,6 +81,26 @@ private extension SpecialCharacter {
     static let c1Labels: [String] = [
         "PAD", "HOP", "BPH", "NBH", "IND", "NEL", "SSA", "ESA", "HTS", "HTJ", "VTS", "PLD", "PLU", "RI", "SS2", "SS3",
         "DCS", "PU1", "PU2", "STS", "CCH", "MW", "SPA", "EPA", "SOS", "SGC", "SCI", "CSI", "ST", "OSC", "PM", "APC"
+    ]
+
+    static let controlNames: [String] = [
+        "null", "start of heading", "start of text", "end of text", "end of transmission", "enquiry",
+        "acknowledge", "bell", "backspace", "horizontal tabulation", "line feed", "vertical tabulation",
+        "form feed", "carriage return", "shift out", "shift in", "data link escape", "device control one",
+        "device control two", "device control three", "device control four", "negative acknowledge",
+        "synchronous idle", "end of transmission block", "cancel", "end of medium", "substitute", "escape",
+        "file separator", "group separator", "record separator", "unit separator"
+    ]
+
+    static let c1Names: [String] = [
+        "padding character", "high octet preset", "break permitted here", "no break here", "index", "next line",
+        "start of selected area", "end of selected area", "horizontal tabulation set",
+        "horizontal tabulation with justification", "vertical tabulation set", "partial line down",
+        "partial line up", "reverse index", "single shift two", "single shift three", "device control string",
+        "private use one", "private use two", "set transmit state", "cancel character", "message waiting",
+        "start of protected area", "end of protected area", "start of string",
+        "single graphic character introducer", "single character introducer", "control sequence introducer",
+        "string terminator", "operating system command", "privacy message", "application program command"
     ]
 
     static let formatLabels: [UInt32: String] = [
@@ -145,6 +173,19 @@ private extension SpecialCharacter {
             return c1Labels[Int(value - 0x80)]
         default:
             return hexLabel(for: value)
+        }
+    }
+
+    static func controlName(for value: UInt32) -> String? {
+        switch value {
+        case 0x00...0x1F:
+            return controlNames[Int(value)]
+        case 0x7F:
+            return "delete"
+        case 0x80...0x9F:
+            return c1Names[Int(value - 0x80)]
+        default:
+            return nil
         }
     }
 

--- a/LocalPackages/CodeEditTextView/Tests/CodeEditTextViewTests/SpecialCharacterTests.swift
+++ b/LocalPackages/CodeEditTextView/Tests/CodeEditTextViewTests/SpecialCharacterTests.swift
@@ -23,6 +23,30 @@ struct SpecialCharacterTests {
     }
 
     @Test(
+        "A control is named by what it does and every other character by its Unicode name",
+        arguments: [
+            ("\u{0}", "null"), ("\u{8}", "backspace"), ("\u{1B}", "escape"), ("\u{1F}", "unit separator"),
+            ("\u{7F}", "delete"), ("\u{80}", "padding character"), ("\u{85}", "next line"),
+            ("\u{9B}", "control sequence introducer"), ("\u{9F}", "application program command"),
+            ("\u{A0}", "no-break space"), ("\u{200B}", "zero width space"), ("\u{202E}", "right-to-left override"),
+            ("\u{E0001}", "language tag")
+        ]
+    )
+    func names(text: String, name: String) {
+        #expect(SpecialCharacter.classify(in: text as NSString, at: 0)?.name == name)
+    }
+
+    @Test("Every control the classifier marks has a name of its own")
+    func everyControlIsNamed() {
+        for value in UInt32(0)...0x9F {
+            guard let scalar = Unicode.Scalar(value),
+                  let classified = SpecialCharacter.classify(in: String(Character(scalar)) as NSString, at: 0),
+                  case .marker = classified.character else { continue }
+            #expect(!classified.name.isEmpty && !classified.name.hasPrefix("U+"), "U+\(String(value, radix: 16))")
+        }
+    }
+
+    @Test(
         "Spaces that draw as an ordinary blank are outlined",
         arguments: ["\u{A0}", "\u{2002}", "\u{200A}", "\u{202F}", "\u{205F}", "\u{3000}"]
     )

--- a/TablePro/Core/Utilities/Text/RevealedText.swift
+++ b/TablePro/Core/Utilities/Text/RevealedText.swift
@@ -1,0 +1,86 @@
+//
+//  RevealedText.swift
+//  TablePro
+//
+
+import CodeEditTextView
+import Foundation
+
+internal struct RevealedText: Equatable, Sendable {
+    internal enum Segment: Equatable, Sendable {
+        case text(String)
+        case marker(label: String, spokenName: String)
+        case blankSpace(String, spokenName: String)
+
+        internal var shownText: String {
+            switch self {
+            case .text(let text), .blankSpace(let text, _):
+                return text
+            case .marker(let label, _):
+                return "<\(label)>"
+            }
+        }
+    }
+
+    internal let segments: [Segment]
+
+    internal init(_ text: String) {
+        segments = Self.segments(of: text as NSString)
+    }
+
+    internal var revealsAnyCharacter: Bool {
+        segments.contains { segment in
+            guard case .text = segment else { return true }
+            return false
+        }
+    }
+
+    internal var plainText: String {
+        segments.map(\.shownText).joined()
+    }
+
+    internal var spokenText: String {
+        segments.map { segment in
+            switch segment {
+            case .text(let text):
+                return text
+            case .marker(_, let spokenName), .blankSpace(_, let spokenName):
+                return " \(spokenName) "
+            }
+        }
+        .joined()
+    }
+}
+
+private extension RevealedText {
+    static func segments(of text: NSString) -> [Segment] {
+        var segments: [Segment] = []
+        var runStart = 0
+        var index = 0
+        while index < text.length {
+            guard let classified = SpecialCharacter.classify(in: text, at: index) else {
+                index += 1
+                continue
+            }
+            if index > runStart {
+                segments.append(.text(text.substring(with: NSRange(location: runStart, length: index - runStart))))
+            }
+            segments.append(segment(for: classified, in: text))
+            index = NSMaxRange(classified.range)
+            runStart = index
+        }
+        if runStart < text.length {
+            segments.append(.text(text.substring(from: runStart)))
+        }
+        return segments
+    }
+
+    static func segment(for classified: ClassifiedSpecialCharacter, in text: NSString) -> Segment {
+        switch classified.character {
+        case .marker(let label):
+            return .marker(label: label, spokenName: classified.name)
+        case .blankSpace:
+            return .blankSpace(text.substring(with: classified.range), spokenName: classified.name)
+        }
+    }
+}

--- a/TablePro/Core/Utilities/UI/AlertHelper.swift
+++ b/TablePro/Core/Utilities/UI/AlertHelper.swift
@@ -265,9 +265,7 @@ final class AlertHelper {
     ) {
         let alert = NSAlert()
         alert.messageText = title
-        alert.informativeText = [message, recoverySuggestion]
-            .compactMap { $0 }
-            .joined(separator: "\n\n")
+        alert.informativeText = errorInformativeText(message: message, recoverySuggestion: recoverySuggestion)
         alert.alertStyle = .critical
         alert.addButton(withTitle: String(localized: "OK"))
         present(alert, in: window)
@@ -283,10 +281,7 @@ final class AlertHelper {
     ) {
         let alert = NSAlert()
         alert.messageText = title
-        alert.informativeText = [message, recoverySuggestion]
-            .compactMap { $0 }
-            .filter { !$0.isEmpty }
-            .joined(separator: "\n\n")
+        alert.informativeText = errorInformativeText(message: message, recoverySuggestion: recoverySuggestion)
         alert.alertStyle = .warning
         alert.addButton(withTitle: recoveryTitle)
         addCancelButton(to: alert, title: String(localized: "Cancel"))
@@ -294,6 +289,14 @@ final class AlertHelper {
             guard response == .alertFirstButtonReturn else { return }
             onRecover()
         }
+    }
+
+    nonisolated static func errorInformativeText(message: String, recoverySuggestion: String?) -> String {
+        let text = [message, recoverySuggestion]
+            .compactMap { $0 }
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n\n")
+        return RevealedText(text).plainText
     }
 
     static func showInfoSheet(

--- a/TablePro/Views/Backup/ServerSideExportSheet.swift
+++ b/TablePro/Views/Backup/ServerSideExportSheet.swift
@@ -154,7 +154,7 @@ struct ServerSideExportSheet: View {
                     .fixedSize(horizontal: false, vertical: true)
             }
             if let errorMessage {
-                Text(errorMessage)
+                RevealedTextView(errorMessage)
                     .font(.subheadline)
                     .foregroundStyle(.red)
                     .fixedSize(horizontal: false, vertical: true)

--- a/TablePro/Views/Compare/CompareApplySheetView.swift
+++ b/TablePro/Views/Compare/CompareApplySheetView.swift
@@ -276,7 +276,7 @@ internal struct CompareApplySheetView: View {
                     .foregroundStyle(.secondary)
             }
             if let error = outcome.error {
-                Text(error)
+                RevealedTextView(error)
                     .font(.caption)
                     .foregroundStyle(CompareStatusStyle.error)
                     .textSelection(.enabled)

--- a/TablePro/Views/Compare/CompareDetailView.swift
+++ b/TablePro/Views/Compare/CompareDetailView.swift
@@ -81,7 +81,7 @@ internal struct CompareDefinitionsPane: View {
         VStack(alignment: .leading, spacing: 16) {
             if let error = result.comparisonError {
                 Label {
-                    Text(error)
+                    RevealedTextView(error)
                         .textSelection(.enabled)
                 } icon: {
                     Image(systemName: "exclamationmark.triangle.fill")

--- a/TablePro/Views/Compare/CompareProgressView.swift
+++ b/TablePro/Views/Compare/CompareProgressView.swift
@@ -68,7 +68,7 @@ internal struct CompareProgressView: View {
 
     private func messageLabel(_ text: String, systemImage: String, tint: Color) -> some View {
         Label {
-            Text(text)
+            RevealedTextView(text)
                 .textSelection(.enabled)
                 .fixedSize(horizontal: false, vertical: true)
         } icon: {
@@ -146,7 +146,7 @@ internal struct CompareMessageBanner: View {
     ) -> some View {
         HStack(alignment: .firstTextBaseline, spacing: 8) {
             Label {
-                Text(text)
+                RevealedTextView(text)
                     .textSelection(.enabled)
                     .fixedSize(horizontal: false, vertical: true)
             } icon: {

--- a/TablePro/Views/Components/DatabaseEndpointPicker.swift
+++ b/TablePro/Views/Components/DatabaseEndpointPicker.swift
@@ -309,7 +309,7 @@ internal struct DatabaseEndpointPicker: View {
         ContentUnavailableView {
             Label("Cannot Read This Connection", systemImage: "exclamationmark.triangle")
         } description: {
-            Text(message)
+            RevealedTextView(message)
         } actions: {
             Button("Try Again") {
                 Task { await retry() }

--- a/TablePro/Views/Components/RevealedTextView.swift
+++ b/TablePro/Views/Components/RevealedTextView.swift
@@ -1,0 +1,50 @@
+//
+//  RevealedTextView.swift
+//  TablePro
+//
+
+import AppKit
+import SwiftUI
+
+internal struct RevealedTextView: View {
+    private let text: String
+    private let revealed: RevealedText
+
+    internal init(_ text: String) {
+        self.text = text
+        revealed = RevealedText(text)
+    }
+
+    internal var body: some View {
+        if revealed.revealsAnyCharacter {
+            Text(revealed.styledText)
+                .accessibilityRepresentation {
+                    Text(verbatim: revealed.spokenText)
+                }
+        } else {
+            Text(verbatim: text)
+        }
+    }
+}
+
+internal extension RevealedText {
+    static let markColor = Color(nsColor: .systemOrange)
+    static let markBackground = markColor.opacity(0.18)
+    static let blankSpaceBackground = markColor.opacity(0.4)
+
+    var styledText: AttributedString {
+        segments.reduce(into: AttributedString()) { styled, segment in
+            var run = AttributedString(segment.shownText)
+            switch segment {
+            case .text:
+                break
+            case .marker:
+                run.foregroundColor = Self.markColor
+                run.backgroundColor = Self.markBackground
+            case .blankSpace:
+                run.backgroundColor = Self.blankSpaceBackground
+            }
+            styled += run
+        }
+    }
+}

--- a/TablePro/Views/Components/TransferResultAlert.swift
+++ b/TablePro/Views/Components/TransferResultAlert.swift
@@ -193,18 +193,20 @@ internal enum TransferResultAlert {
 
         if let pluginError = error as? PluginImportError,
            case .statementFailed(let statement, let line, let underlyingError) = pluginError {
-            alert.informativeText = String(
+            alert.informativeText = RevealedText(String(
                 format: String(localized: "Failed at line %lld. %@"),
                 Int64(line),
                 underlyingError.localizedDescription
-            )
+            )).plainText
             alert.accessoryView = TransferReportView(
                 shown: statement,
                 copied: failureReport(for: error) ?? statement
             )
             alert.layout()
         } else {
-            alert.informativeText = error?.localizedDescription ?? String(localized: "Unknown error")
+            alert.informativeText = RevealedText(
+                error?.localizedDescription ?? String(localized: "Unknown error")
+            ).plainText
         }
 
         AlertHelper.present(alert, in: window) { _ in completion() }
@@ -320,7 +322,7 @@ internal final class TransferReportView: NSView {
             height: Self.textHeight + Self.spacing + button.frame.height
         ))
 
-        let scroll = TransferResultAlert.scrollingText(shown)
+        let scroll = TransferResultAlert.scrollingText(RevealedText(shown).plainText)
         scroll.frame = NSRect(
             x: 0,
             y: button.frame.height + Self.spacing,

--- a/TablePro/Views/Connection/ConnectionUnavailableView.swift
+++ b/TablePro/Views/Connection/ConnectionUnavailableView.swift
@@ -23,7 +23,7 @@ internal struct ConnectionUnavailableView: View {
             VStack(spacing: 8) {
                 ConnectionEndpointLabel(connection: connection)
                 ForEach(Array(detailLines.enumerated()), id: \.offset) { _, line in
-                    Text(line)
+                    RevealedTextView(line)
                         .font(.callout)
                         .foregroundStyle(.secondary)
                         .multilineTextAlignment(.center)

--- a/TablePro/Views/DatabaseSwitcher/CreateDatabaseSheet.swift
+++ b/TablePro/Views/DatabaseSwitcher/CreateDatabaseSheet.swift
@@ -96,7 +96,7 @@ struct CreateDatabaseSheet: View {
         VStack(alignment: .leading, spacing: 6) {
             Text(String(localized: "Failed to load options"))
                 .font(.body.weight(.medium))
-            Text(message)
+            RevealedTextView(message)
                 .font(.callout)
                 .foregroundStyle(.secondary)
             Button(String(localized: "Retry")) {
@@ -110,7 +110,7 @@ struct CreateDatabaseSheet: View {
         HStack(spacing: 8) {
             Image(systemName: "exclamationmark.triangle.fill")
                 .foregroundStyle(.orange)
-            Text(message)
+            RevealedTextView(message)
                 .font(.callout)
                 .foregroundStyle(.primary)
                 .lineLimit(2)

--- a/TablePro/Views/DatabaseSwitcher/DatabaseSwitcherPopover.swift
+++ b/TablePro/Views/DatabaseSwitcher/DatabaseSwitcherPopover.swift
@@ -390,7 +390,7 @@ struct DatabaseSwitcherPopover: View {
                 .foregroundStyle(.orange)
             Text(String(format: String(localized: "Failed to load %@"), containerNamePlural.lowercased()))
                 .font(.callout.weight(.medium))
-            Text(message)
+            RevealedTextView(message)
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)

--- a/TablePro/Views/DatabaseSwitcher/DatabaseSwitcherSheet.swift
+++ b/TablePro/Views/DatabaseSwitcher/DatabaseSwitcherSheet.swift
@@ -189,7 +189,7 @@ struct DatabaseSwitcherSheet: View {
                 .foregroundStyle(.orange)
             Text(String(localized: "Failed to load databases"))
                 .font(.callout.weight(.medium))
-            Text(message)
+            RevealedTextView(message)
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)

--- a/TablePro/Views/ERDiagram/ERDiagramView.swift
+++ b/TablePro/Views/ERDiagram/ERDiagramView.swift
@@ -28,7 +28,7 @@ struct ERDiagramView: View {
                         .font(.largeTitle)
                         .foregroundStyle(.secondary)
                         .accessibilityHidden(true)
-                    Text(message)
+                    RevealedTextView(message)
                         .foregroundStyle(.secondary)
                     Button(String(localized: "Retry")) {
                         Task { await viewModel.loadDiagram() }

--- a/TablePro/Views/Editor/History/HistoryDetailPane.swift
+++ b/TablePro/Views/Editor/History/HistoryDetailPane.swift
@@ -64,7 +64,7 @@ struct HistoryDetailPane: View {
             }
 
             if let errorMessage = entry.errorMessage {
-                Text(errorMessage)
+                RevealedTextView(errorMessage)
                     .font(.caption)
                     .foregroundStyle(.red)
                     .textSelection(.enabled)

--- a/TablePro/Views/Export/TableTransferSheet.swift
+++ b/TablePro/Views/Export/TableTransferSheet.swift
@@ -157,7 +157,7 @@ struct TableTransferSheet: View {
                 .toggleStyle(.checkbox)
 
             if let errorMessage {
-                Text(errorMessage)
+                RevealedTextView(errorMessage)
                     .font(.subheadline)
                     .foregroundStyle(.red)
                     .fixedSize(horizontal: false, vertical: true)

--- a/TablePro/Views/ObjectCopy/CopyObjectsListView.swift
+++ b/TablePro/Views/ObjectCopy/CopyObjectsListView.swift
@@ -76,7 +76,7 @@ internal struct CopyObjectsListView: View {
             ContentUnavailableView {
                 Label("Cannot Read the Source", systemImage: "exclamationmark.triangle")
             } description: {
-                Text(message)
+                RevealedTextView(message)
             } actions: {
                 Button("Try Again") { Task { await session.loadObjects() } }
             }

--- a/TablePro/Views/ObjectCopy/CopyObjectsSheet.swift
+++ b/TablePro/Views/ObjectCopy/CopyObjectsSheet.swift
@@ -109,12 +109,16 @@ internal struct CopyObjectsSheet: View {
             /// A driver's message is the only account of what went wrong, and it is routinely
             /// longer than two lines, so it stays selectable and reachable in full from the
             /// pointer rather than being truncated into something nobody can act on.
-            Label(message, systemImage: "exclamationmark.triangle")
-                .font(.callout)
-                .foregroundStyle(.red)
-                .lineLimit(2)
-                .textSelection(.enabled)
-                .help(message)
+            Label {
+                RevealedTextView(message)
+            } icon: {
+                Image(systemName: "exclamationmark.triangle")
+            }
+            .font(.callout)
+            .foregroundStyle(.red)
+            .lineLimit(2)
+            .textSelection(.enabled)
+            .help(RevealedText(message).plainText)
         } else if session.step == .configuring, let reason = session.reviewDisabledReason {
             Text(reason)
                 .font(.callout)

--- a/TablePro/Views/ObjectSource/EnumLabelListView.swift
+++ b/TablePro/Views/ObjectSource/EnumLabelListView.swift
@@ -57,12 +57,16 @@ struct EnumLabelListView: View {
             .environment(\.defaultMinListRowHeight, Self.rowHeight)
             .frame(height: listHeight)
             if let errorMessage {
-                Label(errorMessage, systemImage: "exclamationmark.triangle.fill")
-                    .foregroundStyle(.red)
-                    .font(.callout)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.horizontal)
-                    .padding(.bottom, 6)
+                Label {
+                    RevealedTextView(errorMessage)
+                } icon: {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                }
+                .foregroundStyle(.red)
+                .font(.callout)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal)
+                .padding(.bottom, 6)
             }
             if canEdit {
                 Divider()

--- a/TablePro/Views/ObjectSource/ObjectSourceTabView.swift
+++ b/TablePro/Views/ObjectSource/ObjectSourceTabView.swift
@@ -197,7 +197,7 @@ struct ObjectSourceTabView: View {
             ContentUnavailableView {
                 Label("Source Unavailable", systemImage: "exclamationmark.triangle")
             } description: {
-                Text(message)
+                RevealedTextView(message)
             } actions: {
                 Button("Try Again") {
                     Task { await loader.load() }

--- a/TablePro/Views/QueryInsights/QueryInsightsGroupList.swift
+++ b/TablePro/Views/QueryInsights/QueryInsightsGroupList.swift
@@ -46,7 +46,7 @@ struct QueryInsightsGroupList: View {
                     .foregroundStyle(.secondary)
 
                 if let error = group.latestErrorMessage, case .failures = metric {
-                    Text(error)
+                    RevealedTextView(error)
                         .font(.caption)
                         .foregroundStyle(.orange)
                         .lineLimit(2)

--- a/TablePro/Views/Results/ForeignKeyPickerView.swift
+++ b/TablePro/Views/Results/ForeignKeyPickerView.swift
@@ -95,7 +95,7 @@ struct ForeignKeyPickerView: View {
     @ViewBuilder
     private var content: some View {
         if let errorMessage {
-            Text(errorMessage)
+            RevealedTextView(errorMessage)
                 .foregroundStyle(.red)
                 .font(.callout)
                 .frame(maxWidth: .infinity, alignment: .leading)

--- a/TablePro/Views/Results/ForeignKeyPreviewView.swift
+++ b/TablePro/Views/Results/ForeignKeyPreviewView.swift
@@ -103,7 +103,7 @@ struct ForeignKeyPreviewView: View {
                 .frame(maxWidth: .infinity, alignment: .center)
                 .frame(height: 60)
         } else if let errorMessage {
-            Text(errorMessage)
+            RevealedTextView(errorMessage)
                 .foregroundStyle(.red)
                 .font(.callout)
                 .padding(10)

--- a/TablePro/Views/Results/InlineErrorBanner.swift
+++ b/TablePro/Views/Results/InlineErrorBanner.swift
@@ -23,7 +23,7 @@ struct InlineErrorBanner: View {
             Image(systemName: "exclamationmark.triangle.fill")
                 .foregroundStyle(.red)
             ScrollView(.vertical) {
-                Text(message)
+                RevealedTextView(message)
                     .font(.subheadline)
                     .textSelection(.enabled)
                     .frame(maxWidth: .infinity, alignment: .leading)

--- a/TablePro/Views/Results/ResultTabBar.swift
+++ b/TablePro/Views/Results/ResultTabBar.swift
@@ -62,7 +62,7 @@ struct ResultTabBar: View {
             return Self.truncated(query)
         }
         if let errorMessage = rs.errorMessage {
-            return Self.truncated(errorMessage)
+            return Self.truncated(RevealedText(errorMessage).plainText)
         }
         return rs.label
     }

--- a/TablePro/Views/ServerDashboard/MetricsBarView.swift
+++ b/TablePro/Views/ServerDashboard/MetricsBarView.swift
@@ -11,9 +11,13 @@ struct MetricsBarView: View {
                     .font(.headline)
                 Spacer()
                 if let error {
-                    Label(error, systemImage: "exclamationmark.triangle")
-                        .font(.caption)
-                        .foregroundStyle(.red)
+                    Label {
+                        RevealedTextView(error)
+                    } icon: {
+                        Image(systemName: "exclamationmark.triangle")
+                    }
+                    .font(.caption)
+                    .foregroundStyle(.red)
                 }
             }
             .padding(.horizontal, 12)

--- a/TablePro/Views/ServerDashboard/ServerDashboardView.swift
+++ b/TablePro/Views/ServerDashboard/ServerDashboardView.swift
@@ -44,7 +44,7 @@ struct ServerDashboardView: View {
             Button(String(localized: "OK"), role: .cancel) { viewModel.actionError = nil }
         } message: {
             if let error = viewModel.actionError {
-                Text(error)
+                Text(verbatim: RevealedText(error).plainText)
             }
         }
     }

--- a/TablePro/Views/ServerDashboard/SessionsTableView.swift
+++ b/TablePro/Views/ServerDashboard/SessionsTableView.swift
@@ -13,9 +13,13 @@ struct SessionsTableView: View {
                     .foregroundStyle(.secondary)
                 Spacer()
                 if let error = viewModel.panelErrors[.activeSessions] {
-                    Label(error, systemImage: "exclamationmark.triangle")
-                        .font(.caption)
-                        .foregroundStyle(.red)
+                    Label {
+                        RevealedTextView(error)
+                    } icon: {
+                        Image(systemName: "exclamationmark.triangle")
+                    }
+                    .font(.caption)
+                    .foregroundStyle(.red)
                 }
             }
             .padding(.horizontal, 12)

--- a/TablePro/Views/ServerDashboard/SlowQueryListView.swift
+++ b/TablePro/Views/ServerDashboard/SlowQueryListView.swift
@@ -13,9 +13,13 @@ struct SlowQueryListView: View {
                     .foregroundStyle(.secondary)
                 Spacer()
                 if let error {
-                    Label(error, systemImage: "exclamationmark.triangle.fill")
-                        .font(.caption)
-                        .foregroundStyle(.orange)
+                    Label {
+                        RevealedTextView(error)
+                    } icon: {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                    }
+                    .font(.caption)
+                    .foregroundStyle(.orange)
                 }
             }
             .padding(.horizontal, 12)

--- a/TablePro/Views/Sidebar/DatabaseTreeRowView.swift
+++ b/TablePro/Views/Sidebar/DatabaseTreeRowView.swift
@@ -227,10 +227,14 @@ struct DatabaseTreeRowView: View {
                 .font(.callout)
                 .foregroundStyle(.secondary)
         case .error(let message):
-            Label(message, systemImage: "exclamationmark.triangle")
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                .lineLimit(2)
+            Label {
+                RevealedTextView(message)
+            } icon: {
+                Image(systemName: "exclamationmark.triangle")
+            }
+            .font(.callout)
+            .foregroundStyle(.secondary)
+            .lineLimit(2)
         case .truncated(let message):
             Text(message)
                 .font(.caption)

--- a/TablePro/Views/Sidebar/DatabaseTreeView.swift
+++ b/TablePro/Views/Sidebar/DatabaseTreeView.swift
@@ -188,7 +188,7 @@ struct DatabaseTreeView: View {
             Image(systemName: "exclamationmark.triangle")
                 .font(.title)
                 .foregroundStyle(.orange)
-            Text(message)
+            RevealedTextView(message)
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)

--- a/TablePro/Views/Sidebar/SidebarView.swift
+++ b/TablePro/Views/Sidebar/SidebarView.swift
@@ -294,7 +294,7 @@ struct SidebarView: View {
             Image(systemName: "exclamationmark.triangle")
                 .font(.title)
                 .foregroundStyle(.orange)
-            Text(message)
+            RevealedTextView(message)
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)

--- a/TablePro/Views/Structure/ClickHousePartsView.swift
+++ b/TablePro/Views/Structure/ClickHousePartsView.swift
@@ -32,7 +32,7 @@ struct ClickHousePartsView: View {
                         .font(.largeTitle)
                         .foregroundStyle(.orange)
                         .accessibilityHidden(true)
-                    Text(error)
+                    RevealedTextView(error)
                         .foregroundStyle(.secondary)
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/TablePro/Views/Structure/CreateTableView.swift
+++ b/TablePro/Views/Structure/CreateTableView.swift
@@ -130,7 +130,7 @@ struct CreateTableView: View {
         .alert(String(localized: "Create Table Failed"), isPresented: $showError) {
             Button("OK") {}
         } message: {
-            Text(errorMessage ?? "")
+            Text(verbatim: RevealedText(errorMessage ?? "").plainText)
         }
     }
 

--- a/TablePro/Views/Structure/TableStructureView.swift
+++ b/TablePro/Views/Structure/TableStructureView.swift
@@ -590,7 +590,7 @@ struct TableStructureView: View {
                 .font(.largeTitle)
                 .foregroundStyle(.orange)
                 .accessibilityHidden(true)
-            Text(message)
+            RevealedTextView(message)
                 .foregroundStyle(.secondary)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/TablePro/Views/Structure/TriggerDetailView.swift
+++ b/TablePro/Views/Structure/TriggerDetailView.swift
@@ -117,7 +117,7 @@ struct TriggerDetailView: View {
         ) {
             Button(String(localized: "OK"), role: .cancel) { actionError = nil }
         } message: {
-            Text(actionError ?? "")
+            Text(verbatim: RevealedText(actionError ?? "").plainText)
         }
     }
 

--- a/TablePro/Views/Structure/TriggerEditorView.swift
+++ b/TablePro/Views/Structure/TriggerEditorView.swift
@@ -60,11 +60,15 @@ struct TriggerEditorView: View {
             )
             if let errorMessage {
                 Divider()
-                Label(errorMessage, systemImage: "exclamationmark.triangle.fill")
-                    .foregroundStyle(.red)
-                    .font(.callout)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(8)
+                Label {
+                    RevealedTextView(errorMessage)
+                } icon: {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                }
+                .foregroundStyle(.red)
+                .font(.callout)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(8)
             }
         }
         .frame(minWidth: 560, idealWidth: 680, minHeight: 360, idealHeight: 460)

--- a/TablePro/Views/UsersRoles/UsersRolesTabView.swift
+++ b/TablePro/Views/UsersRoles/UsersRolesTabView.swift
@@ -43,7 +43,7 @@ struct UsersRolesTabView: View {
         ) { _ in
             Button(String(localized: "OK"), role: .cancel) { viewModel.actionError = nil }
         } message: { message in
-            Text(message)
+            Text(verbatim: RevealedText(message).plainText)
         }
         .onAppear { install() }
         .onDisappear { teardown() }

--- a/TablePro/Views/Welcome/WelcomePresentations.swift
+++ b/TablePro/Views/Welcome/WelcomePresentations.swift
@@ -61,7 +61,7 @@ internal struct WelcomePresentations: ViewModifier {
                 }
             } message: {
                 if let error = vm.connectionError {
-                    Text(error)
+                    Text(verbatim: RevealedText(error).plainText)
                 }
             }
             .fileImporter(

--- a/TableProTests/Core/Utilities/ErrorSheetTextTests.swift
+++ b/TableProTests/Core/Utilities/ErrorSheetTextTests.swift
@@ -1,0 +1,41 @@
+//
+//  ErrorSheetTextTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("Error sheet text")
+struct ErrorSheetTextTests {
+    @Test("A database message shows its hidden characters in the error sheet")
+    func revealsHiddenCharacters() {
+        let text = AlertHelper.errorInformativeText(
+            message: "unrecognized token: \"\u{8}\"",
+            recoverySuggestion: nil
+        )
+        #expect(text == "unrecognized token: \"<BS>\"")
+    }
+
+    @Test("The recovery suggestion follows the message after a blank line")
+    func joinsRecoverySuggestion() {
+        let text = AlertHelper.errorInformativeText(
+            message: "column \"name\u{200B}\" does not exist",
+            recoverySuggestion: "Check the column name."
+        )
+        #expect(text == "column \"name<ZWSP>\" does not exist\n\nCheck the column name.")
+    }
+
+    @Test("An empty part adds no blank lines")
+    func dropsEmptyParts() {
+        #expect(AlertHelper.errorInformativeText(message: "", recoverySuggestion: "Try again.") == "Try again.")
+        #expect(AlertHelper.errorInformativeText(message: "Failed.", recoverySuggestion: "") == "Failed.")
+    }
+
+    @Test("A formatter's narrow no-break space is left alone")
+    func keepsSpecialSpaces() {
+        let message = "The session expired at 10:30\u{202F}PM."
+        #expect(AlertHelper.errorInformativeText(message: message, recoverySuggestion: nil) == message)
+    }
+}

--- a/TableProTests/Core/Utilities/Text/RevealedTextTests.swift
+++ b/TableProTests/Core/Utilities/Text/RevealedTextTests.swift
@@ -1,0 +1,131 @@
+//
+//  RevealedTextTests.swift
+//  TableProTests
+//
+
+import Foundation
+import SwiftUI
+@testable import TablePro
+import Testing
+
+@Suite("Revealed text")
+struct RevealedTextTests {
+    @Test("A message with nothing invisible is left as it is")
+    func ordinaryMessage() {
+        let revealed = RevealedText("no such table: nope")
+        #expect(revealed.segments == [.text("no such table: nope")])
+        #expect(revealed.revealsAnyCharacter == false)
+        #expect(revealed.plainText == "no such table: nope")
+        #expect(revealed.spokenText == "no such table: nope")
+    }
+
+    @Test("An empty message has no segments")
+    func emptyMessage() {
+        let revealed = RevealedText("")
+        #expect(revealed.segments.isEmpty)
+        #expect(revealed.plainText.isEmpty)
+    }
+
+    @Test("The reported backspace between the quotes is named")
+    func reportedBackspace() {
+        let revealed = RevealedText("unrecognized token: \"\u{8}\"")
+        #expect(revealed.segments == [
+            .text("unrecognized token: \""),
+            .marker(label: "BS", spokenName: "backspace"),
+            .text("\"")
+        ])
+        #expect(revealed.revealsAnyCharacter)
+        #expect(revealed.plainText == "unrecognized token: \"<BS>\"")
+        #expect(revealed.spokenText == "unrecognized token: \" backspace \"")
+    }
+
+    @Test("A format character is labelled as the editor labels it and spoken by its Unicode name")
+    func zeroWidthSpace() {
+        let revealed = RevealedText("near \"SELECT\u{200B}Name\": syntax error")
+        #expect(revealed.segments == [
+            .text("near \"SELECT"),
+            .marker(label: "ZWSP", spokenName: "zero width space"),
+            .text("Name\": syntax error")
+        ])
+        #expect(revealed.plainText == "near \"SELECT<ZWSP>Name\": syntax error")
+        #expect(revealed.spokenText == "near \"SELECT zero width space Name\": syntax error")
+    }
+
+    @Test("A special space keeps its width in plain text and is still spoken")
+    func noBreakSpace() {
+        let message = "near \"SELECT\u{A0}Name\": syntax error"
+        let revealed = RevealedText(message)
+        #expect(revealed.segments == [
+            .text("near \"SELECT"),
+            .blankSpace("\u{A0}", spokenName: "no-break space"),
+            .text("Name\": syntax error")
+        ])
+        #expect(revealed.revealsAnyCharacter)
+        #expect(revealed.plainText == message)
+        #expect(revealed.spokenText == "near \"SELECT no-break space Name\": syntax error")
+    }
+
+    @Test("Tabs, line feeds and carriage returns are ordinary layout, not hidden characters")
+    func preservedWhitespace() {
+        let message = "ERROR:  syntax error\n\tLINE 1: SELECT\r\n"
+        #expect(RevealedText(message).segments == [.text(message)])
+    }
+
+    @Test("A joiner inside an emoji sequence stays part of the emoji")
+    func emojiJoiner() {
+        let message = "invalid value \"👩\u{200D}💻\""
+        #expect(RevealedText(message).revealsAnyCharacter == false)
+    }
+
+    @Test("Bidi controls cannot reorder the message they sit in")
+    func bidiOverride() {
+        let revealed = RevealedText("column \"a\u{202E}b\" does not exist")
+        #expect(revealed.plainText == "column \"a<RLO>b\" does not exist")
+    }
+
+    @Test("A character outside the Basic Multilingual Plane is revealed whole")
+    func supplementaryCharacter() {
+        let revealed = RevealedText("tag\u{E0001}here")
+        #expect(revealed.segments == [
+            .text("tag"),
+            .marker(label: "E0001", spokenName: "language tag"),
+            .text("here")
+        ])
+    }
+
+    @Test("Neighbouring hidden characters are each revealed")
+    func adjacentCharacters() {
+        let revealed = RevealedText("\u{0}\u{0}\u{FEFF}")
+        #expect(revealed.plainText == "<NUL><NUL><BOM>")
+        #expect(revealed.segments.count == 3)
+    }
+
+    @Test("The styled text shows each label in the mark colour and tints a special space")
+    func styledRuns() {
+        let styled = RevealedText("a\u{8}b\u{A0}c").styledText
+        #expect(String(styled.characters) == "a<BS>b\u{A0}c")
+
+        let runs = styled.runs.map { run in
+            (String(styled[run.range].characters), run.foregroundColor, run.backgroundColor)
+        }
+        #expect(runs.count == 5)
+        #expect(runs[0].0 == "a" && runs[0].1 == nil && runs[0].2 == nil)
+        #expect(runs[1].0 == "<BS>" && runs[1].1 == RevealedText.markColor && runs[1].2 == RevealedText.markBackground)
+        #expect(runs[2].0 == "b" && runs[2].1 == nil && runs[2].2 == nil)
+        #expect(runs[3].0 == "\u{A0}" && runs[3].1 == nil && runs[3].2 == RevealedText.blankSpaceBackground)
+        #expect(runs[4].0 == "c" && runs[4].1 == nil && runs[4].2 == nil)
+    }
+
+    @Test("A selection copied from a marked message reads as the error alert shows it")
+    func styledCharactersMatchPlainText() {
+        let messages = [
+            "unrecognized token: \"\u{8}\"",
+            "near \"SELECT\u{A0}1\u{200B}\u{1B}\": syntax error",
+            "tag\u{E0001}here\u{0}"
+        ]
+        for message in messages {
+            let revealed = RevealedText(message)
+            #expect(String(revealed.styledText.characters) == revealed.plainText)
+        }
+    }
+}

--- a/TableProTests/Views/TransferFailureReportTests.swift
+++ b/TableProTests/Views/TransferFailureReportTests.swift
@@ -109,6 +109,25 @@ struct TransferFailureReportTests {
         #expect(clipboard.text?.contains("Duplicate entry") == true)
         #expect(clipboard.text?.contains("INSERT INTO users VALUES (1)") == true)
     }
+
+    @Test("The box names a hidden character and the copy keeps the database's own text")
+    func hiddenCharactersAreShownButCopiedVerbatim() {
+        let original = ClipboardService.shared
+        defer { ClipboardService.shared = original }
+        let clipboard = TransferReportClipboard()
+        ClipboardService.shared = clipboard
+
+        let report = "Line 3: unrecognized token: \"\u{8}\""
+        let view = TransferReportView(report: report)
+        view.copyReport()
+
+        let shown = view.subviews
+            .compactMap { ($0 as? NSScrollView)?.documentView as? NSTextView }
+            .first?
+            .string
+        #expect(shown == "Line 3: unrecognized token: \"<BS>\"")
+        #expect(clipboard.text == report)
+    }
 }
 
 private struct TransferReportStubError: LocalizedError {

--- a/TableProUITests/QueryErrorBannerUITests.swift
+++ b/TableProUITests/QueryErrorBannerUITests.swift
@@ -39,13 +39,34 @@ final class QueryErrorBannerUITests: UITestCase {
         )
     }
 
+    func testAHiddenCharacterInTheErrorIsNamed() throws {
+        let app = try launchWithSampleDatabase()
+        openQueryEditor(in: app)
+        app.typeText("SELECT")
+        app.typeKey(" ", modifierFlags: .option)
+        app.typeText("1;")
+        app.typeKey(.return, modifierFlags: .command)
+
+        let banner = app.windows.firstMatch.staticTexts["query-error-message"].firstMatch
+        XCTAssertTrue(banner.waitToExist(timeout: 20))
+        let exposed = [banner.value as? String, banner.label].compactMap { $0 }
+        XCTAssertTrue(
+            exposed.contains { $0.contains("no-break space") },
+            "The no-break space SQLite quotes back must be named, not read as a plain space; got \(exposed)"
+        )
+    }
+
     private func runQuery(_ sql: String, in app: XCUIApplication) {
+        openQueryEditor(in: app)
+        app.typeText(sql)
+        app.typeKey(.return, modifierFlags: .command)
+    }
+
+    private func openQueryEditor(in app: XCUIApplication) {
         app.typeKey("t", modifierFlags: .command)
         let queryEditor = editorTextView(in: app)
         XCTAssertTrue(queryEditor.waitToExist(timeout: 10))
         queryEditor.click()
-        app.typeText(sql)
-        app.typeKey(.return, modifierFlags: .command)
     }
 
     private func waitForDisappearance(of element: XCUIElement, timeout: TimeInterval) -> Bool {

--- a/docs/features/query-results.mdx
+++ b/docs/features/query-results.mdx
@@ -68,4 +68,4 @@ When the cap trims a result the status bar reads **Showing N rows** and offers *
 
 INSERT, UPDATE, DELETE and DDL show a success view with the affected row count and the execution time.
 
-A failed statement shows a red banner above the results with the database's own error message and a **Fix with AI** button. See [AI Assistant](/features/ai-assistant).
+A failed statement shows a red banner above the results with the database's own error message and a **Fix with AI** button. See [AI Assistant](/features/ai-assistant). A control character or zero-width space in the message shows as its short name in angle brackets, such as `<BS>`; see [Invisible characters](/features/sql-editor#invisible-characters).

--- a/docs/features/sql-editor.mdx
+++ b/docs/features/sql-editor.mdx
@@ -162,7 +162,9 @@ Choose **Query > Remove Invisible Characters** to clean a query. With nothing se
 
 A statement containing a NUL character is not sent to the database. Remove the character and run it again.
 
-To hide the marks in the editor, turn off **Show invisible characters** in **Settings > Editor**. Read-only views, such as the AI assistant's code blocks, always show them.
+A database often quotes the offending character back in its error message. Error messages show each marked character as its short name in angle brackets, so SQLite's reply to a stray backspace reads `unrecognized token: "<BS>"`. The error banner, query history and the other panes that show a database error also color the name orange and tint a special space. In an error alert, a special space shows as an ordinary space. The banner's copy button copies the database's text as it arrived, for a search or a bug report.
+
+To hide the marks in the editor, turn off **Show invisible characters** in **Settings > Editor**. Read-only views, such as the AI assistant's code blocks, and error messages always show them.
 
 ## AI assistance
 


### PR DESCRIPTION
Found while investigating #2717 (PR #2724).

## Root cause

PR #2724 taught the SQL editor to draw invisible characters through `SpecialCharacter.classify` in CodeEditTextView. Database error messages never went through that classifier. The error banner, the history pane, the sidebar and sheet error states, and every error alert rendered the driver's string as it arrived. When a database quotes the offending character back, the message hides the exact thing it is about. SQLite's reply to a stray backspace, `unrecognized token: "\b"`, renders as `unrecognized token: ""`. A no-break space in `near "SELECT 1"` reads as an ordinary space.

## What changed

- `RevealedText` (new, `Core/Utilities/Text`) splits a message into plain runs, labelled markers such as `<BS>` or `<ZWSP>`, and special spaces. It reuses the editor's classifier, so both places label a character the same way. It also produces a spoken form that names each character.
- `ClassifiedSpecialCharacter.name` in CodeEditTextView gives each character a spoken name. Controls have no Unicode name, so C0, DEL and C1 use a table of their standard names; everything else uses `Unicode.Scalar.Properties.name`.
- `RevealedTextView` (new) is the SwiftUI view for one message. It draws the markers in orange and tints a special space. VoiceOver gets the spoken form through `accessibilityRepresentation`. 31 error views use it.
- AppKit alerts (`AlertHelper.errorInformativeText`, `TransferResultAlert`, the trigger editor) show the plain marked text, since `NSAlert` takes a plain string.
- The banner's copy button and the transfer report's Copy button still copy the database's original text.
- Docs: `query-results.mdx` and `sql-editor.mdx` describe how error messages show these characters.

### Why `accessibilityRepresentation` and not `accessibilityLabel`

Running the new UI test in the publish stage exposed two SwiftUI behaviours, both measured:

1. A `Text`-level `.accessibilityLabel(_:)` is dropped once the text is selectable. The banner's message is selectable, so the spoken form never reached the accessibility tree. XCUITest read `near "SELECT 1": syntax error` with a plain space.
2. A view-level `.accessibilityLabel` on selectable text crashes the app. SwiftUI's `AccessibilityNode.accessibilityLabel()` recurses through `_NSAccessibilityOverrideValueForAttribute` until the main thread's stack overflows (`EXC_BAD_ACCESS`, stack guard). It happens when the text appears in a tree an accessibility client has already read. That is exactly the error banner: it appears after the query fails, while VoiceOver or XCUITest is attached. Where the selection is applied does not matter: on the view itself, on its caller, on an ancestor, or with a `String` label.

To isolate it I built a small standalone SwiftUI app (macOS 14 deployment target, like the app) with one variant per process, plus a client that walks its tree through `AXUIElementCopyMultipleAttributeValues`, the call XCTest makes. With the text inserted after the first walk, every selectable view-level label variant died with SIGSEGV. `accessibilityRepresentation { Text(verbatim: spoken) }` survived every case: inserted late, selection applied inside, outside or by an ancestor, inside a `ScrollView`. It still exposed the spoken form on the element that carries the identifier. Callers keep the native `.textSelection(.enabled)`, and the view needs no selection parameter.

The trade-off: a revealed message is published to accessibility as one static text, without the selectable-text child SwiftUI adds. That only happens when the message contains a hidden character, and that child read the character wrongly anyway. Mouse selection and the copy buttons are unchanged.

## Verification

- Build: PASS (`.analysis/fix-error-banner-invisible-characters/logs/build-TablePro-171307.log`).
- Unit tests: 32 of 32 passed across `RevealedTextTests` (12), `TransferFailureReportTests` (9), `StringCatalogIntegrityTests` (6), `ErrorSheetTextTests` (4) and `IconOnlyControlLabelTests` (1). Each suite's cases were confirmed in the log (`logs/test-RevealedTextTests-171634.log`).
- Package: `swift test` in `LocalPackages/CodeEditTextView` passed, 259 Swift Testing tests in 25 suites plus 52 XCTest cases, 0 failures.
- UI tests: `QueryErrorBannerUITests` passed 3 of 3 (`logs/test-QueryErrorBannerUITests-171349.log`). The new case, `testAHiddenCharacterInTheErrorIsNamed`, types `SELECT`, Option-Space, `1;` into the sample SQLite database and checks that the banner exposes "no-break space". It failed on the first implementation, where the label was dropped (`logs/test-QueryErrorBannerUITests-164031.log`), and on the second, where the app crashed (`logs/test-QueryErrorBannerUITests-165604.log`). It passes with this one.
- SwiftLint `--strict` on every changed Swift file: no violations.

## Notes

- Codex review was unavailable (usage limit), so an adversarial reviewer agent read the diff instead.
- Dismissed: the reviewer checked whether `String(localized:)` wraps interpolated arguments in bidi isolates (U+2068/U+2069), which would then show up as markers in our own messages. Measured: interpolation, `String(format:)` and `localizedStringWithFormat` produce no isolate characters, so no markers appear in the app's own text.
- Addressed: `Unicode.Scalar.Properties.name` is nil for every C0 and C1 control and for DEL. The spoken name table covers them, and `SpecialCharacterTests.everyControlIsNamed` checks every control the classifier marks.
- The crash in behaviour 2 is a SwiftUI defect: it needs an accessibility label on a selectable `Text`. Two other views pair a label with selectable content, and I measured both shapes in the harness under the same late-insertion condition. A labelled icon inside a selectable row, as in `JSONNodeRowView`, survived. So did a combined element labelled over selectable text, as in `QueryPlanComparisonView`. The crashing control variant died on every run. This is worth a Feedback Assistant report with the harness.

https://claude.ai/code/session_011THKc9TRHE8xjcxXidDHXP
