### PR TITLE
feat(editor): warn about full-width punctuation, curly quotes and non-ASCII spaces in SQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Invisible characters shown in the SQL editor: control characters, zero-width spaces, bidi controls and special spaces. (#2717)
 - **Remove Invisible Characters** in the Query menu. (#2717)
 - **Show invisible characters** in Settings > Editor. (#2717)
+- Warnings in the SQL editor for full-width punctuation, curly quotes and non-ASCII spaces. (#2717)
 
 ### Changed
 

--- a/TablePro/Core/Diagnostics/ConfusableSQLCharacter.swift
+++ b/TablePro/Core/Diagnostics/ConfusableSQLCharacter.swift
@@ -1,0 +1,139 @@
+//
+//  ConfusableSQLCharacter.swift
+//  TablePro
+//
+
+import Foundation
+
+enum ConfusableSQLCharacter: Equatable, Sendable {
+    case fullWidthPunctuation(Unicode.Scalar)
+    case fullWidthText(asciiSpelling: String)
+    case curlyQuote(Unicode.Scalar)
+    case nonASCIISpace(Unicode.Scalar)
+
+    private static let fullWidthForms: ClosedRange<UInt16> = 0xFF01...0xFF5E
+    private static let fullWidthOffset: UInt16 = 0xFEE0
+
+    static func isFullWidthWordUnit(_ unit: UInt16) -> Bool {
+        switch unit {
+        case 0xFF10...0xFF19, 0xFF21...0xFF3A, 0xFF3F, 0xFF41...0xFF5A:
+            return true
+        default:
+            return false
+        }
+    }
+
+    static func separating(_ unit: UInt16) -> ConfusableSQLCharacter? {
+        guard let scalar = Unicode.Scalar(unit) else { return nil }
+        switch unit {
+        case fullWidthForms where !isFullWidthWordUnit(unit):
+            return .fullWidthPunctuation(scalar)
+        case 0x2018, 0x2019, 0x201C, 0x201D:
+            return .curlyQuote(scalar)
+        case 0x00A0, 0x2000...0x200A, 0x202F, 0x205F, 0x3000:
+            return .nonASCIISpace(scalar)
+        default:
+            return nil
+        }
+    }
+
+    static func asciiSpelling(of text: NSString, in range: NSRange) -> String {
+        var units: [UInt16] = []
+        units.reserveCapacity(range.length)
+        for offset in range.location..<NSMaxRange(range) {
+            let unit = text.character(at: offset)
+            units.append(fullWidthForms.contains(unit) ? unit - fullWidthOffset : unit)
+        }
+        return String(decoding: units, as: UTF16.self)
+    }
+
+    var message: String {
+        switch self {
+        case .fullWidthPunctuation(let scalar):
+            return Self.fullWidthPunctuationMessage(scalar)
+        case .fullWidthText(let asciiSpelling):
+            return String(
+                format: String(localized: "Full-width letters or digits. SQL needs the ASCII %@."),
+                asciiSpelling
+            )
+        case .curlyQuote(let scalar):
+            return String(
+                format: String(localized: "Curly quote (%1$@). SQL needs the straight quote (%2$@)."),
+                Self.codePoint(scalar.value),
+                Self.codePoint(Self.straightQuote(for: scalar))
+            )
+        case .nonASCIISpace(let scalar):
+            return String(
+                format: String(localized: "Non-ASCII space (%@). SQL needs an ASCII space (U+0020)."),
+                Self.codePoint(scalar.value)
+            )
+        }
+    }
+
+    private static func fullWidthPunctuationMessage(_ scalar: Unicode.Scalar) -> String {
+        let asciiValue = scalar.value - UInt32(fullWidthOffset)
+        guard let ascii = Unicode.Scalar(asciiValue), ascii != ";" else {
+            return String(localized: "Full-width semicolon (U+FF1B). SQL reads only ; as a statement separator.")
+        }
+        return String(
+            format: String(localized: "Full-width %1$@ (%2$@). SQL needs the ASCII %1$@ (%3$@)."),
+            punctuationName(ascii),
+            codePoint(scalar.value),
+            codePoint(asciiValue)
+        )
+    }
+
+    private static func straightQuote(for scalar: Unicode.Scalar) -> UInt32 {
+        switch scalar.value {
+        case 0x201C, 0x201D:
+            return 0x22
+        default:
+            return 0x27
+        }
+    }
+
+    private static func codePoint(_ value: UInt32) -> String {
+        String(format: "U+%04X", value)
+    }
+
+    private static func punctuationName(_ ascii: Unicode.Scalar) -> String {
+        switch ascii {
+        case "!": return String(localized: "exclamation mark")
+        case "\"": return String(localized: "quotation mark")
+        case "#": return String(localized: "number sign")
+        case "$": return String(localized: "dollar sign")
+        case "%": return String(localized: "percent sign")
+        case "&": return String(localized: "ampersand")
+        case "'": return String(localized: "apostrophe")
+        case "(": return String(localized: "left parenthesis")
+        case ")": return String(localized: "right parenthesis")
+        case "*": return String(localized: "asterisk")
+        case "+": return String(localized: "plus sign")
+        case ",": return String(localized: "comma")
+        case "-": return String(localized: "hyphen")
+        case ".": return String(localized: "period")
+        case "/": return String(localized: "slash")
+        case ":": return String(localized: "colon")
+        case "<": return String(localized: "less-than sign")
+        case "=": return String(localized: "equals sign")
+        case ">": return String(localized: "greater-than sign")
+        case "?": return String(localized: "question mark")
+        case "@": return String(localized: "at sign")
+        case "[": return String(localized: "left square bracket")
+        case "\\": return String(localized: "backslash")
+        case "]": return String(localized: "right square bracket")
+        case "^": return String(localized: "caret")
+        case "`": return String(localized: "backtick")
+        case "{": return String(localized: "left curly bracket")
+        case "|": return String(localized: "vertical bar")
+        case "}": return String(localized: "right curly bracket")
+        case "~": return String(localized: "tilde")
+        default: return String(ascii)
+        }
+    }
+}
+
+struct ConfusableSQLCharacterMatch: Equatable, Sendable {
+    let character: ConfusableSQLCharacter
+    let range: NSRange
+}

--- a/TablePro/Core/Diagnostics/MongoDiagnosticsProducer.swift
+++ b/TablePro/Core/Diagnostics/MongoDiagnosticsProducer.swift
@@ -7,11 +7,9 @@ import TableProPluginKit
 /// a list of method names. Checking against a list said `forEach` was an unsupported method and
 /// underlined every script that iterated a cursor, while saying nothing about a missing brace.
 struct MongoDiagnosticsProducer: QueryDiagnosticsProducing {
-    private static let maximumLength = 100_000
-
     func diagnostics(for text: String) -> [QueryDiagnostic] {
         let source = text as NSString
-        guard source.length > 0, source.length <= Self.maximumLength else { return [] }
+        guard source.length > 0, source.length <= QueryDiagnosticsLimits.maximumDocumentLength else { return [] }
 
         // The bracket scanner has no regex state, so `db.c.find({x:/[)]/})` reads as an unmatched
         // closer. The syntax checker below knows JavaScript properly, so the structural pass is

--- a/TablePro/Core/Diagnostics/QueryDiagnostic.swift
+++ b/TablePro/Core/Diagnostics/QueryDiagnostic.swift
@@ -28,14 +28,34 @@ protocol QueryDiagnosticsProducing: Sendable {
     func diagnostics(for text: String) -> [QueryDiagnostic]
 }
 
+enum QueryDiagnosticsLimits {
+    static let maximumDocumentLength = 100_000
+}
+
+struct CombinedQueryDiagnosticsProducer: QueryDiagnosticsProducing {
+    let producers: [QueryDiagnosticsProducing]
+
+    func diagnostics(for text: String) -> [QueryDiagnostic] {
+        producers.flatMap { $0.diagnostics(for: text) }
+    }
+}
+
 @MainActor
 enum QueryDiagnosticsFactory {
     static func make(for databaseType: DatabaseType?) -> QueryDiagnosticsProducing {
-        let dialect = databaseType ?? .mysql
+        let resolvedType = databaseType ?? .mysql
 
-        switch PluginManager.shared.editorLanguage(for: dialect) {
+        switch PluginManager.shared.editorLanguage(for: resolvedType) {
         case .javascript:
             return MongoDiagnosticsProducer()
+        case .sql:
+            return CombinedQueryDiagnosticsProducer(producers: [
+                SQLDiagnosticsProducer(),
+                SQLConfusableCharacterDiagnosticsProducer(rules: SQLLexicalRules(
+                    databaseType: resolvedType,
+                    descriptor: PluginManager.shared.sqlDialect(for: resolvedType)
+                ))
+            ])
         default:
             return SQLDiagnosticsProducer()
         }

--- a/TablePro/Core/Diagnostics/SQLConfusableCharacterDiagnosticsProducer.swift
+++ b/TablePro/Core/Diagnostics/SQLConfusableCharacterDiagnosticsProducer.swift
@@ -1,0 +1,19 @@
+//
+//  SQLConfusableCharacterDiagnosticsProducer.swift
+//  TablePro
+//
+
+import Foundation
+
+struct SQLConfusableCharacterDiagnosticsProducer: QueryDiagnosticsProducing {
+    let rules: SQLLexicalRules
+
+    func diagnostics(for text: String) -> [QueryDiagnostic] {
+        let source = text as NSString
+        guard source.length > 0, source.length <= QueryDiagnosticsLimits.maximumDocumentLength else { return [] }
+
+        return SQLConfusableCharacterScanner.scan(source, rules: rules).map { match in
+            QueryDiagnostic(range: match.range, message: match.character.message, severity: .warning)
+        }
+    }
+}

--- a/TablePro/Core/Diagnostics/SQLConfusableCharacterScanner.swift
+++ b/TablePro/Core/Diagnostics/SQLConfusableCharacterScanner.swift
@@ -1,0 +1,182 @@
+//
+//  SQLConfusableCharacterScanner.swift
+//  TablePro
+//
+
+import Foundation
+import TableProPluginKit
+
+enum SQLConfusableCharacterScanner {
+    static func scan(_ text: NSString, rules: SQLLexicalRules) -> [ConfusableSQLCharacterMatch] {
+        var scan = ConfusableCharacterScan(text: text, rules: rules)
+        scan.run()
+        return scan.matches
+    }
+}
+
+private struct ConfusableCharacterScan {
+    private static let openBracket = UInt16(UnicodeScalar("[").value)
+    private static let closeBracket = UInt16(UnicodeScalar("]").value)
+    private static let capitalE = UInt16(UnicodeScalar("E").value)
+    private static let smallE = UInt16(UnicodeScalar("e").value)
+
+    private let text: NSString
+    private let length: Int
+    private let rules: SQLLexicalRules
+
+    private(set) var matches: [ConfusableSQLCharacterMatch] = []
+    private var index = 0
+
+    init(text: NSString, rules: SQLLexicalRules) {
+        self.text = text
+        self.length = text.length
+        self.rules = rules
+    }
+
+    mutating func run() {
+        while index < length {
+            step()
+        }
+    }
+
+    private mutating func step() {
+        let character = text.character(at: index)
+
+        if let end = endOfCommentOrQuotedText(startingWith: character) {
+            index = end
+            return
+        }
+        if Self.isWordUnit(character) {
+            consumeWord()
+            return
+        }
+        if let confusable = ConfusableSQLCharacter.separating(character) {
+            consumeRun(of: character, as: confusable)
+            return
+        }
+        index += 1
+    }
+
+    private mutating func consumeRun(of character: UInt16, as confusable: ConfusableSQLCharacter) {
+        let start = index
+        while index < length, text.character(at: index) == character {
+            index += 1
+        }
+        matches.append(ConfusableSQLCharacterMatch(
+            character: confusable,
+            range: NSRange(location: start, length: index - start)
+        ))
+    }
+
+    private mutating func consumeWord() {
+        let start = index
+        var firstFullWidth: Int?
+        var lastFullWidth = start
+        var isNativeScript = false
+
+        while index < length {
+            let unit = text.character(at: index)
+            guard Self.isWordUnit(unit) else { break }
+            if ConfusableSQLCharacter.isFullWidthWordUnit(unit) {
+                firstFullWidth = firstFullWidth ?? index
+                lastFullWidth = index
+            } else if Self.isNativeScriptUnit(unit) {
+                isNativeScript = true
+            }
+            index += 1
+        }
+
+        if let firstFullWidth, !isNativeScript {
+            let range = NSRange(location: firstFullWidth, length: lastFullWidth - firstFullWidth + 1)
+            let spelling = ConfusableSQLCharacter.asciiSpelling(of: text, in: range)
+            matches.append(ConfusableSQLCharacterMatch(character: .fullWidthText(asciiSpelling: spelling), range: range))
+        }
+
+        skipEscapeString(afterWordStartingAt: start)
+    }
+
+    private mutating func skipEscapeString(afterWordStartingAt start: Int) {
+        guard rules.dialect.supportsEscapeStringPrefix, index - start == 1, index < length,
+              text.character(at: index) == SqlLexer.singleQuote else { return }
+        let prefix = text.character(at: start)
+        guard prefix == Self.capitalE || prefix == Self.smallE else { return }
+        index = SqlLexer.skipQuotedString(
+            text,
+            from: index,
+            quote: SqlLexer.singleQuote,
+            length: length,
+            backslashEscapes: true
+        ).next
+    }
+
+    private func endOfCommentOrQuotedText(startingWith character: UInt16) -> Int? {
+        if SqlLexer.startsLineComment(text, at: index, length: length)
+            || (rules.dialect.supportsHashLineComments && character == SqlLexer.hash) {
+            return SqlLexer.endOfLine(text, from: index, length: length)
+        }
+        if SqlLexer.startsBlockComment(text, at: index, length: length) {
+            return endOfBlockComment()
+        }
+        if SqlLexer.isQuote(character) {
+            return SqlLexer.skipQuotedString(
+                text,
+                from: index,
+                quote: character,
+                length: length,
+                backslashEscapes: rules.backslashEscapes
+            ).next
+        }
+        if rules.bracketsDelimitIdentifiers, character == Self.openBracket {
+            return endOfBracketedIdentifier()
+        }
+        return endOfDollarQuotedBody(startingWith: character)
+    }
+
+    private func endOfBlockComment() -> Int? {
+        switch rules.dialect {
+        case .mysql where SqlLexer.startsConditionalComment(text, at: index, length: length):
+            return nil
+        case .postgres:
+            return SqlLexer.skipNestedBlockComment(text, from: index, length: length).next
+        default:
+            return SqlLexer.skipBlockComment(text, from: index, length: length).next
+        }
+    }
+
+    private func endOfBracketedIdentifier() -> Int {
+        var cursor = index + 1
+        while cursor < length {
+            guard text.character(at: cursor) == Self.closeBracket else {
+                cursor += 1
+                continue
+            }
+            guard cursor + 1 < length, text.character(at: cursor + 1) == Self.closeBracket else {
+                return cursor + 1
+            }
+            cursor += 2
+        }
+        return length
+    }
+
+    private func endOfDollarQuotedBody(startingWith character: UInt16) -> Int? {
+        guard rules.dialect.supportsDollarQuotes, character == SqlDollarQuote.dollar,
+              case .opener(let openerLength, let tag) = SqlDollarQuote.scanOpener(at: index, in: text, bufLen: length)
+        else {
+            return nil
+        }
+        return SqlLexer.skipDollarQuotedBody(text, from: index + openerLength, tag: tag, length: length).span.next
+    }
+
+    private static func isWordUnit(_ unit: UInt16) -> Bool {
+        if unit < 0x80 {
+            return SqlDollarQuote.isIdentifierPart(unit)
+        }
+        return ConfusableSQLCharacter.separating(unit) == nil
+    }
+
+    private static func isNativeScriptUnit(_ unit: UInt16) -> Bool {
+        guard unit >= 0x80 else { return false }
+        guard let scalar = Unicode.Scalar(unit) else { return true }
+        return scalar.properties.isAlphabetic || scalar.properties.numericType != nil
+    }
+}

--- a/TablePro/Core/Diagnostics/SQLConfusableCharacterScanner.swift
+++ b/TablePro/Core/Diagnostics/SQLConfusableCharacterScanner.swift
@@ -15,11 +15,6 @@ enum SQLConfusableCharacterScanner {
 }
 
 private struct ConfusableCharacterScan {
-    private static let openBracket = UInt16(UnicodeScalar("[").value)
-    private static let closeBracket = UInt16(UnicodeScalar("]").value)
-    private static let capitalE = UInt16(UnicodeScalar("E").value)
-    private static let smallE = UInt16(UnicodeScalar("e").value)
-
     private let text: NSString
     private let length: Int
     private let rules: SQLLexicalRules
@@ -42,11 +37,11 @@ private struct ConfusableCharacterScan {
     private mutating func step() {
         let character = text.character(at: index)
 
-        if let end = endOfCommentOrQuotedText(startingWith: character) {
+        if let end = SQLNonCodeSpan.end(at: index, in: text, rules: rules) {
             index = end
             return
         }
-        if Self.isWordUnit(character) {
+        if SQLNonCodeSpan.isWordUnit(character) {
             consumeWord()
             return
         }
@@ -76,7 +71,7 @@ private struct ConfusableCharacterScan {
 
         while index < length {
             let unit = text.character(at: index)
-            guard Self.isWordUnit(unit) else { break }
+            guard SQLNonCodeSpan.isWordUnit(unit) else { break }
             if ConfusableSQLCharacter.isFullWidthWordUnit(unit) {
                 firstFullWidth = firstFullWidth ?? index
                 lastFullWidth = index
@@ -91,87 +86,6 @@ private struct ConfusableCharacterScan {
             let spelling = ConfusableSQLCharacter.asciiSpelling(of: text, in: range)
             matches.append(ConfusableSQLCharacterMatch(character: .fullWidthText(asciiSpelling: spelling), range: range))
         }
-
-        skipEscapeString(afterWordStartingAt: start)
-    }
-
-    private mutating func skipEscapeString(afterWordStartingAt start: Int) {
-        guard rules.dialect.supportsEscapeStringPrefix, index - start == 1, index < length,
-              text.character(at: index) == SqlLexer.singleQuote else { return }
-        let prefix = text.character(at: start)
-        guard prefix == Self.capitalE || prefix == Self.smallE else { return }
-        index = SqlLexer.skipQuotedString(
-            text,
-            from: index,
-            quote: SqlLexer.singleQuote,
-            length: length,
-            backslashEscapes: true
-        ).next
-    }
-
-    private func endOfCommentOrQuotedText(startingWith character: UInt16) -> Int? {
-        if SqlLexer.startsLineComment(text, at: index, length: length)
-            || (rules.dialect.supportsHashLineComments && character == SqlLexer.hash) {
-            return SqlLexer.endOfLine(text, from: index, length: length)
-        }
-        if SqlLexer.startsBlockComment(text, at: index, length: length) {
-            return endOfBlockComment()
-        }
-        if SqlLexer.isQuote(character) {
-            return SqlLexer.skipQuotedString(
-                text,
-                from: index,
-                quote: character,
-                length: length,
-                backslashEscapes: rules.backslashEscapes
-            ).next
-        }
-        if rules.bracketsDelimitIdentifiers, character == Self.openBracket {
-            return endOfBracketedIdentifier()
-        }
-        return endOfDollarQuotedBody(startingWith: character)
-    }
-
-    private func endOfBlockComment() -> Int? {
-        switch rules.dialect {
-        case .mysql where SqlLexer.startsConditionalComment(text, at: index, length: length):
-            return nil
-        case .postgres:
-            return SqlLexer.skipNestedBlockComment(text, from: index, length: length).next
-        default:
-            return SqlLexer.skipBlockComment(text, from: index, length: length).next
-        }
-    }
-
-    private func endOfBracketedIdentifier() -> Int {
-        var cursor = index + 1
-        while cursor < length {
-            guard text.character(at: cursor) == Self.closeBracket else {
-                cursor += 1
-                continue
-            }
-            guard cursor + 1 < length, text.character(at: cursor + 1) == Self.closeBracket else {
-                return cursor + 1
-            }
-            cursor += 2
-        }
-        return length
-    }
-
-    private func endOfDollarQuotedBody(startingWith character: UInt16) -> Int? {
-        guard rules.dialect.supportsDollarQuotes, character == SqlDollarQuote.dollar,
-              case .opener(let openerLength, let tag) = SqlDollarQuote.scanOpener(at: index, in: text, bufLen: length)
-        else {
-            return nil
-        }
-        return SqlLexer.skipDollarQuotedBody(text, from: index + openerLength, tag: tag, length: length).span.next
-    }
-
-    private static func isWordUnit(_ unit: UInt16) -> Bool {
-        if unit < 0x80 {
-            return SqlDollarQuote.isIdentifierPart(unit)
-        }
-        return ConfusableSQLCharacter.separating(unit) == nil
     }
 
     private static func isNativeScriptUnit(_ unit: UInt16) -> Bool {

--- a/TablePro/Core/Diagnostics/SQLDiagnosticsProducer.swift
+++ b/TablePro/Core/Diagnostics/SQLDiagnosticsProducer.swift
@@ -3,11 +3,9 @@ import Foundation
 /// Reports only structural problems more typing cannot fix. TablePro has no SQL grammar, and a
 /// half-written statement must never be flagged, so an unclosed bracket is deliberately silent.
 struct SQLDiagnosticsProducer: QueryDiagnosticsProducing {
-    private static let maximumLength = 100_000
-
     func diagnostics(for text: String) -> [QueryDiagnostic] {
         let source = text as NSString
-        guard source.length > 0, source.length <= Self.maximumLength else { return [] }
+        guard source.length > 0, source.length <= QueryDiagnosticsLimits.maximumDocumentLength else { return [] }
 
         let structure = QueryBracketScanner.scan(source, comments: .sql)
         var results: [QueryDiagnostic] = []

--- a/TablePro/Core/Diagnostics/SQLLexicalRules.swift
+++ b/TablePro/Core/Diagnostics/SQLLexicalRules.swift
@@ -1,0 +1,42 @@
+//
+//  SQLLexicalRules.swift
+//  TablePro
+//
+
+import Foundation
+import TableProPluginKit
+
+struct SQLLexicalRules: Equatable, Sendable {
+    private static let enginesAcceptingBracketedIdentifiers: Set<DatabaseType> = [
+        .sqlite, .libsql, .turso, .cloudflareD1
+    ]
+
+    let dialect: SqlDialect
+    let backslashEscapes: Bool
+    let bracketsDelimitIdentifiers: Bool
+
+    init(dialect: SqlDialect, backslashEscapes: Bool, bracketsDelimitIdentifiers: Bool) {
+        self.dialect = dialect
+        self.backslashEscapes = backslashEscapes
+        self.bracketsDelimitIdentifiers = bracketsDelimitIdentifiers
+    }
+
+    init(dialect: SqlDialect) {
+        self.init(
+            dialect: dialect,
+            backslashEscapes: dialect.requiresBackslashEscapesInSingleQuotes,
+            bracketsDelimitIdentifiers: false
+        )
+    }
+
+    init(databaseType: DatabaseType, descriptor: SQLDialectDescriptor?) {
+        let dialect = SqlDialect.from(databaseTypeId: databaseType.rawValue)
+        self.init(
+            dialect: dialect,
+            backslashEscapes: dialect.requiresBackslashEscapesInSingleQuotes
+                || descriptor?.requiresBackslashEscaping == true,
+            bracketsDelimitIdentifiers: descriptor?.identifierQuote == "["
+                || Self.enginesAcceptingBracketedIdentifiers.contains(databaseType)
+        )
+    }
+}

--- a/TablePro/Core/Utilities/SQL/InvisibleCharacterRemover.swift
+++ b/TablePro/Core/Utilities/SQL/InvisibleCharacterRemover.swift
@@ -5,7 +5,6 @@
 
 import CodeEditTextView
 import Foundation
-import TableProPluginKit
 
 internal enum InvisibleCharacterRemover {
     private static let lineBreaks: Set<UInt32> = [0x85, 0x2028, 0x2029]
@@ -15,14 +14,14 @@ internal enum InvisibleCharacterRemover {
         in text: NSString,
         scope: NSRange,
         skippingLiteralsAndComments: Bool,
-        dialect: SqlDialect,
+        rules: SQLLexicalRules,
         lineEnding: String
     ) -> [TextReplacement] {
         let end = min(NSMaxRange(scope), text.length)
         var replacements: [TextReplacement] = []
         var index = max(scope.location, 0)
         while index < end {
-            if skippingLiteralsAndComments, let skipTo = endOfLiteralOrComment(at: index, in: text, dialect: dialect) {
+            if skippingLiteralsAndComments, let skipTo = SQLNonCodeSpan.end(at: index, in: text, rules: rules) {
                 index = skipTo
                 continue
             }
@@ -60,29 +59,5 @@ internal enum InvisibleCharacterRemover {
             return " "
         }
         return ""
-    }
-
-    private static func endOfLiteralOrComment(at index: Int, in text: NSString, dialect: SqlDialect) -> Int? {
-        let length = text.length
-        let character = text.character(at: index)
-        if SqlLexer.startsLineComment(text, at: index, length: length)
-            || (dialect.supportsHashLineComments && character == SqlLexer.hash) {
-            return SqlLexer.endOfLine(text, from: index, length: length)
-        }
-        if SqlLexer.startsBlockComment(text, at: index, length: length) {
-            guard !(dialect == .mysql && SqlLexer.startsConditionalComment(text, at: index, length: length)) else {
-                return nil
-            }
-            return SqlLexer.skipBlockComment(text, from: index, length: length).next
-        }
-        if SqlLexer.isQuote(character) {
-            return SqlLexer.skipQuotedString(text, from: index, quote: character, length: length, dialect: dialect).next
-        }
-        guard dialect.supportsDollarQuotes, character == SqlDollarQuote.dollar,
-              case .opener(let openerLength, let tag) = SqlDollarQuote.scanOpener(at: index, in: text, bufLen: length)
-        else {
-            return nil
-        }
-        return SqlLexer.skipDollarQuotedBody(text, from: index + openerLength, tag: tag, length: length).span.next
     }
 }

--- a/TablePro/Core/Utilities/SQL/SQLNonCodeSpan.swift
+++ b/TablePro/Core/Utilities/SQL/SQLNonCodeSpan.swift
@@ -1,0 +1,109 @@
+//
+//  SQLNonCodeSpan.swift
+//  TablePro
+//
+
+import Foundation
+import TableProPluginKit
+
+enum SQLNonCodeSpan {
+    private static let openBracket = UInt16(UnicodeScalar("[").value)
+    private static let closeBracket = UInt16(UnicodeScalar("]").value)
+    private static let capitalE = UInt16(UnicodeScalar("E").value)
+    private static let smallE = UInt16(UnicodeScalar("e").value)
+
+    static func end(at index: Int, in text: NSString, rules: SQLLexicalRules) -> Int? {
+        let length = text.length
+        guard index >= 0, index < length else { return nil }
+        let character = text.character(at: index)
+
+        if SqlLexer.startsLineComment(text, at: index, length: length)
+            || (rules.dialect.supportsHashLineComments && character == SqlLexer.hash) {
+            return SqlLexer.endOfLine(text, from: index, length: length)
+        }
+        if SqlLexer.startsBlockComment(text, at: index, length: length) {
+            return endOfBlockComment(at: index, in: text, rules: rules)
+        }
+        if SqlLexer.isQuote(character) {
+            return SqlLexer.skipQuotedString(
+                text,
+                from: index,
+                quote: character,
+                length: length,
+                backslashEscapes: rules.backslashEscapes
+            ).next
+        }
+        if let end = endOfEscapeString(at: index, in: text, rules: rules) {
+            return end
+        }
+        if rules.bracketsDelimitIdentifiers, character == openBracket {
+            return endOfBracketedIdentifier(at: index, in: text)
+        }
+        return endOfDollarQuotedBody(at: index, in: text, rules: rules)
+    }
+
+    static func isWordUnit(_ unit: UInt16) -> Bool {
+        if unit < 0x80 {
+            return SqlDollarQuote.isIdentifierPart(unit)
+        }
+        return ConfusableSQLCharacter.separating(unit) == nil
+    }
+
+    private static func endOfBlockComment(at index: Int, in text: NSString, rules: SQLLexicalRules) -> Int? {
+        let length = text.length
+        switch rules.dialect {
+        case .mysql where SqlLexer.startsConditionalComment(text, at: index, length: length):
+            return nil
+        case .postgres:
+            return SqlLexer.skipNestedBlockComment(text, from: index, length: length).next
+        default:
+            return SqlLexer.skipBlockComment(text, from: index, length: length).next
+        }
+    }
+
+    private static func endOfEscapeString(at index: Int, in text: NSString, rules: SQLLexicalRules) -> Int? {
+        let length = text.length
+        let character = text.character(at: index)
+        guard rules.dialect.supportsEscapeStringPrefix,
+              character == capitalE || character == smallE,
+              index + 1 < length,
+              text.character(at: index + 1) == SqlLexer.singleQuote,
+              index == 0 || !isWordUnit(text.character(at: index - 1))
+        else {
+            return nil
+        }
+        return SqlLexer.skipQuotedString(
+            text,
+            from: index + 1,
+            quote: SqlLexer.singleQuote,
+            length: length,
+            backslashEscapes: true
+        ).next
+    }
+
+    private static func endOfBracketedIdentifier(at index: Int, in text: NSString) -> Int {
+        let length = text.length
+        var cursor = index + 1
+        while cursor < length {
+            guard text.character(at: cursor) == closeBracket else {
+                cursor += 1
+                continue
+            }
+            guard cursor + 1 < length, text.character(at: cursor + 1) == closeBracket else {
+                return cursor + 1
+            }
+            cursor += 2
+        }
+        return length
+    }
+
+    private static func endOfDollarQuotedBody(at index: Int, in text: NSString, rules: SQLLexicalRules) -> Int? {
+        let length = text.length
+        guard rules.dialect.supportsDollarQuotes, text.character(at: index) == SqlDollarQuote.dollar,
+              case .opener(let openerLength, let tag) = SqlDollarQuote.scanOpener(at: index, in: text, bufLen: length)
+        else {
+            return nil
+        }
+        return SqlLexer.skipDollarQuotedBody(text, from: index + openerLength, tag: tag, length: length).span.next
+    }
+}

--- a/TablePro/Core/Utilities/SQL/SqlLexer.swift
+++ b/TablePro/Core/Utilities/SQL/SqlLexer.swift
@@ -88,6 +88,31 @@ enum SqlLexer {
         return Span(next: length, newlines: newlines)
     }
 
+    static func skipNestedBlockComment(_ text: NSString, from offset: Int, length: Int) -> Span {
+        var cursor = offset + 2
+        var depth = 1
+        var newlines = 0
+        while cursor < length {
+            let character = text.character(at: cursor)
+            if character == newline {
+                newlines += 1
+            }
+            if startsBlockComment(text, at: cursor, length: length) {
+                depth += 1
+                cursor += 2
+                continue
+            }
+            if character == star, cursor + 1 < length, text.character(at: cursor + 1) == slash {
+                depth -= 1
+                cursor += 2
+                guard depth > 0 else { return Span(next: cursor, newlines: newlines) }
+                continue
+            }
+            cursor += 1
+        }
+        return Span(next: length, newlines: newlines)
+    }
+
     /// Runs past the closing quote, or to the end of the document when the string is never closed.
     ///
     /// A doubled quote always escapes. A backslash only escapes where the dialect says it does, so `'a\'` ends the
@@ -99,9 +124,24 @@ enum SqlLexer {
         length: Int,
         dialect: SqlDialect
     ) -> Span {
+        skipQuotedString(
+            text,
+            from: offset,
+            quote: quote,
+            length: length,
+            backslashEscapes: dialect.requiresBackslashEscapesInSingleQuotes
+        )
+    }
+
+    static func skipQuotedString(
+        _ text: NSString,
+        from offset: Int,
+        quote: UInt16,
+        length: Int,
+        backslashEscapes: Bool
+    ) -> Span {
         var cursor = offset + 1
         var newlines = 0
-        let backslashEscapes = dialect.requiresBackslashEscapesInSingleQuotes
         while cursor < length {
             let character = text.character(at: cursor)
             if character == newline {

--- a/TablePro/Resources/Localizable.xcstrings
+++ b/TablePro/Resources/Localizable.xcstrings
@@ -219,6 +219,76 @@
         }
       }
     },
+    "ampersand" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "앰퍼샌드"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ve işareti"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "dấu và"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "和号"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "和號"
+          }
+        }
+      }
+    },
+    "apostrophe" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "작은따옴표"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "kesme işareti"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "dấu nháy đơn"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "单引号"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "單引號"
+          }
+        }
+      }
+    },
     "Are you sure you want to delete the group \"%@\" and its subgroups? Their connections will be moved to the top level." : {
       "localizations" : {
         "ko" : {
@@ -253,6 +323,76 @@
         }
       }
     },
+    "asterisk" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "별표"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "yıldız işareti"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "dấu sao"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "星号"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "星號"
+          }
+        }
+      }
+    },
+    "at sign" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "골뱅이표"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "et işareti"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ký hiệu a còng"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "at 符号"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "at 符號"
+          }
+        }
+      }
+    },
     "Autocomplete from your schema, editor tabs, and a searchable query history." : {
       "localizations" : {
         "ko" : {
@@ -283,6 +423,111 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "依結構描述自動完成、編輯器標籤頁與可搜尋的查詢記錄。"
+          }
+        }
+      }
+    },
+    "backslash" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "백슬래시"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ters eğik çizgi"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "dấu gạch chéo ngược"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "反斜杠"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "反斜線"
+          }
+        }
+      }
+    },
+    "backtick" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "백틱"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ters tırnak"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "dấu nháy ngược"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "反引号"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "反引號"
+          }
+        }
+      }
+    },
+    "caret" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "캐럿"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "şapka işareti"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "dấu mũ"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "脱字符"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "插入符號"
           }
         }
       }
