### PR TITLE
feat(plugin-weaviate): add Weaviate REST driver

### DIFF
--- a/.github/plugin-registry.json
+++ b/.github/plugin-registry.json
@@ -415,6 +415,20 @@
       "category": "database-driver",
       "homepage": "https://docs.tablepro.app/databases/typesense"
     },
+    "weaviate": {
+      "target": "WeaviateDriverPlugin",
+      "bundleName": "WeaviateDriverPlugin",
+      "bundleId": "com.TablePro.WeaviateDriverPlugin",
+      "bundled": false,
+      "displayName": "Weaviate Driver",
+      "summary": "Weaviate driver over the REST API with a GraphQL console",
+      "databaseTypeIds": [
+        "Weaviate"
+      ],
+      "icon": "weaviate-icon",
+      "category": "database-driver",
+      "homepage": "https://docs.tablepro.app/databases/weaviate"
+    },
     "xlsx": {
       "target": "XLSXExport",
       "bundleName": "XLSXExport",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Google Cloud Spanner as a registry plugin over the REST API. (#1226, #2480)
+- Weaviate as a registry REST plugin, collections as tables. (#1724)
 - TiDB and Databend connection types on the MySQL driver. (#1066, #2514)
 - Empty state in the inspector and the assistant for a connection that is not up.
 - **Check connections** in Settings > General, including Only when I use the connection. (#2700)

--- a/Packages/TableProCore/Package.swift
+++ b/Packages/TableProCore/Package.swift
@@ -23,6 +23,7 @@ let package = Package(
         .library(name: "TableProTrinoCore", targets: ["TableProTrinoCore"]),
         .library(name: "TableProGoogleCloud", targets: ["TableProGoogleCloud"]),
         .library(name: "TableProSpannerCore", targets: ["TableProSpannerCore"]),
+        .library(name: "TableProWeaviateCore", targets: ["TableProWeaviateCore"]),
         .library(name: "TableProNumberFormatting", targets: ["TableProNumberFormatting"]),
         .library(name: "TableProR2SQLCore", targets: ["TableProR2SQLCore"])
     ],
@@ -103,6 +104,11 @@ let package = Package(
             path: "Sources/TableProSpannerCore"
         ),
         .target(
+            name: "TableProWeaviateCore",
+            dependencies: [],
+            path: "Sources/TableProWeaviateCore"
+        ),
+        .target(
             name: "TableProR2SQLCore",
             dependencies: [],
             path: "Sources/TableProR2SQLCore"
@@ -161,6 +167,11 @@ let package = Package(
             name: "TableProSpannerCoreTests",
             dependencies: ["TableProSpannerCore", "TableProGoogleCloud"],
             path: "Tests/TableProSpannerCoreTests"
+        ),
+        .testTarget(
+            name: "TableProWeaviateCoreTests",
+            dependencies: ["TableProWeaviateCore"],
+            path: "Tests/TableProWeaviateCoreTests"
         ),
         .testTarget(
             name: "TableProR2SQLCoreTests",

--- a/Packages/TableProCore/Sources/TableProCoreTypes/DatabaseType.swift
+++ b/Packages/TableProCore/Sources/TableProCoreTypes/DatabaseType.swift
@@ -40,12 +40,13 @@ public struct DatabaseType: Hashable, Codable, Sendable, RawRepresentable {
     public static let trino = DatabaseType(rawValue: "Trino")
     public static let kafka = DatabaseType(rawValue: "Kafka")
     public static let cloudflareR2SQL = DatabaseType(rawValue: "Cloudflare R2 SQL")
+    public static let weaviate = DatabaseType(rawValue: "Weaviate")
 
     public static let allKnownTypes: [DatabaseType] = [
         .mysql, .mariadb, .tidb, .databend, .postgresql, .sqlite, .redis, .mongodb,
         .clickhouse, .mssql, .oracle, .dameng, .duckdb, .cassandra, .redshift,
         .etcd, .cloudflareD1, .dynamodb, .bigquery, .spanner, .snowflake, .libsql, .beancount,
-        .surrealdb, .teradata, .trino, .kafka, .cloudflareR2SQL
+        .surrealdb, .teradata, .trino, .kafka, .cloudflareR2SQL, .weaviate
     ]
 
     /// Icon name for this database type — asset catalog name (e.g. "mysql-icon") or SF Symbol fallback
@@ -79,6 +80,7 @@ public struct DatabaseType: Hashable, Codable, Sendable, RawRepresentable {
         case .trino: return "trino-icon"
         case .kafka: return "kafka-icon"
         case .cloudflareR2SQL: return "cloudflare-r2-sql-icon"
+        case .weaviate: return "weaviate-icon"
         default: return "externaldrive"
         }
     }

--- a/Packages/TableProCore/Sources/TableProWeaviateCore/WeaviateAuth.swift
+++ b/Packages/TableProCore/Sources/TableProWeaviateCore/WeaviateAuth.swift
@@ -27,13 +27,8 @@ public struct WeaviateAuth: Sendable, Equatable {
     }
 
     public var authorizationHeader: String? {
-        switch method {
-        case .none:
-            return nil
-        case .apiKey:
-            guard !apiKey.isEmpty else { return nil }
-            return "Bearer \(apiKey)"
-        }
+        guard !apiKey.isEmpty else { return nil }
+        return "Bearer \(apiKey)"
     }
 }
 

--- a/Packages/TableProCore/Sources/TableProWeaviateCore/WeaviateAuth.swift
+++ b/Packages/TableProCore/Sources/TableProWeaviateCore/WeaviateAuth.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+public enum WeaviateFieldID {
+    public static let authMethod = "wvAuthMethod"
+    public static let apiKey = "wvApiKey"
+    public static let skipTLSVerify = "wvSkipTLSVerify"
+}
+
+public enum WeaviateAuthMethod: String, Sendable, Equatable {
+    case none
+    case apiKey
+}
+
+public struct WeaviateAuth: Sendable, Equatable {
+    public let method: WeaviateAuthMethod
+    public let apiKey: String
+
+    public init(method: WeaviateAuthMethod, apiKey: String = "") {
+        self.method = method
+        self.apiKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    public static func parse(fields: [String: String]) -> WeaviateAuth {
+        let raw = fields[WeaviateFieldID.authMethod] ?? WeaviateAuthMethod.none.rawValue
+        let method = WeaviateAuthMethod(rawValue: raw) ?? .none
+        return WeaviateAuth(method: method, apiKey: fields[WeaviateFieldID.apiKey] ?? "")
+    }
+
+    public var authorizationHeader: String? {
+        switch method {
+        case .none:
+            return nil
+        case .apiKey:
+            guard !apiKey.isEmpty else { return nil }
+            return "Bearer \(apiKey)"
+        }
+    }
+}
+
+public struct WeaviateConnectionSettings: Sendable, Equatable {
+    public static let defaultPort = 8_080
+
+    public let host: String
+    public let port: Int
+    public let usesTLS: Bool
+    public let auth: WeaviateAuth
+    public let skipTLSVerify: Bool
+
+    public init(
+        host: String,
+        port: Int,
+        usesTLS: Bool,
+        auth: WeaviateAuth,
+        skipTLSVerify: Bool
+    ) {
+        self.host = host.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.port = port
+        self.usesTLS = usesTLS
+        self.auth = auth
+        self.skipTLSVerify = skipTLSVerify
+    }
+
+    public static func parse(
+        host: String,
+        port: Int,
+        usesTLS: Bool,
+        fields: [String: String]
+    ) throws -> WeaviateConnectionSettings {
+        let resolvedHost = host.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedPort = port > 0 ? port : defaultPort
+        let skipTLS = fields[WeaviateFieldID.skipTLSVerify] == "true"
+        let settings = WeaviateConnectionSettings(
+            host: resolvedHost.isEmpty ? "localhost" : resolvedHost,
+            port: resolvedPort,
+            usesTLS: usesTLS,
+            auth: WeaviateAuth.parse(fields: fields),
+            skipTLSVerify: skipTLS
+        )
+        _ = try settings.baseURL()
+        if settings.auth.method == .apiKey, settings.auth.apiKey.isEmpty {
+            throw WeaviateError.configuration("Enter a Weaviate API key.")
+        }
+        return settings
+    }
+
+    public func baseURL() throws -> URL {
+        var components = URLComponents()
+        components.scheme = usesTLS ? "https" : "http"
+        components.host = host
+        components.port = port
+        guard let url = components.url else {
+            throw WeaviateError.configuration("The host is not valid in a URL.")
+        }
+        return url
+    }
+}

--- a/Packages/TableProCore/Sources/TableProWeaviateCore/WeaviateAuth.swift
+++ b/Packages/TableProCore/Sources/TableProWeaviateCore/WeaviateAuth.swift
@@ -26,8 +26,10 @@ public struct WeaviateAuth: Sendable, Equatable {
         return WeaviateAuth(method: method, apiKey: fields[WeaviateFieldID.apiKey] ?? "")
     }
 
+    /// A key left in the form after the user switches back to None must not be sent: the form
+    /// keeps the field's text, and only the method says whether the connection is authenticated.
     public var authorizationHeader: String? {
-        guard !apiKey.isEmpty else { return nil }
+        guard method == .apiKey, !apiKey.isEmpty else { return nil }
         return "Bearer \(apiKey)"
     }
 }
@@ -73,7 +75,7 @@ public struct WeaviateConnectionSettings: Sendable, Equatable {
         )
         _ = try settings.baseURL()
         if settings.auth.method == .apiKey, settings.auth.apiKey.isEmpty {
-            throw WeaviateError.configuration("Enter a Weaviate API key.")
+            throw WeaviateError.configuration(String(localized: "Enter a Weaviate API key."))
         }
         return settings
     }
@@ -84,7 +86,7 @@ public struct WeaviateConnectionSettings: Sendable, Equatable {
         components.host = host
         components.port = port
         guard let url = components.url else {
-            throw WeaviateError.configuration("The host is not valid in a URL.")
+            throw WeaviateError.configuration(String(localized: "The host is not valid in a URL."))
         }
         return url
     }

--- a/Packages/TableProCore/Sources/TableProWeaviateCore/WeaviateError.swift
+++ b/Packages/TableProCore/Sources/TableProWeaviateCore/WeaviateError.swift
@@ -14,18 +14,19 @@ public enum WeaviateError: Error, LocalizedError, Equatable, Sendable {
         case .configuration(let detail), .transport(let detail), .malformedResponse(let detail):
             return detail
         case .notConnected:
-            return "Not connected to Weaviate."
+            return String(localized: "Not connected to Weaviate.")
         case .authentication(let detail):
             return detail
         case .api(_, let message):
             return message
         case .cancelled:
-            return "The request was cancelled."
+            return String(localized: "The request was cancelled.")
         }
     }
 
     public static func from(status: Int, body: Data) -> WeaviateError {
-        let message = apiMessage(from: body) ?? "Weaviate returned HTTP \(status)."
+        let message = apiMessage(from: body)
+            ?? String(format: String(localized: "Weaviate returned HTTP %d."), status)
         if status == 401 || status == 403 {
             return .authentication(message)
         }

--- a/Packages/TableProCore/Sources/TableProWeaviateCore/WeaviateError.swift
+++ b/Packages/TableProCore/Sources/TableProWeaviateCore/WeaviateError.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+public enum WeaviateError: Error, LocalizedError, Equatable, Sendable {
+    case configuration(String)
+    case notConnected
+    case transport(String)
+    case authentication(String)
+    case api(status: Int, message: String)
+    case malformedResponse(String)
+    case cancelled
+
+    public var errorDescription: String? {
+        switch self {
+        case .configuration(let detail), .transport(let detail), .malformedResponse(let detail):
+            return detail
+        case .notConnected:
+            return "Not connected to Weaviate."
+        case .authentication(let detail):
+            return detail
+        case .api(_, let message):
+            return message
+        case .cancelled:
+            return "The request was cancelled."
+        }
+    }
+
+    public static func from(status: Int, body: Data) -> WeaviateError {
+        let message = apiMessage(from: body) ?? "Weaviate returned HTTP \(status)."
+        if status == 401 || status == 403 {
+            return .authentication(message)
+        }
+        return .api(status: status, message: message)
+    }
+
+    public static func apiMessage(from body: Data) -> String? {
+        guard let json = try? JSONSerialization.jsonObject(with: body) else {
+            let text = String(data: body, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+            return (text?.isEmpty ?? true) ? nil : text
+        }
+        if let object = json as? [String: Any] {
+            if let errors = object["error"] as? [[String: Any]] {
+                let messages = errors.compactMap { $0["message"] as? String }.filter { !$0.isEmpty }
+                if !messages.isEmpty {
+                    return messages.joined(separator: "\n")
+                }
+            }
+            if let error = object["error"] as? String, !error.isEmpty {
+                return error
+            }
+            if let message = object["message"] as? String, !message.isEmpty {
+                return message
+            }
+        }
+        return nil
+    }
+}

--- a/Packages/TableProCore/Sources/TableProWeaviateCore/WeaviateFilterBuilder.swift
+++ b/Packages/TableProCore/Sources/TableProWeaviateCore/WeaviateFilterBuilder.swift
@@ -1,0 +1,309 @@
+import Foundation
+
+public enum WeaviateFilterError: Error, LocalizedError, Equatable {
+    case unsupportedOperator(String)
+    case missingUpperBound(column: String)
+    case notANumber(column: String, value: String)
+    case notABoolean(column: String, value: String)
+    case notADate(column: String, value: String)
+    case emptyList(column: String)
+    case comparisonNeedsNumberOrDate(column: String, op: String)
+    case textMatchNeedsText(column: String, op: String)
+    case vectorNotFilterable(column: String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .unsupportedOperator(let op):
+            return String(format: String(localized: "Weaviate cannot filter with %@."), op)
+        case .missingUpperBound(let column):
+            return String(format: String(localized: "BETWEEN on %@ needs an upper bound."), column)
+        case .notANumber(let column, let value):
+            return String(
+                format: String(localized: "%@ is a numeric property, and %@ is not a number."),
+                column, value
+            )
+        case .notABoolean(let column, let value):
+            return String(
+                format: String(localized: "%@ is a boolean property, so it matches only true or false, not %@."),
+                column, value
+            )
+        case .notADate(let column, let value):
+            return String(
+                format: String(localized: "%@ is a date property, and %@ is not an RFC 3339 timestamp such as 2024-01-31T00:00:00Z."),
+                column, value
+            )
+        case .emptyList(let column):
+            return String(format: String(localized: "IN on %@ needs at least one value."), column)
+        case .comparisonNeedsNumberOrDate(let column, let op):
+            return String(
+                format: String(localized: "Weaviate compares only numbers and dates with %@, and %@ is neither."),
+                op, column
+            )
+        case .textMatchNeedsText(let column, let op):
+            return String(
+                format: String(localized: "Weaviate matches text with %@, and %@ is not a text property."),
+                op, column
+            )
+        case .vectorNotFilterable(let column):
+            return String(format: String(localized: "Weaviate cannot filter on %@."), column)
+        }
+    }
+}
+
+/// Weaviate has no array value field: an `int[]` property filters with `valueInt`, so the kind is
+/// always the element's.
+public enum WeaviateValueKind: String, Sendable, Equatable {
+    case text
+    case uuid
+    case int
+    case number
+    case boolean
+    case date
+
+    public var graphQLField: String {
+        switch self {
+        case .text, .uuid: return "valueText"
+        case .int: return "valueInt"
+        case .number: return "valueNumber"
+        case .boolean: return "valueBoolean"
+        case .date: return "valueDate"
+        }
+    }
+
+    public var isOrdered: Bool {
+        self == .int || self == .number || self == .date
+    }
+
+    /// `Like` compiles to a regex over the inverted index, which Weaviate only builds for text.
+    public var acceptsPatternMatch: Bool {
+        self == .text
+    }
+
+    public static func forDataType(_ dataType: String) -> WeaviateValueKind {
+        var name = dataType.trimmingCharacters(in: .whitespaces).lowercased()
+        while name.hasSuffix("[]") {
+            name = String(name.dropLast(2))
+        }
+        switch name {
+        case "int": return .int
+        case "number": return .number
+        case "boolean", "bool": return .boolean
+        case "date": return .date
+        case "uuid": return .uuid
+        default: return .text
+        }
+    }
+}
+
+public enum WeaviateFilterBuilder {
+    public static func graphQLWhere(
+        filters: [WeaviateFilterSpec],
+        logicMode: String,
+        types: [String: String]
+    ) throws -> String? {
+        guard !filters.isEmpty else { return nil }
+        let operands = try filters.map { try operand(for: $0, types: types) }
+        guard operands.count > 1 else { return operands[0] }
+        let op = logicMode.uppercased() == "OR" ? "Or" : "And"
+        return "{ operator: \(op) operands: [\(operands.joined(separator: " "))] }"
+    }
+
+    public static func operand(for filter: WeaviateFilterSpec, types: [String: String]) throws -> String {
+        let column = filter.column
+        guard column != WeaviateSchema.vectorColumn else {
+            throw WeaviateFilterError.vectorNotFilterable(column: column)
+        }
+        let path = column == WeaviateSchema.uuidColumn ? WeaviateSchema.uuidGraphQLPath : column
+        let kind = column == WeaviateSchema.uuidColumn
+            ? WeaviateValueKind.text
+            : WeaviateValueKind.forDataType(types[column] ?? "text")
+        let op = filter.op.uppercased()
+
+        switch op {
+        case "=":
+            return try comparison("Equal", path: path, column: column, value: filter.value, kind: kind)
+        case "!=", "<>":
+            return try comparison("NotEqual", path: path, column: column, value: filter.value, kind: kind)
+        case ">", ">=", "<", "<=":
+            guard kind.isOrdered else {
+                throw WeaviateFilterError.comparisonNeedsNumberOrDate(column: column, op: op)
+            }
+            return try comparison(orderedOperator(op), path: path, column: column, value: filter.value, kind: kind)
+        case "CONTAINS":
+            return try like(pattern: "*\(filter.value)*", path: path, column: column, kind: kind, op: op)
+        case "NOT CONTAINS":
+            return negated(try like(pattern: "*\(filter.value)*", path: path, column: column, kind: kind, op: op))
+        case "STARTS WITH":
+            return try like(pattern: "\(filter.value)*", path: path, column: column, kind: kind, op: op)
+        case "ENDS WITH":
+            return try like(pattern: "*\(filter.value)", path: path, column: column, kind: kind, op: op)
+        case "IN":
+            return try containsList("ContainsAny", filter.value, path: path, column: column, kind: kind)
+        case "NOT IN":
+            return try containsList("ContainsNone", filter.value, path: path, column: column, kind: kind)
+        case "BETWEEN":
+            return try between(filter, path: path, column: column, kind: kind)
+        case "IS NULL":
+            return "{ path: [\"\(escape(path))\"] operator: IsNull valueBoolean: true }"
+        case "IS NOT NULL":
+            return "{ path: [\"\(escape(path))\"] operator: IsNull valueBoolean: false }"
+        case "IS EMPTY":
+            return try emptiness("Equal", path: path, column: column, kind: kind, op: op)
+        case "IS NOT EMPTY":
+            return try emptiness("GreaterThan", path: path, column: column, kind: kind, op: op)
+        default:
+            throw WeaviateFilterError.unsupportedOperator(op)
+        }
+    }
+
+    private static func orderedOperator(_ op: String) -> String {
+        switch op {
+        case ">": return "GreaterThan"
+        case ">=": return "GreaterThanEqual"
+        case "<": return "LessThan"
+        default: return "LessThanEqual"
+        }
+    }
+
+    private static func comparison(
+        _ operatorName: String,
+        path: String,
+        column: String,
+        value: String,
+        kind: WeaviateValueKind
+    ) throws -> String {
+        let literal = try literal(value, column: column, kind: kind)
+        return "{ path: [\"\(escape(path))\"] operator: \(operatorName) \(kind.graphQLField): \(literal) }"
+    }
+
+    /// Weaviate compiles a `Like` value into a regex over the inverted index. An int, number or
+    /// date property crashes that compile, and a uuid property is refused outright.
+    private static func like(
+        pattern: String,
+        path: String,
+        column: String,
+        kind: WeaviateValueKind,
+        op: String
+    ) throws -> String {
+        guard kind.acceptsPatternMatch else {
+            throw WeaviateFilterError.textMatchNeedsText(column: column, op: op)
+        }
+        return "{ path: [\"\(escape(path))\"] operator: Like valueText: \"\(escape(pattern))\" }"
+    }
+
+    private static func containsList(
+        _ operatorName: String,
+        _ value: String,
+        path: String,
+        column: String,
+        kind: WeaviateValueKind
+    ) throws -> String {
+        let parts = value
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+        guard !parts.isEmpty else {
+            throw WeaviateFilterError.emptyList(column: column)
+        }
+        let literals = try parts.map { try literal($0, column: column, kind: kind) }
+        return "{ path: [\"\(escape(path))\"] operator: \(operatorName) \(kind.graphQLField): [\(literals.joined(separator: ", "))] }"
+    }
+
+    /// Weaviate has no "is empty": it counts with `len(prop)`, which needs `indexPropertyLength` on
+    /// the collection and answers with what to turn on when it is off. There is no `len(id)`, and a
+    /// uuid property has no length either.
+    private static func emptiness(
+        _ operatorName: String,
+        path: String,
+        column: String,
+        kind: WeaviateValueKind,
+        op: String
+    ) throws -> String {
+        guard kind == .text, column != WeaviateSchema.uuidColumn else {
+            throw WeaviateFilterError.textMatchNeedsText(column: column, op: op)
+        }
+        return "{ path: [\"len(\(escape(path)))\"] operator: \(operatorName) valueInt: 0 }"
+    }
+
+    private static func between(
+        _ filter: WeaviateFilterSpec,
+        path: String,
+        column: String,
+        kind: WeaviateValueKind
+    ) throws -> String {
+        guard kind.isOrdered else {
+            throw WeaviateFilterError.comparisonNeedsNumberOrDate(column: column, op: "BETWEEN")
+        }
+        guard let upperBound = filter.secondValue, !upperBound.trimmingCharacters(in: .whitespaces).isEmpty else {
+            throw WeaviateFilterError.missingUpperBound(column: column)
+        }
+        let lower = try comparison(
+            "GreaterThanEqual", path: path, column: column, value: filter.value, kind: kind
+        )
+        let upper = try comparison(
+            "LessThanEqual", path: path, column: column, value: upperBound, kind: kind
+        )
+        return "{ operator: And operands: [\(lower) \(upper)] }"
+    }
+
+    private static func negated(_ operand: String) -> String {
+        "{ operator: Not operands: [\(operand)] }"
+    }
+
+    private static func literal(_ value: String, column: String, kind: WeaviateValueKind) throws -> String {
+        let trimmed = value.trimmingCharacters(in: .whitespaces)
+        switch kind {
+        case .text, .uuid:
+            return "\"\(escape(value))\""
+        case .int:
+            guard let number = Int(trimmed) else {
+                throw WeaviateFilterError.notANumber(column: column, value: value)
+            }
+            return String(number)
+        case .number:
+            guard let number = Double(trimmed) else {
+                throw WeaviateFilterError.notANumber(column: column, value: value)
+            }
+            return String(number)
+        case .boolean:
+            switch trimmed.lowercased() {
+            case "true", "1": return "true"
+            case "false", "0": return "false"
+            default: throw WeaviateFilterError.notABoolean(column: column, value: value)
+            }
+        case .date:
+            guard WeaviateDateLiteral.isRFC3339(trimmed) else {
+                throw WeaviateFilterError.notADate(column: column, value: value)
+            }
+            return "\"\(escape(trimmed))\""
+        }
+    }
+
+    static func escape(_ value: String) -> String {
+        var result = ""
+        result.reserveCapacity(value.count)
+        for character in value {
+            switch character {
+            case "\\": result += "\\\\"
+            case "\"": result += "\\\""
+            case "\n": result += "\\n"
+            case "\r": result += "\\r"
+            case "\t": result += "\\t"
+            default: result.append(character)
+            }
+        }
+        return result
+    }
+}
+
+/// Weaviate parses a `valueDate` with Go's RFC 3339 layout and answers
+/// `trying parse time as RFC3339 string` for anything else, including a bare `2024-01-31`.
+public enum WeaviateDateLiteral {
+    public static func isRFC3339(_ value: String) -> Bool {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        if formatter.date(from: value) != nil { return true }
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.date(from: value) != nil
+    }
+}

--- a/Packages/TableProCore/Sources/TableProWeaviateCore/WeaviateGraphQL.swift
+++ b/Packages/TableProCore/Sources/TableProWeaviateCore/WeaviateGraphQL.swift
@@ -1,93 +1,5 @@
 import Foundation
 
-public enum WeaviateFilterBuilder {
-    public static func graphQLWhere(
-        filters: [WeaviateFilterSpec],
-        logicMode: String
-    ) -> String? {
-        let operands = filters.compactMap(operand(for:))
-        guard !operands.isEmpty else { return nil }
-        if operands.count == 1 {
-            return operands[0]
-        }
-        let joined = operands.joined(separator: " ")
-        let op = logicMode.uppercased() == "OR" ? "Or" : "And"
-        return "{ operator: \(op) operands: [\(joined)] }"
-    }
-
-    public static func operand(for filter: WeaviateFilterSpec) -> String? {
-        if WeaviateSchema.immutableColumns.contains(filter.column), filter.column != WeaviateSchema.uuidColumn {
-            return nil
-        }
-        let path = filter.column == WeaviateSchema.uuidColumn ? "id" : filter.column
-        let operatorName: String
-        var value = filter.value
-        switch filter.op.uppercased() {
-        case "=", "EQUAL", "EQ":
-            operatorName = "Equal"
-        case "!=", "<>", "NOT EQUAL":
-            operatorName = "NotEqual"
-        case ">":
-            operatorName = "GreaterThan"
-        case ">=":
-            operatorName = "GreaterThanEqual"
-        case "<":
-            operatorName = "LessThan"
-        case "<=":
-            operatorName = "LessThanEqual"
-        case "CONTAINS", "LIKE":
-            operatorName = "Like"
-            if !value.contains("*") {
-                value = "*\(value)*"
-            }
-        case "STARTS WITH":
-            operatorName = "Like"
-            if !value.hasSuffix("*") {
-                value += "*"
-            }
-        case "IS NULL":
-            return "{ path: [\"\(escape(path))\"] operator: IsNull valueBoolean: true }"
-        case "IS NOT NULL":
-            return "{ path: [\"\(escape(path))\"] operator: IsNull valueBoolean: false }"
-        default:
-            return nil
-        }
-        return "{ path: [\"\(escape(path))\"] operator: \(operatorName) \(valueField(filter.typeName)): \(literal(value, typeName: filter.typeName)) }"
-    }
-
-    private static func valueField(_ typeName: String) -> String {
-        switch typeName.lowercased() {
-        case "int":
-            return "valueInt"
-        case "number":
-            return "valueNumber"
-        case "boolean", "bool":
-            return "valueBoolean"
-        default:
-            return "valueText"
-        }
-    }
-
-    private static func literal(_ value: String, typeName: String) -> String {
-        switch typeName.lowercased() {
-        case "int":
-            return Int(value).map(String.init) ?? "0"
-        case "number":
-            return Double(value).map { String($0) } ?? "0"
-        case "boolean", "bool":
-            return value.lowercased() == "true" ? "true" : "false"
-        default:
-            return "\"\(escape(value))\""
-        }
-    }
-
-    private static func escape(_ value: String) -> String {
-        value
-            .replacingOccurrences(of: "\\", with: "\\\\")
-            .replacingOccurrences(of: "\"", with: "\\\"")
-    }
-}
-
 public enum WeaviateGraphQL {
     public static func getQuery(
         collection: String,
@@ -96,19 +8,24 @@ public enum WeaviateGraphQL {
         offset: Int,
         sorts: [WeaviateSortSpec],
         filters: [WeaviateFilterSpec],
-        logicMode: String
-    ) -> String {
+        logicMode: String,
+        schema: [String: WeaviateProperty]
+    ) throws -> String {
+        let types = schema.mapValues(\.dataType)
         let fields = properties
             .filter { $0 != WeaviateSchema.uuidColumn && $0 != WeaviateSchema.vectorColumn }
+            .compactMap { selection(for: $0, schema: schema) }
             .joined(separator: " ")
         var args: [String] = ["limit: \(max(limit, 0))", "offset: \(max(offset, 0))"]
-        if let whereClause = WeaviateFilterBuilder.graphQLWhere(filters: filters, logicMode: logicMode) {
+        if let whereClause = try WeaviateFilterBuilder.graphQLWhere(
+            filters: filters, logicMode: logicMode, types: types
+        ) {
             args.append("where: \(whereClause)")
         }
         let sortArgs = sorts.compactMap { sort -> String? in
-            let path = sort.column == WeaviateSchema.uuidColumn ? "id" : sort.column
-            if path == WeaviateSchema.vectorColumn { return nil }
-            return "{ path: [\"\(path)\"] order: \(sort.ascending ? "asc" : "desc") }"
+            guard let path = sortPath(for: sort) else { return nil }
+            let order = sort.ascending ? "asc" : "desc"
+            return "{ path: [\"\(WeaviateFilterBuilder.escape(path))\"] order: \(order) }"
         }
         if !sortArgs.isEmpty {
             args.append("sort: [\(sortArgs.joined(separator: " "))]")
@@ -119,16 +36,44 @@ public enum WeaviateGraphQL {
         """
     }
 
+    /// A structured property needs its own sub-selection, and an `object` with no declared nested
+    /// properties has nothing to select, so it is left out rather than failing the query.
+    private static func selection(for name: String, schema: [String: WeaviateProperty]) -> String? {
+        guard let property = schema[name] else { return name }
+        switch WeaviatePropertyShape.of(property) {
+        case .scalar:
+            return name
+        case .geoCoordinates:
+            return "\(name) { latitude longitude }"
+        case .phoneNumber:
+            return "\(name) { input internationalFormatted nationalFormatted countryCode national valid defaultCountry }"
+        case .object:
+            let nested = property.nestedProperties
+                .compactMap { selection(for: $0.name, schema: [$0.name: $0]) }
+                .joined(separator: " ")
+            return nested.isEmpty ? nil : "\(name) { \(nested) }"
+        case .crossReference(let targets):
+            let fragments = targets.map { "... on \($0) { _additional { id } }" }.joined(separator: " ")
+            return "\(name) { \(fragments) }"
+        }
+    }
+
+    /// `vector` is a grid column rather than a property, so Weaviate has nothing to sort on. Every
+    /// real property is passed through: a type it cannot sort, such as uuid, is reported by the
+    /// server, which beats painting a sort chevron over rows in insertion order.
+    private static func sortPath(for sort: WeaviateSortSpec) -> String? {
+        if sort.column == WeaviateSchema.uuidColumn {
+            return WeaviateSchema.uuidGraphQLPath
+        }
+        return sort.column == WeaviateSchema.vectorColumn ? nil : sort.column
+    }
+
     public static func looksLikeGraphQL(_ text: String) -> Bool {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.hasPrefix("{") { return true }
         let lowered = trimmed.lowercased()
         return lowered.hasPrefix("query") || lowered.hasPrefix("mutation") || lowered.hasPrefix("subscription")
             || lowered.hasPrefix("fragment")
-    }
-
-    public static func isMutation(_ text: String) -> Bool {
-        text.trimmingCharacters(in: .whitespacesAndNewlines).lowercased().hasPrefix("mutation")
     }
 
     public static func requestBody(query: String) throws -> Data {

--- a/Packages/TableProCore/Sources/TableProWeaviateCore/WeaviateGraphQL.swift
+++ b/Packages/TableProCore/Sources/TableProWeaviateCore/WeaviateGraphQL.swift
@@ -173,10 +173,9 @@ public enum WeaviateConsoleParser {
         guard ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"].contains(method) else {
             return nil
         }
-        var path = String(parts[1])
-        if !path.hasPrefix("/") {
-            path = "/" + path
-        }
+        let rawPath = String(parts[1])
+        guard rawPath.hasPrefix("/") else { return nil }
+        var path = rawPath
         if !path.hasPrefix("/v1") && path != "/" {
             if path.hasPrefix("/objects") || path.hasPrefix("/schema") || path.hasPrefix("/graphql")
                 || path.hasPrefix("/meta") {

--- a/Packages/TableProCore/Sources/TableProWeaviateCore/WeaviateGraphQL.swift
+++ b/Packages/TableProCore/Sources/TableProWeaviateCore/WeaviateGraphQL.swift
@@ -1,0 +1,188 @@
+import Foundation
+
+public enum WeaviateFilterBuilder {
+    public static func graphQLWhere(
+        filters: [WeaviateFilterSpec],
+        logicMode: String
+    ) -> String? {
+        let operands = filters.compactMap(operand(for:))
+        guard !operands.isEmpty else { return nil }
+        if operands.count == 1 {
+            return operands[0]
+        }
+        let joined = operands.joined(separator: " ")
+        let op = logicMode.uppercased() == "OR" ? "Or" : "And"
+        return "{ operator: \(op) operands: [\(joined)] }"
+    }
+
+    public static func operand(for filter: WeaviateFilterSpec) -> String? {
+        if WeaviateSchema.immutableColumns.contains(filter.column), filter.column != WeaviateSchema.uuidColumn {
+            return nil
+        }
+        let path = filter.column == WeaviateSchema.uuidColumn ? "id" : filter.column
+        let operatorName: String
+        var value = filter.value
+        switch filter.op.uppercased() {
+        case "=", "EQUAL", "EQ":
+            operatorName = "Equal"
+        case "!=", "<>", "NOT EQUAL":
+            operatorName = "NotEqual"
+        case ">":
+            operatorName = "GreaterThan"
+        case ">=":
+            operatorName = "GreaterThanEqual"
+        case "<":
+            operatorName = "LessThan"
+        case "<=":
+            operatorName = "LessThanEqual"
+        case "CONTAINS", "LIKE":
+            operatorName = "Like"
+            if !value.contains("*") {
+                value = "*\(value)*"
+            }
+        case "STARTS WITH":
+            operatorName = "Like"
+            if !value.hasSuffix("*") {
+                value += "*"
+            }
+        case "IS NULL":
+            return "{ path: [\"\(escape(path))\"] operator: IsNull valueBoolean: true }"
+        case "IS NOT NULL":
+            return "{ path: [\"\(escape(path))\"] operator: IsNull valueBoolean: false }"
+        default:
+            return nil
+        }
+        return "{ path: [\"\(escape(path))\"] operator: \(operatorName) \(valueField(filter.typeName)): \(literal(value, typeName: filter.typeName)) }"
+    }
+
+    private static func valueField(_ typeName: String) -> String {
+        switch typeName.lowercased() {
+        case "int":
+            return "valueInt"
+        case "number":
+            return "valueNumber"
+        case "boolean", "bool":
+            return "valueBoolean"
+        default:
+            return "valueText"
+        }
+    }
+
+    private static func literal(_ value: String, typeName: String) -> String {
+        switch typeName.lowercased() {
+        case "int":
+            return Int(value).map(String.init) ?? "0"
+        case "number":
+            return Double(value).map { String($0) } ?? "0"
+        case "boolean", "bool":
+            return value.lowercased() == "true" ? "true" : "false"
+        default:
+            return "\"\(escape(value))\""
+        }
+    }
+
+    private static func escape(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+    }
+}
+
+public enum WeaviateGraphQL {
+    public static func getQuery(
+        collection: String,
+        properties: [String],
+        limit: Int,
+        offset: Int,
+        sorts: [WeaviateSortSpec],
+        filters: [WeaviateFilterSpec],
+        logicMode: String
+    ) -> String {
+        let fields = properties
+            .filter { $0 != WeaviateSchema.uuidColumn && $0 != WeaviateSchema.vectorColumn }
+            .joined(separator: " ")
+        var args: [String] = ["limit: \(max(limit, 0))", "offset: \(max(offset, 0))"]
+        if let whereClause = WeaviateFilterBuilder.graphQLWhere(filters: filters, logicMode: logicMode) {
+            args.append("where: \(whereClause)")
+        }
+        let sortArgs = sorts.compactMap { sort -> String? in
+            let path = sort.column == WeaviateSchema.uuidColumn ? "id" : sort.column
+            if path == WeaviateSchema.vectorColumn { return nil }
+            return "{ path: [\"\(path)\"] order: \(sort.ascending ? "asc" : "desc") }"
+        }
+        if !sortArgs.isEmpty {
+            args.append("sort: [\(sortArgs.joined(separator: " "))]")
+        }
+        let argumentList = args.joined(separator: ", ")
+        return """
+        { Get { \(collection)(\(argumentList)) { \(fields) _additional { id vector } } } }
+        """
+    }
+
+    public static func looksLikeGraphQL(_ text: String) -> Bool {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.hasPrefix("{") { return true }
+        let lowered = trimmed.lowercased()
+        return lowered.hasPrefix("query") || lowered.hasPrefix("mutation") || lowered.hasPrefix("subscription")
+            || lowered.hasPrefix("fragment")
+    }
+
+    public static func isMutation(_ text: String) -> Bool {
+        text.trimmingCharacters(in: .whitespacesAndNewlines).lowercased().hasPrefix("mutation")
+    }
+
+    public static func requestBody(query: String) throws -> Data {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let data = trimmed.data(using: .utf8),
+           let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+           object["query"] != nil {
+            return try WeaviateJSON.data(object)
+        }
+        return try WeaviateJSON.data(["query": trimmed])
+    }
+}
+
+public struct WeaviateConsoleRequest: Sendable, Equatable {
+    public let method: String
+    public let path: String
+    public let body: String?
+
+    public init(method: String, path: String, body: String?) {
+        self.method = method
+        self.path = path
+        self.body = body
+    }
+}
+
+public enum WeaviateConsoleParser {
+    public static func parse(_ input: String) -> WeaviateConsoleRequest? {
+        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let newline = trimmed.firstIndex(where: \.isNewline) else {
+            return parseHeader(trimmed, body: nil)
+        }
+        let header = String(trimmed[..<newline])
+        let rest = trimmed[trimmed.index(after: newline)...]
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return parseHeader(header, body: rest.isEmpty ? nil : rest)
+    }
+
+    private static func parseHeader(_ header: String, body: String?) -> WeaviateConsoleRequest? {
+        let parts = header.split(whereSeparator: { $0.isWhitespace })
+        guard parts.count >= 2 else { return nil }
+        let method = String(parts[0]).uppercased()
+        guard ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"].contains(method) else {
+            return nil
+        }
+        var path = String(parts[1])
+        if !path.hasPrefix("/") {
+            path = "/" + path
+        }
+        if !path.hasPrefix("/v1") && path != "/" {
+            if path.hasPrefix("/objects") || path.hasPrefix("/schema") || path.hasPrefix("/graphql")
+                || path.hasPrefix("/meta") {
+                path = "/v1" + path
+            }
+        }
+        return WeaviateConsoleRequest(method: method, path: path, body: body)
+    }
+}

--- a/Packages/TableProCore/Sources/TableProWeaviateCore/WeaviateGraphQL.swift
+++ b/Packages/TableProCore/Sources/TableProWeaviateCore/WeaviateGraphQL.swift
@@ -9,7 +9,8 @@ public enum WeaviateGraphQL {
         sorts: [WeaviateSortSpec],
         filters: [WeaviateFilterSpec],
         logicMode: String,
-        schema: [String: WeaviateProperty]
+        schema: [String: WeaviateProperty],
+        includeVector: Bool = true
     ) throws -> String {
         let types = schema.mapValues(\.dataType)
         let fields = properties
@@ -31,8 +32,9 @@ public enum WeaviateGraphQL {
             args.append("sort: [\(sortArgs.joined(separator: " "))]")
         }
         let argumentList = args.joined(separator: ", ")
+        let additional = includeVector ? "id vector" : "id"
         return """
-        { Get { \(collection)(\(argumentList)) { \(fields) _additional { id vector } } } }
+        { Get { \(collection)(\(argumentList)) { \(fields) _additional { \(additional) } } } }
         """
     }
 
@@ -111,8 +113,10 @@ public enum WeaviateConsoleParser {
         return parseHeader(header, body: rest.isEmpty ? nil : rest)
     }
 
+    /// The whole REST API lives under `/v1`, so any other path is prefixed rather than a hand-listed
+    /// four: `GET /nodes` and `POST /batch/objects` used to reach the base URL and answer 404.
     private static func parseHeader(_ header: String, body: String?) -> WeaviateConsoleRequest? {
-        let parts = header.split(whereSeparator: { $0.isWhitespace })
+        let parts = header.split(maxSplits: 2, omittingEmptySubsequences: true, whereSeparator: \.isWhitespace)
         guard parts.count >= 2 else { return nil }
         let method = String(parts[0]).uppercased()
         guard ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"].contains(method) else {
@@ -121,12 +125,16 @@ public enum WeaviateConsoleParser {
         let rawPath = String(parts[1])
         guard rawPath.hasPrefix("/") else { return nil }
         var path = rawPath
-        if !path.hasPrefix("/v1") && path != "/" {
-            if path.hasPrefix("/objects") || path.hasPrefix("/schema") || path.hasPrefix("/graphql")
-                || path.hasPrefix("/meta") {
-                path = "/v1" + path
-            }
+        if path != "/", path != "/v1", !path.hasPrefix("/v1/"), !path.hasPrefix("/v1?") {
+            path = "/v1" + path
         }
-        return WeaviateConsoleRequest(method: method, path: path, body: body)
+        let inlineBody = parts.count > 2
+            ? String(parts[2]).trimmingCharacters(in: .whitespacesAndNewlines)
+            : ""
+        return WeaviateConsoleRequest(
+            method: method,
+            path: path,
+            body: body ?? (inlineBody.isEmpty ? nil : inlineBody)
+        )
     }
 }

--- a/Packages/TableProCore/Sources/TableProWeaviateCore/WeaviateJSON.swift
+++ b/Packages/TableProCore/Sources/TableProWeaviateCore/WeaviateJSON.swift
@@ -41,24 +41,33 @@ public enum WeaviateJSON {
         }
     }
 
+    /// Only a property the grid renders as JSON is parsed back as JSON. Running the parser over
+    /// every type sends a `text` cell holding `{"a":1}` as an object, which Weaviate rejects while
+    /// the grid reports the save.
     public static func parsedValue(_ text: String, typeName: String) -> Any {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        let lowered = typeName.lowercased()
-        if lowered == "boolean" || lowered == "bool" {
-            if trimmed.lowercased() == "true" { return true }
-            if trimmed.lowercased() == "false" { return false }
+        let declared = typeName.trimmingCharacters(in: .whitespaces)
+        let isArray = declared.hasSuffix("[]")
+        if !isArray {
+            switch WeaviateValueKind.forDataType(declared) {
+            case .boolean:
+                if trimmed.lowercased() == "true" { return true }
+                if trimmed.lowercased() == "false" { return false }
+                return text
+            case .int:
+                return Int(trimmed) ?? text
+            case .number:
+                return Double(trimmed) ?? text
+            case .text, .uuid, .date:
+                break
+            }
         }
-        if lowered == "int" || lowered == "int[]" || lowered.hasPrefix("int") {
-            if let intVal = Int(trimmed) { return intVal }
-        }
-        if lowered == "number" || lowered == "number[]" {
-            if let doubleVal = Double(trimmed) { return doubleVal }
-        }
-        if let data = trimmed.data(using: .utf8),
-           let parsed = try? JSONSerialization.jsonObject(with: data) {
-            if parsed is [Any] { return parsed }
-            if parsed is [String: Any] { return parsed }
-        }
-        return text
+        let shape = WeaviatePropertyShape.of(WeaviateProperty(name: "", dataType: declared))
+        guard isArray || shape != .scalar else { return text }
+        guard let data = trimmed.data(using: .utf8),
+              let parsed = try? JSONSerialization.jsonObject(with: data),
+              parsed is [Any] || parsed is [String: Any]
+        else { return text }
+        return parsed
     }
 }

--- a/Packages/TableProCore/Sources/TableProWeaviateCore/WeaviateJSON.swift
+++ b/Packages/TableProCore/Sources/TableProWeaviateCore/WeaviateJSON.swift
@@ -1,21 +1,13 @@
 import Foundation
 
 public enum WeaviateJSON {
-    public static func object(from data: Data) throws -> Any {
-        do {
-            return try JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])
-        } catch {
-            throw WeaviateError.malformedResponse(error.localizedDescription)
-        }
-    }
-
     public static func dictionary(_ value: Any?) -> [String: Any]? {
         value as? [String: Any]
     }
 
     public static func data(_ object: Any, pretty: Bool = false) throws -> Data {
         guard JSONSerialization.isValidJSONObject(object) else {
-            throw WeaviateError.malformedResponse("Request body is not valid JSON.")
+            throw WeaviateError.malformedResponse(String(localized: "Request body is not valid JSON."))
         }
         var options: JSONSerialization.WritingOptions = [.sortedKeys]
         if pretty {

--- a/Packages/TableProCore/Sources/TableProWeaviateCore/WeaviateJSON.swift
+++ b/Packages/TableProCore/Sources/TableProWeaviateCore/WeaviateJSON.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+public enum WeaviateJSON {
+    public static func object(from data: Data) throws -> Any {
+        do {
+            return try JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])
+        } catch {
+            throw WeaviateError.malformedResponse(error.localizedDescription)
+        }
+    }
+
+    public static func dictionary(_ value: Any?) -> [String: Any]? {
+        value as? [String: Any]
+    }
+
+    public static func data(_ object: Any, pretty: Bool = false) throws -> Data {
+        guard JSONSerialization.isValidJSONObject(object) else {
+            throw WeaviateError.malformedResponse("Request body is not valid JSON.")
+        }
+        var options: JSONSerialization.WritingOptions = [.sortedKeys]
+        if pretty {
+            options.insert(.prettyPrinted)
+        }
+        return try JSONSerialization.data(withJSONObject: object, options: options)
+    }
+
+    public static func text(_ object: Any, pretty: Bool = false) throws -> String {
+        let encoded = try data(object, pretty: pretty)
+        return String(data: encoded, encoding: .utf8) ?? "{}"
+    }
+
+    public static func displayText(_ value: Any?) -> String? {
+        switch value {
+        case nil, is NSNull:
+            return nil
+        case let text as String:
+            return text
+        case let number as NSNumber:
+            if CFGetTypeID(number) == CFBooleanGetTypeID() {
+                return number.boolValue ? "true" : "false"
+            }
+            return number.stringValue
+        case let object as [String: Any], let object as [Any]:
+            return (try? text(object)) ?? nil
+        default:
+            return String(describing: value as Any)
+        }
+    }
+
+    public static func parsedValue(_ text: String, typeName: String) -> Any {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let lowered = typeName.lowercased()
+        if lowered == "boolean" || lowered == "bool" {
+            if trimmed.lowercased() == "true" { return true }
+            if trimmed.lowercased() == "false" { return false }
+        }
+        if lowered == "int" || lowered == "int[]" || lowered.hasPrefix("int") {
+            if let intVal = Int(trimmed) { return intVal }
+        }
+        if lowered == "number" || lowered == "number[]" {
+            if let doubleVal = Double(trimmed) { return doubleVal }
+        }
+        if let data = trimmed.data(using: .utf8),
+           let parsed = try? JSONSerialization.jsonObject(with: data) {
+            if parsed is [Any] { return parsed }
+            if parsed is [String: Any] { return parsed }
+        }
+        return text
+    }
+}

--- a/Packages/TableProCore/Sources/TableProWeaviateCore/WeaviateJSON.swift
+++ b/Packages/TableProCore/Sources/TableProWeaviateCore/WeaviateJSON.swift
@@ -40,7 +40,9 @@ public enum WeaviateJSON {
                 return number.boolValue ? "true" : "false"
             }
             return number.stringValue
-        case let object as [String: Any], let object as [Any]:
+        case let object as [String: Any]:
+            return (try? text(object)) ?? nil
+        case let object as [Any]:
             return (try? text(object)) ?? nil
         default:
             return String(describing: value as Any)

--- a/Packages/TableProCore/Sources/TableProWeaviateCore/WeaviateObjectCodec.swift
+++ b/Packages/TableProCore/Sources/TableProWeaviateCore/WeaviateObjectCodec.swift
@@ -1,0 +1,130 @@
+import Foundation
+
+public struct WeaviateObject: Sendable, Equatable {
+    public let uuid: String
+    public let className: String
+    public let properties: [String: String?]
+    public let vector: [Double]?
+
+    public init(uuid: String, className: String, properties: [String: String?], vector: [Double]?) {
+        self.uuid = uuid
+        self.className = className
+        self.properties = properties
+        self.vector = vector
+    }
+
+    public static func parse(_ json: [String: Any]) -> WeaviateObject? {
+        let uuid = (json["id"] as? String) ?? ""
+        let className = (json["class"] as? String) ?? ""
+        let raw = json["properties"] as? [String: Any] ?? [:]
+        var properties: [String: String?] = [:]
+        for (key, value) in raw {
+            properties[key] = WeaviateJSON.displayText(value)
+        }
+        let vector = vector(from: json["vector"])
+        if uuid.isEmpty, properties.isEmpty, vector == nil {
+            return nil
+        }
+        return WeaviateObject(uuid: uuid, className: className, properties: properties, vector: vector)
+    }
+
+    public static func parseList(_ json: Any) -> [WeaviateObject] {
+        let objects: [[String: Any]]
+        if let object = json as? [String: Any] {
+            objects = object["objects"] as? [[String: Any]] ?? []
+        } else if let array = json as? [[String: Any]] {
+            objects = array
+        } else {
+            return []
+        }
+        return objects.compactMap(parse)
+    }
+
+    public var vectorText: String? {
+        guard let vector, !vector.isEmpty else {
+            return vector == nil ? nil : "[]"
+        }
+        return "[" + vector.map(Self.numberText).joined(separator: ",") + "]"
+    }
+
+    private static func numberText(_ value: Double) -> String {
+        if value.rounded() == value, value >= Double(Int.min), value <= Double(Int.max) {
+            return String(Int(value))
+        }
+        return String(value)
+    }
+
+    static func vector(from value: Any?) -> [Double]? {
+        if let numbers = value as? [Double] {
+            return numbers
+        }
+        if let numbers = value as? [NSNumber] {
+            return numbers.map(\.doubleValue)
+        }
+        return nil
+    }
+}
+
+public enum WeaviateObjectCodec {
+    public static func row(for object: WeaviateObject, columns: [String]) -> [String?] {
+        return columns.map { column in
+            switch column {
+            case WeaviateSchema.uuidColumn:
+                return object.uuid.isEmpty ? nil : object.uuid
+            case WeaviateSchema.vectorColumn:
+                return object.vectorText
+            default:
+                if let value = object.properties[column] {
+                    return value
+                }
+                return nil
+            }
+        }
+    }
+
+    public static func objects(fromGraphQL json: Any) -> [WeaviateObject] {
+        guard let root = json as? [String: Any] else { return [] }
+        if let errors = root["errors"] as? [[String: Any]], !errors.isEmpty {
+            return []
+        }
+        guard let data = root["data"] as? [String: Any] else { return [] }
+        if let get = data["Get"] as? [String: Any] {
+            return objects(fromGet: get)
+        }
+        return []
+    }
+
+    public static func graphQLErrors(from json: Any) -> [String] {
+        guard let root = json as? [String: Any],
+              let errors = root["errors"] as? [[String: Any]]
+        else { return [] }
+        return errors.compactMap { $0["message"] as? String }.filter { !$0.isEmpty }
+    }
+
+    private static func objects(fromGet get: [String: Any]) -> [WeaviateObject] {
+        var result: [WeaviateObject] = []
+        for (className, value) in get {
+            guard let rows = value as? [[String: Any]] else { continue }
+            for row in rows {
+                result.append(object(fromGetRow: row, className: className))
+            }
+        }
+        return result
+    }
+
+    private static func object(fromGetRow row: [String: Any], className: String) -> WeaviateObject {
+        var properties: [String: String?] = [:]
+        var uuid = ""
+        var vector: [Double]?
+        for (key, value) in row {
+            if key == "_additional", let additional = value as? [String: Any] {
+                uuid = (additional["id"] as? String) ?? uuid
+                vector = WeaviateObject.vector(from: additional["vector"]) ?? vector
+                continue
+            }
+            properties[key] = WeaviateJSON.displayText(value)
+        }
+        return WeaviateObject(uuid: uuid, className: className, properties: properties, vector: vector)
+    }
+}
+

--- a/Packages/TableProCore/Sources/TableProWeaviateCore/WeaviateObjectCodec.swift
+++ b/Packages/TableProCore/Sources/TableProWeaviateCore/WeaviateObjectCodec.swift
@@ -48,8 +48,8 @@ public struct WeaviateObject: Sendable, Equatable {
     }
 
     private static func numberText(_ value: Double) -> String {
-        if value.rounded() == value, value >= Double(Int.min), value <= Double(Int.max) {
-            return String(Int(value))
+        if value.rounded() == value, let whole = Int(exactly: value) {
+            return String(whole)
         }
         return String(value)
     }
@@ -66,6 +66,8 @@ public struct WeaviateObject: Sendable, Equatable {
 }
 
 public enum WeaviateObjectCodec {
+    static let additionalKey = "_additional"
+
     public static func row(for object: WeaviateObject, columns: [String]) -> [String?] {
         return columns.map { column in
             switch column {
@@ -112,17 +114,26 @@ public enum WeaviateObjectCodec {
         return result
     }
 
+    /// `_additional` is where a vector search puts `distance`, `score` and `certainty`, which are
+    /// the whole point of the query the user wrote. Only `id` and `vector` have a column of their
+    /// own; the rest become properties so they reach the grid.
     private static func object(fromGetRow row: [String: Any], className: String) -> WeaviateObject {
         var properties: [String: String?] = [:]
+        var additional: [String: Any] = [:]
         var uuid = ""
         var vector: [Double]?
         for (key, value) in row {
-            if key == "_additional", let additional = value as? [String: Any] {
-                uuid = (additional["id"] as? String) ?? uuid
-                vector = WeaviateObject.vector(from: additional["vector"]) ?? vector
+            if key == additionalKey, let fields = value as? [String: Any] {
+                additional = fields
                 continue
             }
             properties[key] = WeaviateJSON.displayText(value)
+        }
+        uuid = (additional["id"] as? String) ?? uuid
+        vector = WeaviateObject.vector(from: additional["vector"])
+        for (key, value) in additional where key != "id" && key != WeaviateSchema.vectorColumn {
+            let name = properties[key] == nil ? key : "\(additionalKey).\(key)"
+            properties[name] = WeaviateJSON.displayText(value)
         }
         return WeaviateObject(uuid: uuid, className: className, properties: properties, vector: vector)
     }

--- a/Packages/TableProCore/Sources/TableProWeaviateCore/WeaviatePathEncoding.swift
+++ b/Packages/TableProCore/Sources/TableProWeaviateCore/WeaviatePathEncoding.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+public enum WeaviatePathEncoding {
+    private static let allowed: CharacterSet = {
+        var set = CharacterSet.alphanumerics
+        set.insert(charactersIn: "-_")
+        return set
+    }()
+
+    public static func segment(_ value: String) -> String {
+        value.addingPercentEncoding(withAllowedCharacters: allowed) ?? value
+    }
+
+    public static func resolve(_ path: String, query: [String: String] = [:], against base: URL) -> URL? {
+        guard path.hasPrefix("/"), !path.contains("://") else { return nil }
+        guard var components = URLComponents(url: base, resolvingAgainstBaseURL: false) else {
+            return nil
+        }
+        components.path = path
+        if query.isEmpty {
+            components.queryItems = nil
+        } else {
+            components.queryItems = query.keys.sorted().map { URLQueryItem(name: $0, value: query[$0]) }
+        }
+        return components.url
+    }
+}

--- a/Packages/TableProCore/Sources/TableProWeaviateCore/WeaviatePathEncoding.swift
+++ b/Packages/TableProCore/Sources/TableProWeaviateCore/WeaviatePathEncoding.swift
@@ -11,17 +11,18 @@ public enum WeaviatePathEncoding {
         value.addingPercentEncoding(withAllowedCharacters: allowed) ?? value
     }
 
+    /// A console line carries its own query string (`GET /v1/objects?class=Article`), so the path
+    /// is parsed rather than assigned whole: `URLComponents.path` percent-encodes `?` into `%3F`
+    /// and sends the request to a path that does not exist.
     public static func resolve(_ path: String, query: [String: String] = [:], against base: URL) -> URL? {
         guard path.hasPrefix("/"), !path.contains("://") else { return nil }
-        guard var components = URLComponents(url: base, resolvingAgainstBaseURL: false) else {
-            return nil
-        }
-        components.path = path
-        if query.isEmpty {
-            components.queryItems = nil
-        } else {
-            components.queryItems = query.keys.sorted().map { URLQueryItem(name: $0, value: query[$0]) }
-        }
+        guard var components = URLComponents(url: base, resolvingAgainstBaseURL: false),
+              let requested = URLComponents(string: path)
+        else { return nil }
+        components.percentEncodedPath = requested.percentEncodedPath
+        var items = requested.queryItems ?? []
+        items += query.keys.sorted().map { URLQueryItem(name: $0, value: query[$0]) }
+        components.queryItems = items.isEmpty ? nil : items
         return components.url
     }
 }

--- a/Packages/TableProCore/Sources/TableProWeaviateCore/WeaviateQuery.swift
+++ b/Packages/TableProCore/Sources/TableProWeaviateCore/WeaviateQuery.swift
@@ -348,7 +348,7 @@ public enum WeaviateStatementGenerator {
         var result: [String: Any] = [:]
         for (column, text) in values {
             if WeaviateSchema.immutableColumns.contains(column) { continue }
-            if column.hasPrefix("_") { continue }
+            if column.hasPrefix("\(WeaviateObjectCodec.additionalKey).") { continue }
             if let text {
                 result[column] = WeaviateJSON.parsedValue(text, typeName: types[column] ?? "text")
             } else {

--- a/Packages/TableProCore/Sources/TableProWeaviateCore/WeaviateQuery.swift
+++ b/Packages/TableProCore/Sources/TableProWeaviateCore/WeaviateQuery.swift
@@ -4,13 +4,16 @@ public struct WeaviateFilterSpec: Codable, Sendable, Equatable {
     public let column: String
     public let op: String
     public let value: String
-    public let typeName: String
 
-    public init(column: String, op: String, value: String, typeName: String = "text") {
+    /// The upper bound of `BETWEEN`, carried apart from `value` so a value holding a comma cannot
+    /// be mistaken for the separator between the two bounds.
+    public let secondValue: String?
+
+    public init(column: String, op: String, value: String, secondValue: String? = nil) {
         self.column = column
         self.op = op
         self.value = value
-        self.typeName = typeName
+        self.secondValue = secondValue
     }
 }
 
@@ -51,8 +54,15 @@ public struct WeaviateParsedSearch: Sendable, Equatable {
         self.propertyNames = propertyNames
     }
 
+    /// `GET /v1/objects` sorts, but only on a property: the grid's `vector` column is not one, and
+    /// Weaviate answers `no such prop with name 'vector'`. Everything else goes through GraphQL,
+    /// whose `sort` argument takes the object id as well.
+    public var sortableSorts: [WeaviateSortSpec] {
+        sorts.filter { $0.column != WeaviateSchema.vectorColumn }
+    }
+
     public var usesGraphQL: Bool {
-        !filters.isEmpty || !sorts.filter({ $0.column != WeaviateSchema.uuidColumn }).isEmpty
+        !filters.isEmpty || !sortableSorts.isEmpty
     }
 }
 
@@ -74,8 +84,12 @@ public enum WeaviateBrowseQuery {
             "limit": limit,
             "logicMode": logicMode,
             "sorts": sorts.map { ["column": $0.column, "ascending": $0.ascending] },
-            "filters": filters.map {
-                ["column": $0.column, "op": $0.op, "value": $0.value, "typeName": $0.typeName]
+            "filters": filters.map { filter -> [String: Any] in
+                var encoded: [String: Any] = ["column": filter.column, "op": filter.op, "value": filter.value]
+                if let secondValue = filter.secondValue {
+                    encoded["secondValue"] = secondValue
+                }
+                return encoded
             },
             "properties": propertyNames
         ]
@@ -109,7 +123,7 @@ public enum WeaviateBrowseQuery {
                     column: column,
                     op: op,
                     value: item["value"] as? String ?? "",
-                    typeName: item["typeName"] as? String ?? "text"
+                    secondValue: item["secondValue"] as? String
                 )
             },
             logicMode: json["logicMode"] as? String ?? "AND",
@@ -184,7 +198,7 @@ public struct WeaviateCellChange: Sendable, Equatable {
 }
 
 public struct WeaviateTrackedChange: Sendable, Equatable {
-    public enum Kind: Sendable, Equatable {
+    public enum Kind: String, Sendable, Equatable {
         case insert
         case update
         case delete
@@ -208,24 +222,79 @@ public struct WeaviateTrackedChange: Sendable, Equatable {
     }
 }
 
+public enum WeaviateSkipReason: String, Sendable, Equatable {
+    case missingUUID
+    case noEditableColumns
+    case payloadNotEncodable
+}
+
+public struct WeaviateSkippedChange: Sendable, Equatable {
+    public let kind: WeaviateTrackedChange.Kind
+    public let reason: WeaviateSkipReason
+
+    public init(kind: WeaviateTrackedChange.Kind, reason: WeaviateSkipReason) {
+        self.kind = kind
+        self.reason = reason
+    }
+}
+
+/// A skipped change writes nothing while the grid reports the save succeeded, so the driver has to
+/// be able to say what it dropped. Same reason the MongoDB generator logs its own skips.
+public struct WeaviateWriteBatch: Sendable, Equatable {
+    public let requests: [WeaviateWriteRequest]
+    public let skipped: [WeaviateSkippedChange]
+
+    public init(requests: [WeaviateWriteRequest], skipped: [WeaviateSkippedChange]) {
+        self.requests = requests
+        self.skipped = skipped
+    }
+}
+
 public enum WeaviateStatementGenerator {
     public static func generate(
         collection: String,
         columns: [String],
         typeNames: [String],
         changes: [WeaviateTrackedChange]
-    ) -> [WeaviateWriteRequest] {
-        let types = Dictionary(uniqueKeysWithValues: zip(columns, typeNames))
-        return changes.compactMap { change in
+    ) -> WeaviateWriteBatch {
+        let types = Dictionary(zip(columns, typeNames), uniquingKeysWith: { first, _ in first })
+        var requests: [WeaviateWriteRequest] = []
+        var skipped: [WeaviateSkippedChange] = []
+        for change in changes {
+            let request: WeaviateWriteRequest?
             switch change.kind {
             case .insert:
-                return insert(collection: collection, types: types, change: change)
+                request = insert(collection: collection, types: types, change: change)
             case .update:
-                return update(collection: collection, types: types, change: change)
+                request = update(collection: collection, types: types, change: change)
             case .delete:
-                return delete(collection: collection, change: change)
+                request = delete(collection: collection, change: change)
+            }
+            if let request {
+                requests.append(request)
+            } else {
+                skipped.append(WeaviateSkippedChange(kind: change.kind, reason: reason(for: change)))
             }
         }
+        return WeaviateWriteBatch(requests: requests, skipped: skipped)
+    }
+
+    private static func reason(for change: WeaviateTrackedChange) -> WeaviateSkipReason {
+        if change.kind != .insert, change.uuid?.isEmpty ?? true {
+            return .missingUUID
+        }
+        if change.kind == .update, editablePatch(from: change).isEmpty {
+            return .noEditableColumns
+        }
+        return .payloadNotEncodable
+    }
+
+    private static func editablePatch(from change: WeaviateTrackedChange) -> [String: String?] {
+        var patch: [String: String?] = [:]
+        for cell in change.cellChanges where !WeaviateSchema.immutableColumns.contains(cell.column) {
+            patch[cell.column] = cell.newText
+        }
+        return patch
     }
 
     private static func insert(
@@ -250,10 +319,7 @@ public enum WeaviateStatementGenerator {
         change: WeaviateTrackedChange
     ) -> WeaviateWriteRequest? {
         guard let uuid = change.uuid, !uuid.isEmpty else { return nil }
-        var patch: [String: String?] = [:]
-        for cell in change.cellChanges where !WeaviateSchema.immutableColumns.contains(cell.column) {
-            patch[cell.column] = cell.newText
-        }
+        let patch = editablePatch(from: change)
         guard !patch.isEmpty else { return nil }
         let payload: [String: Any] = [
             "class": collection,

--- a/Packages/TableProCore/Sources/TableProWeaviateCore/WeaviateQuery.swift
+++ b/Packages/TableProCore/Sources/TableProWeaviateCore/WeaviateQuery.swift
@@ -1,0 +1,294 @@
+import Foundation
+
+public struct WeaviateFilterSpec: Codable, Sendable, Equatable {
+    public let column: String
+    public let op: String
+    public let value: String
+    public let typeName: String
+
+    public init(column: String, op: String, value: String, typeName: String = "text") {
+        self.column = column
+        self.op = op
+        self.value = value
+        self.typeName = typeName
+    }
+}
+
+public struct WeaviateSortSpec: Codable, Sendable, Equatable {
+    public let column: String
+    public let ascending: Bool
+
+    public init(column: String, ascending: Bool) {
+        self.column = column
+        self.ascending = ascending
+    }
+}
+
+public struct WeaviateParsedSearch: Sendable, Equatable {
+    public let collection: String
+    public let offset: Int
+    public let limit: Int
+    public let sorts: [WeaviateSortSpec]
+    public let filters: [WeaviateFilterSpec]
+    public let logicMode: String
+    public let propertyNames: [String]
+
+    public init(
+        collection: String,
+        offset: Int,
+        limit: Int,
+        sorts: [WeaviateSortSpec],
+        filters: [WeaviateFilterSpec],
+        logicMode: String,
+        propertyNames: [String]
+    ) {
+        self.collection = collection
+        self.offset = offset
+        self.limit = limit
+        self.sorts = sorts
+        self.filters = filters
+        self.logicMode = logicMode
+        self.propertyNames = propertyNames
+    }
+
+    public var usesGraphQL: Bool {
+        !filters.isEmpty || !sorts.filter({ $0.column != WeaviateSchema.uuidColumn }).isEmpty
+    }
+}
+
+public enum WeaviateBrowseQuery {
+    public static let searchTag = "WEAVIATE_SEARCH:"
+
+    public static func encode(
+        collection: String,
+        offset: Int,
+        limit: Int,
+        sorts: [WeaviateSortSpec],
+        filters: [WeaviateFilterSpec],
+        logicMode: String,
+        propertyNames: [String]
+    ) -> String {
+        let payload: [String: Any] = [
+            "collection": collection,
+            "offset": offset,
+            "limit": limit,
+            "logicMode": logicMode,
+            "sorts": sorts.map { ["column": $0.column, "ascending": $0.ascending] },
+            "filters": filters.map {
+                ["column": $0.column, "op": $0.op, "value": $0.value, "typeName": $0.typeName]
+            },
+            "properties": propertyNames
+        ]
+        let body = (try? WeaviateJSON.data(payload)) ?? Data()
+        return searchTag + body.base64EncodedString()
+    }
+
+    public static func parse(_ query: String) -> WeaviateParsedSearch? {
+        guard query.hasPrefix(searchTag) else { return nil }
+        let encoded = String(query.dropFirst(searchTag.count))
+        guard let data = Data(base64Encoded: encoded),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let collection = json["collection"] as? String
+        else { return nil }
+        let sortsJSON = json["sorts"] as? [[String: Any]] ?? []
+        let filtersJSON = json["filters"] as? [[String: Any]] ?? []
+        let properties = json["properties"] as? [String] ?? []
+        return WeaviateParsedSearch(
+            collection: collection,
+            offset: json["offset"] as? Int ?? 0,
+            limit: json["limit"] as? Int ?? 25,
+            sorts: sortsJSON.compactMap { item in
+                guard let column = item["column"] as? String else { return nil }
+                return WeaviateSortSpec(column: column, ascending: item["ascending"] as? Bool ?? true)
+            },
+            filters: filtersJSON.compactMap { item in
+                guard let column = item["column"] as? String, let op = item["op"] as? String else {
+                    return nil
+                }
+                return WeaviateFilterSpec(
+                    column: column,
+                    op: op,
+                    value: item["value"] as? String ?? "",
+                    typeName: item["typeName"] as? String ?? "text"
+                )
+            },
+            logicMode: json["logicMode"] as? String ?? "AND",
+            propertyNames: properties
+        )
+    }
+
+    public static func isTagged(_ query: String) -> Bool {
+        query.hasPrefix(searchTag)
+    }
+}
+
+public struct WeaviateWriteRequest: Sendable, Equatable {
+    public let method: String
+    public let path: String
+    public let query: [String: String]
+    public let body: String?
+
+    public init(method: String, path: String, query: [String: String] = [:], body: String?) {
+        self.method = method
+        self.path = path
+        self.query = query
+        self.body = body
+    }
+}
+
+public enum WeaviateWriteCodec {
+    public static let writeTag = "WEAVIATE_WRITE:"
+
+    public static func encode(_ request: WeaviateWriteRequest) -> String {
+        let payload: [String: Any] = [
+            "method": request.method,
+            "path": request.path,
+            "query": request.query,
+            "body": request.body ?? ""
+        ]
+        let data = (try? WeaviateJSON.data(payload)) ?? Data()
+        return writeTag + data.base64EncodedString()
+    }
+
+    public static func decode(_ statement: String) -> WeaviateWriteRequest? {
+        guard statement.hasPrefix(writeTag) else { return nil }
+        let encoded = String(statement.dropFirst(writeTag.count))
+        guard let data = Data(base64Encoded: encoded),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let method = json["method"] as? String,
+              let path = json["path"] as? String
+        else { return nil }
+        let query = json["query"] as? [String: String] ?? [:]
+        let body = json["body"] as? String
+        return WeaviateWriteRequest(
+            method: method,
+            path: path,
+            query: query,
+            body: (body?.isEmpty ?? true) ? nil : body
+        )
+    }
+
+    public static func isTagged(_ statement: String) -> Bool {
+        statement.hasPrefix(writeTag)
+    }
+}
+
+public struct WeaviateCellChange: Sendable, Equatable {
+    public let column: String
+    public let newText: String?
+
+    public init(column: String, newText: String?) {
+        self.column = column
+        self.newText = newText
+    }
+}
+
+public struct WeaviateTrackedChange: Sendable, Equatable {
+    public enum Kind: Sendable, Equatable {
+        case insert
+        case update
+        case delete
+    }
+
+    public let kind: Kind
+    public let uuid: String?
+    public let values: [String: String?]
+    public let cellChanges: [WeaviateCellChange]
+
+    public init(
+        kind: Kind,
+        uuid: String?,
+        values: [String: String?],
+        cellChanges: [WeaviateCellChange]
+    ) {
+        self.kind = kind
+        self.uuid = uuid
+        self.values = values
+        self.cellChanges = cellChanges
+    }
+}
+
+public enum WeaviateStatementGenerator {
+    public static func generate(
+        collection: String,
+        columns: [String],
+        typeNames: [String],
+        changes: [WeaviateTrackedChange]
+    ) -> [WeaviateWriteRequest] {
+        let types = Dictionary(uniqueKeysWithValues: zip(columns, typeNames))
+        return changes.compactMap { change in
+            switch change.kind {
+            case .insert:
+                return insert(collection: collection, types: types, change: change)
+            case .update:
+                return update(collection: collection, types: types, change: change)
+            case .delete:
+                return delete(collection: collection, change: change)
+            }
+        }
+    }
+
+    private static func insert(
+        collection: String,
+        types: [String: String],
+        change: WeaviateTrackedChange
+    ) -> WeaviateWriteRequest? {
+        var payload: [String: Any] = [
+            "class": collection,
+            "properties": properties(from: change.values, types: types)
+        ]
+        if let uuid = change.uuid, !uuid.isEmpty {
+            payload["id"] = uuid
+        }
+        guard let body = try? WeaviateJSON.text(payload) else { return nil }
+        return WeaviateWriteRequest(method: "POST", path: "/v1/objects", body: body)
+    }
+
+    private static func update(
+        collection: String,
+        types: [String: String],
+        change: WeaviateTrackedChange
+    ) -> WeaviateWriteRequest? {
+        guard let uuid = change.uuid, !uuid.isEmpty else { return nil }
+        var patch: [String: String?] = [:]
+        for cell in change.cellChanges where !WeaviateSchema.immutableColumns.contains(cell.column) {
+            patch[cell.column] = cell.newText
+        }
+        guard !patch.isEmpty else { return nil }
+        let payload: [String: Any] = [
+            "class": collection,
+            "properties": properties(from: patch, types: types)
+        ]
+        guard let body = try? WeaviateJSON.text(payload) else { return nil }
+        return WeaviateWriteRequest(
+            method: "PATCH",
+            path: "/v1/objects/\(WeaviatePathEncoding.segment(uuid))",
+            query: ["class": collection],
+            body: body
+        )
+    }
+
+    private static func delete(collection: String, change: WeaviateTrackedChange) -> WeaviateWriteRequest? {
+        guard let uuid = change.uuid, !uuid.isEmpty else { return nil }
+        return WeaviateWriteRequest(
+            method: "DELETE",
+            path: "/v1/objects/\(WeaviatePathEncoding.segment(uuid))",
+            query: ["class": collection],
+            body: nil
+        )
+    }
+
+    private static func properties(from values: [String: String?], types: [String: String]) -> [String: Any] {
+        var result: [String: Any] = [:]
+        for (column, text) in values {
+            if WeaviateSchema.immutableColumns.contains(column) { continue }
+            if column.hasPrefix("_") { continue }
+            if let text {
+                result[column] = WeaviateJSON.parsedValue(text, typeName: types[column] ?? "text")
+            } else {
+                result[column] = NSNull()
+            }
+        }
+        return result
+    }
+}

--- a/Packages/TableProCore/Sources/TableProWeaviateCore/WeaviateSchema.swift
+++ b/Packages/TableProCore/Sources/TableProWeaviateCore/WeaviateSchema.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+public struct WeaviateProperty: Sendable, Equatable {
+    public let name: String
+    public let dataType: String
+
+    public init(name: String, dataType: String) {
+        self.name = name
+        self.dataType = dataType
+    }
+
+    public static func parse(_ json: [String: Any]) -> WeaviateProperty? {
+        guard let name = json["name"] as? String, !name.isEmpty else { return nil }
+        let types = json["dataType"] as? [String] ?? []
+        let dataType = types.first ?? "text"
+        return WeaviateProperty(name: name, dataType: dataType)
+    }
+}
+
+public struct WeaviateCollection: Sendable, Equatable {
+    public let name: String
+    public let properties: [WeaviateProperty]
+    public let vectorizer: String?
+
+    public init(name: String, properties: [WeaviateProperty], vectorizer: String? = nil) {
+        self.name = name
+        self.properties = properties
+        self.vectorizer = vectorizer
+    }
+
+    public static func parse(_ json: [String: Any]) -> WeaviateCollection? {
+        guard let name = json["class"] as? String, !name.isEmpty else { return nil }
+        let rawProperties = json["properties"] as? [[String: Any]] ?? []
+        let properties = rawProperties.compactMap(WeaviateProperty.parse)
+        return WeaviateCollection(
+            name: name,
+            properties: properties,
+            vectorizer: json["vectorizer"] as? String
+        )
+    }
+}
+
+public enum WeaviateSchema {
+    public static let uuidColumn = "uuid"
+    public static let vectorColumn = "vector"
+    public static let metaColumns: [String] = [uuidColumn, vectorColumn]
+    public static let immutableColumns: [String] = [uuidColumn, vectorColumn]
+
+    public static func collections(from json: Any) -> [WeaviateCollection] {
+        let classes: [[String: Any]]
+        if let object = json as? [String: Any] {
+            classes = object["classes"] as? [[String: Any]] ?? []
+        } else if let array = json as? [[String: Any]] {
+            classes = array
+        } else {
+            return []
+        }
+        return classes.compactMap(WeaviateCollection.parse)
+    }
+
+    public static func columns(for collection: WeaviateCollection) -> [(name: String, type: String, isPrimaryKey: Bool)] {
+        var result: [(name: String, type: String, isPrimaryKey: Bool)] = [
+            (uuidColumn, "uuid", true)
+        ]
+        result += collection.properties.map { ($0.name, $0.dataType, false) }
+        result.append((vectorColumn, "vector", false))
+        return result
+    }
+}

--- a/Packages/TableProCore/Sources/TableProWeaviateCore/WeaviateSchema.swift
+++ b/Packages/TableProCore/Sources/TableProWeaviateCore/WeaviateSchema.swift
@@ -2,18 +2,65 @@ import Foundation
 
 public struct WeaviateProperty: Sendable, Equatable {
     public let name: String
-    public let dataType: String
+    public let dataTypes: [String]
+    public let nestedProperties: [WeaviateProperty]
+
+    public var dataType: String { dataTypes.first ?? "text" }
 
     public init(name: String, dataType: String) {
+        self.init(name: name, dataTypes: [dataType], nestedProperties: [])
+    }
+
+    public init(name: String, dataTypes: [String], nestedProperties: [WeaviateProperty]) {
         self.name = name
-        self.dataType = dataType
+        self.dataTypes = dataTypes.isEmpty ? ["text"] : dataTypes
+        self.nestedProperties = nestedProperties
     }
 
     public static func parse(_ json: [String: Any]) -> WeaviateProperty? {
         guard let name = json["name"] as? String, !name.isEmpty else { return nil }
-        let types = json["dataType"] as? [String] ?? []
-        let dataType = types.first ?? "text"
-        return WeaviateProperty(name: name, dataType: dataType)
+        let nested = json["nestedProperties"] as? [[String: Any]] ?? []
+        return WeaviateProperty(
+            name: name,
+            dataTypes: json["dataType"] as? [String] ?? [],
+            nestedProperties: nested.compactMap(WeaviateProperty.parse)
+        )
+    }
+}
+
+/// A GraphQL field with a structured type is refused without a sub-selection: asking for a
+/// `geoCoordinates` property by name answers `Field "place" ... must have a sub selection` and the
+/// whole query fails, taking the filtered browse with it.
+public enum WeaviatePropertyShape: Sendable, Equatable {
+    case scalar
+    case geoCoordinates
+    case phoneNumber
+    case object
+    case crossReference([String])
+
+    private static let scalarTypes: Set<String> = [
+        "text", "string", "int", "number", "boolean", "bool", "date", "uuid", "blob"
+    ]
+
+    public static func of(_ property: WeaviateProperty) -> WeaviatePropertyShape {
+        let names = property.dataTypes.map { element($0) }
+        guard let first = names.first else { return .scalar }
+        if scalarTypes.contains(first.lowercased()) { return .scalar }
+        switch first {
+        case "geoCoordinates": return .geoCoordinates
+        case "phoneNumber": return .phoneNumber
+        case "object": return .object
+        default:
+            return first.first?.isUppercase == true ? .crossReference(names) : .scalar
+        }
+    }
+
+    private static func element(_ dataType: String) -> String {
+        var name = dataType.trimmingCharacters(in: .whitespaces)
+        while name.hasSuffix("[]") {
+            name = String(name.dropLast(2))
+        }
+        return name
     }
 }
 
@@ -43,8 +90,11 @@ public struct WeaviateCollection: Sendable, Equatable {
 public enum WeaviateSchema {
     public static let uuidColumn = "uuid"
     public static let vectorColumn = "vector"
-    public static let metaColumns: [String] = [uuidColumn, vectorColumn]
     public static let immutableColumns: [String] = [uuidColumn, vectorColumn]
+
+    /// Weaviate names the object id `id` inside a `where` or `sort` argument, and normalizes it to
+    /// `_id` in its own errors. The grid calls the same column `uuid`.
+    public static let uuidGraphQLPath = "id"
 
     public static func collections(from json: Any) -> [WeaviateCollection] {
         let classes: [[String: Any]]

--- a/Packages/TableProCore/Sources/TableProWeaviateCore/Wire/WeaviateClient.swift
+++ b/Packages/TableProCore/Sources/TableProWeaviateCore/Wire/WeaviateClient.swift
@@ -35,8 +35,10 @@ public final class WeaviateClient: @unchecked Sendable {
         }
     }
 
+    /// `/v1/.well-known/ready` is the readiness probe and answers 200 with no key at all, so a
+    /// revoked key would leave the health monitor reporting a session every query then fails on.
     public func ping() async throws {
-        let response = try await send(method: "GET", path: "/v1/.well-known/ready")
+        let response = try await send(method: "GET", path: "/v1/meta")
         try throwIfFailed(response)
     }
 

--- a/Packages/TableProCore/Sources/TableProWeaviateCore/Wire/WeaviateClient.swift
+++ b/Packages/TableProCore/Sources/TableProWeaviateCore/Wire/WeaviateClient.swift
@@ -1,0 +1,138 @@
+import Foundation
+
+public final class WeaviateClient: @unchecked Sendable {
+    public let settings: WeaviateConnectionSettings
+    private let transport: WeaviateTransport
+    private let timeout: @Sendable () -> TimeInterval
+    private let lock = NSLock()
+    private var _version: String?
+
+    public init(
+        settings: WeaviateConnectionSettings,
+        transport: WeaviateTransport,
+        timeout: @escaping @Sendable () -> TimeInterval
+    ) {
+        self.settings = settings
+        self.transport = transport
+        self.timeout = timeout
+    }
+
+    public var serverVersion: String? {
+        lock.withLock { _version }
+    }
+
+    public func cancelAll() {
+        transport.cancelAll()
+    }
+
+    public func connect() async throws {
+        let ready = try await send(method: "GET", path: "/v1/.well-known/ready")
+        try throwIfFailed(ready)
+        let meta = try await send(method: "GET", path: "/v1/meta")
+        try throwIfFailed(meta)
+        if let json = WeaviateJSON.dictionary(meta.json), let version = json["version"] as? String {
+            lock.withLock { _version = version }
+        }
+    }
+
+    public func ping() async throws {
+        let response = try await send(method: "GET", path: "/v1/.well-known/ready")
+        try throwIfFailed(response)
+    }
+
+    public func schema() async throws -> [WeaviateCollection] {
+        let response = try await send(method: "GET", path: "/v1/schema")
+        try throwIfFailed(response)
+        guard let json = response.json else {
+            throw WeaviateError.malformedResponse("Schema response was empty.")
+        }
+        return WeaviateSchema.collections(from: json)
+    }
+
+    public func objects(
+        collection: String,
+        limit: Int,
+        offset: Int,
+        includeVector: Bool = true
+    ) async throws -> [WeaviateObject] {
+        var query = [
+            "class": collection,
+            "limit": String(max(limit, 0)),
+            "offset": String(max(offset, 0))
+        ]
+        if includeVector {
+            query["include"] = "vector"
+        }
+        let response = try await send(method: "GET", path: "/v1/objects", query: query)
+        try throwIfFailed(response)
+        guard let json = response.json else { return [] }
+        return WeaviateObject.parseList(json)
+    }
+
+    public func graphql(_ query: String) async throws -> WeaviateHTTPResponse {
+        let body = try WeaviateGraphQL.requestBody(query: query)
+        let response = try await send(method: "POST", path: "/v1/graphql", body: body)
+        try throwIfFailed(response)
+        if let json = response.json {
+            let errors = WeaviateObjectCodec.graphQLErrors(from: json)
+            if !errors.isEmpty {
+                throw WeaviateError.api(status: response.statusCode, message: errors.joined(separator: "\n"))
+            }
+        }
+        return response
+    }
+
+    public func execute(write request: WeaviateWriteRequest) async throws -> WeaviateHTTPResponse {
+        let body = request.body.flatMap { $0.data(using: .utf8) }
+        let response = try await send(
+            method: request.method,
+            path: request.path,
+            query: request.query,
+            body: body
+        )
+        try throwIfFailed(response)
+        return response
+    }
+
+    public func execute(console request: WeaviateConsoleRequest) async throws -> WeaviateHTTPResponse {
+        let body = request.body.flatMap { $0.data(using: .utf8) }
+        let response = try await send(method: request.method, path: request.path, body: body)
+        try throwIfFailed(response)
+        return response
+    }
+
+    public func send(
+        method: String,
+        path: String,
+        query: [String: String] = [:],
+        body: Data? = nil
+    ) async throws -> WeaviateHTTPResponse {
+        let base = try settings.baseURL()
+        guard let url = WeaviatePathEncoding.resolve(path, query: query, against: base) else {
+            throw WeaviateError.configuration("Invalid path: \(path)")
+        }
+        var headers = [
+            "Accept": "application/json"
+        ]
+        if body != nil {
+            headers["Content-Type"] = "application/json"
+        }
+        if let authorization = settings.auth.authorizationHeader {
+            headers["Authorization"] = authorization
+        }
+        let request = WeaviateHTTPRequest(
+            method: method,
+            url: url,
+            headers: headers,
+            body: body,
+            timeoutInterval: timeout()
+        )
+        return try await transport.send(request)
+    }
+
+    public func throwIfFailed(_ response: WeaviateHTTPResponse) throws {
+        guard (200..<300).contains(response.statusCode) else {
+            throw WeaviateError.from(status: response.statusCode, body: response.body)
+        }
+    }
+}

--- a/Packages/TableProCore/Sources/TableProWeaviateCore/Wire/WeaviateClient.swift
+++ b/Packages/TableProCore/Sources/TableProWeaviateCore/Wire/WeaviateClient.swift
@@ -44,7 +44,7 @@ public final class WeaviateClient: @unchecked Sendable {
         let response = try await send(method: "GET", path: "/v1/schema")
         try throwIfFailed(response)
         guard let json = response.json else {
-            throw WeaviateError.malformedResponse("Schema response was empty.")
+            throw WeaviateError.malformedResponse(String(localized: "Schema response was empty."))
         }
         return WeaviateSchema.collections(from: json)
     }
@@ -109,7 +109,7 @@ public final class WeaviateClient: @unchecked Sendable {
     ) async throws -> WeaviateHTTPResponse {
         let base = try settings.baseURL()
         guard let url = WeaviatePathEncoding.resolve(path, query: query, against: base) else {
-            throw WeaviateError.configuration("Invalid path: \(path)")
+            throw WeaviateError.configuration(String(format: String(localized: "Invalid path: %@"), path))
         }
         var headers = [
             "Accept": "application/json"

--- a/Packages/TableProCore/Sources/TableProWeaviateCore/Wire/WeaviateTransport.swift
+++ b/Packages/TableProCore/Sources/TableProWeaviateCore/Wire/WeaviateTransport.swift
@@ -25,18 +25,47 @@ public struct WeaviateHTTPRequest: Sendable, Equatable {
 public struct WeaviateHTTPResponse: Sendable, Equatable {
     public let statusCode: Int
     public let body: Data
+    private let parsed: ParsedResponseJSON
 
     public init(statusCode: Int, body: Data) {
         self.statusCode = statusCode
         self.body = body
+        self.parsed = ParsedResponseJSON(body)
     }
 
+    /// A filtered browse reads this two or three times, and a page of 1536-dimension vectors is
+    /// several megabytes, so the body is parsed once and the result held.
     public var json: Any? {
-        try? JSONSerialization.jsonObject(with: body, options: [.fragmentsAllowed])
+        parsed.value
     }
 
     public var text: String {
         String(data: body, encoding: .utf8) ?? ""
+    }
+
+    public static func == (lhs: WeaviateHTTPResponse, rhs: WeaviateHTTPResponse) -> Bool {
+        lhs.statusCode == rhs.statusCode && lhs.body == rhs.body
+    }
+}
+
+private final class ParsedResponseJSON: @unchecked Sendable {
+    private let body: Data
+    private let lock = NSLock()
+    private var value_: Any?
+    private var hasParsed = false
+
+    init(_ body: Data) {
+        self.body = body
+    }
+
+    var value: Any? {
+        lock.withLock {
+            if !hasParsed {
+                value_ = try? JSONSerialization.jsonObject(with: body, options: [.fragmentsAllowed])
+                hasParsed = true
+            }
+            return value_
+        }
     }
 }
 
@@ -87,7 +116,7 @@ public final class URLSessionWeaviateTransport: WeaviateTransport, @unchecked Se
         do {
             let (data, response) = try await session.data(for: urlRequest, delegate: tracker)
             guard let httpResponse = response as? HTTPURLResponse else {
-                throw WeaviateError.transport("Weaviate answered with something other than HTTP.")
+                throw WeaviateError.transport(String(localized: "Weaviate answered with something other than HTTP."))
             }
             return WeaviateHTTPResponse(statusCode: httpResponse.statusCode, body: data)
         } catch let error as URLError where error.code == .cancelled {
@@ -97,10 +126,6 @@ public final class URLSessionWeaviateTransport: WeaviateTransport, @unchecked Se
         } catch let error as URLError {
             throw WeaviateError.transport(error.localizedDescription)
         }
-    }
-
-    var inFlightCount: Int {
-        lock.withLock { inFlight.count }
     }
 
     fileprivate func register(_ task: URLSessionTask) {

--- a/Packages/TableProCore/Sources/TableProWeaviateCore/Wire/WeaviateTransport.swift
+++ b/Packages/TableProCore/Sources/TableProWeaviateCore/Wire/WeaviateTransport.swift
@@ -1,0 +1,149 @@
+import Foundation
+
+public struct WeaviateHTTPRequest: Sendable, Equatable {
+    public let method: String
+    public let url: URL
+    public let headers: [String: String]
+    public let body: Data?
+    public let timeoutInterval: TimeInterval
+
+    public init(
+        method: String,
+        url: URL,
+        headers: [String: String],
+        body: Data?,
+        timeoutInterval: TimeInterval
+    ) {
+        self.method = method
+        self.url = url
+        self.headers = headers
+        self.body = body
+        self.timeoutInterval = timeoutInterval
+    }
+}
+
+public struct WeaviateHTTPResponse: Sendable, Equatable {
+    public let statusCode: Int
+    public let body: Data
+
+    public init(statusCode: Int, body: Data) {
+        self.statusCode = statusCode
+        self.body = body
+    }
+
+    public var json: Any? {
+        try? JSONSerialization.jsonObject(with: body, options: [.fragmentsAllowed])
+    }
+
+    public var text: String {
+        String(data: body, encoding: .utf8) ?? ""
+    }
+}
+
+public protocol WeaviateTransport: Sendable {
+    func send(_ request: WeaviateHTTPRequest) async throws -> WeaviateHTTPResponse
+    func cancelAll()
+}
+
+public final class URLSessionWeaviateTransport: WeaviateTransport, @unchecked Sendable {
+    private let session: URLSession
+    private let lock = NSLock()
+    private var inFlight: [ObjectIdentifier: URLSessionTask] = [:]
+
+    public init(
+        configuration: URLSessionConfiguration = .ephemeral,
+        resourceTimeout: TimeInterval,
+        skipTLSVerify: Bool = false
+    ) {
+        configuration.timeoutIntervalForResource = resourceTimeout
+        if skipTLSVerify {
+            let delegate = InsecureTLSDelegate()
+            session = URLSession(configuration: configuration, delegate: delegate, delegateQueue: nil)
+        } else {
+            session = URLSession(configuration: configuration)
+        }
+    }
+
+    deinit {
+        session.invalidateAndCancel()
+    }
+
+    public func cancelAll() {
+        let tasks = lock.withLock { Array(inFlight.values) }
+        tasks.forEach { $0.cancel() }
+    }
+
+    public func send(_ request: WeaviateHTTPRequest) async throws -> WeaviateHTTPResponse {
+        var urlRequest = URLRequest(url: request.url)
+        urlRequest.httpMethod = request.method
+        urlRequest.httpBody = request.body
+        urlRequest.timeoutInterval = request.timeoutInterval
+        for (name, value) in request.headers {
+            urlRequest.setValue(value, forHTTPHeaderField: name)
+        }
+
+        let tracker = TaskTracker(transport: self)
+        defer { tracker.finish() }
+        do {
+            let (data, response) = try await session.data(for: urlRequest, delegate: tracker)
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw WeaviateError.transport("Weaviate answered with something other than HTTP.")
+            }
+            return WeaviateHTTPResponse(statusCode: httpResponse.statusCode, body: data)
+        } catch let error as URLError where error.code == .cancelled {
+            throw WeaviateError.cancelled
+        } catch let error as WeaviateError {
+            throw error
+        } catch let error as URLError {
+            throw WeaviateError.transport(error.localizedDescription)
+        }
+    }
+
+    var inFlightCount: Int {
+        lock.withLock { inFlight.count }
+    }
+
+    fileprivate func register(_ task: URLSessionTask) {
+        lock.withLock { inFlight[ObjectIdentifier(task)] = task }
+    }
+
+    fileprivate func unregister(_ task: URLSessionTask) {
+        lock.withLock { inFlight[ObjectIdentifier(task)] = nil }
+    }
+}
+
+private final class InsecureTLSDelegate: NSObject, URLSessionDelegate {
+    func urlSession(
+        _ session: URLSession,
+        didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        guard challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
+              let trust = challenge.protectionSpace.serverTrust
+        else {
+            completionHandler(.performDefaultHandling, nil)
+            return
+        }
+        completionHandler(.useCredential, URLCredential(trust: trust))
+    }
+}
+
+private final class TaskTracker: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
+    private weak var transport: URLSessionWeaviateTransport?
+    private let lock = NSLock()
+    private var task: URLSessionTask?
+
+    init(transport: URLSessionWeaviateTransport) {
+        self.transport = transport
+    }
+
+    func urlSession(_ session: URLSession, didCreateTask task: URLSessionTask) {
+        lock.withLock { self.task = task }
+        transport?.register(task)
+    }
+
+    func finish() {
+        guard let task = lock.withLock({ task }) else { return }
+        transport?.unregister(task)
+    }
+}

--- a/Packages/TableProCore/Tests/TableProModelsTests/DatabaseTypeTests.swift
+++ b/Packages/TableProCore/Tests/TableProModelsTests/DatabaseTypeTests.swift
@@ -59,7 +59,7 @@ struct DatabaseTypeTests {
 
     @Test("allKnownTypes contains all expected types")
     func allKnownTypesComplete() {
-        #expect(DatabaseType.allKnownTypes.count == 28)
+        #expect(DatabaseType.allKnownTypes.count == 29)
         #expect(DatabaseType.allKnownTypes.contains(.mysql))
         #expect(DatabaseType.allKnownTypes.contains(.tidb))
         #expect(DatabaseType.allKnownTypes.contains(.databend))
@@ -74,6 +74,7 @@ struct DatabaseTypeTests {
         #expect(DatabaseType.allKnownTypes.contains(.dameng))
         #expect(DatabaseType.allKnownTypes.contains(.kafka))
         #expect(DatabaseType.allKnownTypes.contains(.cloudflareR2SQL))
+        #expect(DatabaseType.allKnownTypes.contains(.weaviate))
     }
 
     /// The list has no duplicates, which a count alone would not catch: adding a type twice
@@ -89,6 +90,13 @@ struct DatabaseTypeTests {
         #expect(DatabaseType.cloudflareR2SQL.rawValue == "Cloudflare R2 SQL")
         #expect(DatabaseType.cloudflareR2SQL.iconName == "cloudflare-r2-sql-icon")
         #expect(DatabaseType.cloudflareR2SQL.pluginTypeId == "Cloudflare R2 SQL")
+    }
+
+    @Test("Weaviate resolves its icon and plugin type id")
+    func weaviateIdentity() {
+        #expect(DatabaseType.weaviate.rawValue == "Weaviate")
+        #expect(DatabaseType.weaviate.iconName == "weaviate-icon")
+        #expect(DatabaseType.weaviate.pluginTypeId == "Weaviate")
     }
 
     @Test("Hashable conformance")

--- a/Packages/TableProCore/Tests/TableProWeaviateCoreTests/WeaviateAuthAndQueryTests.swift
+++ b/Packages/TableProCore/Tests/TableProWeaviateCoreTests/WeaviateAuthAndQueryTests.swift
@@ -164,6 +164,8 @@ struct WeaviateGraphQLTests {
     @Test("A SQL delete is not a console request")
     func sqlIsNotConsole() {
         #expect(WeaviateConsoleParser.parse("DELETE FROM Article") == nil)
+        #expect(WeaviateConsoleParser.parse("UPDATE Article SET title = 'x'") == nil)
+        #expect(WeaviateConsoleParser.parse("GET schema") == nil)
     }
 }
 

--- a/Packages/TableProCore/Tests/TableProWeaviateCoreTests/WeaviateAuthAndQueryTests.swift
+++ b/Packages/TableProCore/Tests/TableProWeaviateCoreTests/WeaviateAuthAndQueryTests.swift
@@ -25,6 +25,20 @@ struct WeaviateAuthTests {
         }
     }
 
+    @Test("A pasted key is sent even when Auth Method is still None")
+    func noneModeSendsAPastedKey() throws {
+        let settings = try WeaviateConnectionSettings.parse(
+            host: "localhost",
+            port: 8_080,
+            usesTLS: false,
+            fields: [
+                WeaviateFieldID.authMethod: "none",
+                WeaviateFieldID.apiKey: "wv-secret"
+            ]
+        )
+        #expect(settings.auth.authorizationHeader == "Bearer wv-secret")
+    }
+
     @Test("None mode does not require a key")
     func noneModeConnects() throws {
         let settings = try WeaviateConnectionSettings.parse(

--- a/Packages/TableProCore/Tests/TableProWeaviateCoreTests/WeaviateAuthAndQueryTests.swift
+++ b/Packages/TableProCore/Tests/TableProWeaviateCoreTests/WeaviateAuthAndQueryTests.swift
@@ -166,4 +166,14 @@ struct WeaviateSchemaTests {
         #expect(columns.first?.isPrimaryKey == true)
         #expect(WeaviateSchema.immutableColumns == ["uuid", "vector"])
     }
+
+    @Test("Object and array properties display as JSON")
+    func displayTextEncodesCollections() {
+        #expect(WeaviateJSON.displayText(["title": "Hello"]) == "{\"title\":\"Hello\"}")
+        let vector = WeaviateJSON.displayText([0.1, 0.2])
+        #expect(vector?.hasPrefix("[") == true)
+        #expect(vector?.hasSuffix("]") == true)
+        #expect(WeaviateJSON.displayText(true) == "true")
+        #expect(WeaviateJSON.displayText(NSNull()) == nil)
+    }
 }

--- a/Packages/TableProCore/Tests/TableProWeaviateCoreTests/WeaviateAuthAndQueryTests.swift
+++ b/Packages/TableProCore/Tests/TableProWeaviateCoreTests/WeaviateAuthAndQueryTests.swift
@@ -25,8 +25,8 @@ struct WeaviateAuthTests {
         }
     }
 
-    @Test("A pasted key is sent even when Auth Method is still None")
-    func noneModeSendsAPastedKey() throws {
+    @Test("A pasted key is not sent when Auth Method is None")
+    func noneModeIgnoresAPastedKey() throws {
         let settings = try WeaviateConnectionSettings.parse(
             host: "localhost",
             port: 8_080,
@@ -36,7 +36,7 @@ struct WeaviateAuthTests {
                 WeaviateFieldID.apiKey: "wv-secret"
             ]
         )
-        #expect(settings.auth.authorizationHeader == "Bearer wv-secret")
+        #expect(settings.auth.authorizationHeader == nil)
     }
 
     @Test("None mode does not require a key")
@@ -122,15 +122,16 @@ struct WeaviateQueryTests {
 @Suite("Weaviate GraphQL and console")
 struct WeaviateGraphQLTests {
     @Test("A Get query asks for _additional id and vector")
-    func getQueryIncludesAdditional() {
-        let query = WeaviateGraphQL.getQuery(
+    func getQueryIncludesAdditional() throws {
+        let query = try WeaviateGraphQL.getQuery(
             collection: "Article",
             properties: ["uuid", "title", "vector"],
             limit: 10,
             offset: 0,
             sorts: [],
             filters: [WeaviateFilterSpec(column: "title", op: "=", value: "Hello")],
-            logicMode: "AND"
+            logicMode: "AND",
+            schema: ["title": WeaviateProperty(name: "title", dataType: "text")]
         )
         #expect(query.contains("Get"))
         #expect(query.contains("Article"))
@@ -145,7 +146,6 @@ struct WeaviateGraphQLTests {
     func detection() {
         #expect(WeaviateGraphQL.looksLikeGraphQL("{ Get { Article { title } } }"))
         #expect(WeaviateGraphQL.looksLikeGraphQL("query { Get { Article { title } } }"))
-        #expect(WeaviateGraphQL.isMutation("mutation { delete { Article } }"))
         #expect(!WeaviateGraphQL.looksLikeGraphQL("GET /v1/schema"))
     }
 

--- a/Packages/TableProCore/Tests/TableProWeaviateCoreTests/WeaviateAuthAndQueryTests.swift
+++ b/Packages/TableProCore/Tests/TableProWeaviateCoreTests/WeaviateAuthAndQueryTests.swift
@@ -1,0 +1,169 @@
+import Foundation
+import Testing
+@testable import TableProWeaviateCore
+
+@Suite("Weaviate auth and settings")
+struct WeaviateAuthTests {
+    @Test("Field ids stay Weaviate-prefixed")
+    func fieldIdsArePrefixed() {
+        #expect(WeaviateFieldID.authMethod == "wvAuthMethod")
+        #expect(WeaviateFieldID.apiKey == "wvApiKey")
+        #expect(WeaviateFieldID.skipTLSVerify == "wvSkipTLSVerify")
+        #expect(WeaviateFieldID.authMethod != "esAuthMethod")
+        #expect(WeaviateFieldID.apiKey != "esApiKey")
+    }
+
+    @Test("API key mode without a key is refused")
+    func apiKeyRequiresValue() {
+        #expect(throws: WeaviateError.configuration("Enter a Weaviate API key.")) {
+            _ = try WeaviateConnectionSettings.parse(
+                host: "localhost",
+                port: 8_080,
+                usesTLS: false,
+                fields: [WeaviateFieldID.authMethod: "apiKey"]
+            )
+        }
+    }
+
+    @Test("None mode does not require a key")
+    func noneModeConnects() throws {
+        let settings = try WeaviateConnectionSettings.parse(
+            host: "localhost",
+            port: 0,
+            usesTLS: false,
+            fields: [WeaviateFieldID.authMethod: "none"]
+        )
+        #expect(settings.port == 8_080)
+        #expect(settings.auth.authorizationHeader == nil)
+        #expect(try settings.baseURL().absoluteString == "http://localhost:8080")
+    }
+
+    @Test("TLS uses https")
+    func tlsUsesHTTPS() throws {
+        let settings = try WeaviateConnectionSettings.parse(
+            host: "example.weaviate.cloud",
+            port: 443,
+            usesTLS: true,
+            fields: [
+                WeaviateFieldID.authMethod: "apiKey",
+                WeaviateFieldID.apiKey: "key"
+            ]
+        )
+        #expect(try settings.baseURL().absoluteString == "https://example.weaviate.cloud:443")
+        #expect(settings.auth.authorizationHeader == "Bearer key")
+    }
+}
+
+@Suite("Weaviate query tags")
+struct WeaviateQueryTests {
+    @Test("Browse tags round-trip")
+    func browseRoundTrip() throws {
+        let encoded = WeaviateBrowseQuery.encode(
+            collection: "Article",
+            offset: 10,
+            limit: 25,
+            sorts: [WeaviateSortSpec(column: "title", ascending: true)],
+            filters: [WeaviateFilterSpec(column: "title", op: "=", value: "Hello")],
+            logicMode: "AND",
+            propertyNames: ["uuid", "title"]
+        )
+        #expect(WeaviateBrowseQuery.isTagged(encoded))
+        let parsed = try #require(WeaviateBrowseQuery.parse(encoded))
+        #expect(parsed.collection == "Article")
+        #expect(parsed.offset == 10)
+        #expect(parsed.limit == 25)
+        #expect(parsed.usesGraphQL)
+        #expect(parsed.filters.first?.value == "Hello")
+    }
+
+    @Test("An unfiltered browse stays on REST objects")
+    func unfilteredUsesREST() throws {
+        let encoded = WeaviateBrowseQuery.encode(
+            collection: "Article",
+            offset: 0,
+            limit: 25,
+            sorts: [],
+            filters: [],
+            logicMode: "AND",
+            propertyNames: ["uuid", "title"]
+        )
+        let parsed = try #require(WeaviateBrowseQuery.parse(encoded))
+        #expect(!parsed.usesGraphQL)
+    }
+
+    @Test("Write tags round-trip")
+    func writeRoundTrip() throws {
+        let original = WeaviateWriteRequest(
+            method: "PATCH",
+            path: "/v1/objects/abc",
+            query: ["class": "Article"],
+            body: "{\"title\":\"x\"}"
+        )
+        let encoded = WeaviateWriteCodec.encode(original)
+        #expect(WeaviateWriteCodec.isTagged(encoded))
+        #expect(WeaviateWriteCodec.decode(encoded) == original)
+    }
+}
+
+@Suite("Weaviate GraphQL and console")
+struct WeaviateGraphQLTests {
+    @Test("A Get query asks for _additional id and vector")
+    func getQueryIncludesAdditional() {
+        let query = WeaviateGraphQL.getQuery(
+            collection: "Article",
+            properties: ["uuid", "title", "vector"],
+            limit: 10,
+            offset: 0,
+            sorts: [],
+            filters: [WeaviateFilterSpec(column: "title", op: "=", value: "Hello")],
+            logicMode: "AND"
+        )
+        #expect(query.contains("Get"))
+        #expect(query.contains("Article"))
+        #expect(query.contains("title"))
+        #expect(query.contains("_additional { id vector }"))
+        #expect(query.contains("operator: Equal"))
+        #expect(query.contains("valueText: \"Hello\""))
+        #expect(!query.contains(" uuid "))
+    }
+
+    @Test("GraphQL detection")
+    func detection() {
+        #expect(WeaviateGraphQL.looksLikeGraphQL("{ Get { Article { title } } }"))
+        #expect(WeaviateGraphQL.looksLikeGraphQL("query { Get { Article { title } } }"))
+        #expect(WeaviateGraphQL.isMutation("mutation { delete { Article } }"))
+        #expect(!WeaviateGraphQL.looksLikeGraphQL("GET /v1/schema"))
+    }
+
+    @Test("Console parser reads a method and path")
+    func consoleParser() throws {
+        let request = try #require(WeaviateConsoleParser.parse("GET /v1/schema"))
+        #expect(request.method == "GET")
+        #expect(request.path == "/v1/schema")
+        #expect(request.body == nil)
+
+        let withBody = try #require(WeaviateConsoleParser.parse("POST /v1/graphql\n{ \"query\": \"{ Get { Article { title } } }\" }"))
+        #expect(withBody.method == "POST")
+        #expect(withBody.body?.contains("Get") == true)
+    }
+
+    @Test("A SQL delete is not a console request")
+    func sqlIsNotConsole() {
+        #expect(WeaviateConsoleParser.parse("DELETE FROM Article") == nil)
+    }
+}
+
+@Suite("Weaviate columns")
+struct WeaviateSchemaTests {
+    @Test("uuid leads and vector trails, and both are the primary key surface")
+    func columnOrder() {
+        let collection = WeaviateCollection(
+            name: "Article",
+            properties: [WeaviateProperty(name: "title", dataType: "text")]
+        )
+        let columns = WeaviateSchema.columns(for: collection)
+        #expect(columns.map(\.name) == ["uuid", "title", "vector"])
+        #expect(columns.first?.isPrimaryKey == true)
+        #expect(WeaviateSchema.immutableColumns == ["uuid", "vector"])
+    }
+}

--- a/Packages/TableProCore/Tests/TableProWeaviateCoreTests/WeaviateClientTests.swift
+++ b/Packages/TableProCore/Tests/TableProWeaviateCoreTests/WeaviateClientTests.swift
@@ -20,7 +20,7 @@ struct WeaviateClientTests {
     @Test("An API key is sent as a Bearer header")
     func apiKeyIsBearer() async throws {
         let transport = FakeWeaviateTransport()
-        transport.respond(method: "GET", path: "/v1/.well-known/ready", status: 200, body: ".")
+        transport.respond(method: "GET", path: "/v1/meta", status: 200, json: WeaviateFixtures.meta)
         let client = testClient(
             transport: transport,
             auth: WeaviateAuth(method: .apiKey, apiKey: "wv-secret")
@@ -31,10 +31,21 @@ struct WeaviateClientTests {
         #expect(transport.requests.first?.headers["Authorization"] == "Bearer wv-secret")
     }
 
+    @Test("A ping asks an endpoint that checks the key")
+    func pingIsAuthenticated() async throws {
+        let transport = FakeWeaviateTransport()
+        transport.respond(method: "GET", path: "/v1/meta", status: 200, json: WeaviateFixtures.meta)
+        let client = testClient(transport: transport)
+
+        try await client.ping()
+
+        #expect(transport.requests.map { $0.url.path } == ["/v1/meta"])
+    }
+
     @Test("Anonymous auth sends no Authorization header")
     func anonymousHasNoAuthorization() async throws {
         let transport = FakeWeaviateTransport()
-        transport.respond(method: "GET", path: "/v1/.well-known/ready", status: 200, body: ".")
+        transport.respond(method: "GET", path: "/v1/meta", status: 200, json: WeaviateFixtures.meta)
         let client = testClient(transport: transport)
 
         try await client.ping()
@@ -81,7 +92,7 @@ struct WeaviateClientTests {
         let transport = FakeWeaviateTransport()
         transport.respond(
             method: "GET",
-            path: "/v1/.well-known/ready",
+            path: "/v1/meta",
             status: 401,
             json: ["error": [["message": "invalid api key"]]]
         )

--- a/Packages/TableProCore/Tests/TableProWeaviateCoreTests/WeaviateClientTests.swift
+++ b/Packages/TableProCore/Tests/TableProWeaviateCoreTests/WeaviateClientTests.swift
@@ -144,7 +144,7 @@ struct WeaviateClientTests {
 struct WeaviateUUIDEditTests {
     @Test("An update is a PATCH keyed by uuid and does not write uuid or vector")
     func updateIsPatchByUUID() async throws {
-        let requests = WeaviateStatementGenerator.generate(
+        let batch = WeaviateStatementGenerator.generate(
             collection: "Article",
             columns: ["uuid", "title", "vector"],
             typeNames: ["uuid", "text", "vector"],
@@ -161,7 +161,7 @@ struct WeaviateUUIDEditTests {
                 )
             ]
         )
-        let request = try #require(requests.first)
+        let request = try #require(batch.requests.first)
         #expect(request.method == "PATCH")
         #expect(request.path == "/v1/objects/\(WeaviateFixtures.articleUUID)")
         #expect(request.query["class"] == "Article")
@@ -185,7 +185,7 @@ struct WeaviateUUIDEditTests {
 
     @Test("A delete is DELETE /v1/objects/{uuid}")
     func deleteUsesUUID() async throws {
-        let requests = WeaviateStatementGenerator.generate(
+        let batch = WeaviateStatementGenerator.generate(
             collection: "Article",
             columns: ["uuid", "title"],
             typeNames: ["uuid", "text"],
@@ -198,7 +198,7 @@ struct WeaviateUUIDEditTests {
                 )
             ]
         )
-        let request = try #require(requests.first)
+        let request = try #require(batch.requests.first)
         #expect(request.method == "DELETE")
         #expect(request.path.hasSuffix(WeaviateFixtures.articleUUID))
 
@@ -216,7 +216,7 @@ struct WeaviateUUIDEditTests {
 
     @Test("An update without a uuid is skipped")
     func updateWithoutUUIDIsSkipped() {
-        let requests = WeaviateStatementGenerator.generate(
+        let batch = WeaviateStatementGenerator.generate(
             collection: "Article",
             columns: ["uuid", "title"],
             typeNames: ["uuid", "text"],
@@ -229,12 +229,13 @@ struct WeaviateUUIDEditTests {
                 )
             ]
         )
-        #expect(requests.isEmpty)
+        #expect(batch.requests.isEmpty)
+        #expect(batch.skipped == [WeaviateSkippedChange(kind: .update, reason: .missingUUID)])
     }
 
     @Test("Insert posts the collection and properties, and an explicit uuid")
     func insertPostsObject() throws {
-        let requests = WeaviateStatementGenerator.generate(
+        let batch = WeaviateStatementGenerator.generate(
             collection: "Article",
             columns: ["uuid", "title", "wordCount"],
             typeNames: ["uuid", "text", "int"],
@@ -251,7 +252,7 @@ struct WeaviateUUIDEditTests {
                 )
             ]
         )
-        let request = try #require(requests.first)
+        let request = try #require(batch.requests.first)
         #expect(request.method == "POST")
         #expect(request.path == "/v1/objects")
         let body = try #require(request.body)

--- a/Packages/TableProCore/Tests/TableProWeaviateCoreTests/WeaviateClientTests.swift
+++ b/Packages/TableProCore/Tests/TableProWeaviateCoreTests/WeaviateClientTests.swift
@@ -1,0 +1,267 @@
+import Foundation
+import Testing
+@testable import TableProWeaviateCore
+
+@Suite("Weaviate client")
+struct WeaviateClientTests {
+    @Test("Connect reads ready and meta, and stores the version")
+    func connectStoresVersion() async throws {
+        let transport = FakeWeaviateTransport()
+        transport.respond(method: "GET", path: "/v1/.well-known/ready", status: 200, body: ".")
+        transport.respond(method: "GET", path: "/v1/meta", status: 200, json: WeaviateFixtures.meta)
+        let client = testClient(transport: transport)
+
+        try await client.connect()
+
+        #expect(client.serverVersion == "1.27.0")
+        #expect(transport.requests.map { $0.url.path } == ["/v1/.well-known/ready", "/v1/meta"])
+    }
+
+    @Test("An API key is sent as a Bearer header")
+    func apiKeyIsBearer() async throws {
+        let transport = FakeWeaviateTransport()
+        transport.respond(method: "GET", path: "/v1/.well-known/ready", status: 200, body: ".")
+        let client = testClient(
+            transport: transport,
+            auth: WeaviateAuth(method: .apiKey, apiKey: "wv-secret")
+        )
+
+        try await client.ping()
+
+        #expect(transport.requests.first?.headers["Authorization"] == "Bearer wv-secret")
+    }
+
+    @Test("Anonymous auth sends no Authorization header")
+    func anonymousHasNoAuthorization() async throws {
+        let transport = FakeWeaviateTransport()
+        transport.respond(method: "GET", path: "/v1/.well-known/ready", status: 200, body: ".")
+        let client = testClient(transport: transport)
+
+        try await client.ping()
+
+        #expect(transport.requests.first?.headers["Authorization"] == nil)
+    }
+
+    @Test("Schema lists collections and properties")
+    func schemaListsCollections() async throws {
+        let transport = FakeWeaviateTransport()
+        transport.respond(method: "GET", path: "/v1/schema", status: 200, json: WeaviateFixtures.schema)
+        let client = testClient(transport: transport)
+
+        let collections = try await client.schema()
+
+        #expect(collections.map(\.name) == ["Article"])
+        #expect(collections.first?.properties.map(\.name) == ["title", "wordCount"])
+        #expect(collections.first?.properties.map(\.dataType) == ["text", "int"])
+    }
+
+    @Test("Objects include uuid, properties and the vector as display text")
+    func objectsIncludeUUIDAndVector() async throws {
+        let transport = FakeWeaviateTransport()
+        transport.respond(method: "GET", path: "/v1/objects", status: 200, json: WeaviateFixtures.objects)
+        let client = testClient(transport: transport)
+
+        let objects = try await client.objects(collection: "Article", limit: 25, offset: 0)
+        let object = try #require(objects.first)
+        let columns = ["uuid", "title", "wordCount", "vector"]
+        let row = WeaviateObjectCodec.row(for: object, columns: columns)
+
+        #expect(object.uuid == WeaviateFixtures.articleUUID)
+        #expect(row[0] == WeaviateFixtures.articleUUID)
+        #expect(row[1] == "Hello")
+        #expect(row[2] == "12")
+        #expect(row[3]?.contains("0.1") == true)
+        #expect(row[3]?.hasPrefix("[") == true)
+        #expect(transport.requests.first?.url.query?.contains("class=Article") == true)
+        #expect(transport.requests.first?.url.query?.contains("include=vector") == true)
+    }
+
+    @Test("HTTP 401 becomes an authentication error")
+    func unauthorizedIsAuthentication() async throws {
+        let transport = FakeWeaviateTransport()
+        transport.respond(
+            method: "GET",
+            path: "/v1/.well-known/ready",
+            status: 401,
+            json: ["error": [["message": "invalid api key"]]]
+        )
+        let client = testClient(transport: transport)
+
+        await #expect(throws: WeaviateError.authentication("invalid api key")) {
+            try await client.ping()
+        }
+    }
+
+    @Test("A server error body is surfaced")
+    func serverErrorMessage() async throws {
+        let transport = FakeWeaviateTransport()
+        transport.respond(
+            method: "GET",
+            path: "/v1/schema",
+            status: 500,
+            json: ["error": [["message": "store unavailable"]]]
+        )
+        let client = testClient(transport: transport)
+
+        await #expect(throws: WeaviateError.api(status: 500, message: "store unavailable")) {
+            _ = try await client.schema()
+        }
+    }
+
+    @Test("GraphQL Get rows flatten uuid from _additional")
+    func graphqlGetFlattensUUID() async throws {
+        let transport = FakeWeaviateTransport()
+        transport.respond(method: "POST", path: "/v1/graphql", status: 200, json: WeaviateFixtures.graphqlGet)
+        let client = testClient(transport: transport)
+
+        let response = try await client.graphql("{ Get { Article { title } } }")
+        let objects = WeaviateObjectCodec.objects(fromGraphQL: response.json as Any)
+        let object = try #require(objects.first)
+
+        #expect(object.uuid == WeaviateFixtures.articleUUID)
+        #expect(object.properties["title"] == "Hello")
+        #expect(object.vectorText?.contains("0.1") == true)
+    }
+
+    @Test("GraphQL errors in a 200 response still fail")
+    func graphqlErrorsFail() async throws {
+        let transport = FakeWeaviateTransport()
+        transport.respond(
+            method: "POST",
+            path: "/v1/graphql",
+            status: 200,
+            json: ["errors": [["message": "Cannot query field"]]]
+        )
+        let client = testClient(transport: transport)
+
+        await #expect(throws: WeaviateError.api(status: 200, message: "Cannot query field")) {
+            _ = try await client.graphql("{ Get { Missing { title } } }")
+        }
+    }
+}
+
+@Suite("Weaviate uuid edits")
+struct WeaviateUUIDEditTests {
+    @Test("An update is a PATCH keyed by uuid and does not write uuid or vector")
+    func updateIsPatchByUUID() async throws {
+        let requests = WeaviateStatementGenerator.generate(
+            collection: "Article",
+            columns: ["uuid", "title", "vector"],
+            typeNames: ["uuid", "text", "vector"],
+            changes: [
+                WeaviateTrackedChange(
+                    kind: .update,
+                    uuid: WeaviateFixtures.articleUUID,
+                    values: [:],
+                    cellChanges: [
+                        WeaviateCellChange(column: "title", newText: "Edited"),
+                        WeaviateCellChange(column: "vector", newText: "[9,9]"),
+                        WeaviateCellChange(column: "uuid", newText: "nope")
+                    ]
+                )
+            ]
+        )
+        let request = try #require(requests.first)
+        #expect(request.method == "PATCH")
+        #expect(request.path == "/v1/objects/\(WeaviateFixtures.articleUUID)")
+        #expect(request.query["class"] == "Article")
+        let body = try #require(request.body)
+        #expect(body.contains("\"title\":\"Edited\""))
+        #expect(!body.contains("vector"))
+        #expect(!body.contains("nope"))
+
+        let transport = FakeWeaviateTransport()
+        transport.respond(
+            method: "PATCH",
+            path: "/v1/objects/\(WeaviateFixtures.articleUUID)",
+            status: 200,
+            json: ["id": WeaviateFixtures.articleUUID]
+        )
+        let client = testClient(transport: transport)
+        let response = try await client.execute(write: request)
+        #expect(response.statusCode == 200)
+        #expect(transport.requests.first?.httpMethodMatchesPatch == true)
+    }
+
+    @Test("A delete is DELETE /v1/objects/{uuid}")
+    func deleteUsesUUID() async throws {
+        let requests = WeaviateStatementGenerator.generate(
+            collection: "Article",
+            columns: ["uuid", "title"],
+            typeNames: ["uuid", "text"],
+            changes: [
+                WeaviateTrackedChange(
+                    kind: .delete,
+                    uuid: WeaviateFixtures.articleUUID,
+                    values: [:],
+                    cellChanges: []
+                )
+            ]
+        )
+        let request = try #require(requests.first)
+        #expect(request.method == "DELETE")
+        #expect(request.path.hasSuffix(WeaviateFixtures.articleUUID))
+
+        let transport = FakeWeaviateTransport()
+        transport.respond(
+            method: "DELETE",
+            path: "/v1/objects/\(WeaviateFixtures.articleUUID)",
+            status: 204,
+            body: ""
+        )
+        let client = testClient(transport: transport)
+        let response = try await client.execute(write: request)
+        #expect(response.statusCode == 204)
+    }
+
+    @Test("An update without a uuid is skipped")
+    func updateWithoutUUIDIsSkipped() {
+        let requests = WeaviateStatementGenerator.generate(
+            collection: "Article",
+            columns: ["uuid", "title"],
+            typeNames: ["uuid", "text"],
+            changes: [
+                WeaviateTrackedChange(
+                    kind: .update,
+                    uuid: nil,
+                    values: [:],
+                    cellChanges: [WeaviateCellChange(column: "title", newText: "Edited")]
+                )
+            ]
+        )
+        #expect(requests.isEmpty)
+    }
+
+    @Test("Insert posts the collection and properties, and an explicit uuid")
+    func insertPostsObject() throws {
+        let requests = WeaviateStatementGenerator.generate(
+            collection: "Article",
+            columns: ["uuid", "title", "wordCount"],
+            typeNames: ["uuid", "text", "int"],
+            changes: [
+                WeaviateTrackedChange(
+                    kind: .insert,
+                    uuid: WeaviateFixtures.articleUUID,
+                    values: [
+                        "uuid": WeaviateFixtures.articleUUID,
+                        "title": "Hello",
+                        "wordCount": "12"
+                    ],
+                    cellChanges: []
+                )
+            ]
+        )
+        let request = try #require(requests.first)
+        #expect(request.method == "POST")
+        #expect(request.path == "/v1/objects")
+        let body = try #require(request.body)
+        #expect(body.contains("\"class\":\"Article\""))
+        #expect(body.contains("\"id\":\"\(WeaviateFixtures.articleUUID)\""))
+        #expect(body.contains("\"title\":\"Hello\""))
+        #expect(body.contains("\"wordCount\":12"))
+    }
+}
+
+private extension WeaviateHTTPRequest {
+    var httpMethodMatchesPatch: Bool { method == "PATCH" }
+}

--- a/Packages/TableProCore/Tests/TableProWeaviateCoreTests/WeaviateFilterAndPathTests.swift
+++ b/Packages/TableProCore/Tests/TableProWeaviateCoreTests/WeaviateFilterAndPathTests.swift
@@ -462,3 +462,104 @@ struct WeaviateSelectionSetTests {
         #expect(WeaviatePropertyShape.of(properties[1]) == .crossReference(["Category"]))
     }
 }
+
+@Suite("Weaviate value round-trip")
+struct WeaviateParsedValueTests {
+    @Test("Text keeps its own punctuation instead of being parsed as JSON")
+    func textStaysText() {
+        #expect(WeaviateJSON.parsedValue("{\"a\":1}", typeName: "text") as? String == "{\"a\":1}")
+        #expect(WeaviateJSON.parsedValue("[1,2]", typeName: "text") as? String == "[1,2]")
+        #expect(WeaviateJSON.parsedValue("{\"a\":1}", typeName: "string") as? String == "{\"a\":1}")
+        #expect(WeaviateJSON.parsedValue("2024-01-31T00:00:00Z", typeName: "date") as? String == "2024-01-31T00:00:00Z")
+    }
+
+    @Test("A type the grid renders as JSON parses back")
+    func structuredParsesBack() {
+        #expect(WeaviateJSON.parsedValue("[\"a\",\"b\"]", typeName: "text[]") as? [String] == ["a", "b"])
+        #expect(WeaviateJSON.parsedValue("[1,2]", typeName: "int[]") as? [Int] == [1, 2])
+        let object = WeaviateJSON.parsedValue("{\"k\":\"v\"}", typeName: "object") as? [String: Any]
+        #expect(object?["k"] as? String == "v")
+        let geo = WeaviateJSON.parsedValue("{\"latitude\":1}", typeName: "geoCoordinates") as? [String: Any]
+        #expect(geo?["latitude"] as? Int == 1)
+    }
+
+    @Test("A scalar parses to its own type, and an unparsable one stays text")
+    func scalarsParse() {
+        #expect(WeaviateJSON.parsedValue("12", typeName: "int") as? Int == 12)
+        #expect(WeaviateJSON.parsedValue("1.5", typeName: "number") as? Double == 1.5)
+        #expect(WeaviateJSON.parsedValue("true", typeName: "boolean") as? Bool == true)
+        #expect(WeaviateJSON.parsedValue("abc", typeName: "int") as? String == "abc")
+        #expect(WeaviateJSON.parsedValue("yes", typeName: "boolean") as? String == "yes")
+    }
+
+    @Test("A property named with a leading underscore is written, and a synthetic column is not")
+    func underscoreNamedPropertyIsWritten() throws {
+        let batch = WeaviateStatementGenerator.generate(
+            collection: "Event",
+            columns: ["uuid", "_source", "distance"],
+            typeNames: ["uuid", "text", "number"],
+            changes: [
+                WeaviateTrackedChange(
+                    kind: .update,
+                    uuid: "c8f5c3e0-1b2a-4d3e-9f10-111213141516",
+                    values: [:],
+                    cellChanges: [
+                        WeaviateCellChange(column: "_source", newText: "manual"),
+                        WeaviateCellChange(column: "_additional.distance", newText: "0.4")
+                    ]
+                )
+            ]
+        )
+        let body = try #require(batch.requests.first?.body)
+        #expect(body.contains("\"_source\":\"manual\""))
+        #expect(!body.contains("_additional"))
+    }
+}
+
+@Suite("Weaviate console requests")
+struct WeaviateConsoleRequestTests {
+    @Test("A body typed on the request line is kept")
+    func inlineBodySurvives() throws {
+        let request = try #require(
+            WeaviateConsoleParser.parse("POST /v1/objects {\"class\": \"Article\"}")
+        )
+        #expect(request.method == "POST")
+        #expect(request.path == "/v1/objects")
+        #expect(request.body == "{\"class\": \"Article\"}")
+    }
+
+    @Test("A body on the lines below still wins")
+    func multilineBodyWins() throws {
+        let request = try #require(WeaviateConsoleParser.parse("POST /v1/graphql\n{ \"query\": \"x\" }"))
+        #expect(request.body == "{ \"query\": \"x\" }")
+    }
+
+    @Test("Any path is resolved under /v1")
+    func everyPathIsPrefixed() throws {
+        #expect(try #require(WeaviateConsoleParser.parse("GET /nodes")).path == "/v1/nodes")
+        #expect(try #require(WeaviateConsoleParser.parse("POST /batch/objects")).path == "/v1/batch/objects")
+        #expect(try #require(WeaviateConsoleParser.parse("GET /v1/schema")).path == "/v1/schema")
+        #expect(try #require(WeaviateConsoleParser.parse("GET /")).path == "/")
+    }
+
+    @Test("SQL is still not a console request")
+    func sqlIsRefused() {
+        #expect(WeaviateConsoleParser.parse("DELETE FROM Article") == nil)
+        #expect(WeaviateConsoleParser.parse("UPDATE Article SET title = 'x'") == nil)
+    }
+
+    @Test("A browse that is not showing the vector does not ask for it")
+    func vectorIsOptional() throws {
+        let withVector = try WeaviateGraphQL.getQuery(
+            collection: "Article", properties: ["uuid", "title"], limit: 5, offset: 0,
+            sorts: [], filters: [], logicMode: "AND", schema: [:], includeVector: true
+        )
+        let withoutVector = try WeaviateGraphQL.getQuery(
+            collection: "Article", properties: ["uuid", "title"], limit: 5, offset: 0,
+            sorts: [], filters: [], logicMode: "AND", schema: [:], includeVector: false
+        )
+        #expect(withVector.contains("_additional { id vector }"))
+        #expect(withoutVector.contains("_additional { id }"))
+        #expect(!withoutVector.contains("vector"))
+    }
+}

--- a/Packages/TableProCore/Tests/TableProWeaviateCoreTests/WeaviateFilterAndPathTests.swift
+++ b/Packages/TableProCore/Tests/TableProWeaviateCoreTests/WeaviateFilterAndPathTests.swift
@@ -1,0 +1,464 @@
+import Foundation
+import Testing
+@testable import TableProWeaviateCore
+
+private let articleTypes = [
+    "title": "text",
+    "wordCount": "int",
+    "ratio": "number",
+    "live": "boolean",
+    "published": "date",
+    "tags": "text[]",
+    "scores": "int[]"
+]
+
+private let articleSchema = articleTypes.mapValues { WeaviateProperty(name: "", dataType: $0) }
+
+private func operand(_ column: String, _ op: String, _ value: String, second: String? = nil) throws -> String {
+    try WeaviateFilterBuilder.operand(
+        for: WeaviateFilterSpec(column: column, op: op, value: value, secondValue: second),
+        types: articleTypes
+    )
+}
+
+@Suite("Weaviate filter value types")
+struct WeaviateFilterValueTypeTests {
+    @Test("Each data type picks the value field Weaviate demands")
+    func valueFieldFollowsDataType() throws {
+        #expect(try operand("title", "=", "Hello").contains("valueText: \"Hello\""))
+        #expect(try operand("wordCount", "=", "12").contains("valueInt: 12"))
+        #expect(try operand("ratio", ">", "1.5").contains("valueNumber: 1.5"))
+        #expect(try operand("live", "=", "true").contains("valueBoolean: true"))
+        #expect(try operand("published", ">", "2024-01-31T00:00:00Z")
+            .contains("valueDate: \"2024-01-31T00:00:00Z\""))
+    }
+
+    @Test("An array property filters on its element type")
+    func arrayUsesElementField() throws {
+        #expect(try operand("tags", "=", "alpha").contains("valueText: \"alpha\""))
+        #expect(try operand("scores", "=", "3").contains("valueInt: 3"))
+    }
+
+    @Test("The uuid column filters as text on the id path")
+    func uuidFiltersAsText() throws {
+        let clause = try operand(WeaviateSchema.uuidColumn, "=", "c8f5c3e0-1b2a-4d3e-9f10-111213141516")
+        #expect(clause.contains("path: [\"id\"]"))
+        #expect(clause.contains("valueText:"))
+    }
+
+    @Test("A value that is not a number is refused instead of becoming zero")
+    func badNumberThrows() {
+        #expect(throws: WeaviateFilterError.notANumber(column: "wordCount", value: "abc")) {
+            _ = try operand("wordCount", "=", "abc")
+        }
+        #expect(throws: WeaviateFilterError.notANumber(column: "ratio", value: "abc")) {
+            _ = try operand("ratio", "=", "abc")
+        }
+    }
+
+    @Test("A value that is not a boolean is refused instead of becoming false")
+    func badBooleanThrows() {
+        #expect(throws: WeaviateFilterError.notABoolean(column: "live", value: "yes")) {
+            _ = try operand("live", "=", "yes")
+        }
+    }
+
+    @Test("A date needs a full RFC 3339 timestamp")
+    func badDateThrows() {
+        #expect(throws: WeaviateFilterError.notADate(column: "published", value: "2024-01-31")) {
+            _ = try operand("published", ">", "2024-01-31")
+        }
+        #expect(WeaviateDateLiteral.isRFC3339("2024-01-31T00:00:00+07:00"))
+        #expect(WeaviateDateLiteral.isRFC3339("2024-01-31T00:00:00.123Z"))
+    }
+}
+
+@Suite("Weaviate filter operators")
+struct WeaviateFilterOperatorTests {
+    @Test("Substring operators become Like patterns")
+    func likePatterns() throws {
+        #expect(try operand("title", "CONTAINS", "ell").contains("operator: Like valueText: \"*ell*\""))
+        #expect(try operand("title", "STARTS WITH", "He").contains("valueText: \"He*\""))
+        #expect(try operand("title", "ENDS WITH", "lo").contains("valueText: \"*lo\""))
+        #expect(try operand("title", "NOT CONTAINS", "ell").hasPrefix("{ operator: Not operands: ["))
+    }
+
+    @Test("IN and NOT IN become ContainsAny")
+    func listOperators() throws {
+        let inClause = try operand("wordCount", "IN", "10, 30")
+        #expect(inClause.contains("operator: ContainsAny valueInt: [10, 30]"))
+        let notIn = try operand("title", "NOT IN", "a,b")
+        #expect(notIn.contains("operator: ContainsNone valueText: [\"a\", \"b\"]"))
+    }
+
+    @Test("IN with no values is refused")
+    func emptyListThrows() {
+        #expect(throws: WeaviateFilterError.emptyList(column: "title")) {
+            _ = try operand("title", "IN", " , ")
+        }
+    }
+
+    @Test("BETWEEN becomes a bounded And and needs its upper bound")
+    func betweenBounds() throws {
+        let clause = try operand("wordCount", "BETWEEN", "5", second: "10")
+        #expect(clause.hasPrefix("{ operator: And operands: ["))
+        #expect(clause.contains("operator: GreaterThanEqual valueInt: 5"))
+        #expect(clause.contains("operator: LessThanEqual valueInt: 10"))
+
+        #expect(throws: WeaviateFilterError.missingUpperBound(column: "wordCount")) {
+            _ = try operand("wordCount", "BETWEEN", "5")
+        }
+    }
+
+    @Test("IS NULL maps to IsNull in both directions")
+    func nullOperators() throws {
+        #expect(try operand("title", "IS NULL", "").contains("operator: IsNull valueBoolean: true"))
+        #expect(try operand("title", "IS NOT NULL", "").contains("operator: IsNull valueBoolean: false"))
+    }
+
+    @Test("An operator Weaviate cannot express is reported, not dropped")
+    func unsupportedOperatorsThrow() {
+        #expect(throws: WeaviateFilterError.unsupportedOperator("REGEX")) {
+            _ = try operand("title", "REGEX", "^a")
+        }
+    }
+
+    @Test("Emptiness counts with len(), which is what Weaviate offers")
+    func emptinessUsesLength() throws {
+        #expect(try operand("title", "IS EMPTY", "")
+            .contains("path: [\"len(title)\"] operator: Equal valueInt: 0"))
+        #expect(try operand("title", "IS NOT EMPTY", "")
+            .contains("path: [\"len(title)\"] operator: GreaterThan valueInt: 0"))
+        #expect(throws: WeaviateFilterError.textMatchNeedsText(column: "wordCount", op: "IS EMPTY")) {
+            _ = try operand("wordCount", "IS EMPTY", "")
+        }
+    }
+
+    @Test("Comparing text, and matching a number as text, are both refused")
+    func mismatchedOperatorsThrow() {
+        #expect(throws: WeaviateFilterError.comparisonNeedsNumberOrDate(column: "title", op: ">")) {
+            _ = try operand("title", ">", "Row 1")
+        }
+        #expect(throws: WeaviateFilterError.textMatchNeedsText(column: "wordCount", op: "CONTAINS")) {
+            _ = try operand("wordCount", "CONTAINS", "1")
+        }
+    }
+
+    @Test("The vector column cannot be filtered")
+    func vectorFilterThrows() {
+        #expect(throws: WeaviateFilterError.vectorNotFilterable(column: "vector")) {
+            _ = try operand(WeaviateSchema.vectorColumn, "=", "[1,2]")
+        }
+    }
+
+    @Test("A quote in a value cannot break out of the GraphQL string")
+    func valuesAreEscaped() throws {
+        let clause = try operand("title", "=", "a\"b\\c")
+        #expect(clause.contains("valueText: \"a\\\"b\\\\c\""))
+    }
+
+    @Test("Several filters join under one logic operator")
+    func logicMode() throws {
+        let built = try WeaviateFilterBuilder.graphQLWhere(
+            filters: [
+                WeaviateFilterSpec(column: "title", op: "=", value: "a"),
+                WeaviateFilterSpec(column: "wordCount", op: ">", value: "3")
+            ],
+            logicMode: "OR",
+            types: articleTypes
+        )
+        let clause = try #require(built)
+        #expect(clause.hasPrefix("{ operator: Or operands: ["))
+    }
+}
+
+@Suite("Weaviate sorting")
+struct WeaviateSortTests {
+    @Test("A uuid sort reaches GraphQL, which can sort by the object id")
+    func uuidSortUsesGraphQL() throws {
+        let encoded = WeaviateBrowseQuery.encode(
+            collection: "Article",
+            offset: 0,
+            limit: 25,
+            sorts: [WeaviateSortSpec(column: WeaviateSchema.uuidColumn, ascending: false)],
+            filters: [],
+            logicMode: "AND",
+            propertyNames: ["uuid", "title"]
+        )
+        let parsed = try #require(WeaviateBrowseQuery.parse(encoded))
+        #expect(parsed.usesGraphQL)
+
+        let query = try WeaviateGraphQL.getQuery(
+            collection: "Article",
+            properties: parsed.propertyNames,
+            limit: parsed.limit,
+            offset: parsed.offset,
+            sorts: parsed.sortableSorts,
+            filters: [],
+            logicMode: "AND",
+            schema: articleSchema
+        )
+        #expect(query.contains("sort: [{ path: [\"id\"] order: desc }]"))
+    }
+
+    @Test("A vector sort is dropped, because Weaviate has no such property")
+    func vectorSortIsDropped() throws {
+        let encoded = WeaviateBrowseQuery.encode(
+            collection: "Article",
+            offset: 0,
+            limit: 25,
+            sorts: [WeaviateSortSpec(column: WeaviateSchema.vectorColumn, ascending: true)],
+            filters: [],
+            logicMode: "AND",
+            propertyNames: ["uuid", "vector"]
+        )
+        let parsed = try #require(WeaviateBrowseQuery.parse(encoded))
+        #expect(parsed.sortableSorts.isEmpty)
+        #expect(!parsed.usesGraphQL)
+    }
+
+    @Test("BETWEEN survives the browse tag round-trip")
+    func secondValueRoundTrips() throws {
+        let encoded = WeaviateBrowseQuery.encode(
+            collection: "Article",
+            offset: 0,
+            limit: 25,
+            sorts: [],
+            filters: [WeaviateFilterSpec(column: "wordCount", op: "BETWEEN", value: "5", secondValue: "10")],
+            logicMode: "AND",
+            propertyNames: ["uuid"]
+        )
+        let parsed = try #require(WeaviateBrowseQuery.parse(encoded))
+        #expect(parsed.filters.first?.secondValue == "10")
+    }
+}
+
+@Suite("Weaviate request paths")
+struct WeaviatePathTests {
+    private let base = URL(string: "http://localhost:8080")!
+
+    @Test("A console path keeps its query string instead of encoding the question mark")
+    func consoleQueryStringSurvives() throws {
+        let url = try #require(
+            WeaviatePathEncoding.resolve("/v1/objects?class=Article&limit=10", against: base)
+        )
+        #expect(url.path == "/v1/objects")
+        #expect(!url.absoluteString.contains("%3F"))
+        #expect(url.query == "class=Article&limit=10")
+    }
+
+    @Test("A path and passed query items merge")
+    func mergedQueryItems() throws {
+        let url = try #require(
+            WeaviatePathEncoding.resolve("/v1/objects?class=Article", query: ["limit": "5"], against: base)
+        )
+        let items = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems)
+        #expect(items.contains(URLQueryItem(name: "class", value: "Article")))
+        #expect(items.contains(URLQueryItem(name: "limit", value: "5")))
+    }
+
+    @Test("An already-encoded segment is not encoded twice")
+    func encodedSegmentSurvives() throws {
+        let uuid = "c8f5c3e0-1b2a-4d3e-9f10-111213141516"
+        let url = try #require(
+            WeaviatePathEncoding.resolve("/v1/objects/\(WeaviatePathEncoding.segment(uuid))", against: base)
+        )
+        #expect(url.path == "/v1/objects/\(uuid)")
+    }
+
+    @Test("An absolute or relative path is refused")
+    func hostiledPathsRefused() {
+        #expect(WeaviatePathEncoding.resolve("http://evil.example/v1", against: base) == nil)
+        #expect(WeaviatePathEncoding.resolve("v1/schema", against: base) == nil)
+    }
+}
+
+@Suite("Weaviate response decoding")
+struct WeaviateResponseDecodingTests {
+    @Test("A vector component at the edge of Int does not trap")
+    func hugeVectorComponent() {
+        let object = WeaviateObject(
+            uuid: "u1",
+            className: "Article",
+            properties: [:],
+            vector: [9_223_372_036_854_775_808.0, 1.5]
+        )
+        let text = object.vectorText
+        #expect(text?.hasPrefix("[9.223372036854776e+18") == true)
+        #expect(text?.hasSuffix("1.5]") == true)
+    }
+
+    @Test("A Get row keeps the _additional fields a vector search returns")
+    func additionalFieldsBecomeColumns() {
+        let objects = WeaviateObjectCodec.objects(fromGraphQL: [
+            "data": [
+                "Get": [
+                    "Article": [
+                        [
+                            "title": "Hello",
+                            "_additional": ["id": "u1", "distance": 0.42, "score": "0.9"]
+                        ]
+                    ]
+                ]
+            ]
+        ])
+        let object = objects.first
+        #expect(object?.uuid == "u1")
+        #expect(object?.properties["title"] == "Hello")
+        #expect(object?.properties["distance"] == "0.42")
+        #expect(object?.properties["score"] == "0.9")
+    }
+
+    @Test("A property keeps its name when _additional carries the same one")
+    func propertyWinsOverAdditional() {
+        let objects = WeaviateObjectCodec.objects(fromGraphQL: [
+            "data": ["Get": ["Article": [["distance": "mine", "_additional": ["id": "u1", "distance": 0.42]]]]]
+        ])
+        #expect(objects.first?.properties["distance"] == "mine")
+        #expect(objects.first?.properties["_additional.distance"] == "0.42")
+    }
+
+    @Test("A response body is parsed once and still compares by its bytes")
+    func responseEquality() {
+        let body = Data(#"{"a":1}"#.utf8)
+        let first = WeaviateHTTPResponse(statusCode: 200, body: body)
+        let second = WeaviateHTTPResponse(statusCode: 200, body: body)
+        #expect(first == second)
+        #expect(WeaviateJSON.dictionary(first.json)?["a"] as? Int == 1)
+        #expect(WeaviateJSON.dictionary(first.json)?["a"] as? Int == 1)
+        #expect(first != WeaviateHTTPResponse(statusCode: 500, body: body))
+    }
+}
+
+@Suite("Weaviate write generation")
+struct WeaviateWriteGenerationTests {
+    @Test("A duplicate column name does not trap the generator")
+    func duplicateColumnNames() throws {
+        let batch = WeaviateStatementGenerator.generate(
+            collection: "Article",
+            columns: ["uuid", "title", "title"],
+            typeNames: ["uuid", "text", "int"],
+            changes: [
+                WeaviateTrackedChange(
+                    kind: .update,
+                    uuid: "c8f5c3e0-1b2a-4d3e-9f10-111213141516",
+                    values: [:],
+                    cellChanges: [WeaviateCellChange(column: "title", newText: "Edited")]
+                )
+            ]
+        )
+        let body = try #require(batch.requests.first?.body)
+        #expect(body.contains("\"title\":\"Edited\""))
+    }
+
+    @Test("A delete with no uuid is reported rather than dropped in silence")
+    func deleteWithoutUUIDIsReported() {
+        let batch = WeaviateStatementGenerator.generate(
+            collection: "Article",
+            columns: ["uuid", "title"],
+            typeNames: ["uuid", "text"],
+            changes: [WeaviateTrackedChange(kind: .delete, uuid: nil, values: [:], cellChanges: [])]
+        )
+        #expect(batch.requests.isEmpty)
+        #expect(batch.skipped == [WeaviateSkippedChange(kind: .delete, reason: .missingUUID)])
+    }
+
+    @Test("An update touching only read-only columns is reported")
+    func updateWithNoEditableColumns() {
+        let batch = WeaviateStatementGenerator.generate(
+            collection: "Article",
+            columns: ["uuid", "vector"],
+            typeNames: ["uuid", "vector"],
+            changes: [
+                WeaviateTrackedChange(
+                    kind: .update,
+                    uuid: "c8f5c3e0-1b2a-4d3e-9f10-111213141516",
+                    values: [:],
+                    cellChanges: [WeaviateCellChange(column: "vector", newText: "[1,2]")]
+                )
+            ]
+        )
+        #expect(batch.requests.isEmpty)
+        #expect(batch.skipped == [WeaviateSkippedChange(kind: .update, reason: .noEditableColumns)])
+    }
+}
+
+
+@Suite("Weaviate selection sets")
+struct WeaviateSelectionSetTests {
+    private func query(_ properties: [WeaviateProperty]) throws -> String {
+        try WeaviateGraphQL.getQuery(
+            collection: "Article",
+            properties: properties.map(\.name),
+            limit: 5,
+            offset: 0,
+            sorts: [],
+            filters: [],
+            logicMode: "AND",
+            schema: Dictionary(properties.map { ($0.name, $0) }, uniquingKeysWith: { first, _ in first })
+        )
+    }
+
+    @Test("A structured property asks for its own fields instead of failing the query")
+    func structuredPropertiesGetSubSelections() throws {
+        let built = try query([
+            WeaviateProperty(name: "title", dataType: "text"),
+            WeaviateProperty(name: "place", dataType: "geoCoordinates"),
+            WeaviateProperty(name: "phone", dataType: "phoneNumber")
+        ])
+        #expect(built.contains("place { latitude longitude }"))
+        #expect(built.contains("phone { input internationalFormatted"))
+        #expect(built.contains(" title "))
+    }
+
+    @Test("An object property selects its declared nested properties")
+    func objectSelectsNested() throws {
+        let built = try query([
+            WeaviateProperty(
+                name: "meta",
+                dataTypes: ["object"],
+                nestedProperties: [
+                    WeaviateProperty(name: "k", dataType: "text"),
+                    WeaviateProperty(name: "inner", dataTypes: ["object"], nestedProperties: [
+                        WeaviateProperty(name: "deep", dataType: "int")
+                    ])
+                ]
+            )
+        ])
+        #expect(built.contains("meta { k inner { deep } }"))
+    }
+
+    @Test("An object with no declared nested properties is left out")
+    func emptyObjectIsOmitted() throws {
+        let built = try query([
+            WeaviateProperty(name: "title", dataType: "text"),
+            WeaviateProperty(name: "meta", dataTypes: ["object"], nestedProperties: [])
+        ])
+        #expect(!built.contains("meta"))
+        #expect(built.contains("title"))
+    }
+
+    @Test("A cross-reference asks for the referenced ids")
+    func crossReferenceUsesFragments() throws {
+        let built = try query([
+            WeaviateProperty(name: "category", dataTypes: ["Category", "Topic"], nestedProperties: [])
+        ])
+        #expect(built.contains("category { ... on Category { _additional { id } } ... on Topic { _additional { id } } }"))
+    }
+
+    @Test("A nested property list survives schema parsing")
+    func schemaParsesNestedProperties() throws {
+        let collections = WeaviateSchema.collections(from: [
+            "classes": [[
+                "class": "Article",
+                "properties": [
+                    ["name": "meta", "dataType": ["object"], "nestedProperties": [["name": "k", "dataType": ["text"]]]],
+                    ["name": "category", "dataType": ["Category"]]
+                ]
+            ]]
+        ])
+        let properties = try #require(collections.first?.properties)
+        #expect(properties.first?.nestedProperties.map(\.name) == ["k"])
+        #expect(WeaviatePropertyShape.of(properties[1]) == .crossReference(["Category"]))
+    }
+}

--- a/Packages/TableProCore/Tests/TableProWeaviateCoreTests/WeaviateTestSupport.swift
+++ b/Packages/TableProCore/Tests/TableProWeaviateCoreTests/WeaviateTestSupport.swift
@@ -66,47 +66,55 @@ func testClient(
 enum WeaviateFixtures {
     static let articleUUID = "c8f5c3e0-1b2a-4d3e-9f10-111213141516"
 
-    static let schema: [String: Any] = [
-        "classes": [
-            [
-                "class": "Article",
-                "vectorizer": "none",
-                "properties": [
-                    ["name": "title", "dataType": ["text"]],
-                    ["name": "wordCount", "dataType": ["int"]]
+    static var schema: [String: Any] {
+        [
+            "classes": [
+                [
+                    "class": "Article",
+                    "vectorizer": "none",
+                    "properties": [
+                        ["name": "title", "dataType": ["text"]],
+                        ["name": "wordCount", "dataType": ["int"]]
+                    ]
                 ]
             ]
         ]
-    ]
+    }
 
-    static let objects: [String: Any] = [
-        "objects": [
-            [
-                "id": articleUUID,
-                "class": "Article",
-                "properties": ["title": "Hello", "wordCount": 12],
-                "vector": [0.1, 0.2, 0.3]
-            ]
-        ],
-        "totalResults": 1
-    ]
+    static var objects: [String: Any] {
+        [
+            "objects": [
+                [
+                    "id": articleUUID,
+                    "class": "Article",
+                    "properties": ["title": "Hello", "wordCount": 12],
+                    "vector": [0.1, 0.2, 0.3]
+                ]
+            ],
+            "totalResults": 1
+        ]
+    }
 
-    static let graphqlGet: [String: Any] = [
-        "data": [
-            "Get": [
-                "Article": [
-                    [
-                        "title": "Hello",
-                        "wordCount": 12,
-                        "_additional": [
-                            "id": articleUUID,
-                            "vector": [0.1, 0.2]
+    static var graphqlGet: [String: Any] {
+        [
+            "data": [
+                "Get": [
+                    "Article": [
+                        [
+                            "title": "Hello",
+                            "wordCount": 12,
+                            "_additional": [
+                                "id": articleUUID,
+                                "vector": [0.1, 0.2]
+                            ]
                         ]
                     ]
                 ]
             ]
         ]
-    ]
+    }
 
-    static let meta: [String: Any] = ["version": "1.27.0"]
+    static var meta: [String: Any] {
+        ["version": "1.27.0"]
+    }
 }

--- a/Packages/TableProCore/Tests/TableProWeaviateCoreTests/WeaviateTestSupport.swift
+++ b/Packages/TableProCore/Tests/TableProWeaviateCoreTests/WeaviateTestSupport.swift
@@ -1,0 +1,112 @@
+import Foundation
+@testable import TableProWeaviateCore
+
+final class FakeWeaviateTransport: WeaviateTransport, @unchecked Sendable {
+    struct Route: Equatable {
+        let method: String
+        let path: String
+    }
+
+    var responses: [String: WeaviateHTTPResponse] = [:]
+    var requests: [WeaviateHTTPRequest] = []
+    var error: WeaviateError?
+
+    func send(_ request: WeaviateHTTPRequest) async throws -> WeaviateHTTPResponse {
+        if let error {
+            throw error
+        }
+        requests.append(request)
+        let key = Self.key(method: request.method, url: request.url)
+        if let response = responses[key] ?? responses[request.url.path] {
+            return response
+        }
+        throw WeaviateError.malformedResponse("No fake response for \(key)")
+    }
+
+    func cancelAll() {}
+
+    func respond(method: String, path: String, status: Int, json: Any) {
+        let data = (try? JSONSerialization.data(withJSONObject: json)) ?? Data()
+        responses[Self.key(method: method, path: path)] = WeaviateHTTPResponse(statusCode: status, body: data)
+    }
+
+    func respond(method: String, path: String, status: Int, body: String) {
+        responses[Self.key(method: method, path: path)] = WeaviateHTTPResponse(
+            statusCode: status,
+            body: Data(body.utf8)
+        )
+    }
+
+    static func key(method: String, path: String) -> String {
+        "\(method.uppercased()) \(path)"
+    }
+
+    static func key(method: String, url: URL) -> String {
+        key(method: method, path: url.path)
+    }
+}
+
+func testSettings(auth: WeaviateAuth = WeaviateAuth(method: .none)) -> WeaviateConnectionSettings {
+    WeaviateConnectionSettings(
+        host: "localhost",
+        port: 8_080,
+        usesTLS: false,
+        auth: auth,
+        skipTLSVerify: false
+    )
+}
+
+func testClient(
+    transport: FakeWeaviateTransport,
+    auth: WeaviateAuth = WeaviateAuth(method: .none)
+) -> WeaviateClient {
+    WeaviateClient(settings: testSettings(auth: auth), transport: transport, timeout: { 30 })
+}
+
+enum WeaviateFixtures {
+    static let articleUUID = "c8f5c3e0-1b2a-4d3e-9f10-111213141516"
+
+    static let schema: [String: Any] = [
+        "classes": [
+            [
+                "class": "Article",
+                "vectorizer": "none",
+                "properties": [
+                    ["name": "title", "dataType": ["text"]],
+                    ["name": "wordCount", "dataType": ["int"]]
+                ]
+            ]
+        ]
+    ]
+
+    static let objects: [String: Any] = [
+        "objects": [
+            [
+                "id": articleUUID,
+                "class": "Article",
+                "properties": ["title": "Hello", "wordCount": 12],
+                "vector": [0.1, 0.2, 0.3]
+            ]
+        ],
+        "totalResults": 1
+    ]
+
+    static let graphqlGet: [String: Any] = [
+        "data": [
+            "Get": [
+                "Article": [
+                    [
+                        "title": "Hello",
+                        "wordCount": 12,
+                        "_additional": [
+                            "id": articleUUID,
+                            "vector": [0.1, 0.2]
+                        ]
+                    ]
+                ]
+            ]
+        ]
+    ]
+
+    static let meta: [String: Any] = ["version": "1.27.0"]
+}

--- a/Plugins/WeaviateDriverPlugin/Info.plist
+++ b/Plugins/WeaviateDriverPlugin/Info.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>TableProMinAppVersion</key>
+	<string>0.73.0</string>
+	<key>TableProPluginKitVersion</key>
+	<integer>25</integer>
+	<key>TableProProvidesDatabaseTypeIds</key>
+	<array>
+		<string>Weaviate</string>
+	</array>
+</dict>
+</plist>

--- a/Plugins/WeaviateDriverPlugin/WeaviatePlugin.swift
+++ b/Plugins/WeaviateDriverPlugin/WeaviatePlugin.swift
@@ -65,21 +65,16 @@ func weaviateConnectionFields() -> [ConnectionField] {
                 .init(value: WeaviateAuthMethod.none.rawValue, label: "None"),
                 .init(value: WeaviateAuthMethod.apiKey.rawValue, label: "API Key")
             ]),
-            section: .authentication,
-            hidesPassword: true
-        ).withHidesUsername(true),
+            section: .authentication
+        ),
         ConnectionField(
             id: WeaviateFieldID.apiKey,
             label: String(localized: "API Key"),
             placeholder: "Weaviate API key",
-            required: true,
             fieldType: .secure,
             section: .authentication,
-            visibleWhen: FieldVisibilityRule(
-                fieldId: WeaviateFieldID.authMethod,
-                values: [WeaviateAuthMethod.apiKey.rawValue]
-            )
-        ),
+            hidesPassword: true
+        ).withHidesUsername(true),
         ConnectionField(
             id: WeaviateFieldID.skipTLSVerify,
             label: String(localized: "Skip TLS Verification"),

--- a/Plugins/WeaviateDriverPlugin/WeaviatePlugin.swift
+++ b/Plugins/WeaviateDriverPlugin/WeaviatePlugin.swift
@@ -1,0 +1,151 @@
+import Foundation
+import TableProPluginKit
+import TableProWeaviateCore
+
+final class WeaviatePlugin: NSObject, TableProPlugin, DriverPlugin {
+    static let pluginName = "Weaviate Driver"
+    static let pluginVersion = "1.0.0"
+    static let pluginDescription = "Weaviate support over the REST API with a GraphQL console"
+    static let capabilities: [PluginCapability] = [.databaseDriver]
+
+    static let databaseTypeId = "Weaviate"
+    static let databaseDisplayName = "Weaviate"
+    static let iconName = "weaviate-icon"
+    static let defaultPort = WeaviateConnectionSettings.defaultPort
+    static let isDownloadable = true
+
+    static let navigationModel: NavigationModel = .standard
+    static let pathFieldRole: PathFieldRole = .database
+    static let requiresAuthentication = false
+    static let brandColorHex = "#01B0D3"
+    static let queryLanguageName = "GraphQL"
+    static let editorLanguage: EditorLanguage = .javascript
+    static let supportsForeignKeys = false
+    static let supportsSchemaEditing = false
+    static let supportsDatabaseSwitching = false
+    static let supportsImport = false
+    static let supportsExport = true
+    static let supportsSSH = false
+    static let supportsSSL = true
+    static let supportsReadOnlyMode = true
+    static let supportsForeignKeyDisable = false
+    static let supportsAddColumn = false
+    static let supportsModifyColumn = false
+    static let supportsDropColumn = false
+    static let supportsAddIndex = false
+    static let supportsDropIndex = false
+    static let supportsModifyPrimaryKey = false
+    static let databaseGroupingStrategy: GroupingStrategy = .flat
+    static let defaultGroupName = "default"
+    static let tableEntityName = "Collections"
+    static let containerEntityName = "Cluster"
+    static let immutableColumns: [String] = WeaviateSchema.immutableColumns
+    static let defaultPrimaryKeyColumn: String? = WeaviateSchema.uuidColumn
+    static let structureColumnFields: [StructureColumnField] = [.name, .type, .nullable]
+    static let sqlDialect: SQLDialectDescriptor? = nil
+
+    static let columnTypesByCategory: [String: [String]] = weaviateColumnTypes
+
+    static let additionalConnectionFields: [ConnectionField] = weaviateConnectionFields()
+
+    static var statementCompletions: [CompletionEntry] { weaviateCompletions }
+
+    func createDriver(config: DriverConnectionConfig) -> any PluginDatabaseDriver {
+        WeaviatePluginDriver(config: config)
+    }
+}
+
+func weaviateConnectionFields() -> [ConnectionField] {
+    [
+        ConnectionField(
+            id: WeaviateFieldID.authMethod,
+            label: String(localized: "Auth Method"),
+            defaultValue: WeaviateAuthMethod.none.rawValue,
+            fieldType: .dropdown(options: [
+                .init(value: WeaviateAuthMethod.none.rawValue, label: "None"),
+                .init(value: WeaviateAuthMethod.apiKey.rawValue, label: "API Key")
+            ]),
+            section: .authentication,
+            hidesPassword: true
+        ).withHidesUsername(true),
+        ConnectionField(
+            id: WeaviateFieldID.apiKey,
+            label: String(localized: "API Key"),
+            placeholder: "Weaviate API key",
+            required: true,
+            fieldType: .secure,
+            section: .authentication,
+            visibleWhen: FieldVisibilityRule(
+                fieldId: WeaviateFieldID.authMethod,
+                values: [WeaviateAuthMethod.apiKey.rawValue]
+            )
+        ),
+        ConnectionField(
+            id: WeaviateFieldID.skipTLSVerify,
+            label: String(localized: "Skip TLS Verification"),
+            defaultValue: "false",
+            fieldType: .toggle,
+            section: .advanced
+        )
+    ]
+}
+
+let weaviateCompletions: [CompletionEntry] = [
+    CompletionEntry(
+        label: "Get",
+        insertText: """
+        {
+          Get {
+            Article(limit: 10) {
+              title
+              _additional { id distance }
+            }
+          }
+        }
+        """
+    ),
+    CompletionEntry(
+        label: "Near text",
+        insertText: """
+        {
+          Get {
+            Article(
+              nearText: { concepts: ["search term"] }
+              limit: 10
+            ) {
+              title
+              _additional { id distance }
+            }
+          }
+        }
+        """
+    ),
+    CompletionEntry(
+        label: "Hybrid",
+        insertText: """
+        {
+          Get {
+            Article(
+              hybrid: { query: "search term", alpha: 0.5 }
+              limit: 10
+            ) {
+              title
+              _additional { id score }
+            }
+          }
+        }
+        """
+    ),
+    CompletionEntry(label: "GET /v1/schema", insertText: "GET /v1/schema"),
+    CompletionEntry(label: "GET /v1/meta", insertText: "GET /v1/meta"),
+    CompletionEntry(label: "GET /v1/objects", insertText: "GET /v1/objects?class=Article&limit=10")
+]
+
+let weaviateColumnTypes: [String: [String]] = [
+    "Text": ["text", "text[]", "string", "string[]", "uuid", "uuid[]"],
+    "Numeric": ["int", "int[]", "number", "number[]"],
+    "Boolean": ["boolean", "boolean[]"],
+    "Date": ["date", "date[]"],
+    "Structured": ["object", "object[]", "geoCoordinates", "phoneNumber"],
+    "Vector": ["vector"]
+]

--- a/Plugins/WeaviateDriverPlugin/WeaviatePluginDriver+Execution.swift
+++ b/Plugins/WeaviateDriverPlugin/WeaviatePluginDriver+Execution.swift
@@ -46,6 +46,8 @@ extension WeaviatePluginDriver {
             throw WeaviateError.malformedResponse(String(localized: "Invalid browse request."))
         }
         let collection = try await cachedCollection(parsed.collection)
+        let wantsVector = parsed.propertyNames.isEmpty
+            || parsed.propertyNames.contains(WeaviateSchema.vectorColumn)
         let objects: [WeaviateObject]
         if parsed.usesGraphQL {
             let graphql = try WeaviateGraphQL.getQuery(
@@ -56,7 +58,8 @@ extension WeaviatePluginDriver {
                 sorts: parsed.sortableSorts,
                 filters: parsed.filters,
                 logicMode: parsed.logicMode,
-                schema: propertySchema(of: collection)
+                schema: propertySchema(of: collection),
+                includeVector: wantsVector
             )
             let response = try await client.graphql(graphql)
             objects = WeaviateObjectCodec.objects(fromGraphQL: response.json as Any)
@@ -64,7 +67,8 @@ extension WeaviatePluginDriver {
             objects = try await client.objects(
                 collection: parsed.collection,
                 limit: parsed.limit,
-                offset: parsed.offset
+                offset: parsed.offset,
+                includeVector: wantsVector
             )
         }
         return render(objects: objects, collection: collection, columns: parsed.propertyNames, started: started)

--- a/Plugins/WeaviateDriverPlugin/WeaviatePluginDriver+Execution.swift
+++ b/Plugins/WeaviateDriverPlugin/WeaviatePluginDriver+Execution.swift
@@ -1,0 +1,188 @@
+import Foundation
+import TableProPluginKit
+import TableProWeaviateCore
+
+extension WeaviatePluginDriver {
+    func execute(query: String) async throws -> PluginQueryResult {
+        let started = Date()
+        let client = try requireClient()
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if trimmed.lowercased() == "select 1" {
+            try await client.ping()
+            return PluginQueryResult(
+                columns: ["ok"],
+                columnTypeNames: ["int"],
+                rows: [[.text("1")]],
+                rowsAffected: 0,
+                executionTime: Date().timeIntervalSince(started)
+            )
+        }
+
+        if WeaviateBrowseQuery.isTagged(trimmed) {
+            return try await executeSearch(trimmed, client: client, started: started)
+        }
+        if WeaviateWriteCodec.isTagged(trimmed) {
+            return try await executeWrite(trimmed, client: client, started: started)
+        }
+        if let console = WeaviateConsoleParser.parse(trimmed) {
+            return try await executeConsole(console, client: client, started: started)
+        }
+        if WeaviateGraphQL.looksLikeGraphQL(trimmed) {
+            return try await executeGraphQL(trimmed, client: client, started: started)
+        }
+
+        throw WeaviateError.malformedResponse(
+            String(localized: "Enter a GraphQL query, or a request like GET /v1/schema.")
+        )
+    }
+
+    private func executeSearch(
+        _ query: String,
+        client: WeaviateClient,
+        started: Date
+    ) async throws -> PluginQueryResult {
+        guard let parsed = WeaviateBrowseQuery.parse(query) else {
+            throw WeaviateError.malformedResponse("Invalid browse request.")
+        }
+        let collection = try await cachedCollection(parsed.collection)
+        let objects: [WeaviateObject]
+        if parsed.usesGraphQL {
+            let graphql = WeaviateGraphQL.getQuery(
+                collection: parsed.collection,
+                properties: parsed.propertyNames,
+                limit: parsed.limit,
+                offset: parsed.offset,
+                sorts: parsed.sorts,
+                filters: parsed.filters,
+                logicMode: parsed.logicMode
+            )
+            let response = try await client.graphql(graphql)
+            objects = WeaviateObjectCodec.objects(fromGraphQL: response.json as Any)
+        } else {
+            objects = try await client.objects(
+                collection: parsed.collection,
+                limit: parsed.limit,
+                offset: parsed.offset
+            )
+        }
+        return render(objects: objects, collection: collection, columns: parsed.propertyNames, started: started)
+    }
+
+    private func executeWrite(
+        _ statement: String,
+        client: WeaviateClient,
+        started: Date
+    ) async throws -> PluginQueryResult {
+        guard let request = WeaviateWriteCodec.decode(statement) else {
+            throw WeaviateError.malformedResponse("Invalid write request.")
+        }
+        let response = try await client.execute(write: request)
+        let outcome: String
+        if let json = WeaviateJSON.dictionary(response.json), let id = json["id"] as? String {
+            outcome = id
+        } else if response.statusCode == 204 {
+            outcome = "deleted"
+        } else {
+            outcome = "ok"
+        }
+        return PluginQueryResult(
+            columns: ["result"],
+            columnTypeNames: ["text"],
+            rows: [[.text(outcome)]],
+            rowsAffected: 1,
+            executionTime: Date().timeIntervalSince(started)
+        )
+    }
+
+    private func executeConsole(
+        _ request: WeaviateConsoleRequest,
+        client: WeaviateClient,
+        started: Date
+    ) async throws -> PluginQueryResult {
+        if request.method == "POST", request.path.hasPrefix("/v1/graphql"), let body = request.body {
+            return try await executeGraphQL(body, client: client, started: started)
+        }
+        let response = try await client.execute(console: request)
+        if request.path.hasPrefix("/v1/objects"), let json = response.json {
+            let objects = WeaviateObject.parseList(json)
+            if !objects.isEmpty {
+                let collectionName = objects.first?.className ?? ""
+                let collection = (try? await cachedCollection(collectionName))
+                    ?? WeaviateCollection(name: collectionName, properties: [])
+                let columns = WeaviateSchema.columns(for: collection).map(\.name)
+                return render(objects: objects, collection: collection, columns: columns, started: started)
+            }
+        }
+        return renderJSON(response, started: started)
+    }
+
+    private func executeGraphQL(
+        _ query: String,
+        client: WeaviateClient,
+        started: Date
+    ) async throws -> PluginQueryResult {
+        let response = try await client.graphql(query)
+        let objects = WeaviateObjectCodec.objects(fromGraphQL: response.json as Any)
+        if !objects.isEmpty {
+            let collectionName = objects.first?.className ?? ""
+            let collection = (try? await cachedCollection(collectionName))
+                ?? WeaviateCollection(name: collectionName, properties: [])
+            var columns = WeaviateSchema.columns(for: collection).map(\.name)
+            if columns.count <= WeaviateSchema.metaColumns.count {
+                var seen = Set<String>()
+                columns = []
+                for name in [WeaviateSchema.uuidColumn]
+                    + objects.flatMap({ $0.properties.keys.sorted() })
+                    + [WeaviateSchema.vectorColumn]
+                {
+                    if seen.insert(name).inserted {
+                        columns.append(name)
+                    }
+                }
+            }
+            return render(objects: objects, collection: collection, columns: columns, started: started)
+        }
+        return renderJSON(response, started: started)
+    }
+
+    private func render(
+        objects: [WeaviateObject],
+        collection: WeaviateCollection,
+        columns: [String],
+        started: Date
+    ) -> PluginQueryResult {
+        let resolved = columns.isEmpty
+            ? WeaviateSchema.columns(for: collection).map(\.name)
+            : columns
+        let rows = objects.map { object in
+            WeaviateObjectCodec.row(for: object, columns: resolved).map { value in
+                value.map(PluginCellValue.text) ?? .null
+            }
+        }
+        return PluginQueryResult(
+            columns: resolved,
+            columnTypeNames: resolved.map { typeName(for: $0, collection: collection) },
+            rows: rows,
+            rowsAffected: 0,
+            executionTime: Date().timeIntervalSince(started)
+        )
+    }
+
+    private func renderJSON(_ response: WeaviateHTTPResponse, started: Date) -> PluginQueryResult {
+        let pretty: String
+        if let json = response.json, JSONSerialization.isValidJSONObject(json),
+           let text = try? WeaviateJSON.text(json, pretty: true) {
+            pretty = text
+        } else {
+            pretty = response.text
+        }
+        return PluginQueryResult(
+            columns: ["response"],
+            columnTypeNames: ["json"],
+            rows: [[.text(pretty)]],
+            rowsAffected: 0,
+            executionTime: Date().timeIntervalSince(started)
+        )
+    }
+}

--- a/Plugins/WeaviateDriverPlugin/WeaviatePluginDriver+Execution.swift
+++ b/Plugins/WeaviateDriverPlugin/WeaviatePluginDriver+Execution.swift
@@ -43,19 +43,20 @@ extension WeaviatePluginDriver {
         started: Date
     ) async throws -> PluginQueryResult {
         guard let parsed = WeaviateBrowseQuery.parse(query) else {
-            throw WeaviateError.malformedResponse("Invalid browse request.")
+            throw WeaviateError.malformedResponse(String(localized: "Invalid browse request."))
         }
         let collection = try await cachedCollection(parsed.collection)
         let objects: [WeaviateObject]
         if parsed.usesGraphQL {
-            let graphql = WeaviateGraphQL.getQuery(
+            let graphql = try WeaviateGraphQL.getQuery(
                 collection: parsed.collection,
                 properties: parsed.propertyNames,
                 limit: parsed.limit,
                 offset: parsed.offset,
-                sorts: parsed.sorts,
+                sorts: parsed.sortableSorts,
                 filters: parsed.filters,
-                logicMode: parsed.logicMode
+                logicMode: parsed.logicMode,
+                schema: propertySchema(of: collection)
             )
             let response = try await client.graphql(graphql)
             objects = WeaviateObjectCodec.objects(fromGraphQL: response.json as Any)
@@ -75,7 +76,7 @@ extension WeaviatePluginDriver {
         started: Date
     ) async throws -> PluginQueryResult {
         guard let request = WeaviateWriteCodec.decode(statement) else {
-            throw WeaviateError.malformedResponse("Invalid write request.")
+            throw WeaviateError.malformedResponse(String(localized: "Invalid write request."))
         }
         let response = try await client.execute(write: request)
         let outcome: String
@@ -107,11 +108,7 @@ extension WeaviatePluginDriver {
         if request.path.hasPrefix("/v1/objects"), let json = response.json {
             let objects = WeaviateObject.parseList(json)
             if !objects.isEmpty {
-                let collectionName = objects.first?.className ?? ""
-                let collection = (try? await cachedCollection(collectionName))
-                    ?? WeaviateCollection(name: collectionName, properties: [])
-                let columns = WeaviateSchema.columns(for: collection).map(\.name)
-                return render(objects: objects, collection: collection, columns: columns, started: started)
+                return await renderReturnedColumns(objects, started: started)
             }
         }
         return renderJSON(response, started: started)
@@ -125,25 +122,38 @@ extension WeaviatePluginDriver {
         let response = try await client.graphql(query)
         let objects = WeaviateObjectCodec.objects(fromGraphQL: response.json as Any)
         if !objects.isEmpty {
-            let collectionName = objects.first?.className ?? ""
-            let collection = (try? await cachedCollection(collectionName))
-                ?? WeaviateCollection(name: collectionName, properties: [])
-            var columns = WeaviateSchema.columns(for: collection).map(\.name)
-            if columns.count <= WeaviateSchema.metaColumns.count {
-                var seen = Set<String>()
-                columns = []
-                for name in [WeaviateSchema.uuidColumn]
-                    + objects.flatMap({ $0.properties.keys.sorted() })
-                    + [WeaviateSchema.vectorColumn]
-                {
-                    if seen.insert(name).inserted {
-                        columns.append(name)
-                    }
-                }
-            }
-            return render(objects: objects, collection: collection, columns: columns, started: started)
+            return await renderReturnedColumns(objects, started: started)
         }
         return renderJSON(response, started: started)
+    }
+
+    /// A console query selects its own fields, so the result shows what came back rather than every
+    /// column the collection has. That is also what carries `_additional { distance }` into the grid.
+    private func renderReturnedColumns(_ objects: [WeaviateObject], started: Date) async -> PluginQueryResult {
+        let collectionName = objects.first?.className ?? ""
+        let collection = (try? await cachedCollection(collectionName))
+            ?? WeaviateCollection(name: collectionName, properties: [])
+        return render(
+            objects: objects,
+            collection: collection,
+            columns: returnedColumns(of: objects, collection: collection),
+            started: started
+        )
+    }
+
+    private func returnedColumns(of objects: [WeaviateObject], collection: WeaviateCollection) -> [String] {
+        let declared = collection.properties.map(\.name)
+        let returned = Set(objects.flatMap { $0.properties.keys })
+        var columns: [String] = []
+        if objects.contains(where: { !$0.uuid.isEmpty }) {
+            columns.append(WeaviateSchema.uuidColumn)
+        }
+        columns += declared.filter { returned.contains($0) }
+        columns += returned.subtracting(declared).sorted()
+        if objects.contains(where: { $0.vector != nil }) {
+            columns.append(WeaviateSchema.vectorColumn)
+        }
+        return columns.isEmpty ? [WeaviateSchema.uuidColumn] : columns
     }
 
     private func render(

--- a/Plugins/WeaviateDriverPlugin/WeaviatePluginDriver+Metadata.swift
+++ b/Plugins/WeaviateDriverPlugin/WeaviatePluginDriver+Metadata.swift
@@ -61,7 +61,7 @@ extension WeaviatePluginDriver {
     }
 
     func fetchViewDefinition(view: String, schema: String?) async throws -> String {
-        throw WeaviateError.configuration("Weaviate does not support views.")
+        throw WeaviateError.configuration(String(localized: "Weaviate does not support views."))
     }
 
     func fetchTableMetadata(table: String, schema: String?) async throws -> PluginTableMetadata {
@@ -99,22 +99,18 @@ extension WeaviatePluginDriver {
         offset: Int,
         columnKinds: [String: PluginColumnKind]
     ) -> String? {
-        let collection = rememberedCollection(table)
         let sorts = sortColumns.compactMap { sort -> WeaviateSortSpec? in
             guard sort.columnIndex >= 0, sort.columnIndex < columns.count else { return nil }
             let column = columns[sort.columnIndex]
             guard column != WeaviateSchema.vectorColumn else { return nil }
             return WeaviateSortSpec(column: column, ascending: sort.ascending)
         }
-        let typeLookup = Dictionary(
-            uniqueKeysWithValues: (collection?.properties ?? []).map { ($0.name, $0.dataType) }
-        )
         let specs = filters.map { filter in
             WeaviateFilterSpec(
                 column: filter.column,
                 op: filter.op,
                 value: filter.value,
-                typeName: typeLookup[filter.column] ?? "text"
+                secondValue: filter.secondValue
             )
         }
         return WeaviateBrowseQuery.encode(
@@ -150,13 +146,18 @@ extension WeaviatePluginDriver {
                 insertedRowIndices: insertedRowIndices
             )
         }
-        let requests = WeaviateStatementGenerator.generate(
+        let batch = WeaviateStatementGenerator.generate(
             collection: table,
             columns: columns,
             typeNames: typeNames,
             changes: tracked
         )
-        return requests.map { (WeaviateWriteCodec.encode($0), []) }
+        for skipped in batch.skipped {
+            WeaviatePluginDriver.logger.warning(
+                "Skipped a \(skipped.kind.rawValue, privacy: .public) on \(table, privacy: .private): \(skipped.reason.rawValue, privacy: .public)"
+            )
+        }
+        return batch.requests.map { (WeaviateWriteCodec.encode($0), []) }
     }
 
     private func mappedChange(

--- a/Plugins/WeaviateDriverPlugin/WeaviatePluginDriver+Metadata.swift
+++ b/Plugins/WeaviateDriverPlugin/WeaviatePluginDriver+Metadata.swift
@@ -1,0 +1,212 @@
+import Foundation
+import TableProPluginKit
+import TableProWeaviateCore
+
+extension WeaviatePluginDriver {
+    func fetchDatabases() async throws -> [String] {
+        [WeaviatePlugin.defaultGroupName]
+    }
+
+    func fetchDatabaseMetadata(_ database: String) async throws -> PluginDatabaseMetadata {
+        PluginDatabaseMetadata(name: database)
+    }
+
+    func fetchTables(schema: String?) async throws -> [PluginTableInfo] {
+        let collections = try await requireClient().schema()
+        remember(collections)
+        return collections.map { PluginTableInfo(name: $0.name, type: "TABLE") }
+    }
+
+    func fetchColumns(table: String, schema: String?) async throws -> [PluginColumnInfo] {
+        let collection = try await cachedCollection(table)
+        return WeaviateSchema.columns(for: collection).map { column in
+            PluginColumnInfo(
+                name: column.name,
+                dataType: column.type,
+                isNullable: !column.isPrimaryKey,
+                isPrimaryKey: column.isPrimaryKey
+            )
+        }
+    }
+
+    func fetchIndexes(table: String, schema: String?) async throws -> [PluginIndexInfo] {
+        [
+            PluginIndexInfo(
+                name: WeaviateSchema.uuidColumn,
+                columns: [WeaviateSchema.uuidColumn],
+                isUnique: true,
+                isPrimary: true,
+                type: "PRIMARY KEY"
+            )
+        ]
+    }
+
+    func fetchForeignKeys(table: String, schema: String?) async throws -> [PluginForeignKeyInfo] {
+        []
+    }
+
+    func fetchTableDDL(table: String, schema: String?) async throws -> String {
+        let collections = try await requireClient().schema()
+        guard let collection = collections.first(where: { $0.name == table }) else {
+            return "{}"
+        }
+        var payload: [String: Any] = [
+            "class": collection.name,
+            "properties": collection.properties.map { ["name": $0.name, "dataType": [$0.dataType]] }
+        ]
+        if let vectorizer = collection.vectorizer {
+            payload["vectorizer"] = vectorizer
+        }
+        return (try? WeaviateJSON.text(payload, pretty: true)) ?? "{}"
+    }
+
+    func fetchViewDefinition(view: String, schema: String?) async throws -> String {
+        throw WeaviateError.configuration("Weaviate does not support views.")
+    }
+
+    func fetchTableMetadata(table: String, schema: String?) async throws -> PluginTableMetadata {
+        PluginTableMetadata(tableName: table, engine: "Weaviate")
+    }
+
+    func buildBrowseQuery(
+        table: String,
+        sortColumns: [(columnIndex: Int, ascending: Bool)],
+        columns: [String],
+        limit: Int,
+        offset: Int
+    ) -> String? {
+        buildFilteredQuery(
+            table: table,
+            schema: nil,
+            queryFilters: [],
+            logicMode: "AND",
+            sortColumns: sortColumns,
+            columns: columns,
+            limit: limit,
+            offset: offset,
+            columnKinds: [:]
+        )
+    }
+
+    func buildFilteredQuery(
+        table: String,
+        schema: String?,
+        queryFilters filters: [PluginQueryFilter],
+        logicMode: String,
+        sortColumns: [(columnIndex: Int, ascending: Bool)],
+        columns: [String],
+        limit: Int,
+        offset: Int,
+        columnKinds: [String: PluginColumnKind]
+    ) -> String? {
+        let collection = rememberedCollection(table)
+        let sorts = sortColumns.compactMap { sort -> WeaviateSortSpec? in
+            guard sort.columnIndex >= 0, sort.columnIndex < columns.count else { return nil }
+            let column = columns[sort.columnIndex]
+            guard column != WeaviateSchema.vectorColumn else { return nil }
+            return WeaviateSortSpec(column: column, ascending: sort.ascending)
+        }
+        let typeLookup = Dictionary(
+            uniqueKeysWithValues: (collection?.properties ?? []).map { ($0.name, $0.dataType) }
+        )
+        let specs = filters.map { filter in
+            WeaviateFilterSpec(
+                column: filter.column,
+                op: filter.op,
+                value: filter.value,
+                typeName: typeLookup[filter.column] ?? "text"
+            )
+        }
+        return WeaviateBrowseQuery.encode(
+            collection: table,
+            offset: offset,
+            limit: limit,
+            sorts: sorts,
+            filters: specs,
+            logicMode: logicMode,
+            propertyNames: columns
+        )
+    }
+
+    func generateStatements(
+        table: String,
+        columns: [String],
+        primaryKeyColumns: [String],
+        changes: [PluginRowChange],
+        insertedRowData: [Int: [PluginCellValue]],
+        deletedRowIndices: Set<Int>,
+        insertedRowIndices: Set<Int>
+    ) -> [(statement: String, parameters: [PluginCellValue])]? {
+        let collection = rememberedCollection(table)
+        let typeNames = columns.map { column in
+            typeName(for: column, collection: collection ?? WeaviateCollection(name: table, properties: []))
+        }
+        let tracked = changes.compactMap { change -> WeaviateTrackedChange? in
+            mappedChange(
+                change,
+                columns: columns,
+                insertedRowData: insertedRowData,
+                deletedRowIndices: deletedRowIndices,
+                insertedRowIndices: insertedRowIndices
+            )
+        }
+        let requests = WeaviateStatementGenerator.generate(
+            collection: table,
+            columns: columns,
+            typeNames: typeNames,
+            changes: tracked
+        )
+        return requests.map { (WeaviateWriteCodec.encode($0), []) }
+    }
+
+    private func mappedChange(
+        _ change: PluginRowChange,
+        columns: [String],
+        insertedRowData: [Int: [PluginCellValue]],
+        deletedRowIndices: Set<Int>,
+        insertedRowIndices: Set<Int>
+    ) -> WeaviateTrackedChange? {
+        switch change.type {
+        case .insert:
+            guard insertedRowIndices.contains(change.rowIndex) else { return nil }
+            var values: [String: String?] = [:]
+            if let row = insertedRowData[change.rowIndex] {
+                for (index, column) in columns.enumerated() where index < row.count {
+                    values[column] = row[index].asText
+                }
+            } else {
+                for cell in change.cellChanges {
+                    values[cell.columnName] = cell.newValue.asText
+                }
+            }
+            return WeaviateTrackedChange(
+                kind: .insert,
+                uuid: values[WeaviateSchema.uuidColumn] ?? nil,
+                values: values,
+                cellChanges: []
+            )
+        case .update:
+            let uuid = uuid(from: change, columns: columns)
+            let cells = change.cellChanges.map {
+                WeaviateCellChange(column: $0.columnName, newText: $0.newValue.asText)
+            }
+            return WeaviateTrackedChange(kind: .update, uuid: uuid, values: [:], cellChanges: cells)
+        case .delete:
+            guard deletedRowIndices.contains(change.rowIndex) else { return nil }
+            return WeaviateTrackedChange(
+                kind: .delete,
+                uuid: uuid(from: change, columns: columns),
+                values: [:],
+                cellChanges: []
+            )
+        }
+    }
+
+    private func uuid(from change: PluginRowChange, columns: [String]) -> String? {
+        guard let original = change.originalRow,
+              let index = columns.firstIndex(of: WeaviateSchema.uuidColumn),
+              index < original.count
+        else { return nil }
+        return original[index].asText
+    }
+}

--- a/Plugins/WeaviateDriverPlugin/WeaviatePluginDriver+Metadata.swift
+++ b/Plugins/WeaviateDriverPlugin/WeaviatePluginDriver+Metadata.swift
@@ -173,11 +173,13 @@ extension WeaviatePluginDriver {
             var values: [String: String?] = [:]
             if let row = insertedRowData[change.rowIndex] {
                 for (index, column) in columns.enumerated() where index < row.count {
-                    values[column] = row[index].asText
+                    guard let text = row[index].asText else { continue }
+                    values[column] = text
                 }
             } else {
                 for cell in change.cellChanges {
-                    values[cell.columnName] = cell.newValue.asText
+                    guard let text = cell.newValue.asText else { continue }
+                    values[cell.columnName] = text
                 }
             }
             return WeaviateTrackedChange(

--- a/Plugins/WeaviateDriverPlugin/WeaviatePluginDriver.swift
+++ b/Plugins/WeaviateDriverPlugin/WeaviatePluginDriver.swift
@@ -102,6 +102,13 @@ internal final class WeaviatePluginDriver: PluginDatabaseDriver, @unchecked Send
         return rememberedCollection(name) ?? WeaviateCollection(name: name, properties: [])
     }
 
+    func propertySchema(of collection: WeaviateCollection) -> [String: WeaviateProperty] {
+        Dictionary(
+            collection.properties.map { ($0.name, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+    }
+
     func typeName(for column: String, collection: WeaviateCollection) -> String {
         switch column {
         case WeaviateSchema.uuidColumn:

--- a/Plugins/WeaviateDriverPlugin/WeaviatePluginDriver.swift
+++ b/Plugins/WeaviateDriverPlugin/WeaviatePluginDriver.swift
@@ -1,0 +1,115 @@
+import Foundation
+import os
+import TableProPluginKit
+import TableProWeaviateCore
+
+internal final class WeaviatePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
+    static let logger = Logger(subsystem: "com.TablePro", category: "WeaviatePluginDriver")
+
+    private let config: DriverConnectionConfig
+    private let lock = NSLock()
+    private var client: WeaviateClient?
+    private var cachedCollections: [String: WeaviateCollection] = [:]
+    let queryTimeout = HttpQueryTimeoutBox()
+
+    init(config: DriverConnectionConfig) {
+        self.config = config
+    }
+
+    var serverVersion: String? { lock.withLock { client?.serverVersion } }
+
+    var supportsTransactions: Bool { false }
+
+    var capabilities: PluginCapabilities { [.cancelQuery] }
+
+    var parameterStyle: ParameterStyle { .questionMark }
+
+    func beginTransaction() async throws {}
+    func commitTransaction() async throws {}
+    func rollbackTransaction() async throws {}
+
+    func connect() async throws {
+        let settings = try WeaviateConnectionSettings.parse(
+            host: config.host,
+            port: config.port,
+            usesTLS: config.ssl.isEnabled,
+            fields: config.additionalFields
+        )
+        let skipTLS = settings.skipTLSVerify
+            || (config.ssl.isEnabled && !config.ssl.verifiesCertificate)
+        let timeout = queryTimeout
+        let transport = URLSessionWeaviateTransport(
+            resourceTimeout: HttpQueryTimeout.sessionResourceTimeout,
+            skipTLSVerify: skipTLS
+        )
+        let client = WeaviateClient(
+            settings: settings,
+            transport: transport,
+            timeout: { timeout.requestTimeoutInterval }
+        )
+        try await client.connect()
+        lock.withLock {
+            self.client = client
+            cachedCollections.removeAll()
+        }
+    }
+
+    func disconnect() {
+        lock.withLock {
+            client?.cancelAll()
+            client = nil
+            cachedCollections.removeAll()
+        }
+    }
+
+    func ping() async throws {
+        try await requireClient().ping()
+    }
+
+    func cancelQuery() throws {
+        lock.withLock { client?.cancelAll() }
+    }
+
+    func applyQueryTimeout(_ seconds: Int) async throws {
+        queryTimeout.set(serverTimeoutSeconds: seconds)
+    }
+
+    func requireClient() throws -> WeaviateClient {
+        guard let client = lock.withLock({ client }) else {
+            throw WeaviateError.notConnected
+        }
+        return client
+    }
+
+    func remember(_ collections: [WeaviateCollection]) {
+        lock.withLock {
+            for collection in collections {
+                cachedCollections[collection.name] = collection
+            }
+        }
+    }
+
+    func rememberedCollection(_ name: String) -> WeaviateCollection? {
+        lock.withLock { cachedCollections[name] }
+    }
+
+    func cachedCollection(_ name: String) async throws -> WeaviateCollection {
+        if let cached = rememberedCollection(name) {
+            return cached
+        }
+        let collections = try await requireClient().schema()
+        remember(collections)
+        return rememberedCollection(name) ?? WeaviateCollection(name: name, properties: [])
+    }
+
+    func typeName(for column: String, collection: WeaviateCollection) -> String {
+        switch column {
+        case WeaviateSchema.uuidColumn:
+            return "uuid"
+        case WeaviateSchema.vectorColumn:
+            return "vector"
+        default:
+            return collection.properties.first { $0.name == column }?.dataType ?? "text"
+        }
+    }
+}

--- a/TablePro/Assets.xcassets/weaviate-icon.imageset/Contents.json
+++ b/TablePro/Assets.xcassets/weaviate-icon.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images": [
+    {
+      "filename": "weaviate.svg",
+      "idiom": "universal"
+    }
+  ],
+  "info": {
+    "author": "xcode",
+    "version": 1
+  },
+  "properties": {
+    "preserves-vector-representation": true,
+    "template-rendering-intent": "template"
+  }
+}

--- a/TablePro/Assets.xcassets/weaviate-icon.imageset/weaviate.svg
+++ b/TablePro/Assets.xcassets/weaviate-icon.imageset/weaviate.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Weaviate</title><path fill="currentColor" d="M12 1.2l9.4 5.43v10.74L12 22.8 2.6 17.37V6.63L12 1.2zm0 2.08L4.52 7.5v9l7.48 4.32L19.48 16.5v-9L12 3.28zm0 3.12l5.18 2.99v5.22L12 17.6l-5.18-2.99V9.39L12 6.4z"/></svg>

--- a/TablePro/Core/Plugins/PluginMetadataRegistry+RegistryDefaults.swift
+++ b/TablePro/Core/Plugins/PluginMetadataRegistry+RegistryDefaults.swift
@@ -1141,6 +1141,7 @@ extension PluginMetadataRegistry {
             + duckdbPluginDefaults(dialect: duckdbDialect, columnTypes: duckdbColumnTypes)
             + cloudPluginDefaults() + elasticsearchPluginDefaults() + surrealDBPluginDefaults()
             + kafkaPluginDefaults() + typesensePluginDefaults() + r2SQLPluginDefaults()
+            + weaviatePluginDefaults()
     }
     // swiftlint:enable function_body_length
 }

--- a/TablePro/Core/Plugins/PluginMetadataRegistry+WeaviateDefaults.swift
+++ b/TablePro/Core/Plugins/PluginMetadataRegistry+WeaviateDefaults.swift
@@ -1,0 +1,157 @@
+import Foundation
+import TableProPluginKit
+
+extension PluginMetadataRegistry {
+    func weaviatePluginDefaults() -> [(typeId: String, snapshot: PluginMetadataSnapshot)] {
+        [
+            ("Weaviate", PluginMetadataSnapshot(
+                displayName: "Weaviate", iconName: "weaviate-icon", defaultPort: 8_080,
+                requiresAuthentication: false, supportsForeignKeys: false, supportsSchemaEditing: false,
+                isDownloadable: true, primaryUrlScheme: "", parameterStyle: .questionMark,
+                navigationModel: .standard, explainVariants: [], pathFieldRole: .database,
+                supportsHealthMonitor: true, urlSchemes: [], postConnectActions: [],
+                brandColorHex: "#01B0D3",
+                queryLanguageName: "GraphQL", editorLanguage: .javascript,
+                connectionMode: .network, supportsDatabaseSwitching: false,
+                capabilities: PluginMetadataSnapshot.CapabilityFlags(
+                    supportsSchemaSwitching: false,
+                    supportsImport: false,
+                    supportsExport: true,
+                    supportsSSH: false,
+                    supportsSSL: true,
+                    supportsCascadeDrop: false,
+                    supportsForeignKeyDisable: false,
+                    supportsReadOnlyMode: true,
+                    supportsQueryProgress: false,
+                    requiresReconnectForDatabaseSwitch: false,
+                    supportsDropDatabase: false,
+                    supportsAddColumn: false,
+                    supportsModifyColumn: false,
+                    supportsDropColumn: false,
+                    supportsAddIndex: false,
+                    supportsDropIndex: false,
+                    supportsModifyPrimaryKey: false,
+                    supportsOpportunisticTLS: false,
+                    supportsCloudflareTunnel: false,
+                    supportsPrincipalConnectionLimit: false
+                ),
+                schema: PluginMetadataSnapshot.SchemaInfo(
+                    defaultSchemaName: "",
+                    defaultGroupName: "default",
+                    tableEntityName: "Collections",
+                    containerEntityName: "Cluster",
+                    defaultPrimaryKeyColumn: "uuid",
+                    immutableColumns: ["uuid", "vector"],
+                    systemDatabaseNames: [],
+                    systemSchemaNames: [],
+                    fileExtensions: [],
+                    databaseGroupingStrategy: .flat,
+                    structureColumnFields: [.name, .type, .nullable]
+                ),
+                editor: PluginMetadataSnapshot.EditorConfig(
+                    sqlDialect: nil,
+                    statementCompletions: weaviateCompletions,
+                    columnTypesByCategory: weaviateColumnTypes
+                ),
+                connection: PluginMetadataSnapshot.ConnectionConfig(
+                    additionalConnectionFields: weaviateConnectionFields(),
+                    category: .document,
+                    tagline: String(localized: "Open-source vector database"),
+                    hidesBuiltInDatabase: true
+                )
+            )),
+        ]
+    }
+}
+
+private let weaviateCompletions: [CompletionEntry] = [
+    CompletionEntry(
+        label: "Get",
+        insertText: """
+        {
+          Get {
+            Article(limit: 10) {
+              title
+              _additional { id distance }
+            }
+          }
+        }
+        """
+    ),
+    CompletionEntry(
+        label: "Near text",
+        insertText: """
+        {
+          Get {
+            Article(
+              nearText: { concepts: ["search term"] }
+              limit: 10
+            ) {
+              title
+              _additional { id distance }
+            }
+          }
+        }
+        """
+    ),
+    CompletionEntry(
+        label: "Hybrid",
+        insertText: """
+        {
+          Get {
+            Article(
+              hybrid: { query: "search term", alpha: 0.5 }
+              limit: 10
+            ) {
+              title
+              _additional { id score }
+            }
+          }
+        }
+        """
+    ),
+    CompletionEntry(label: "GET /v1/schema", insertText: "GET /v1/schema"),
+    CompletionEntry(label: "GET /v1/meta", insertText: "GET /v1/meta"),
+    CompletionEntry(label: "GET /v1/objects", insertText: "GET /v1/objects?class=Article&limit=10")
+]
+
+private let weaviateColumnTypes: [String: [String]] = [
+    "Text": ["text", "text[]", "string", "string[]", "uuid", "uuid[]"],
+    "Numeric": ["int", "int[]", "number", "number[]"],
+    "Boolean": ["boolean", "boolean[]"],
+    "Date": ["date", "date[]"],
+    "Structured": ["object", "object[]", "geoCoordinates", "phoneNumber"],
+    "Vector": ["vector"]
+]
+
+func weaviateConnectionFields() -> [ConnectionField] {
+    [
+        ConnectionField(
+            id: "wvAuthMethod",
+            label: String(localized: "Auth Method"),
+            defaultValue: "none",
+            fieldType: .dropdown(options: [
+                .init(value: "none", label: "None"),
+                .init(value: "apiKey", label: "API Key")
+            ]),
+            section: .authentication,
+            hidesPassword: true
+        ).withHidesUsername(true),
+        ConnectionField(
+            id: "wvApiKey",
+            label: String(localized: "API Key"),
+            placeholder: "Weaviate API key",
+            required: true,
+            fieldType: .secure,
+            section: .authentication,
+            visibleWhen: FieldVisibilityRule(fieldId: "wvAuthMethod", values: ["apiKey"])
+        ),
+        ConnectionField(
+            id: "wvSkipTLSVerify",
+            label: String(localized: "Skip TLS Verification"),
+            defaultValue: "false",
+            fieldType: .toggle,
+            section: .advanced
+        )
+    ]
+}

--- a/TablePro/Core/Plugins/PluginMetadataRegistry+WeaviateDefaults.swift
+++ b/TablePro/Core/Plugins/PluginMetadataRegistry+WeaviateDefaults.swift
@@ -57,6 +57,7 @@ extension PluginMetadataRegistry {
                     additionalConnectionFields: weaviateConnectionFields(),
                     category: .document,
                     tagline: String(localized: "Open-source vector database"),
+                    hidesBuiltInPassword: true,
                     hidesBuiltInDatabase: true
                 )
             )),
@@ -134,18 +135,16 @@ func weaviateConnectionFields() -> [ConnectionField] {
                 .init(value: "none", label: "None"),
                 .init(value: "apiKey", label: "API Key")
             ]),
-            section: .authentication,
-            hidesPassword: true
-        ).withHidesUsername(true),
+            section: .authentication
+        ),
         ConnectionField(
             id: "wvApiKey",
             label: String(localized: "API Key"),
             placeholder: "Weaviate API key",
-            required: true,
             fieldType: .secure,
             section: .authentication,
-            visibleWhen: FieldVisibilityRule(fieldId: "wvAuthMethod", values: ["apiKey"])
-        ),
+            hidesPassword: true
+        ).withHidesUsername(true),
         ConnectionField(
             id: "wvSkipTLSVerify",
             label: String(localized: "Skip TLS Verification"),

--- a/TablePro/Core/Plugins/PluginMetadataRegistry+WeaviateDefaults.swift
+++ b/TablePro/Core/Plugins/PluginMetadataRegistry+WeaviateDefaults.swift
@@ -60,7 +60,7 @@ extension PluginMetadataRegistry {
                     hidesBuiltInPassword: true,
                     hidesBuiltInDatabase: true
                 )
-            )),
+            ))
         ]
     }
 }

--- a/TablePro/Core/Plugins/PluginMetadataRegistry.swift
+++ b/TablePro/Core/Plugins/PluginMetadataRegistry.swift
@@ -686,7 +686,7 @@ final class PluginMetadataRegistry: @unchecked Sendable {
             return .analytical
         case "Spanner":
             return .relational
-        case "MongoDB", "Elasticsearch", "SurrealDB", "Typesense":
+        case "MongoDB", "Elasticsearch", "SurrealDB", "Typesense", "Weaviate":
             return .document
         case "Redis":
             return .keyValue
@@ -728,6 +728,7 @@ final class PluginMetadataRegistry: @unchecked Sendable {
         case "SurrealDB":      return String(localized: "Multi-model database with SurrealQL")
         case "Kafka":          return String(localized: "Event streaming platform")
         case "Typesense":      return String(localized: "Typo-tolerant open-source search engine")
+        case "Weaviate":       return String(localized: "Open-source vector database")
         default:               return ""
         }
     }

--- a/TablePro/Core/Utilities/SQL/QueryClassifier.swift
+++ b/TablePro/Core/Utilities/SQL/QueryClassifier.swift
@@ -752,6 +752,28 @@ private extension QueryClassifier {
         return QueryClassification(tier: .write, reachesFilesystemOrExecutesCode: touchesUnsafeSurface)
     }
 
+    /// A bare operation, a `{"query": ...}` envelope and a console body are the same request, and
+    /// the driver forwards the envelope verbatim, so the read-only gate has to read all three.
+    static func weaviateDeclaresMutation(_ body: String) -> Bool {
+        let trimmed = body.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.lowercased().hasPrefix("mutation") {
+            return true
+        }
+        guard let data = trimmed.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let query = object["query"] as? String
+        else { return false }
+        return query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased().hasPrefix("mutation")
+    }
+
+    static func weaviateConsoleBody(_ trimmed: String) -> String {
+        trimmed
+            .split(separator: "\n", maxSplits: 1, omittingEmptySubsequences: false)
+            .dropFirst()
+            .first
+            .map(String.init) ?? ""
+    }
+
     static func weaviateClassification(_ trimmed: String) -> QueryClassification {
         if trimmed.hasPrefix("WEAVIATE_SEARCH:") {
             return .safe
@@ -770,15 +792,18 @@ private extension QueryClassifier {
             return QueryClassification(tier: .write, reachesFilesystemOrExecutesCode: false)
         }
         if trimmed.hasPrefix("{") || lowered.hasPrefix("query") || lowered.hasPrefix("fragment") {
-            return .safe
+            return weaviateDeclaresMutation(trimmed)
+                ? QueryClassification(tier: .write, reachesFilesystemOrExecutesCode: false)
+                : .safe
         }
         let (verb, path) = typesenseRequestLine(trimmed)
-        let upperPath = path.uppercased()
         if verb == "GET" || verb == "HEAD" {
             return .safe
         }
-        if verb == "POST", upperPath == "/V1/GRAPHQL" || upperPath.hasPrefix("/V1/GRAPHQL?") {
-            return .safe
+        if verb == "POST", path == "/V1/GRAPHQL" {
+            return weaviateDeclaresMutation(weaviateConsoleBody(trimmed))
+                ? QueryClassification(tier: .write, reachesFilesystemOrExecutesCode: false)
+                : .safe
         }
         if verb == "DELETE" {
             return QueryClassification(tier: .destructive, reachesFilesystemOrExecutesCode: false)

--- a/TablePro/Core/Utilities/SQL/QueryClassifier.swift
+++ b/TablePro/Core/Utilities/SQL/QueryClassifier.swift
@@ -766,12 +766,15 @@ private extension QueryClassifier {
         return query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased().hasPrefix("mutation")
     }
 
+    /// The driver takes a body from the rest of the request line as well as from the lines below
+    /// it, so the gate has to read the same two places.
     static func weaviateConsoleBody(_ trimmed: String) -> String {
-        trimmed
-            .split(separator: "\n", maxSplits: 1, omittingEmptySubsequences: false)
-            .dropFirst()
-            .first
-            .map(String.init) ?? ""
+        let lines = trimmed.split(separator: "\n", maxSplits: 1, omittingEmptySubsequences: false)
+        let header = lines.first.map(String.init) ?? ""
+        let following = lines.count > 1 ? String(lines[1]) : ""
+        let parts = header.split(maxSplits: 2, omittingEmptySubsequences: true, whereSeparator: \.isWhitespace)
+        let inline = parts.count > 2 ? String(parts[2]) : ""
+        return inline.isEmpty ? following : inline
     }
 
     static func weaviateClassification(_ trimmed: String) -> QueryClassification {

--- a/TablePro/Core/Utilities/SQL/QueryClassifier.swift
+++ b/TablePro/Core/Utilities/SQL/QueryClassifier.swift
@@ -581,6 +581,8 @@ private extension QueryClassifier {
             return elasticsearchClassification(trimmed)
         case .typesense:
             return typesenseClassification(trimmed)
+        case .weaviate:
+            return weaviateClassification(trimmed)
         default:
             return nil
         }
@@ -748,5 +750,42 @@ private extension QueryClassifier {
             return QueryClassification(tier: .destructive, reachesFilesystemOrExecutesCode: touchesUnsafeSurface)
         }
         return QueryClassification(tier: .write, reachesFilesystemOrExecutesCode: touchesUnsafeSurface)
+    }
+
+    static func weaviateClassification(_ trimmed: String) -> QueryClassification {
+        if trimmed.hasPrefix("WEAVIATE_SEARCH:") {
+            return .safe
+        }
+        if trimmed.hasPrefix("WEAVIATE_WRITE:") {
+            let encoded = String(trimmed.dropFirst("WEAVIATE_WRITE:".count))
+            if let data = Data(base64Encoded: encoded),
+               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               (json["method"] as? String)?.uppercased() == "DELETE" {
+                return QueryClassification(tier: .destructive, reachesFilesystemOrExecutesCode: false)
+            }
+            return QueryClassification(tier: .write, reachesFilesystemOrExecutesCode: false)
+        }
+        let lowered = trimmed.lowercased()
+        if lowered.hasPrefix("mutation") {
+            return QueryClassification(tier: .write, reachesFilesystemOrExecutesCode: false)
+        }
+        if trimmed.hasPrefix("{") || lowered.hasPrefix("query") || lowered.hasPrefix("fragment") {
+            return .safe
+        }
+        let (verb, path) = typesenseRequestLine(trimmed)
+        let upperPath = path.uppercased()
+        if verb == "GET" || verb == "HEAD" {
+            return .safe
+        }
+        if verb == "POST", upperPath == "/V1/GRAPHQL" || upperPath.hasPrefix("/V1/GRAPHQL?") {
+            return .safe
+        }
+        if verb == "DELETE" {
+            return QueryClassification(tier: .destructive, reachesFilesystemOrExecutesCode: false)
+        }
+        if verb.isEmpty {
+            return .safe
+        }
+        return QueryClassification(tier: .write, reachesFilesystemOrExecutesCode: false)
     }
 }

--- a/TablePro/Models/Connection/DatabaseType.swift
+++ b/TablePro/Models/Connection/DatabaseType.swift
@@ -49,6 +49,7 @@ extension DatabaseType {
     static let typesense = DatabaseType(rawValue: "Typesense")
     static let teradata = DatabaseType(rawValue: "Teradata")
     static let trino = DatabaseType(rawValue: "Trino")
+    static let weaviate = DatabaseType(rawValue: "Weaviate")
 }
 
 extension DatabaseType: Codable {

--- a/TableProMobile/TableProMobile/Assets.xcassets/weaviate-icon.imageset/Contents.json
+++ b/TableProMobile/TableProMobile/Assets.xcassets/weaviate-icon.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images": [
+    {
+      "filename": "weaviate.svg",
+      "idiom": "universal"
+    }
+  ],
+  "info": {
+    "author": "xcode",
+    "version": 1
+  },
+  "properties": {
+    "preserves-vector-representation": true,
+    "template-rendering-intent": "template"
+  }
+}

--- a/TableProMobile/TableProMobile/Assets.xcassets/weaviate-icon.imageset/weaviate.svg
+++ b/TableProMobile/TableProMobile/Assets.xcassets/weaviate-icon.imageset/weaviate.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Weaviate</title><path fill="currentColor" d="M12 1.2l9.4 5.43v10.74L12 22.8 2.6 17.37V6.63L12 1.2zm0 2.08L4.52 7.5v9l7.48 4.32L19.48 16.5v-9L12 3.28zm0 3.12l5.18 2.99v5.22L12 17.6l-5.18-2.99V9.39L12 6.4z"/></svg>

--- a/TableProMobile/TableProWidget/Assets.xcassets/weaviate-icon.imageset/Contents.json
+++ b/TableProMobile/TableProWidget/Assets.xcassets/weaviate-icon.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images": [
+    {
+      "filename": "weaviate.svg",
+      "idiom": "universal"
+    }
+  ],
+  "info": {
+    "author": "xcode",
+    "version": 1
+  },
+  "properties": {
+    "preserves-vector-representation": true,
+    "template-rendering-intent": "template"
+  }
+}

--- a/TableProMobile/TableProWidget/Assets.xcassets/weaviate-icon.imageset/weaviate.svg
+++ b/TableProMobile/TableProWidget/Assets.xcassets/weaviate-icon.imageset/weaviate.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Weaviate</title><path fill="currentColor" d="M12 1.2l9.4 5.43v10.74L12 22.8 2.6 17.37V6.63L12 1.2zm0 2.08L4.52 7.5v9l7.48 4.32L19.48 16.5v-9L12 3.28zm0 3.12l5.18 2.99v5.22L12 17.6l-5.18-2.99V9.39L12 6.4z"/></svg>

--- a/TableProMobile/TableProWidget/Helpers/DatabaseTypeStyle.swift
+++ b/TableProMobile/TableProWidget/Helpers/DatabaseTypeStyle.swift
@@ -22,6 +22,7 @@ enum DatabaseTypeStyle {
         case "DynamoDB": return "dynamodb-icon"
         case "BigQuery": return "bigquery-icon"
         case "Spanner": return "spanner-icon"
+        case "Weaviate": return "weaviate-icon"
         default: return "externaldrive"
         }
     }

--- a/TableProTests/Core/Plugins/PluginMetadataRegistryTypeCountTests.swift
+++ b/TableProTests/Core/Plugins/PluginMetadataRegistryTypeCountTests.swift
@@ -11,7 +11,7 @@ import Testing
 /// this registry, `docs/snippets/driver-counts.mdx`, and the marketing site. Nothing at runtime
 /// reconciles them, and by August 2026 they read 28, 27 and 25 at once.
 ///
-/// The answer is 34, and the reason it once read 28 is worth keeping. Turso is served by
+/// The answer is 35, and the reason it once read 28 is worth keeping. Turso is served by
 /// the libSQL plugin and was the only alias in `reverseTypeIndex` with no curated entry of its
 /// own, so it was the only type the picker could not offer before its plugin was installed.
 /// ScyllaDB is the shape every other alias already had: an alias of Cassandra with a curated
@@ -24,7 +24,7 @@ import Testing
 /// `docs/scripts/check-docs-against-source.py` reads the registry and holds the docs half.
 ///
 /// The count is taken from the built-in defaults rather than from `allRegisteredTypeIds()`.
-/// Both answer 34 under XCTest, where no plugin bundle ever loads, but the registry is a
+/// Both answer 35 under XCTest, where no plugin bundle ever loads, but the registry is a
 /// process-global singleton and suites that register a synthetic type run alongside this one.
 @MainActor
 @Suite("PluginMetadataRegistry engine count")
@@ -34,7 +34,7 @@ struct PluginMetadataRegistryTypeCountTests {
         "CockroachDB", "Dameng", "Databend", "DuckDB", "DynamoDB", "Elasticsearch", "etcd", "Kafka",
         "libSQL", "MariaDB", "MongoDB", "MySQL", "Oracle", "PGlite", "PostgreSQL", "Redis", "Redshift",
         "ScyllaDB", "Snowflake", "Spanner", "SQL Server", "SQLite", "SurrealDB", "Teradata", "TiDB", "Trino",
-        "Turso", "Typesense"
+        "Turso", "Typesense", "Weaviate"
     ]
 
     private static func builtInTypeIds() -> Set<String> {
@@ -43,10 +43,10 @@ struct PluginMetadataRegistryTypeCountTests {
         return Set(curated + registry)
     }
 
-    @Test("The app ships 34 database types before any plugin loads")
+    @Test("The app ships 35 database types before any plugin loads")
     func builtInDefaultsCoverTwentyNineTypes() {
         let ids = Self.builtInTypeIds()
-        #expect(ids.count == 34)
+        #expect(ids.count == 35)
         #expect(ids == Self.expectedTypeIds)
     }
 

--- a/TableProTests/Core/Utilities/SQL/QueryClassifierHardeningTests.swift
+++ b/TableProTests/Core/Utilities/SQL/QueryClassifierHardeningTests.swift
@@ -545,6 +545,19 @@ struct QueryClassifierNonSqlTests {
         )
     }
 
+    @Test("Weaviate GraphQL reads are safe and uuid deletes are destructive")
+    func weaviateTiers() {
+        #expect(!QueryClassifier.isWriteQuery("{ Get { Article { title } } }", databaseType: .weaviate))
+        #expect(!QueryClassifier.isWriteQuery("query { Get { Article { title } } }", databaseType: .weaviate))
+        #expect(!QueryClassifier.isWriteQuery("GET /v1/schema", databaseType: .weaviate))
+        #expect(!QueryClassifier.isWriteQuery("POST /v1/graphql {}", databaseType: .weaviate))
+        #expect(QueryClassifier.isWriteQuery("mutation { delete { Article } }", databaseType: .weaviate))
+        #expect(QueryClassifier.isWriteQuery("POST /v1/objects {}", databaseType: .weaviate))
+        #expect(QueryClassifier.classifyTier("DELETE /v1/objects/abc", databaseType: .weaviate) == .destructive)
+        let search = "WEAVIATE_SEARCH:e30="
+        #expect(!QueryClassifier.isWriteQuery(search, databaseType: .weaviate))
+    }
+
     @Test("Elasticsearch stored scripts are flagged as code execution on both verbs")
     func elasticsearchScriptsAreFlagged() {
         #expect(

--- a/TableProTests/Core/Utilities/SQL/QueryClassifierHardeningTests.swift
+++ b/TableProTests/Core/Utilities/SQL/QueryClassifierHardeningTests.swift
@@ -558,6 +558,39 @@ struct QueryClassifierNonSqlTests {
         #expect(!QueryClassifier.isWriteQuery(search, databaseType: .weaviate))
     }
 
+    @Test("A console body declaring a mutation is classified the same as a bare one")
+    func weaviateConsoleBodyIsRead() {
+        #expect(QueryClassifier.isWriteQuery(
+            "POST /v1/graphql\nmutation { delete { Article } }",
+            databaseType: .weaviate
+        ))
+        #expect(QueryClassifier.isWriteQuery(
+            "POST /v1/graphql\n{\"query\": \"mutation { delete { Article } }\"}",
+            databaseType: .weaviate
+        ))
+        #expect(!QueryClassifier.isWriteQuery(
+            "POST /v1/graphql\n{\"query\": \"{ Get { Article { title } } }\"}",
+            databaseType: .weaviate
+        ))
+        #expect(!QueryClassifier.isWriteQuery(
+            "POST /v1/graphql?pretty\n{ Get { Article { title } } }",
+            databaseType: .weaviate
+        ))
+    }
+
+    @Test("A mutation inside a query envelope is a write however it is typed")
+    func weaviateEnvelopeIsRead() {
+        #expect(QueryClassifier.isWriteQuery(
+            "{\"query\": \"mutation { delete { Article } }\"}",
+            databaseType: .weaviate
+        ))
+        #expect(!QueryClassifier.isWriteQuery(
+            "{\"query\": \"{ Get { Article { title } } }\"}",
+            databaseType: .weaviate
+        ))
+        #expect(!QueryClassifier.isWriteQuery("{ Get { Article { title } } }", databaseType: .weaviate))
+    }
+
     @Test("Elasticsearch stored scripts are flagged as code execution on both verbs")
     func elasticsearchScriptsAreFlagged() {
         #expect(

--- a/TableProTests/Plugins/WeaviateConnectionFieldsTests.swift
+++ b/TableProTests/Plugins/WeaviateConnectionFieldsTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+@testable import TablePro
+import TableProPluginKit
+import TableProWeaviateCore
+import Testing
+
+@Suite("Weaviate registry snapshot")
+struct WeaviateRegistrySnapshotTests {
+    private func snapshot() throws -> PluginMetadataSnapshot {
+        let defaults = PluginMetadataRegistry.shared.registryPluginDefaults()
+        return try #require(defaults.first { $0.typeId == "Weaviate" }).snapshot
+    }
+
+    @Test("Weaviate is a collection engine on port 8080 with no SQL dialect")
+    func connectionShape() throws {
+        let snapshot = try snapshot()
+        #expect(snapshot.defaultPort == 8_080)
+        #expect(snapshot.editor.sqlDialect == nil)
+        #expect(snapshot.queryLanguageName == "GraphQL")
+        #expect(snapshot.schema.tableEntityName == "Collections")
+        #expect(snapshot.schema.defaultPrimaryKeyColumn == "uuid")
+        #expect(snapshot.schema.immutableColumns == ["uuid", "vector"])
+        #expect(!snapshot.supportsForeignKeys)
+        #expect(!snapshot.capabilities.supportsSSH)
+        #expect(snapshot.capabilities.supportsSSL)
+        #expect(snapshot.connection.category == .document)
+        #expect(snapshot.iconName == "weaviate-icon")
+    }
+
+    @Test("Auth field ids are Weaviate-prefixed and do not collide with Elasticsearch")
+    func authFieldIdsArePrefixed() throws {
+        let ids = try snapshot().connection.additionalConnectionFields.map(\.id)
+        #expect(ids == [
+            WeaviateFieldID.authMethod,
+            WeaviateFieldID.apiKey,
+            WeaviateFieldID.skipTLSVerify
+        ])
+        #expect(!ids.contains("esAuthMethod"))
+        #expect(!ids.contains("esApiKey"))
+        let elasticsearch = try #require(
+            PluginMetadataRegistry.shared.registryPluginDefaults().first { $0.typeId == "Elasticsearch" }
+        )
+        let esIds = elasticsearch.snapshot.connection.additionalConnectionFields.map(\.id)
+        #expect(Set(ids).isDisjoint(with: Set(esIds)))
+    }
+}
+
+@Suite("Weaviate connection fields")
+struct WeaviateConnectionFieldsTests {
+    private func fields() throws -> [ConnectionField] {
+        let defaults = PluginMetadataRegistry.shared.registryPluginDefaults()
+        let entry = try #require(defaults.first { $0.typeId == "Weaviate" })
+        return entry.snapshot.connection.additionalConnectionFields
+    }
+
+    @Test("Auth method defaults to none and hides the built-in password and username")
+    func authMethodHidesBuiltInCredentials() throws {
+        let fields = try fields()
+        let method = try #require(fields.first { $0.id == WeaviateFieldID.authMethod })
+        #expect(method.defaultValue == "none")
+        #expect(method.hidesPassword)
+        #expect(method.hidesUsername)
+        guard case .dropdown(let options) = method.fieldType else {
+            Issue.record("Expected a dropdown field type")
+            return
+        }
+        #expect(options.map(\.value) == ["none", "apiKey"])
+    }
+
+    @Test("API key is a secure field gated to API key mode")
+    func apiKeyIsSecureAndModeGated() throws {
+        let fields = try fields()
+        let apiKey = try #require(fields.first { $0.id == WeaviateFieldID.apiKey })
+        #expect(apiKey.isSecure)
+        #expect(apiKey.visibleWhen == FieldVisibilityRule(
+            fieldId: WeaviateFieldID.authMethod,
+            values: ["apiKey"]
+        ))
+    }
+
+    @Test("Password stays hidden for both auth methods")
+    func passwordStaysHidden() throws {
+        let fields = try fields()
+        #expect(fields.hidesPassword(forValues: [:]))
+        #expect(fields.hidesPassword(forValues: [WeaviateFieldID.authMethod: "none"]))
+        #expect(fields.hidesPassword(forValues: [WeaviateFieldID.authMethod: "apiKey"]))
+    }
+}
+
+@Suite("Weaviate plugin manifest")
+struct WeaviatePluginManifestTests {
+    @Test("Info.plist declares PluginKit 25 and the Weaviate type id")
+    func plistDeclaresType() throws {
+        let url = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Plugins/WeaviateDriverPlugin/Info.plist")
+        let plist = try #require(NSDictionary(contentsOf: url) as? [String: Any])
+        #expect(plist["TableProPluginKitVersion"] as? Int == 25)
+        #expect(plist["TableProProvidesDatabaseTypeIds"] as? [String] == ["Weaviate"])
+    }
+}

--- a/TableProTests/Plugins/WeaviateConnectionFieldsTests.swift
+++ b/TableProTests/Plugins/WeaviateConnectionFieldsTests.swift
@@ -71,7 +71,6 @@ struct WeaviateConnectionFieldsTests {
         let apiKey = try #require(fields.first { $0.id == WeaviateFieldID.apiKey })
         #expect(apiKey.isSecure)
         #expect(!apiKey.isRequired)
-        #expect(apiKey.visibleWhen == nil)
         #expect(apiKey.hidesPassword)
         #expect(fields.hidesPassword(forValues: [:]))
         #expect(fields.hidesUsername(forValues: [:]))
@@ -91,6 +90,37 @@ struct WeaviateConnectionFieldsTests {
             var connection = DatabaseConnection(name: "Weaviate", type: .weaviate)
             connection.additionalFields = [WeaviateFieldID.authMethod: method]
             #expect(PluginManager.shared.hidesPassword(for: connection), "\(method)")
+        }
+    }
+}
+
+@Suite("Weaviate field parity")
+struct WeaviateFieldParityTests {
+    private static let repoRoot = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+
+    private func source(_ path: String) throws -> String {
+        try String(contentsOf: Self.repoRoot.appendingPathComponent(path), encoding: .utf8)
+    }
+
+    /// The plugin's own field list replaces the registry snapshot the moment the plugin is
+    /// installed, and no test can link both copies, so the two sources are compared as text.
+    @Test("The plugin's field list matches the registry copy")
+    func pluginCopyMatchesRegistryCopy() throws {
+        let plugin = try source("Plugins/WeaviateDriverPlugin/WeaviatePlugin.swift")
+        let registry = try source("TablePro/Core/Plugins/PluginMetadataRegistry+WeaviateDefaults.swift")
+        for field in [WeaviateFieldID.authMethod, WeaviateFieldID.apiKey, WeaviateFieldID.skipTLSVerify] {
+            #expect(registry.contains("id: \"\(field)\""), Comment(rawValue: field))
+        }
+        #expect(plugin.contains("id: WeaviateFieldID.authMethod"))
+        #expect(plugin.contains("id: WeaviateFieldID.apiKey"))
+        #expect(plugin.contains("id: WeaviateFieldID.skipTLSVerify"))
+        for copy in [plugin, registry] {
+            #expect(copy.contains("hidesPassword: true"))
+            #expect(copy.contains("withHidesUsername(true)"))
+            #expect(copy.contains("apiKey"))
         }
     }
 }

--- a/TableProTests/Plugins/WeaviateConnectionFieldsTests.swift
+++ b/TableProTests/Plugins/WeaviateConnectionFieldsTests.swift
@@ -90,7 +90,7 @@ struct WeaviateConnectionFieldsTests {
         for method in ["none", "apiKey"] {
             var connection = DatabaseConnection(name: "Weaviate", type: .weaviate)
             connection.additionalFields = [WeaviateFieldID.authMethod: method]
-            #expect(PluginManager.shared.hidesPassword(for: connection), method)
+            #expect(PluginManager.shared.hidesPassword(for: connection), "\(method)")
         }
     }
 }

--- a/TableProTests/Plugins/WeaviateConnectionFieldsTests.swift
+++ b/TableProTests/Plugins/WeaviateConnectionFieldsTests.swift
@@ -53,13 +53,11 @@ struct WeaviateConnectionFieldsTests {
         return entry.snapshot.connection.additionalConnectionFields
     }
 
-    @Test("Auth method defaults to none and hides the built-in password and username")
-    func authMethodHidesBuiltInCredentials() throws {
+    @Test("Auth method defaults to none")
+    func authMethodDefaultsToNone() throws {
         let fields = try fields()
         let method = try #require(fields.first { $0.id == WeaviateFieldID.authMethod })
         #expect(method.defaultValue == "none")
-        #expect(method.hidesPassword)
-        #expect(method.hidesUsername)
         guard case .dropdown(let options) = method.fieldType else {
             Issue.record("Expected a dropdown field type")
             return
@@ -67,23 +65,33 @@ struct WeaviateConnectionFieldsTests {
         #expect(options.map(\.value) == ["none", "apiKey"])
     }
 
-    @Test("API key is a secure field gated to API key mode")
-    func apiKeyIsSecureAndModeGated() throws {
+    @Test("The API key replaces both built-in credential rows")
+    func apiKeyReplacesUsernameAndPassword() throws {
         let fields = try fields()
         let apiKey = try #require(fields.first { $0.id == WeaviateFieldID.apiKey })
         #expect(apiKey.isSecure)
-        #expect(apiKey.visibleWhen == FieldVisibilityRule(
-            fieldId: WeaviateFieldID.authMethod,
-            values: ["apiKey"]
-        ))
-    }
-
-    @Test("Password stays hidden for both auth methods")
-    func passwordStaysHidden() throws {
-        let fields = try fields()
+        #expect(!apiKey.isRequired)
+        #expect(apiKey.visibleWhen == nil)
+        #expect(apiKey.hidesPassword)
         #expect(fields.hidesPassword(forValues: [:]))
+        #expect(fields.hidesUsername(forValues: [:]))
         #expect(fields.hidesPassword(forValues: [WeaviateFieldID.authMethod: "none"]))
         #expect(fields.hidesPassword(forValues: [WeaviateFieldID.authMethod: "apiKey"]))
+        #expect(fields.hidesUsername(forValues: [WeaviateFieldID.authMethod: "none"]))
+        #expect(fields.hidesUsername(forValues: [WeaviateFieldID.authMethod: "apiKey"]))
+    }
+
+    @Test("The snapshot hides the built-in password for every auth method")
+    @MainActor
+    func snapshotHidesBuiltInPassword() throws {
+        let defaults = PluginMetadataRegistry.shared.registryPluginDefaults()
+        let snapshot = try #require(defaults.first { $0.typeId == "Weaviate" }).snapshot
+        #expect(snapshot.connection.hidesBuiltInPassword)
+        for method in ["none", "apiKey"] {
+            var connection = DatabaseConnection(name: "Weaviate", type: .weaviate)
+            connection.additionalFields = [WeaviateFieldID.authMethod: method]
+            #expect(PluginManager.shared.hidesPassword(for: connection), method)
+        }
     }
 }
 

--- a/docs/connections/connection-form.mdx
+++ b/docs/connections/connection-form.mdx
@@ -128,6 +128,7 @@ Metadata connections, the extra ones TablePro opens to read a database's object 
 | [SurrealDB](/databases/surrealdb) | 8000 | Yes | Yes | Yes | No | Yes | Yes |
 | [Elasticsearch](/databases/elasticsearch) | 9200 | No | Yes | No | No | No | No |
 | [Typesense](/databases/typesense) | 8108 | No | Yes | No | No | No | No |
+| [Weaviate](/databases/weaviate) | 8080 | No | Yes | No | No | No | No |
 | [Snowflake](/databases/snowflake) | 443 | No | No | No | No | No | No |
 | [SQLite](/databases/sqlite) | File | No | No | No | No | No | No |
 | [DuckDB](/databases/duckdb) | File | No | No | No | No | No | No |

--- a/docs/connections/ssh-tunneling.mdx
+++ b/docs/connections/ssh-tunneling.mdx
@@ -37,7 +37,7 @@ To share one SSH config across connections, save it with **Save Current as Profi
   <img className="hidden dark:block" src="/images/ssh-tunnel-config-dark.png" alt="Network section with SSH Tunnel selected and a saved profile in the Profile picker" />
 </Frame>
 
-**SSH Tunnel** is not offered on SQLite, PGlite, libSQL, Beancount, BigQuery, Spanner, Cloudflare D1, Cloudflare R2 SQL, DynamoDB, Elasticsearch, Typesense, or Snowflake: each is reached over a local file, a loopback socket, or a vendor HTTP API.
+**SSH Tunnel** is not offered on SQLite, PGlite, libSQL, Beancount, BigQuery, Spanner, Cloudflare D1, Cloudflare R2 SQL, DynamoDB, Elasticsearch, Typesense, Weaviate, or Snowflake: each is reached over a local file, a loopback socket, or a vendor HTTP API.
 
 ## Authentication methods
 

--- a/docs/connections/ssl.mdx
+++ b/docs/connections/ssl.mdx
@@ -43,7 +43,7 @@ A new connection starts on the mode that matches the driver's own default, and t
 | MySQL, MariaDB | Preferred | Tries TLS, then retries plain on an SSL handshake error. Auth and network errors are not retried |
 | SQL Server | Preferred | FreeTDS `encryption=request`, falls back to plain |
 | Teradata | Disabled | Opens a TLS transport, retries on a plain socket if it fails to come up |
-| MongoDB, Redis, Cassandra, ClickHouse, Elasticsearch, Typesense, SurrealDB | Disabled | Nothing. No fallback exists, so Preferred forces TLS exactly like Required |
+| MongoDB, Redis, Cassandra, ClickHouse, Elasticsearch, Typesense, SurrealDB, Weaviate | Disabled | Nothing. No fallback exists, so Preferred forces TLS exactly like Required |
 | etcd | Disabled | Nothing. The driver never reads these fields. Set **TLS Mode** on the Options section instead, and see [etcd](/databases/etcd) |
 | Trino | Disabled | Sends every request over HTTPS with no fallback, again like Required |
 | Oracle | Disabled | Connects in plain TCP, so it behaves like Disabled. A red warning appears under the picker; use Required to enforce TCPS |

--- a/docs/databases/index.mdx
+++ b/docs/databases/index.mdx
@@ -1,11 +1,11 @@
 ---
 title: Supported Databases
-description: All 34 engines TablePro connects to, their default ports, and which ones need a plugin
+description: All 35 engines TablePro connects to, their default ports, and which ones need a plugin
 ---
 
 import DriverCounts from "/snippets/driver-counts.mdx";
 
-Thirty-four engines, and every one of them is free to use. What differs between them is where the
+Thirty-five engines, and every one of them is free to use. What differs between them is where the
 driver comes from, not what the license covers.
 
 <DriverCounts />
@@ -48,6 +48,7 @@ driver comes from, not what the license covers.
 | [Trino](/databases/trino) | 8080 | Plugin |
 | [Typesense](/databases/typesense) | 8108 | Plugin |
 | [Turso](/databases/libsql) | API-based | Plugin |
+| [Weaviate](/databases/weaviate) | 8080 | Plugin |
 
 Rows sharing a page share a driver. MariaDB reads as MySQL, ScyllaDB as Cassandra, Turso as libSQL,
 and Redshift, CockroachDB and PGlite all speak the PostgreSQL wire protocol. TiDB and Databend

--- a/docs/databases/weaviate.mdx
+++ b/docs/databases/weaviate.mdx
@@ -1,0 +1,109 @@
+---
+title: Weaviate
+description: Connect to Weaviate, browse collections, edit objects by uuid, and run GraphQL
+---
+
+import RegistryPlugin from "/snippets/registry-plugin.mdx";
+
+Collections are tables, objects are rows, and `uuid` is the primary key. The editor speaks GraphQL, not SQL. Vector and hybrid search go through `/v1/graphql`. Browse and row edits use `/v1/objects`.
+
+<RegistryPlugin name="Weaviate" plugin="Weaviate Driver" />
+
+## Quick setup
+
+Click **New Connection…**, select **Weaviate**, enter host and port, pick an **Auth Method**, then click **Save & Connect**.
+
+There is no Database field. One connection reaches one Weaviate instance, and its collections are the objects.
+
+## Connection settings
+
+| Field | Description |
+|-------|-------------|
+| **Host** | Node hostname. `localhost` for Docker, a Weaviate Cloud hostname for hosted clusters |
+| **Port** | `8080` by default. Weaviate Cloud answers on `443` |
+| **Auth Method** | None, or API Key |
+| **API Key** | Sent as `Authorization: Bearer`. Shown when **Auth Method** is API Key |
+| **Skip TLS Verification** | Advanced section. Trusts any certificate, even under **Verify CA** or **Verify Identity** |
+
+## Authentication
+
+| Auth Method | What is sent |
+|-------------|--------------|
+| **None** | Nothing. For a local node with anonymous access |
+| **API Key** | An `Authorization: Bearer` header. Paste the Weaviate Cloud key, or the key the local node was started with |
+
+Weaviate Cloud requires an API key and HTTPS. Set **SSL Mode** to **Required** (or **Verify Identity** if you have the CA) and **Auth Method** to API Key.
+
+## Browsing collections
+
+The sidebar lists collections from `GET /v1/schema`.
+
+Every grid has `uuid` first and `vector` last. `uuid` is the primary key. Both columns are read-only. Property columns come from the collection schema. Arrays and objects render as JSON in the cell.
+
+A vector is shown as a JSON number array. It is not a SQL BLOB and the inline editor does not write it back.
+
+Unfiltered pages load through `GET /v1/objects`. A column filter or a sort becomes a GraphQL `Get` with `where` and `sort`.
+
+Grid edits are REST calls keyed by `uuid`.
+
+| Change | Request |
+|--------|---------|
+| New row | `POST /v1/objects`, with an `id` if you typed one |
+| Edited cells | `PATCH /v1/objects/{uuid}?class=Collection` |
+| Deleted row | `DELETE /v1/objects/{uuid}?class=Collection` |
+
+An update or delete with no `uuid` is skipped.
+
+## GraphQL editor
+
+Type a GraphQL operation and run it. `{ Get { … } }` and `query { … }` read. `mutation { … }` writes.
+
+```graphql
+{
+  Get {
+    Article(
+      nearText: { concepts: ["search term"] }
+      limit: 10
+    ) {
+      title
+      _additional { id distance }
+    }
+  }
+}
+```
+
+`Get` responses render as a grid, with `_additional.id` mapped to `uuid`. Anything else, including `Aggregate`, is shown as formatted JSON.
+
+A REST line also runs, the way the other search drivers do:
+
+```http
+GET /v1/schema
+```
+
+## SSL/TLS
+
+New connections start on **Disabled**, plain HTTP. Every other mode goes over HTTPS. **Preferred** and **Required (skip verify)** accept a self-signed certificate. See [SSL/TLS](/connections/ssl).
+
+## Limitations
+
+- Oracle-style SQL is not available. Use GraphQL, or the REST console for `/v1/schema` and `/v1/objects`.
+- gRPC is not used.
+- Cross-references are properties, not foreign keys. There are no routines, triggers, or schema edits from Structure.
+- Multi-tenancy is not exposed. Name a tenant in GraphQL if the collection requires one.
+- No [SSH tunnel](/connections/ssh-tunneling).
+- The plugin is registry-only. It is not on iPhone or iPad.
+
+## Troubleshooting
+
+### Authentication failed: …
+
+The API key was rejected, or the node expects a key and **Auth Method** is None. Weaviate Cloud needs both HTTPS and an API key.
+
+### Connection failed: …
+
+A TLS or network failure. For a self-signed certificate set **SSL Mode** to **Required (skip verify)**, or turn on **Skip TLS Verification**.
+
+## Related
+
+- [Import & Export](/features/import-export)
+- [Filtering](/features/filtering)

--- a/docs/databases/weaviate.mdx
+++ b/docs/databases/weaviate.mdx
@@ -96,6 +96,8 @@ A REST line also runs, the way the other search drivers do:
 GET /v1/schema
 ```
 
+A path without `/v1` gets it, so `GET /nodes` reaches `/v1/nodes`. A body goes on the same line as the path or on the lines under it.
+
 ## SSL/TLS
 
 New connections start on **Disabled**, plain HTTP. Every other mode goes over HTTPS. **Preferred** and **Required (skip verify)** accept a self-signed certificate. See [SSL/TLS](/connections/ssl).
@@ -106,6 +108,7 @@ New connections start on **Disabled**, plain HTTP. Every other mode goes over HT
 - gRPC is not used.
 - Cross-references are properties, not foreign keys. There are no routines, triggers, or schema edits from Structure.
 - Multi-tenancy is not exposed. Name a tenant in GraphQL if the collection requires one.
+- Paging stops at row 10,000. Weaviate refuses an offset and limit that add up past `QUERY_MAXIMUM_RESULTS`, which defaults to 10,000.
 - No [SSH tunnel](/connections/ssh-tunneling).
 - The plugin is registry-only. It is not on iPhone or iPad.
 
@@ -114,6 +117,10 @@ New connections start on **Disabled**, plain HTTP. Every other mode goes over HT
 ### Authentication failed: …
 
 The API key was rejected, or the node expects a key and **Auth Method** is None. Weaviate Cloud needs both HTTPS and an API key.
+
+### The connection drops after the API key changes
+
+A revoked or rotated key fails the next health check, because the check reads `/v1/meta` rather than the unauthenticated readiness endpoint. Paste the new key and connect again.
 
 ### Connection failed: …
 

--- a/docs/databases/weaviate.mdx
+++ b/docs/databases/weaviate.mdx
@@ -22,14 +22,14 @@ There is no Database field. One connection reaches one Weaviate instance, and it
 | **Host** | Node hostname. `localhost` for Docker, a Weaviate Cloud hostname for hosted clusters |
 | **Port** | `8080` by default. Weaviate Cloud answers on `443` |
 | **Auth Method** | None, or API Key |
-| **API Key** | Sent as `Authorization: Bearer`. Shown when **Auth Method** is API Key |
+| **API Key** | Sent as `Authorization: Bearer`. Leave empty for anonymous access |
 | **Skip TLS Verification** | Advanced section. Trusts any certificate, even under **Verify CA** or **Verify Identity** |
 
 ## Authentication
 
 | Auth Method | What is sent |
 |-------------|--------------|
-| **None** | Nothing. For a local node with anonymous access |
+| **None** | Nothing, unless **API Key** is filled. For a local node with anonymous access |
 | **API Key** | An `Authorization: Bearer` header. Paste the Weaviate Cloud key, or the key the local node was started with |
 
 Weaviate Cloud requires an API key and HTTPS. Set **SSL Mode** to **Required** (or **Verify Identity** if you have the CA) and **Auth Method** to API Key.

--- a/docs/databases/weaviate.mdx
+++ b/docs/databases/weaviate.mdx
@@ -22,14 +22,14 @@ There is no Database field. One connection reaches one Weaviate instance, and it
 | **Host** | Node hostname. `localhost` for Docker, a Weaviate Cloud hostname for hosted clusters |
 | **Port** | `8080` by default. Weaviate Cloud answers on `443` |
 | **Auth Method** | None, or API Key |
-| **API Key** | Sent as `Authorization: Bearer`. Leave empty for anonymous access |
+| **API Key** | Sent as an `Authorization: Bearer` header, and only when **Auth Method** is API Key |
 | **Skip TLS Verification** | Advanced section. Trusts any certificate, even under **Verify CA** or **Verify Identity** |
 
 ## Authentication
 
 | Auth Method | What is sent |
 |-------------|--------------|
-| **None** | Nothing, unless **API Key** is filled. For a local node with anonymous access |
+| **None** | Nothing. For a local node with anonymous access |
 | **API Key** | An `Authorization: Bearer` header. Paste the Weaviate Cloud key, or the key the local node was started with |
 
 Weaviate Cloud requires an API key and HTTPS. Set **SSL Mode** to **Required** (or **Verify Identity** if you have the CA) and **Auth Method** to API Key.
@@ -44,6 +44,22 @@ A vector is shown as a JSON number array. It is not a SQL BLOB and the inline ed
 
 Unfiltered pages load through `GET /v1/objects`. A column filter or a sort becomes a GraphQL `Get` with `where` and `sort`.
 
+## Filtering
+
+Filter values are typed from the collection schema: an `int` property filters as a number, a `date` property needs a full RFC 3339 timestamp such as `2024-01-31T00:00:00Z`, and an array property filters on one element.
+
+| Operator | What Weaviate runs |
+|----------|--------------------|
+| **=**, **!=** | `Equal`, `NotEqual` |
+| **>**, **>=**, **<**, **<=** | Numbers and dates only |
+| **CONTAINS**, **NOT CONTAINS**, **STARTS WITH**, **ENDS WITH** | `Like` with `*` wildcards, text properties only |
+| **IN**, **NOT IN** | `ContainsAny`, `ContainsNone` over a comma-separated list |
+| **BETWEEN** | Two bounds, both inclusive |
+| **IS NULL**, **IS NOT NULL** | `IsNull`, which needs `indexNullState` on the collection |
+| **IS EMPTY**, **IS NOT EMPTY** | `len()`, which needs `indexPropertyLength` on the collection |
+
+**REGEX** has no Weaviate equivalent, and a filter Weaviate cannot run reports why instead of returning the whole collection.
+
 Grid edits are REST calls keyed by `uuid`.
 
 | Change | Request |
@@ -52,11 +68,11 @@ Grid edits are REST calls keyed by `uuid`.
 | Edited cells | `PATCH /v1/objects/{uuid}?class=Collection` |
 | Deleted row | `DELETE /v1/objects/{uuid}?class=Collection` |
 
-An update or delete with no `uuid` is skipped.
+An update or delete with no `uuid` is skipped and logged.
 
 ## GraphQL editor
 
-Type a GraphQL operation and run it. `{ Get { … } }` and `query { … }` read. `mutation { … }` writes.
+Type a GraphQL operation and run it. Weaviate's GraphQL API reads only: `{ Get { … } }` and `query { … }` work, and there is no mutation type. Writes go through REST.
 
 ```graphql
 {
@@ -72,7 +88,7 @@ Type a GraphQL operation and run it. `{ Get { … } }` and `query { … }` read.
 }
 ```
 
-`Get` responses render as a grid, with `_additional.id` mapped to `uuid`. Anything else, including `Aggregate`, is shown as formatted JSON.
+`Get` responses render as a grid of the fields the query selected, with `_additional.id` mapped to `uuid`. The rest of `_additional`, such as `distance` and `score`, each become a column. Anything else, including `Aggregate`, is shown as formatted JSON.
 
 A REST line also runs, the way the other search drivers do:
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -175,7 +175,8 @@
               "databases/teradata",
               "databases/tidb",
               "databases/trino",
-              "databases/typesense"
+              "databases/typesense",
+              "databases/weaviate"
             ]
           },
           {

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Introduction
-description: Native macOS database client for MySQL, PostgreSQL, SQLite, MongoDB, Redis, and 29 more
+description: Native macOS database client for MySQL, PostgreSQL, SQLite, MongoDB, Redis, and 30 more
 ---
 
 import DriverCounts from "/snippets/driver-counts.mdx";

--- a/docs/snippets/driver-counts.mdx
+++ b/docs/snippets/driver-counts.mdx
@@ -1,3 +1,3 @@
-Five drivers ship inside the app and cover eleven databases. Twenty-one registry plugins cover the
-other twenty-three and install on the first connection that needs one. See
+Five drivers ship inside the app and cover eleven databases. Twenty-two registry plugins cover the
+other twenty-four and install on the first connection that needs one. See
 [Plugins & Themes](/features/plugins).

--- a/project.yml
+++ b/project.yml
@@ -618,7 +618,7 @@ targets:
     dependencies:
       - target: TablePro
       - package: TableProCore
-        products: [TableProMSSQLCore, TableProNumberFormatting]
+        products: [TableProMSSQLCore, TableProNumberFormatting, TableProWeaviateCore]
       # The Kafka integration suite drives the real driver, so the test target links what
       # the plugin target links: zstd for decompression and NIO for the transport.
       - package: zstd
@@ -1241,6 +1241,15 @@ targets:
       - package: TableProCore
         product: TableProNumberFormatting
 
+  WeaviateDriverPlugin:
+    templates: [DriverPlugin]
+    templateAttributes:
+      folder: WeaviateDriverPlugin
+      principalClass: WeaviatePlugin
+    dependencies:
+      - package: TableProCore
+        product: TableProWeaviateCore
+
 # Compile-checks every plugin, including the registry-only ones the app does not
 # embed. CI builds this scheme so a registry plugin cannot rot between releases.
 aggregateTargets:
@@ -1285,6 +1294,7 @@ aggregateTargets:
       - TeradataDriver
       - TrinoDriverPlugin
       - TypesenseDriverPlugin
+      - WeaviateDriverPlugin
       - XLSXExport
     scheme: {}
 


### PR DESCRIPTION
Fixes #1724

## Summary

Adds Weaviate as a registry-only REST plugin. Collections are tables, objects are rows, `uuid` is the primary key. Wire, auth and codec live in `TableProWeaviateCore` under Packages/TableProCore. `Plugins/WeaviateDriverPlugin` is a thin adapter, the same shape as Spanner after #2712.

v1:

- Connect: host, port 8080, http/https, API key as `Authorization: Bearer` or anonymous
- `GET /v1/schema` for collections and properties
- `GET/POST/PATCH/DELETE /v1/objects` for browse and row edit
- GraphQL `/v1/graphql` in the editor for vector and hybrid search
- Vectors display as a JSON number array. They are not a SQL BLOB and the inline editor does not write them back
- No FKs, routines, triggers, SSH, or SQL dialect. `tableEntityName` is Collections
- Auth field ids are Weaviate-prefixed (`wvAuthMethod`, `wvApiKey`) so they do not collide with Elasticsearch in TableProTests
- PluginKit 25. No bump. Slug `weaviate`. No `plugin-weaviate-v*` tag

## Verification

This environment has no Docker and no Swift toolchain. Live Weaviate was not measured. Fake-HTTP tests cover schema, objects, 401/500 errors, GraphQL Get flattening of `_additional.id`, GraphQL error bodies, and uuid PATCH/DELETE/POST. Registry, field-id, QueryClassifier, and engine-count tests are in TableProTests.

Docs house style and `check-docs-against-source.py` pass (35 engines). `swiftlint --strict` and `xcodebuild` could not run here.

## Not in this PR

- gRPC
- Weaviate modules beyond browse and GraphQL
- FalkorDB / NornicDB (#1986)
- PluginKit bump
- Tagging `plugin-weaviate-v*`

OceanBase (#1748) is on a separate branch and is not stacked here.