### PR TITLE
test(plugins): find the bundled SQLite plugin by the name the Installed list shows

### DIFF
--- a/TableProUITests/PluginDisabledRecoveryUITests.swift
+++ b/TableProUITests/PluginDisabledRecoveryUITests.swift
@@ -43,13 +43,13 @@ final class PluginDisabledRecoveryUITests: UITestCase {
         XCTAssertTrue(pluginsPane.waitToExist(timeout: 10))
         pluginsPane.click()
 
-        let row = settings.staticTexts["SQLite Driver"].firstMatch
+        let row = settings.staticTexts["SQLite"].firstMatch
         XCTAssertTrue(row.waitToExist(timeout: 15), "The bundled SQLite plugin is listed under Installed")
         XCTAssertTrue(waitUntilHittable(row, timeout: 10))
         row.click()
 
         let toggle = settings.descendants(matching: .any)
-            .matching(NSPredicate(format: "label == %@", "Enable SQLite Driver"))
+            .matching(NSPredicate(format: "label == %@", "Enable SQLite"))
             .firstMatch
         XCTAssertTrue(toggle.waitToExist(timeout: 10))
         XCTAssertTrue(waitUntilHittable(toggle, timeout: 10))

--- a/TableProUITests/PluginDisabledRecoveryUITests.swift
+++ b/TableProUITests/PluginDisabledRecoveryUITests.swift
@@ -43,7 +43,13 @@ final class PluginDisabledRecoveryUITests: UITestCase {
         XCTAssertTrue(pluginsPane.waitToExist(timeout: 10))
         pluginsPane.click()
 
-        let row = settings.staticTexts["SQLite"].firstMatch
+        let filter = settings.searchFields.matching(identifier: "sidebar-filter").firstMatch
+        XCTAssertTrue(filter.waitToExist(timeout: 10), "The Installed list has a filter field")
+        XCTAssertTrue(waitUntilHittable(filter, timeout: 10))
+        filter.click()
+        filter.typeText("SQLite")
+
+        let row = settings.outlines.firstMatch.staticTexts["SQLite"].firstMatch
         XCTAssertTrue(row.waitToExist(timeout: 15), "The bundled SQLite plugin is listed under Installed")
         XCTAssertTrue(waitUntilHittable(row, timeout: 10))
         row.click()


### PR DESCRIPTION
## Problem

`PluginDisabledRecoveryUITests.testConnectingWithTheDriverSwitchedOffOffersToSwitchItBackOn` has failed on every "macOS Tests" run on `main` since it landed in #2720, and on every open PR (#2728 to #2731), in shard "UI tests 1/3":

> XCTAssertTrue failed - The bundled SQLite plugin is listed under Installed

Both the first attempt and the retry fail at the same line. Example: run 34581195570, job 103213393785.

## Root cause

The test looked for a row named `SQLite Driver`. The Installed list never shows that name for the bundled SQLite plugin.

`SQLite Driver` is `SQLitePlugin.pluginName`, which only `PluginManager.registerBundle` reads, and that is the eager load path. The bundled SQLite plugin declares `TableProProvidesDatabaseTypeIds` in its `Info.plist`, so `PluginManifest.supportsLazyLoad` is true and it goes through `registerLazyManifest` instead. That path names the entry from the curated registry snapshot's `displayName`, which is `SQLite`. Activating the bundle later on demand does not rename the entry. The detail pane's toggle label is built from the same name (`Enable %@`), so it reads `Enable SQLite`, not `Enable SQLite Driver`.

The test was never run before it merged: #2720's PR body records `verify.sh uitest PluginDisabledRecoveryUITests` as INCONCLUSIVE locally (0 cases, automation-mode prompt), so the name was never checked against the running app.

This is not a macOS 26 versus 27 accessibility-tree difference, and not state leaking between cases. The naming is plain Swift in `PluginManager` and does not depend on the OS.

## Evidence

The failing case attaches `element-tree-0` to the uploaded result bundle (`macos-ui-test-results-1`). The Settings window's Installed outline in it, from both the first attempt and the retry:

```
Window (Main), identifier: 'settings', title: 'Plugins'
  RadioButton, label: 'Installed', value: 1
  ...
  OutlineRow
    Cell
      Image, label: 'sqlite-icon'
      StaticText, {{200.0, 367.0}, {41.0, 16.0}}, value: SQLite
      StaticText, value: Built-in
      StaticText, value: v1.0
      StaticText, value: ·
      StaticText, value: Database Driver
```

`value: SQLite` appears exactly once in the tree, and `SQLite Driver` appears nowhere in either attempt's tree. The other bundled drivers are named the same way (`PostgreSQL`, `MySQL`, `ClickHouse`).

## Fix

Match the Installed row by `SQLite` and the toggle by `Enable SQLite`, the name the lazy path shows. Both are exact matches. The eager path cannot show `SQLite Driver` for this bundle, because a bundle that declares a database type id always registers lazily, so the test does not accept both spellings. It is not loosened to a prefix or contains match either.

A second problem showed up in the retry's tree: the SQLite row sat at y=883, below the bottom of the 390pt outline. The Installed order comes from iterating a dictionary (`winners.values` in `discoverAllPlugins`), so it changes from launch to launch. The test now types `SQLite` into the list's filter field (`sidebar-filter`) and looks for the row inside the outline, so it is reachable whatever the order, and the filter text itself cannot satisfy the query.

Test-only change, so no CHANGELOG entry. It unblocks the UI gate on #2728 to #2733.

## Verification

- The UI test target compiles: the local `verify.sh uitest` build reached "Running tests" with no errors.
- `swiftlint lint --strict` on the changed file: 0 violations.
- The local UI run itself could not execute: the screen was locked, so Automation Mode could not be enabled ("Timed out while enabling automation mode"). The CI macos-26 run on this PR is the proof. The steps after the toggle (Reconnect, Enable Plugin, reconnect) have never run anywhere before this PR.
- Codex review was unavailable (usage limit); the diff was reviewed by hand against `InstalledPluginsView` and the CI element tree.

## Other findings, not in this PR

- The Installed list order changes on every launch, because `discoverAllPlugins` builds it from a dictionary's values.
- Settings > Plugins > Installed names every bundled export, import and inspector plugin by the last part of its bundle id (`SQLExportPlugin`, `CSVImportPlugin`, `CSVInspectorPlugin`, `MQLExportPlugin`), the same element tree shows. `registerLazyManifest` only has a display name for driver plugins, from the registry snapshot, and falls back to the bundle id for everything else. The same plugin loaded eagerly shows its `pluginName`, so its name depends on which load path took it.
- UI cases share `com.TablePro.uitest` defaults. `UITestCase.setUpWithError` clears it from the XCUITest runner, which is App-Sandboxed and so only reaches its own container. This test switches the SQLite plugin off and relies on its own **Enable Plugin** step to switch it back on. If it ever fails between those two steps, SQLite stays off for every later case in the shard that opens the sample database, and on a developer machine for later runs too.

https://claude.ai/code/session_011THKc9TRHE8xjcxXidDHXP