@@ -351,6 +596,76 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "選擇「檔案 > 快速開啟…」並輸入名稱的一部分，即可開啟表格、資料庫或已儲存的查詢。"
+          }
+        }
+      }
+    },
+    "colon" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "콜론"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iki nokta üst üste"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "dấu hai chấm"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "冒号"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "冒號"
+          }
+        }
+      }
+    },
+    "comma" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "쉼표"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "virgül"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "dấu phẩy"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "逗号"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "逗號"
           }
         }
       }
@@ -457,6 +772,76 @@
         }
       }
     },
+    "Curly quote (%1$@). SQL needs the straight quote (%2$@)." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "둥근 따옴표(%1$@). SQL은 곧은 따옴표(%2$@)만 인식합니다."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kıvrık tırnak (%1$@). SQL düz tırnak (%2$@) bekler."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dấu nháy cong (%1$@). SQL cần dấu nháy thẳng (%2$@)."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "弯引号（%1$@）。SQL 需要直引号（%2$@）。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "彎引號（%1$@）。SQL 需要直引號（%2$@）。"
+          }
+        }
+      }
+    },
+    "dollar sign" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "달러 기호"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "dolar işareti"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ký hiệu đô la"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "美元符号"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "美元符號"
+          }
+        }
+      }
+    },
     "Edit Data in Place" : {
       "localizations" : {
         "ko" : {
@@ -487,6 +872,41 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "就地編輯資料"
+          }
+        }
+      }
+    },
+    "equals sign" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "등호"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "eşittir işareti"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "dấu bằng"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "等号"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "等號"
           }
         }
       }
