### PR TITLE
fix(plugin-postgresql): read SQLSTATE from the right libpq field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Wrong SQLSTATE code in PostgreSQL, Redshift, CockroachDB and PGlite error messages.
+- Read-only write explanation never shown on PostgreSQL servers.
 - Safe Mode minimum from a configuration profile missing from the toolbar, the Database menu and the connection form. (#2030)
 - Stop not ending queries on MySQL and MariaDB servers without TLS.
 - Users & Roles failing, Stop not ending queries and sequences listed as tables on TiDB servers opened as MySQL.

--- a/Plugins/PostgreSQLDriverPlugin/LibPQPluginConnection.swift
+++ b/Plugins/PostgreSQLDriverPlugin/LibPQPluginConnection.swift
@@ -14,21 +14,6 @@ import TableProPluginKit
 
 private let logger = Logger(subsystem: "com.TablePro.PostgreSQLDriver", category: "LibPQPluginConnection")
 
-// MARK: - Error Types
-
-struct LibPQPluginError: Error {
-    let message: String
-    let sqlState: String?
-    let detail: String?
-
-    static let notConnected = LibPQPluginError(
-        message: String(localized: "Not connected to database"), sqlState: nil, detail: nil)
-    static let connectionFailed = LibPQPluginError(
-        message: String(localized: "Failed to establish connection"), sqlState: nil, detail: nil)
-    static let connectionTimedOut = LibPQPluginError(
-        message: String(localized: "Timed out while connecting to the server"), sqlState: nil, detail: nil)
-}
-
 // MARK: - Query Result
 
 struct LibPQPluginQueryResult {
@@ -1243,22 +1228,12 @@ final class LibPQPluginConnection: @unchecked Sendable {
 
     private func getResultError(from result: OpaquePointer) -> LibPQPluginError {
         var message = "Unknown error"
-        var sqlState: String?
-        var detail: String?
-
         if let msgPtr = PQresultErrorMessage(result) {
             message = String(cString: msgPtr).trimmingCharacters(in: .whitespacesAndNewlines)
         }
-
-        if let statePtr = PQresultErrorField(result, Int32(80)) {
-            sqlState = String(cString: statePtr)
+        return LibPQPluginError(message: message) { field in
+            PQresultErrorField(result, field).map { String(cString: $0) }
         }
-
-        if let detailPtr = PQresultErrorField(result, Int32(68)) {
-            detail = String(cString: detailPtr)
-        }
-
-        return LibPQPluginError(message: message, sqlState: sqlState, detail: detail)
     }
 
     private func getAffectedRows(from result: OpaquePointer) -> Int {
@@ -1274,12 +1249,4 @@ final class LibPQPluginConnection: @unchecked Sendable {
         }
         return nil
     }
-}
-
-// MARK: - PluginDriverError Conformance
-
-extension LibPQPluginError: PluginDriverError {
-    var pluginErrorMessage: String { message }
-    var pluginSqlState: String? { sqlState }
-    var pluginErrorDetail: String? { detail }
 }

--- a/Plugins/PostgreSQLDriverPlugin/LibPQPluginError.swift
+++ b/Plugins/PostgreSQLDriverPlugin/LibPQPluginError.swift
@@ -1,0 +1,34 @@
+import Foundation
+import TableProPluginKit
+
+struct LibPQPluginError: Error {
+    let message: String
+    let sqlState: String?
+    let detail: String?
+
+    static let notConnected = LibPQPluginError(
+        message: String(localized: "Not connected to database"), sqlState: nil, detail: nil)
+    static let connectionFailed = LibPQPluginError(
+        message: String(localized: "Failed to establish connection"), sqlState: nil, detail: nil)
+    static let connectionTimedOut = LibPQPluginError(
+        message: String(localized: "Timed out while connecting to the server"), sqlState: nil, detail: nil)
+}
+
+internal extension LibPQPluginError {
+    private static let sqlStateField = Int32(UInt8(ascii: "C"))
+    private static let detailField = Int32(UInt8(ascii: "D"))
+
+    init(message: String, readingResultField readField: (Int32) -> String?) {
+        self.init(
+            message: message,
+            sqlState: readField(Self.sqlStateField),
+            detail: readField(Self.detailField)
+        )
+    }
+}
+
+extension LibPQPluginError: PluginDriverError {
+    var pluginErrorMessage: String { message }
+    var pluginSqlState: String? { sqlState }
+    var pluginErrorDetail: String? { detail }
+}

--- a/TableProTests/Plugins/LibPQPluginErrorTests.swift
+++ b/TableProTests/Plugins/LibPQPluginErrorTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+@testable import TablePro
+import TableProPluginKit
+import Testing
+
+@Suite("LibPQPluginError result fields")
+struct LibPQPluginErrorTests {
+    private static let undefinedFunctionFields: [Int32: String] = [
+        Int32(UInt8(ascii: "C")): "42883",
+        Int32(UInt8(ascii: "P")): "134",
+        Int32(UInt8(ascii: "D")): "no function matches"
+    ]
+
+    private static func decoded(_ fields: [Int32: String], message: String = "ERROR: failed") -> LibPQPluginError {
+        LibPQPluginError(message: message) { fields[$0] }
+    }
+
+    @Test("SQLSTATE comes from the C field, never the statement position")
+    func sqlStateReadsTheSQLStateField() {
+        let error = Self.decoded(Self.undefinedFunctionFields)
+        #expect(error.sqlState == "42883")
+        #expect(error.pluginSqlState == "42883")
+    }
+
+    @Test("Detail comes from the D field")
+    func detailReadsTheDetailField() {
+        let error = Self.decoded(Self.undefinedFunctionFields)
+        #expect(error.detail == "no function matches")
+    }
+
+    @Test("Only the SQLSTATE and detail fields are read")
+    func readsNoOtherField() {
+        var requested: [Int32] = []
+        _ = LibPQPluginError(message: "ERROR: failed") { field in
+            requested.append(field)
+            return nil
+        }
+        #expect(Set(requested) == [Int32(UInt8(ascii: "C")), Int32(UInt8(ascii: "D"))])
+    }
+
+    @Test("A result with no diagnostic fields carries no SQLSTATE")
+    func missingFieldsStayNil() {
+        let error = Self.decoded([:])
+        #expect(error.sqlState == nil)
+        #expect(error.detail == nil)
+    }
+
+    @Test("The error description names the SQLSTATE")
+    func descriptionNamesTheSQLState() {
+        let error = Self.decoded(
+            Self.undefinedFunctionFields,
+            message: "ERROR: function to_regclass(text) does not exist"
+        )
+        #expect(error.errorDescription?.contains("(SQLSTATE: 42883)") == true)
+    }
+
+    @Test("A decoded read-only transaction error is diagnosed as server-enforced read-only")
+    func readOnlyTransactionIsDiagnosed() {
+        let error = Self.decoded(
+            [Int32(UInt8(ascii: "C")): "25006"],
+            message: "ERROR: cannot execute INSERT in a read-only transaction"
+        )
+        #expect(DatabaseWriteRejectionDiagnosis.classify(error) != nil)
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -501,6 +501,7 @@ targets:
       - Plugins/MSSQLDriverPlugin/MSSQLCheckConstraintDefinition.swift
       - Plugins/PostgreSQLDriverPlugin/ColumnQueryShape.swift
       - Plugins/PostgreSQLDriverPlugin/LibPQByteaDecoder.swift
+      - Plugins/PostgreSQLDriverPlugin/LibPQPluginError.swift
       - Plugins/PostgreSQLDriverPlugin/LibPQSSLMapping.swift
       - Plugins/PostgreSQLDriverPlugin/PostGISSpatialRewrite.swift
       - Plugins/PostgreSQLDriverPlugin/PostgreSQLCapabilities.swift


### PR DESCRIPTION
Found while investigating #2734.

## Root cause

`LibPQPluginConnection.getResultError` read the SQLSTATE with `PQresultErrorField(result, 80)`. Field 80 is `'P'`, `PG_DIAG_STATEMENT_POSITION` (`CLibPQ/include/postgres_ext.h:60`). The SQLSTATE is `'C'`, 67 (line 56). So every error from the libpq-backed drivers carried the caret position where the SQLSTATE should be. The `(SQLSTATE: 134)` in #2734 is character 134 of the query, not a code.

Everything that keys off a PostgreSQL SQLSTATE has been dead for PostgreSQL, Redshift, CockroachDB and PGlite:

- the table listing fallback (`PostgreSQLTableListingLadder`, 42883 and 42P01) never degraded, so a missing catalog function failed the whole sidebar list
- the 25P02 guard in `learnTypeNames` never fired, so a type lookup that failed only because the transaction was aborted marked the oid unresolved for the session
- the app's read-only diagnosis (25006) never recognised a read-only transaction or a hot standby
- query-level 28000 was never treated as an authentication failure

## Fix

- `LibPQPluginError` and its `PluginDriverError` conformance move into `LibPQPluginError.swift`, which does not import CLibPQ, so the test target can compile it.
- It gains `init(message:readingResultField:)`, which reads SQLSTATE from `'C'` and detail from `'D'` through a field reader. The field codes are named constants; the `PG_DIAG_*` macros are character literals Swift cannot import.
- `getResultError` passes `PQresultErrorField` as the reader.

The error message, the detail and the connection-level errors (`PQerrorMessage`, no SQLSTATE) are unchanged.

## Behaviour change, audited

With a real SQLSTATE these paths come alive. Each was read and found correct:

- `DatabaseWriteRejectionDiagnosis` 25006: PostgreSQL raises it for a write in a read-only transaction or on a standby, which is exactly the case it names.
- `DatabaseManager.isAuthenticationFailure` 28000: connect and reconnect failures come from `PQerrorMessage` and carry no SQLSTATE, so only a query-level 28000 changes, and that is an authorization failure.
- `GoogleSignInService` 28000: only claims connections with Spanner or BigQuery OAuth fields, which a libpq connection never has.
- The listing ladder: catalog reads raise 42P01 or 42883 only for a missing catalog relation or function, never for a user table dropped mid-read.
- `learnTypeNames` 25P02: now skips the lookup inside an aborted transaction as designed.

On PostgreSQL 9.1 to 9.5 the sidebar table list now loads through the ladder's last rung instead of failing. It lists base tables and views without comments until the catalog SQL itself is fixed in the follow-up PR for #2734.

## Evidence

The real `PostgreSQLPluginDriver`, compiled from this branch with swiftc and run against live servers. The matrix records the SQLSTATE from a libpq protocol trace next to the one the driver reports.

| Server | Before | After |
|---|---|---|
| PostgreSQL 9.1.24 | driver field `134`, `948`, `243`, `112`, `102`, `96` (positions) | driver field equals the true SQLSTATE on every failing call (`42883`, `42601`, `25001`) |
| PostgreSQL 17.11 | positions | equal; failure count unchanged (6) |
| CockroachDB v26.2 | `nil` (no position field) | equal (`42P01`, `25P02`) |

`fetchTables` on 9.1 went from `FAIL 42883` to `ok` (6 relations, from the degraded rung).

## Tests

- `LibPQPluginErrorTests`: SQLSTATE comes from `'C'` and never from `'P'`, detail from `'D'`, only those two fields are read, missing fields stay nil, the description names the SQLSTATE, and a decoded 25006 is diagnosed as server-enforced read-only.

## Verification

- `verify.sh build`: PASS.
- `verify.sh test LibPQPluginErrorTests PostgreSQLPartitionFilterTests PostgreSQLCatalogCompatibilityTests PostgreSQLFetchTablesCommentTests DatabaseWriteRejectionDiagnosisTests ReconnectCredentialRecoveryTests DatabaseCancellationDiagnosisTests`: 38 of 38 passed; re-run after review fixes, 14 of 14.
- `swiftlint --strict` on the changed files: clean.
- Review: Codex was unavailable (usage limit), so the diff was reviewed with the `code-review` skill instead. Its findings on field-code constants, test duplication and CHANGELOG coverage are applied. The repeated DETAIL line in PostgreSQL error text and the message-based connection-loss check predate this change and are handled in their own PRs.

https://claude.ai/code/session_01X1ejXbmyPqUziRWVxJ5cu8