@@ -559,6 +979,41 @@
         }
       }
     },
+    "exclamation mark" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "느낌표"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ünlem işareti"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "dấu chấm than"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "感叹号"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "驚嘆號"
+          }
+        }
+      }
+    },
     "Find Past Queries" : {
       "localizations" : {
         "ko" : {
@@ -589,6 +1044,111 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "尋找過去的查詢"
+          }
+        }
+      }
+    },
+    "Full-width %1$@ (%2$@). SQL needs the ASCII %1$@ (%3$@)." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "전각 %1$@(%2$@). SQL은 ASCII %1$@(%3$@)만 인식합니다."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tam genişlikte %1$@ (%2$@). SQL, ASCII %1$@ (%3$@) bekler."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ký tự toàn độ rộng: %1$@ (%2$@). SQL cần %1$@ ASCII (%3$@)."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全角%1$@（%2$@）。SQL 需要 ASCII %1$@（%3$@）。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全形%1$@（%2$@）。SQL 需要 ASCII %1$@（%3$@）。"
+          }
+        }
+      }
+    },
+    "Full-width letters or digits. SQL needs the ASCII %@." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "전각 문자 또는 숫자. SQL은 ASCII %@만 인식합니다."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tam genişlikte harf veya rakam. SQL, ASCII %@ bekler."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chữ hoặc số toàn độ rộng. SQL cần %@ ASCII."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全角字母或数字。SQL 需要 ASCII %@。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全形字母或數字。SQL 需要 ASCII %@。"
+          }
+        }
+      }
+    },
+    "Full-width semicolon (U+FF1B). SQL reads only ; as a statement separator." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "전각 세미콜론(U+FF1B). SQL은 ;만 문장 구분자로 인식합니다."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tam genişlikte noktalı virgül (U+FF1B). SQL yalnızca ; karakterini deyim ayırıcı olarak okur."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dấu chấm phẩy toàn độ rộng (U+FF1B). SQL chỉ đọc ; là dấu phân tách câu lệnh."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全角分号（U+FF1B）。SQL 只把 ; 当作语句分隔符。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全形分號（U+FF1B）。SQL 只把 ; 當作陳述式分隔符號。"
           }
         }
       }
@@ -627,6 +1187,76 @@
         }
       }
     },
+    "greater-than sign" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "보다 큼 기호"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "büyüktür işareti"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "dấu lớn hơn"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "大于号"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "大於號"
+          }
+        }
+      }
+    },
+    "hyphen" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "하이픈"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "kısa çizgi"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "dấu gạch nối"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "连字符"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "連字號"
+          }
+        }
+      }
+    },
     "Keep a Table Open" : {
       "localizations" : {
         "ko" : {
@@ -657,6 +1287,146 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "保持表格開啟"
+          }
+        }
+      }
+    },
+    "left curly bracket" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "여는 중괄호"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "sol süslü parantez"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "dấu ngoặc nhọn mở"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "左花括号"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "左大括號"
+          }
+        }
+      }
+    },
+    "left parenthesis" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "여는 괄호"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "sol parantez"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "dấu ngoặc đơn mở"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "左括号"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "左括號"
+          }
+        }
+      }
+    },
+    "left square bracket" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "여는 대괄호"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "sol köşeli parantez"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "dấu ngoặc vuông mở"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "左方括号"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "左方括號"
+          }
+        }
+      }
+    },
+    "less-than sign" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "보다 작음 기호"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "küçüktür işareti"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "dấu nhỏ hơn"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "小于号"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "小於號"
           }
         }
       }
@@ -831,6 +1601,76 @@
         }
       }
     },
+    "Non-ASCII space (%@). SQL needs an ASCII space (U+0020)." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ASCII가 아닌 공백(%@). SQL은 ASCII 공백(U+0020)만 인식합니다."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ASCII olmayan boşluk (%@). SQL, ASCII boşluk (U+0020) bekler."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Khoảng trắng không phải ASCII (%@). SQL cần khoảng trắng ASCII (U+0020)."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "非 ASCII 空格（%@）。SQL 需要 ASCII 空格（U+0020）。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "非 ASCII 空格（%@）。SQL 需要 ASCII 空格（U+0020）。"
+          }
+        }
+      }
+    },
+    "number sign" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "샵 기호"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "diyez işareti"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "dấu thăng"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "井号"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "井字號"
+          }
+        }
+      }
+    },
     "Open Any Table by Name" : {
       "localizations" : {
         "ko" : {
@@ -895,6 +1735,111 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "密碼保存在你的鑰匙圈中。可透過 SSH 通道或 SSL/TLS 連線。"
+          }
+        }
+      }
+    },
+    "percent sign" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "퍼센트 기호"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "yüzde işareti"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "dấu phần trăm"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "百分号"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "百分比符號"
+          }
+        }
+      }
+    },
+    "period" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "마침표"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "nokta"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "dấu chấm"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "句点"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "句點"
+          }
+        }
+      }
+    },
+    "plus sign" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "더하기 기호"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "artı işareti"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "dấu cộng"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加号"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加號"
           }
         }
       }
@@ -968,6 +1913,76 @@
         }
       }
     },
+    "question mark" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "물음표"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "soru işareti"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "dấu chấm hỏi"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "问号"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "問號"
+          }
+        }
+      }
+    },
+    "quotation mark" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "큰따옴표"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "çift tırnak"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "dấu ngoặc kép"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "双引号"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "雙引號"
+          }
+        }
+      }
+    },
     "Remove Invisible Characters" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -999,6 +2014,111 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "移除不可見字元"
+          }
+        }
+      }
+    },
+    "right curly bracket" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "닫는 중괄호"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "sağ süslü parantez"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "dấu ngoặc nhọn đóng"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "右花括号"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "右大括號"
+          }
+        }
+      }
+    },
+    "right parenthesis" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "닫는 괄호"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "sağ parantez"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "dấu ngoặc đơn đóng"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "右括号"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "右括號"
+          }
+        }
+      }
+    },
+    "right square bracket" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "닫는 대괄호"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "sağ köşeli parantez"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "dấu ngoặc vuông đóng"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "右方括号"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "右方括號"
           }
         }
       }
@@ -1038,6 +2158,41 @@
         }
       }
     },
+    "slash" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "슬래시"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "eğik çizgi"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "dấu gạch chéo"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "斜杠"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "斜線"
+          }
+        }
+      }
+    },
     "The query contains a NUL character (U+0000) and was not run. Remove it and try again." : {
       "extractionState" : "manual",
       "localizations" : {
@@ -1069,6 +2224,76 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "查詢包含 NUL 字元 (U+0000)，未執行。請刪除後再試一次。"
+          }
+        }
+      }
+    },
+    "tilde" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "물결표"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "tilde"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "dấu ngã"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "波浪号"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "波浪號"
+          }
+        }
+      }
+    },
+    "vertical bar" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "세로 막대"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "dikey çizgi"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "dấu gạch đứng"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "竖线"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "豎線"
           }
         }
       }

--- a/TablePro/Views/Editor/SQLEditorCoordinator+InvisibleCharacters.swift
+++ b/TablePro/Views/Editor/SQLEditorCoordinator+InvisibleCharacters.swift
@@ -13,11 +13,15 @@ extension SQLEditorCoordinator {
         guard let controller, let textView = controller.textView, textView.isEditable else { return }
         let string = textView.string
         let scope = FormatScopeResolver.resolve(fullText: string, selectedRange: textView.selectedRange())
+        let resolvedType = databaseType ?? .mysql
         let replacements = InvisibleCharacterRemover.replacements(
             in: string as NSString,
             scope: scope.range,
             skippingLiteralsAndComments: !scope.isSelection,
-            dialect: SqlDialect.from(databaseTypeId: (databaseType ?? .mysql).rawValue),
+            rules: SQLLexicalRules(
+                databaseType: resolvedType,
+                descriptor: PluginManager.shared.sqlDialect(for: resolvedType)
+            ),
             lineEnding: textView.layoutManager.detectedLineEnding.rawValue
         )
         guard !replacements.isEmpty else { return }

--- a/TableProTests/Core/Diagnostics/SQLConfusableCharacterScannerTests.swift
+++ b/TableProTests/Core/Diagnostics/SQLConfusableCharacterScannerTests.swift
@@ -1,0 +1,354 @@
+//
+//  SQLConfusableCharacterScannerTests.swift
+//  TableProTests
+//
+
+import Foundation
+import TableProPluginKit
+import Testing
+
+@testable import TablePro
+
+@Suite("Confusable SQL characters")
+struct SQLConfusableCharacterScannerTests {
+    private func scan(_ text: String, _ dialect: SqlDialect) -> [ConfusableSQLCharacterMatch] {
+        scan(text, SQLLexicalRules(dialect: dialect))
+    }
+
+    private func scan(_ text: String, _ rules: SQLLexicalRules) -> [ConfusableSQLCharacterMatch] {
+        SQLConfusableCharacterScanner.scan(text as NSString, rules: rules)
+    }
+
+    private func ranges(_ text: String, _ dialect: SqlDialect) -> [NSRange] {
+        scan(text, dialect).map(\.range)
+    }
+
+    private func ranges(_ text: String, _ rules: SQLLexicalRules) -> [NSRange] {
+        scan(text, rules).map(\.range)
+    }
+
+    private func range(of needle: String, in text: String, fromEnd: Bool = false) -> NSRange {
+        (text as NSString).range(of: needle, options: fromEnd ? [.literal, .backwards] : .literal)
+    }
+
+    // MARK: - Flagged outside literals
+
+    @Test("A full-width semicolon is flagged wherever it ends a statement", arguments: SqlDialect.allCases)
+    func fullWidthSemicolon(dialect: SqlDialect) {
+        let text = "SELECT 1\u{FF1B}\nSELECT 2\u{FF1B}"
+        let matches = scan(text, dialect)
+        #expect(matches.map(\.range) == [
+            NSRange(location: 8, length: 1),
+            NSRange(location: 18, length: 1)
+        ])
+        #expect(matches.allSatisfy { $0.character == .fullWidthPunctuation("\u{FF1B}") })
+    }
+
+    @Test("Full-width commas and parentheses are flagged", arguments: SqlDialect.allCases)
+    func fullWidthCommaAndParentheses(dialect: SqlDialect) {
+        let text = "SELECT COUNT\u{FF08}*\u{FF09}\u{FF0C} id FROM t"
+        #expect(ranges(text, dialect) == [
+            NSRange(location: 12, length: 1),
+            NSRange(location: 14, length: 1),
+            NSRange(location: 15, length: 1)
+        ])
+    }
+
+    @Test("Curly quotes around a value are flagged", arguments: SqlDialect.allCases)
+    func curlyQuotes(dialect: SqlDialect) {
+        let text = "SELECT * FROM t WHERE name = \u{2018}Bob\u{2019} OR note = \u{201C}x\u{201D}"
+        let matches = scan(text, dialect)
+        #expect(matches.map(\.character) == [
+            .curlyQuote("\u{2018}"), .curlyQuote("\u{2019}"), .curlyQuote("\u{201C}"), .curlyQuote("\u{201D}")
+        ])
+    }
+
+    @Test("Every non-ASCII space between tokens is flagged", arguments: [
+        0x00A0, 0x2000, 0x2001, 0x2002, 0x2003, 0x2004, 0x2005, 0x2006, 0x2007, 0x2008, 0x2009, 0x200A,
+        0x202F, 0x205F, 0x3000
+    ])
+    func nonASCIISpaces(value: UInt32) throws {
+        let space = try #require(Unicode.Scalar(value))
+        let text = "SELECT *\(Character(space))FROM t"
+        let matches = scan(text, .mysql)
+        #expect(matches == [
+            ConfusableSQLCharacterMatch(character: .nonASCIISpace(space), range: NSRange(location: 8, length: 1))
+        ])
+    }
+
+    @Test("A run of the same character is one warning")
+    func runsMerge() {
+        let text = "SELECT *\u{3000}\u{3000}\u{3000}FROM t\u{FF1B}\u{FF1B}"
+        #expect(ranges(text, .postgres) == [
+            NSRange(location: 8, length: 3),
+            NSRange(location: 17, length: 2)
+        ])
+    }
+
+    @Test("Different characters side by side are separate warnings")
+    func differentCharactersStaySeparate() {
+        #expect(ranges("SELECT \u{FF08}\u{FF09}", .sqlite) == [
+            NSRange(location: 7, length: 1),
+            NSRange(location: 8, length: 1)
+        ])
+    }
+
+    // MARK: - Never flagged inside literals, identifiers and comments
+
+    @Test("Characters inside quoted text and comments are left alone", arguments: SqlDialect.allCases)
+    func quotedTextAndCommentsAreQuiet(dialect: SqlDialect) {
+        let texts = [
+            "SELECT '\u{4F60}\u{597D}\u{FF0C}\u{4E16}\u{754C}\u{FF1B}' FROM t",
+            "SELECT \"\u{540D}\u{524D}\u{FF08}\u{65E7}\u{FF09}\" FROM t",
+            "SELECT `\u{540D}\u{FF1B}` FROM t",
+            "SELECT 1 -- \u{FF1B}\u{3000}\u{201C}",
+            "SELECT 1 /* \u{FF08}\u{00A0}\u{2019} */",
+            "SELECT '\u{2018}quoted\u{2019}'"
+        ]
+        for text in texts {
+            #expect(scan(text, dialect).isEmpty, "\(dialect) flagged \(text)")
+        }
+    }
+
+    @Test("An unquoted identifier in another script is left alone", arguments: SqlDialect.allCases)
+    func nativeScriptIdentifiers(dialect: SqlDialect) {
+        #expect(scan("SELECT \u{540D}\u{524D} FROM \u{9867}\u{5BA2}", dialect).isEmpty)
+        #expect(scan("SELECT * FROM \u{58F2}\u{4E0A}\u{FF12}\u{FF10}\u{FF12}\u{FF14}", dialect).isEmpty)
+        #expect(scan("SELECT caf\u{00E9}\u{FF3F}\u{FF11}", dialect).isEmpty)
+    }
+
+    @Test("Full-width letters and digits outside another script are flagged as one word")
+    func fullWidthWords() {
+        let keyword = "\u{FF33}\u{FF25}\u{FF2C}\u{FF25}\u{FF23}\u{FF34} 1"
+        #expect(scan(keyword, .mysql) == [
+            ConfusableSQLCharacterMatch(
+                character: .fullWidthText(asciiSpelling: "SELECT"),
+                range: NSRange(location: 0, length: 6)
+            )
+        ])
+
+        let digit = "SELECT * FROM t WHERE id = \u{FF11}"
+        #expect(scan(digit, .postgres) == [
+            ConfusableSQLCharacterMatch(
+                character: .fullWidthText(asciiSpelling: "1"),
+                range: range(of: "\u{FF11}", in: digit)
+            )
+        ])
+
+        let mixed = "SELECT user\u{FF3F}\u{FF49}d FROM t"
+        #expect(scan(mixed, .sqlite) == [
+            ConfusableSQLCharacterMatch(
+                character: .fullWidthText(asciiSpelling: "_i"),
+                range: range(of: "\u{FF3F}\u{FF49}", in: mixed)
+            )
+        ])
+    }
+
+    // MARK: - MySQL
+
+    @Test("MySQL: a hash comment is quiet and a conditional comment is read as code")
+    func mysqlComments() {
+        #expect(scan("SELECT 1 # \u{FF1B}", .mysql).isEmpty)
+        let conditional = "SELECT 1 /*!50000 \u{FF1B}*/"
+        #expect(ranges(conditional, .mysql) == [range(of: "\u{FF1B}", in: conditional)])
+    }
+
+    @Test("MySQL: a backslash keeps the string open")
+    func mysqlBackslashEscape() {
+        let text = "SELECT 'it\\'s\u{FF1B}' \u{FF1B}"
+        #expect(ranges(text, .mysql) == [range(of: "\u{FF1B}", in: text, fromEnd: true)])
+    }
+
+    // MARK: - PostgreSQL
+
+    @Test("PostgreSQL: a dollar-quoted body is quiet and the text after it is not")
+    func postgresDollarQuotes() {
+        let text = "CREATE FUNCTION f() RETURNS int AS $fn$ SELECT 1\u{FF1B} $fn$ LANGUAGE sql\u{FF1B}"
+        #expect(ranges(text, .postgres) == [range(of: "\u{FF1B}", in: text, fromEnd: true)])
+        #expect(scan("SELECT $$\u{FF08}\u{3000}\u{201C}$$", .postgres).isEmpty)
+    }
+
+    @Test("PostgreSQL: a dollar sign opens no body in another dialect")
+    func dollarQuotesArePostgresOnly() {
+        #expect(ranges("SELECT $$\u{FF1B}$$", .mysql) == [NSRange(location: 9, length: 1)])
+    }
+
+    @Test("PostgreSQL: a backslash escapes only inside an E string")
+    func postgresEscapeStrings() {
+        let escaped = "SELECT E'it\\'s\u{FF1B}' \u{FF1B}"
+        #expect(ranges(escaped, .postgres) == [range(of: "\u{FF1B}", in: escaped, fromEnd: true)])
+
+        let plain = "SELECT 'a\\' \u{FF1B}"
+        #expect(ranges(plain, .postgres) == [range(of: "\u{FF1B}", in: plain)])
+    }
+
+    @Test("PostgreSQL: a nested block comment stays a comment until its last terminator")
+    func postgresNestedComments() {
+        let text = "SELECT 1 /* a /* b */ \u{FF08} */ \u{FF1B}"
+        #expect(ranges(text, .postgres) == [range(of: "\u{FF1B}", in: text)])
+        #expect(ranges(text, .mysql).count == 2)
+    }
+
+    @Test("PostgreSQL: a hash starts no comment")
+    func postgresHashIsNotAComment() {
+        #expect(ranges("SELECT 1 # \u{FF1B}", .postgres) == [NSRange(location: 11, length: 1)])
+    }
+
+    // MARK: - SQLite
+
+    @Test("SQLite: quoted identifiers and comments are quiet, a hash is not a comment")
+    func sqliteLexing() {
+        #expect(scan("SELECT \"col\u{FF1B}\", `a\u{FF0C}b` FROM t -- \u{FF1B}\n/* \u{3000} */", .sqlite).isEmpty)
+        #expect(ranges("SELECT 1 # \u{FF1B}", .sqlite) == [NSRange(location: 11, length: 1)])
+        #expect(ranges("SELECT 1\u{FF1B}", .sqlite) == [NSRange(location: 8, length: 1)])
+    }
+
+    // MARK: - Bracketed identifiers
+
+    @Test("Bracketed identifiers are quiet only where brackets quote identifiers")
+    func bracketedIdentifiers() {
+        let text = "SELECT [\u{4EF7}\u{683C}\u{FF08}\u{5143}\u{FF09}], [a]]\u{FF1B}] FROM t\u{FF1B}"
+        let bracketRules = SQLLexicalRules(dialect: .generic, backslashEscapes: false, bracketsDelimitIdentifiers: true)
+        #expect(ranges(text, bracketRules) == [range(of: "\u{FF1B}", in: text, fromEnd: true)])
+        #expect(ranges(text, .generic).count == 4)
+    }
+
+    // MARK: - Backslash escapes
+
+    @Test("A backslash keeps the string open wherever the engine escapes with one")
+    func backslashEscapesFollowTheEngine() {
+        let escaping = SQLLexicalRules(dialect: .generic, backslashEscapes: true, bracketsDelimitIdentifiers: false)
+
+        let quoted = "SELECT 'a\\'b', '\u{4E2D}\u{6587}\u{FF0C}'"
+        #expect(scan(quoted, escaping).isEmpty)
+        #expect(ranges(quoted, .generic) == [range(of: "\u{FF0C}", in: quoted)])
+
+        let trailing = "SELECT 'it\\'s' FROM t\u{FF1B}"
+        #expect(ranges(trailing, escaping) == [range(of: "\u{FF1B}", in: trailing)])
+        #expect(scan(trailing, .generic).isEmpty)
+    }
+
+    // MARK: - Messages
+
+    @Test("The message names the character and its ASCII counterpart")
+    func messages() {
+        #expect(
+            ConfusableSQLCharacter.fullWidthPunctuation("\u{FF1B}").message
+                == "Full-width semicolon (U+FF1B). SQL reads only ; as a statement separator."
+        )
+        #expect(
+            ConfusableSQLCharacter.fullWidthPunctuation("\u{FF0C}").message
+                == "Full-width comma (U+FF0C). SQL needs the ASCII comma (U+002C)."
+        )
+        #expect(
+            ConfusableSQLCharacter.fullWidthPunctuation("\u{FF08}").message
+                == "Full-width left parenthesis (U+FF08). SQL needs the ASCII left parenthesis (U+0028)."
+        )
+        #expect(
+            ConfusableSQLCharacter.curlyQuote("\u{201C}").message
+                == "Curly quote (U+201C). SQL needs the straight quote (U+0022)."
+        )
+        #expect(
+            ConfusableSQLCharacter.curlyQuote("\u{2019}").message
+                == "Curly quote (U+2019). SQL needs the straight quote (U+0027)."
+        )
+        #expect(
+            ConfusableSQLCharacter.nonASCIISpace("\u{3000}").message
+                == "Non-ASCII space (U+3000). SQL needs an ASCII space (U+0020)."
+        )
+        #expect(
+            ConfusableSQLCharacter.fullWidthText(asciiSpelling: "SELECT").message
+                == "Full-width letters or digits. SQL needs the ASCII SELECT."
+        )
+    }
+
+    @Test("Every full-width punctuation mark has a name of its own")
+    func everyPunctuationMarkIsNamed() {
+        for value in UInt32(0xFF01)...UInt32(0xFF5E) {
+            guard let unit = UInt16(exactly: value), let scalar = Unicode.Scalar(value),
+                  !ConfusableSQLCharacter.isFullWidthWordUnit(unit) else { continue }
+            let message = ConfusableSQLCharacter.fullWidthPunctuation(scalar).message
+            let ascii = String(Character(Unicode.Scalar(value - 0xFEE0) ?? " "))
+            #expect(!message.contains("ASCII \(ascii) ("), "U+\(String(value, radix: 16)) has no name")
+        }
+    }
+}
+
+@MainActor
+@Suite("Confusable SQL characters in the editor's diagnostics")
+struct SQLConfusableCharacterDiagnosticsTests {
+    @Test("A confusable character is a warning, and a stray closer is still an error")
+    func severities() {
+        let diagnostics = QueryDiagnosticsFactory.make(for: .mysql).diagnostics(for: "SELECT 1)\u{FF1B}")
+        #expect(diagnostics.map(\.severity) == [.error, .warning])
+        #expect(diagnostics.map(\.range) == [NSRange(location: 8, length: 1), NSRange(location: 9, length: 1)])
+    }
+
+    @Test("A document at the length limit is checked, and one past it is not")
+    func lengthLimit() {
+        let producer = SQLConfusableCharacterDiagnosticsProducer(rules: SQLLexicalRules(dialect: .mysql))
+        let atLimit = String(repeating: "a", count: 99_999) + "\u{FF1B}"
+        let pastLimit = String(repeating: "a", count: 100_000) + "\u{FF1B}"
+        #expect(producer.diagnostics(for: atLimit).count == 1)
+        #expect(producer.diagnostics(for: pastLimit).isEmpty)
+    }
+
+    @Test("An editor that is not SQL leaves text in another script alone")
+    func nonSQLEditorsAreQuiet() {
+        let text = "SET greeting \u{4F60}\u{597D}\u{FF0C}\u{4E16}\u{754C}\u{FF01} \u{201C}hi\u{201D}"
+        #expect(QueryDiagnosticsFactory.make(for: .redis).diagnostics(for: text).isEmpty)
+        #expect(QueryDiagnosticsFactory.make(for: .mysql).diagnostics(for: text).count == 4)
+    }
+
+    @Test("The editor checks PostgreSQL with PostgreSQL's quoting")
+    func factoryUsesPostgresDialect() {
+        let text = "SELECT $$\u{FF1B}$$"
+        #expect(QueryDiagnosticsFactory.make(for: .postgresql).diagnostics(for: text).isEmpty)
+        #expect(QueryDiagnosticsFactory.make(for: .mysql).diagnostics(for: text).count == 1)
+    }
+
+    @Test("The editor treats SQL Server brackets as identifiers")
+    func factoryUsesBracketIdentifiers() {
+        let text = "SELECT [\u{4EF7}\u{683C}\u{FF08}\u{5143}\u{FF09}] FROM t"
+        #expect(QueryDiagnosticsFactory.make(for: .mssql).diagnostics(for: text).isEmpty)
+        #expect(QueryDiagnosticsFactory.make(for: .postgresql).diagnostics(for: text).count == 2)
+    }
+
+    @Test(
+        "The editor treats brackets as identifiers on every SQLite engine",
+        arguments: [DatabaseType.sqlite, .libsql, .turso, .cloudflareD1]
+    )
+    func factoryUsesSQLiteBracketIdentifiers(databaseType: DatabaseType) {
+        let text = "SELECT [\u{4EF7}\u{683C}\u{FF08}\u{5143}\u{FF09}] FROM t\u{FF1B}"
+        let diagnostics = QueryDiagnosticsFactory.make(for: databaseType).diagnostics(for: text)
+        #expect(diagnostics.map(\.range) == [NSRange(location: (text as NSString).length - 1, length: 1)])
+    }
+
+    @Test("The editor reads DuckDB brackets as a list, not an identifier")
+    func factoryLeavesDuckDBBracketsAsCode() {
+        let text = "SELECT [1\u{FF0C} 2]"
+        #expect(QueryDiagnosticsFactory.make(for: .duckdb).diagnostics(for: text).map(\.range) == [
+            NSRange(location: 9, length: 1)
+        ])
+    }
+
+    @Test("The editor keeps a string open past a backslash on engines that escape with one", arguments: [
+        DatabaseType.clickhouse, .snowflake
+    ])
+    func factoryUsesEngineBackslashEscapes(databaseType: DatabaseType) {
+        let producer = QueryDiagnosticsFactory.make(for: databaseType)
+
+        #expect(producer.diagnostics(for: "SELECT 'a\\'b', '\u{4E2D}\u{6587}\u{FF0C}'").isEmpty)
+
+        let trailing = "SELECT 'it\\'s' FROM t\u{FF1B}"
+        #expect(producer.diagnostics(for: trailing).map(\.range) == [
+            NSRange(location: (trailing as NSString).length - 1, length: 1)
+        ])
+    }
+
+    @Test("The editor ends a PostgreSQL string at the quote after a backslash")
+    func factoryKeepsPostgresBackslashLiteral() {
+        let text = "SELECT 'a\\'b', '\u{4E2D}\u{6587}\u{FF0C}'"
+        #expect(QueryDiagnosticsFactory.make(for: .postgresql).diagnostics(for: text).count == 1)
+    }
+}

--- a/TableProTests/Core/Diagnostics/SQLLexicalRulesTests.swift
+++ b/TableProTests/Core/Diagnostics/SQLLexicalRulesTests.swift
@@ -1,0 +1,47 @@
+//
+//  SQLLexicalRulesTests.swift
+//  TableProTests
+//
+
+import Foundation
+import TableProPluginKit
+import Testing
+
+@testable import TablePro
+
+@MainActor
+@Suite("SQL lexical rules for an engine")
+struct SQLLexicalRulesTests {
+    private func rules(for databaseType: DatabaseType) -> SQLLexicalRules {
+        SQLLexicalRules(databaseType: databaseType, descriptor: PluginManager.shared.sqlDialect(for: databaseType))
+    }
+
+    @Test("A backslash escapes where the dialect or the engine's descriptor says it does")
+    func backslashEscapes() {
+        #expect(rules(for: .mysql).backslashEscapes)
+        #expect(rules(for: .clickhouse).backslashEscapes)
+        #expect(rules(for: .snowflake).backslashEscapes)
+        #expect(!rules(for: .postgresql).backslashEscapes)
+        #expect(!rules(for: .sqlite).backslashEscapes)
+    }
+
+    @Test("Brackets quote identifiers on SQL Server and on every SQLite engine")
+    func bracketedIdentifiers() {
+        #expect(rules(for: .mssql).bracketsDelimitIdentifiers)
+        for engine in [DatabaseType.sqlite, .libsql, .turso, .cloudflareD1] {
+            #expect(rules(for: engine).bracketsDelimitIdentifiers, "\(engine.rawValue)")
+        }
+        for engine in [DatabaseType.duckdb, .postgresql, .mysql, .clickhouse] {
+            #expect(!rules(for: engine).bracketsDelimitIdentifiers, "\(engine.rawValue)")
+        }
+    }
+
+    @Test("An engine with no descriptor keeps its dialect's rules")
+    func missingDescriptor() {
+        #expect(SQLLexicalRules(databaseType: .mysql, descriptor: nil) == SQLLexicalRules(dialect: .mysql))
+        #expect(
+            SQLLexicalRules(databaseType: DatabaseType(rawValue: "FutureSQL"), descriptor: nil)
+                == SQLLexicalRules(dialect: .generic)
+        )
+    }
+}

--- a/TableProTests/Core/Utilities/SQL/InvisibleCharacterRemoverTests.swift
+++ b/TableProTests/Core/Utilities/SQL/InvisibleCharacterRemoverTests.swift
@@ -14,7 +14,7 @@ struct InvisibleCharacterRemoverTests {
     private func clean(
         _ text: String,
         scope: NSRange? = nil,
-        dialect: SqlDialect = .mysql,
+        rules: SQLLexicalRules = SQLLexicalRules(dialect: .mysql),
         lineEnding: String = "\n"
     ) -> String {
         let nsText = text as NSString
@@ -23,7 +23,7 @@ struct InvisibleCharacterRemoverTests {
             in: nsText,
             scope: range,
             skippingLiteralsAndComments: scope == nil,
-            dialect: dialect,
+            rules: rules,
             lineEnding: lineEnding
         )
         let result = NSMutableString(string: text)
@@ -68,13 +68,32 @@ struct InvisibleCharacterRemoverTests {
     @Test("A PostgreSQL dollar-quoted body is kept")
     func dollarQuotedBodyIsKept() {
         let text = "SELECT\u{A0}$$a\u{A0}b$$"
-        #expect(clean(text, dialect: .postgres) == "SELECT $$a\u{A0}b$$")
+        #expect(clean(text, rules: SQLLexicalRules(dialect: .postgres)) == "SELECT $$a\u{A0}b$$")
     }
 
     @Test("A MySQL conditional comment runs, so it is cleaned like code")
     func conditionalCommentIsCode() {
         #expect(clean("/*!40101 SET\u{A0}NAMES utf8 */") == "/*!40101 SET NAMES utf8 */")
         #expect(clean("/* a\u{A0}b */") == "/* a\u{A0}b */")
+    }
+
+    @Test("A backslash-escaped quote does not end the literal on engines that escape with a backslash")
+    func backslashEscapedQuote() {
+        let rules = SQLLexicalRules(dialect: .generic, backslashEscapes: true, bracketsDelimitIdentifiers: false)
+        #expect(clean("SELECT\u{A0}'it\\'s\u{A0}x'", rules: rules) == "SELECT 'it\\'s\u{A0}x'")
+    }
+
+    @Test("A PostgreSQL escape string and a nested block comment keep their characters")
+    func postgresEscapeStringAndNestedComment() {
+        let rules = SQLLexicalRules(dialect: .postgres)
+        #expect(clean("SELECT\u{A0}E'a\\'\u{A0}b'", rules: rules) == "SELECT E'a\\'\u{A0}b'")
+        #expect(clean("/* a /* b */\u{A0} */ SELECT\u{A0}1", rules: rules) == "/* a /* b */\u{A0} */ SELECT 1")
+    }
+
+    @Test("A bracketed identifier keeps its characters where brackets quote names")
+    func bracketedIdentifier() {
+        let rules = SQLLexicalRules(dialect: .sqlite, backslashEscapes: false, bracketsDelimitIdentifiers: true)
+        #expect(clean("SELECT\u{A0}[a\u{A0}b]", rules: rules) == "SELECT [a\u{A0}b]")
     }
 
     @Test("A MySQL hash comment is kept")
@@ -111,7 +130,7 @@ struct InvisibleCharacterRemoverTests {
             in: text,
             scope: NSRange(location: 0, length: text.length),
             skippingLiteralsAndComments: true,
-            dialect: .mysql,
+            rules: SQLLexicalRules(dialect: .mysql),
             lineEnding: "\n"
         )
         #expect(replacements.isEmpty)
@@ -124,7 +143,7 @@ struct InvisibleCharacterRemoverTests {
             in: text,
             scope: NSRange(location: 0, length: text.length),
             skippingLiteralsAndComments: true,
-            dialect: .mysql,
+            rules: SQLLexicalRules(dialect: .mysql),
             lineEnding: "\n"
         )
         #expect(InvisibleCharacterRemover.mappedOffset(0, through: replacements) == 0)

--- a/TableProTests/Core/Utilities/SQL/SQLNonCodeSpanTests.swift
+++ b/TableProTests/Core/Utilities/SQL/SQLNonCodeSpanTests.swift
@@ -1,0 +1,65 @@
+//
+//  SQLNonCodeSpanTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import TableProPluginKit
+import Testing
+
+@Suite("SQL non-code spans")
+struct SQLNonCodeSpanTests {
+    private func end(
+        _ text: String,
+        at index: Int = 0,
+        rules: SQLLexicalRules = SQLLexicalRules(dialect: .mysql)
+    ) -> Int? {
+        SQLNonCodeSpan.end(at: index, in: text as NSString, rules: rules)
+    }
+
+    @Test("Code is not a span")
+    func codeIsNotASpan() {
+        #expect(end("SELECT 1") == nil)
+        #expect(end("E'x'", rules: SQLLexicalRules(dialect: .mysql)) == nil)
+    }
+
+    @Test("Comments run to their end")
+    func comments() {
+        #expect(end("-- a\nSELECT") == 4)
+        #expect(end("# a\nSELECT") == 3)
+        #expect(end("# a\nSELECT", rules: SQLLexicalRules(dialect: .postgres)) == nil)
+        #expect(end("/* a */ SELECT") == 7)
+        #expect(end("/* a /* b */ c */ x", rules: SQLLexicalRules(dialect: .postgres)) == 17)
+    }
+
+    @Test("A MySQL conditional comment is code")
+    func conditionalComment() {
+        #expect(end("/*!40101 SET NAMES utf8 */") == nil)
+    }
+
+    @Test("Quoted text honours the engine's escape rules")
+    func quotedText() {
+        let backslash = SQLLexicalRules(dialect: .generic, backslashEscapes: true, bracketsDelimitIdentifiers: false)
+        #expect(end("'it''s' x") == 7)
+        #expect(end("'a\\'b' x", rules: backslash) == 6)
+        #expect(end("'a\\'b' x", rules: SQLLexicalRules(dialect: .postgres)) == 4)
+        #expect(end("`a b` x") == 5)
+    }
+
+    @Test("A PostgreSQL escape string starts at its E prefix")
+    func escapeString() {
+        let postgres = SQLLexicalRules(dialect: .postgres)
+        #expect(end("E'a\\'b' x", rules: postgres) == 7)
+        #expect(end("xE'a'", at: 1, rules: postgres) == nil)
+    }
+
+    @Test("Bracketed identifiers and dollar-quoted bodies are spans where the engine has them")
+    func bracketsAndDollarQuotes() {
+        let sqlite = SQLLexicalRules(dialect: .sqlite, backslashEscapes: false, bracketsDelimitIdentifiers: true)
+        #expect(end("[a]]b] x", rules: sqlite) == 6)
+        #expect(end("[a] x") == nil)
+        #expect(end("$$a b$$ x", rules: SQLLexicalRules(dialect: .postgres)) == 7)
+        #expect(end("$$a b$$ x") == nil)
+    }
+}

--- a/TableProTests/Core/Utilities/SQL/SqlLexerTests.swift
+++ b/TableProTests/Core/Utilities/SQL/SqlLexerTests.swift
@@ -73,6 +73,42 @@ struct SqlLexerTests {
         #expect(mysql.next > postgres.next, "MySQL treats the backslash as an escape and reads further")
     }
 
+    @Test("A caller can ask for backslash escapes whatever the dialect")
+    func explicitBackslashEscapes() {
+        let text = "'a\\' , 'b'" as NSString
+        let escaping = SqlLexer.skipQuotedString(
+            text,
+            from: 0,
+            quote: SqlLexer.singleQuote,
+            length: text.length,
+            backslashEscapes: true
+        )
+        let literal = SqlLexer.skipQuotedString(
+            text,
+            from: 0,
+            quote: SqlLexer.singleQuote,
+            length: text.length,
+            backslashEscapes: false
+        )
+        #expect(literal.next == 4)
+        #expect(escaping.next == 8)
+    }
+
+    @Test("A nested block comment runs past its outermost terminator")
+    func nestedBlockComment() {
+        let text = "/* a /* b\n */ c */x" as NSString
+        let span = SqlLexer.skipNestedBlockComment(text, from: 0, length: text.length)
+        #expect(span.next == 18)
+        #expect(span.newlines == 1)
+        #expect(SqlLexer.skipBlockComment(text, from: 0, length: text.length).next == 13)
+    }
+
+    @Test("An unterminated nested block comment stops at the end of the document")
+    func unterminatedNestedBlockComment() {
+        let text = "/* a /* b */ c" as NSString
+        #expect(SqlLexer.skipNestedBlockComment(text, from: 0, length: text.length).next == text.length)
+    }
+
     @Test("An unterminated string stops at the end of the document")
     func unterminatedString() {
         let text = "'abc" as NSString

--- a/TableProTests/Views/Editor/QueryDiagnosticsRefreshTests.swift
+++ b/TableProTests/Views/Editor/QueryDiagnosticsRefreshTests.swift
@@ -185,6 +185,21 @@ struct QueryDiagnosticMessageTests {
         #expect(manager.toolTip(at: plain) == nil)
     }
 
+    @Test("A full-width semicolon is underlined as a warning that names it")
+    func confusableCharacterIsAWarning() throws {
+        let (_, controller) = makeChecked("SELECT 1\u{FF1B}\nSELECT 2")
+        let manager = try #require(controller.textView.emphasisManager)
+        let range = NSRange(location: 8, length: 1)
+
+        let emphases = manager.getEmphases(for: QueryDiagnosticsController.emphasisGroup)
+        #expect(emphases.map(\.range) == [range])
+        #expect(emphases.first?.style == .underline(color: .systemOrange))
+        #expect(
+            manager.toolTip(at: try center(of: range, in: controller))
+                == "Full-width semicolon (U+FF1B). SQL reads only ; as a statement separator."
+        )
+    }
+
     @Test("A cleared diagnostic takes its message with it")
     func clearedDiagnosticDropsToolTip() throws {
         let (diagnostics, controller) = makeChecked("SELECT 1)")

--- a/docs/features/sql-editor.mdx
+++ b/docs/features/sql-editor.mdx
@@ -90,12 +90,27 @@ movement and `Shift`+arrow selection as the editor here.
 
 ## Inline diagnostics
 
-A structural mistake is underlined in red 500ms after you stop typing, and the underline clears as soon as you fix it. Only two things are reported, both of them problems more typing cannot fix:
+Problems more typing cannot fix are underlined 500ms after you stop typing, and the underline clears as soon as you fix it. A red underline marks a structural mistake:
 
-| Underlined | Message |
+| Underlined in red | Message |
 |---|---|
 | A closing bracket with no opener, or one closing the wrong kind | No matching opening bracket |
 | A `/*` with no `*/` after it | Unterminated comment |
+
+An orange underline marks a character that looks like SQL but reaches the server as something else. Chinese, Japanese and Korean input methods type these in full-width mode, and text pasted from a document or a chat often carries them. `SELECT 1；` looks like a complete statement, but `；` does not end it, so the editor and the server read it and the statement after it as one.
+
+| Underlined in orange | Type instead |
+|---|---|
+| Full-width punctuation, such as `；` `，` `（` `）` `＝` | The ASCII character it resembles |
+| Full-width letters and digits, such as `ＳＥＬＥＣＴ` or `１` | ASCII letters and digits |
+| Curly quotes `‘` `’` `“` `”` | A straight `'` or `"` |
+| A no-break space, an ideographic space, or a typographic space such as a thin space | An ordinary space |
+
+Each message names the character and the ASCII character to type instead. **Query > Remove Invisible Characters** turns every flagged space into an ordinary one in a single step. Orange underlines appear on SQL connections only, and none of them stops a query from running.
+
+Full-width letters and digits inside a name written in another script, such as `売上２０２４`, are not underlined. Full-width punctuation is, even inside a name: both parentheses in `价格（元）` are flagged. Write such a name as a quoted identifier and the underline goes.
+
+Text between `'`, `"` or `` ` `` quotes and text in a `--` or `/* */` comment is not checked. Neither is a `#` comment on MySQL and MariaDB, a `$$` body on PostgreSQL, or a `[bracketed]` name on SQL Server and SQLite. On other engines, a `#` comment, a `$$` body or a bracketed name is checked like the rest of the query.
 
 A half-written statement is never flagged. An opener you have not closed yet, a string you are still typing, and brackets inside a string or a comment are all left alone. Documents over 100,000 characters are not checked at all.
 


### PR DESCRIPTION
Found while investigating #2717 (PR #2724).

Stacked on #2728 (`fix/query-diagnostics-refresh`, the diagnostics refresh PR). This PR must merge after it.

## Root cause

#2724 made invisible characters visible in the SQL editor, but a whole class of characters that are visible and still wrong got no signal at all. A Chinese, Japanese or Korean input method in full-width mode types `；` `，` `（` `）` `＝`, and text pasted from a document or a chat carries curly quotes and no-break spaces. They look like SQL, but the server and the editor's own statement splitter read them as other characters. `SELECT 1；` looks finished, yet `；` (U+FF1B) is not a statement separator, so it and the next statement run as one and the server reports a syntax error somewhere else.

The editor's diagnostics had no producer that looked for these. `QueryDiagnosticsFactory` handed SQL editors only `SQLDiagnosticsProducer`, which reports bracket structure and unterminated comments and nothing else.

## What changed

- `SQLConfusableCharacterScanner`: one UTF-16 pass over the document that reports runs of full-width punctuation (U+FF01 to U+FF5E, minus letters, digits and underscore), curly quotes (U+2018, U+2019, U+201C, U+201D), and non-ASCII spaces (U+00A0, U+2000 to U+200A, U+202F, U+205F, U+3000). Full-width letters and digits are reported per word, and only when the word is not written in another script, so `売上２０２４` stays quiet while `ＳＥＬＥＣＴ` is flagged. Full-width punctuation is flagged even inside a name.
- The scanner skips what the engine does not read as code: quoted strings and identifiers, `--` and `/* */` comments, PostgreSQL nested block comments, `$$` bodies and `E'...'` strings, MySQL `#` comments (a MySQL `/*! */` conditional comment is read as code), and `[bracketed]` names on engines that accept them.
- `SQLLexicalRules`: the per-engine lexical facts the scanner needs, built from `SqlDialect` plus the plugin's `SQLDialectDescriptor`. Backslash escaping comes from either source, and brackets delimit identifiers when the descriptor quotes with `[` or the engine is in the SQLite family (SQLite, libSQL, Turso, Cloudflare D1).
- `ConfusableSQLCharacter`: classification and the message. Each message names the character with its code point and the ASCII character to type instead, for example `Full-width comma (U+FF0C). SQL needs the ASCII comma (U+002C).`
- `QueryDiagnosticsFactory`: SQL editors now get a `CombinedQueryDiagnosticsProducer` of the existing structural producer and the new one. The new diagnostics are `.warning` (orange underline), so none of them blocks a query. MongoDB and other non-SQL editors are unchanged.
- `SqlLexer`: a `skipQuotedString` overload that takes `backslashEscapes` directly (the dialect overload forwards to it), and `skipNestedBlockComment` for PostgreSQL.
- `QueryDiagnosticsLimits.maximumDocumentLength` replaces the two private 100,000 constants, so all three producers share the same cap.
- 35 new strings in `Localizable.xcstrings` (5 message formats, 30 punctuation names), each translated into ko, tr, vi, zh-Hans and zh-Hant. No existing entry changed.
- `docs/features/sql-editor.mdx`: the Inline diagnostics section now covers the orange underlines, what is and is not checked per engine, and that Remove Invisible Characters fixes the flagged spaces.
- CHANGELOG: one Added entry.

## Verification

- `verify.sh build`: PASS, `.analysis/fix-confusable-sql-punctuation-diagnostics/logs/build-TablePro-171033.log`.
- `verify.sh test` on the final tree: PASS, 136 executed, 136 passed, 0 failed, `.analysis/fix-confusable-sql-punctuation-diagnostics/logs/test-SQLConfusableCharacterScannerTests-171122.log`. Per suite:
  - `SQLConfusableCharacterScannerTests` 50
  - `SQLConfusableCharacterDiagnosticsTests` 13
  - `SqlLexerTests` 13
  - `SQLLexicalRulesTests` 3
  - `QueryDiagnosticsTests` 14
  - `QueryDiagnosticsRefreshTests` 6
  - `QueryDiagnosticMessageTests` 7
  - `MongoDiagnosticsProducerTests` 10
  - `InvisibleCharacterRemoverTests` 14
  - `StringCatalogIntegrityTests` 6
- Red runs while building the change: `test-SQLConfusableCharacterDiagnosticsTests-164657.log` (13 executed across `SQLConfusableCharacterDiagnosticsTests` and `QueryDiagnosticMessageTests`, 5 failing with the factory wiring removed: Postgres dialect, bracket identifiers, non-SQL editors quiet, severities, and the warning-severity message case), and `test-SQLConfusableCharacterDiagnosticsTests-170529.log` (6 of 13 failing before `SQLLexicalRules`: the ClickHouse and Snowflake backslash cases and the four SQLite-family bracket cases).
- `python3 scripts/localization.py verify`: ok for both catalogs.
- Docs: `check-writing-style.sh` and `check-docs-against-source.py` both pass.
- SwiftLint `--strict` on the changed Swift files: no violation on an added line. It reports two on `TableProTests/Core/Utilities/SQL/SqlLexerTests.swift` lines 9 and 13 (import order, blank line after the opening brace), both from 1e9e9e42ec and outside this diff.
- Package tests: nothing under `LocalPackages/` changed, so the CodeEditTextView `swift test` gate does not apply.
- UI tests: none added. The change is a new diagnostics producer covered end to end by the factory tests, and the underline, tooltip and VoiceOver rotor it feeds are the existing path from #2728, which `QueryDiagnosticsRefreshTests` and `QueryDiagnosticMessageTests` cover (this PR adds the warning-severity message case there).

## Notes

- Codex review was unavailable (usage limit), so an adversarial reviewer agent read the diff and probed the scanner with a standalone harness. It found two gaps, both fixed here with tests that failed first:
  - On engines whose plugin descriptor escapes with a backslash but whose `SqlDialect` does not (ClickHouse, Snowflake), `'it\'s'` closed at the escaped quote, the rest of the line read as an unterminated string, and a trailing `；` was missed.
  - SQLite-family engines accept `[name]` although their descriptor quotes with `"`, so full-width punctuation inside a bracketed name was flagged. DuckDB is left out on purpose: there `[1, 2]` is a list literal, and a test pins that.
- Known limit, not fixed: Oracle's alternative quoting `q'[...]'` is not modelled, so a lone apostrophe inside one ends the string early and can produce a false warning after it. The statement splitter in `SqlLexer` has the same gap today. Modelling it belongs in `SqlLexer` for every caller, not in this scanner alone.
- Full-width punctuation inside a name written in another script (`价格（元）`) is flagged by design, even though MySQL and PostgreSQL accept it in an unquoted identifier. Those are the same characters an input method types by mistake, a warning never blocks the query, and quoting the name clears it, which the docs say.

## Second commit: one SQL lexer for both features

Remove Invisible Characters (#2724) skipped string literals with its own lexer keyed on `SqlDialect` alone, so on ClickHouse and Snowflake a backslash-escaped quote ended the literal early and the command rewrote special spaces inside the string. It also missed PostgreSQL `E'...'` escape strings, nested block comments and SQLite `[bracketed]` names. The confusable-character scanner in this PR already handled all of those through `SQLLexicalRules`.

- `SQLNonCodeSpan` is the one walker for comments, quoted text, escape strings, bracketed identifiers and dollar-quoted bodies. The confusable scanner and the remover both use it.
- The remover takes `SQLLexicalRules` built the same way the diagnostics factory builds them, from the connection's plugin dialect descriptor.
- No CHANGELOG entry: the command is itself unreleased.
- Tests: `SQLNonCodeSpanTests` (6), four new `InvisibleCharacterRemoverTests` cases for backslash escapes, E-strings, nested comments and bracketed names, which the old lexer gets wrong. 121 of 121 pass across the remover, command, confusable, lexical-rules and diagnostics suites (`.analysis/fix-confusable-sql-punctuation-diagnostics/logs/test-InvisibleCharacterRemoverTests-173433.log`).

https://claude.ai/code/session_011THKc9TRHE8xjcxXidDHXP

