### PR TITLE
fix(plugin-postgresql): pin client_encoding to UTF8 in the startup packet on macOS and iOS, and declare it in SQL exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Illegal mix of collations` comparing a column with a user variable on MySQL 8.
 - GEOMETRY values from a parameterized MySQL query shown as raw bytes.
 - Earlier row's text repeated in later rows of a parameterized MySQL query once a value passed 64 KB.
+- Garbled non-ASCII text on PostgreSQL databases not encoded in UTF-8 after `RESET ALL` or `DISCARD ALL`.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GEOMETRY values from a parameterized MySQL query shown as raw bytes.
 - Earlier row's text repeated in later rows of a parameterized MySQL query once a value passed 64 KB.
 - Garbled non-ASCII text on PostgreSQL databases not encoded in UTF-8 after `RESET ALL` or `DISCARD ALL`.
+- Garbled or double-encoded non-ASCII text on iOS with PostgreSQL databases not encoded in UTF-8.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Earlier row's text repeated in later rows of a parameterized MySQL query once a value passed 64 KB.
 - Garbled non-ASCII text on PostgreSQL databases not encoded in UTF-8 after `RESET ALL` or `DISCARD ALL`.
 - Garbled or double-encoded non-ASCII text on iOS with PostgreSQL databases not encoded in UTF-8.
+- Garbled non-ASCII text when restoring a PostgreSQL SQL export into a database not encoded in UTF-8.
 
 ### Security
 

--- a/Plugins/PostgreSQLDriverPlugin/LibPQCellDecoding.swift
+++ b/Plugins/PostgreSQLDriverPlugin/LibPQCellDecoding.swift
@@ -1,0 +1,29 @@
+//
+//  LibPQCellDecoding.swift
+//  PostgreSQLDriverPlugin
+//
+
+import Foundation
+import TableProPluginKit
+
+internal enum LibPQCellDecoding {
+    private static let booleanOid: UInt32 = 16
+    private static let byteaOid: UInt32 = 17
+
+    static func value(from bytes: UnsafeRawBufferPointer, oid: UInt32) -> PluginCellValue {
+        let text = text(from: bytes)
+        switch oid {
+        case byteaOid:
+            guard let data = LibPQByteaDecoder.decode(text) else { return .text(text) }
+            return .bytes(data)
+        case booleanOid:
+            return .text(text == "t" ? "true" : "false")
+        default:
+            return .text(text)
+        }
+    }
+
+    static func text(from bytes: UnsafeRawBufferPointer) -> String {
+        String(decoding: bytes, as: UTF8.self) // swiftlint:disable:this optional_data_string_conversion
+    }
+}

--- a/Plugins/PostgreSQLDriverPlugin/LibPQConnectionString.swift
+++ b/Plugins/PostgreSQLDriverPlugin/LibPQConnectionString.swift
@@ -1,0 +1,66 @@
+//
+//  LibPQConnectionString.swift
+//  PostgreSQLDriverPlugin
+//
+
+import Foundation
+import TableProPluginKit
+
+internal enum LibPQConnectionString {
+    static let clientEncoding = "UTF8"
+
+    private static let clientEncodingNames: Set<String> = ["UTF8", "UNICODE"]
+
+    static func build(
+        host: String,
+        port: Int,
+        user: String,
+        password: String?,
+        database: String,
+        sslConfig: SSLConfiguration,
+        options: String?
+    ) -> String {
+        var parameters: [(String, String)] = [
+            ("host", host),
+            ("port", String(port)),
+            ("dbname", database)
+        ]
+
+        if !user.isEmpty {
+            parameters.append(("user", user))
+        }
+        if let password, !password.isEmpty {
+            parameters.append(("password", password))
+        }
+
+        parameters.append(("sslmode", LibPQSSLMapping.sslmode(for: sslConfig.mode)))
+        if sslConfig.verifiesCertificate, !sslConfig.caCertificatePath.isEmpty {
+            parameters.append(("sslrootcert", sslConfig.caCertificatePath))
+        }
+        if !sslConfig.clientCertificatePath.isEmpty {
+            parameters.append(("sslcert", sslConfig.clientCertificatePath))
+        }
+        if !sslConfig.clientKeyPath.isEmpty {
+            parameters.append(("sslkey", sslConfig.clientKeyPath))
+        }
+
+        parameters.append(("client_encoding", clientEncoding))
+        if let options, !options.isEmpty {
+            parameters.append(("options", options))
+        }
+
+        return parameters
+            .map { "\($0.0)='\(escape($0.1))'" }
+            .joined(separator: " ")
+    }
+
+    static func isClientEncoding(reportedByServer reported: String?) -> Bool {
+        guard let reported else { return false }
+        return clientEncodingNames.contains(reported.uppercased())
+    }
+
+    static func escape(_ value: String) -> String {
+        value.replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "'", with: "\\'")
+    }
+}

--- a/Plugins/PostgreSQLDriverPlugin/LibPQPluginConnection.swift
+++ b/Plugins/PostgreSQLDriverPlugin/LibPQPluginConnection.swift
@@ -200,7 +200,7 @@ final class LibPQPluginConnection: @unchecked Sendable {
     }
 
     private func performConnect(reportingStage report: @escaping ConnectionStageReporter) throws {
-        guard let connection = buildConnectionString().withCString({ PQconnectStart($0) }) else {
+        guard let connection = connectionString.withCString({ PQconnectStart($0) }) else {
             throw LibPQPluginError.connectionFailed
         }
 
@@ -299,10 +299,7 @@ final class LibPQPluginConnection: @unchecked Sendable {
     }
 
     private func configureEstablishedConnection(_ connection: OpaquePointer) {
-        "SET client_encoding TO 'UTF8'".withCString { cStr in
-            let result = PQexec(connection, cStr)
-            PQclear(result)
-        }
+        logUnexpectedClientEncoding(of: connection)
 
         let version = PQserverVersion(connection)
         guard version > 0 else { return }
@@ -319,39 +316,24 @@ final class LibPQPluginConnection: @unchecked Sendable {
         }
     }
 
-    private func buildConnectionString() -> String {
-        func escapeConnParam(_ value: String) -> String {
-            value.replacingOccurrences(of: "\\", with: "\\\\")
-                 .replacingOccurrences(of: "'", with: "\\'")
-        }
+    private func logUnexpectedClientEncoding(of connection: OpaquePointer) {
+        let reported = PQparameterStatus(connection, "client_encoding").map { String(cString: $0) }
+        guard !LibPQConnectionString.isClientEncoding(reportedByServer: reported) else { return }
+        logger.warning(
+            "Server reports client_encoding \(reported ?? "none", privacy: .public) instead of UTF8"
+        )
+    }
 
-        var connStr = "host='\(escapeConnParam(host))' port='\(port)' dbname='\(escapeConnParam(database))'"
-
-        if !user.isEmpty {
-            connStr += " user='\(escapeConnParam(user))'"
-        }
-
-        if let password, !password.isEmpty {
-            connStr += " password='\(escapeConnParam(password))'"
-        }
-
-        connStr += " sslmode='\(LibPQSSLMapping.sslmode(for: sslConfig.mode))'"
-
-        if sslConfig.verifiesCertificate, !sslConfig.caCertificatePath.isEmpty {
-            connStr += " sslrootcert='\(escapeConnParam(sslConfig.caCertificatePath))'"
-        }
-        if !sslConfig.clientCertificatePath.isEmpty {
-            connStr += " sslcert='\(escapeConnParam(sslConfig.clientCertificatePath))'"
-        }
-        if !sslConfig.clientKeyPath.isEmpty {
-            connStr += " sslkey='\(escapeConnParam(sslConfig.clientKeyPath))'"
-        }
-
-        if let options, !options.isEmpty {
-            connStr += " options='\(escapeConnParam(options))'"
-        }
-
-        return connStr
+    private var connectionString: String {
+        LibPQConnectionString.build(
+            host: host,
+            port: port,
+            user: user,
+            password: password,
+            database: database,
+            sslConfig: sslConfig,
+            options: options
+        )
     }
 
     func disconnect() {
@@ -1128,7 +1110,7 @@ final class LibPQPluginConnection: @unchecked Sendable {
             } else if let valuePtr = PQgetvalue(result, Int32(rowIndex), 0) {
                 let length = Int(PQgetlength(result, Int32(rowIndex), 0))
                 let bufferPtr = UnsafeRawBufferPointer(start: valuePtr, count: length)
-                converted.append(.text(String(bytes: bufferPtr, encoding: .utf8) ?? ""))
+                converted.append(.text(LibPQCellDecoding.text(from: bufferPtr)))
             } else {
                 converted.append(.null)
             }
@@ -1148,21 +1130,7 @@ final class LibPQPluginConnection: @unchecked Sendable {
         }
 
         let length = Int(PQgetlength(result, row, column))
-        let bufferPtr = UnsafeRawBufferPointer(start: valuePtr, count: length)
-
-        if oid == 17 {
-            let text = String(bytes: bufferPtr, encoding: .utf8) ?? ""
-            guard let data = LibPQByteaDecoder.decode(text) else { return .text(text) }
-            return .bytes(data)
-        }
-
-        if oid == 16 {
-            let str = String(bytes: bufferPtr, encoding: .utf8) ?? ""
-            return .text(str == "t" ? "true" : "false")
-        }
-
-        if let str = String(bytes: bufferPtr, encoding: .utf8) { return .text(str) }
-        return .text(String(bytes: bufferPtr, encoding: .isoLatin1) ?? "")
+        return LibPQCellDecoding.value(from: UnsafeRawBufferPointer(start: valuePtr, count: length), oid: oid)
     }
 
     private func parseRows(

--- a/Plugins/SQLExportPlugin/SQLExportEncodingDeclaration.swift
+++ b/Plugins/SQLExportPlugin/SQLExportEncodingDeclaration.swift
@@ -12,10 +12,16 @@ internal struct SQLExportEncodingDeclaration: Equatable {
     let prologue: String
     let epilogue: String
 
-    static func forDialect(_ dialect: SqlDialect) -> SQLExportEncodingDeclaration {
-        switch dialect {
+    private static let typesAcceptingSetClientEncoding: Set<String> = [
+        "PostgreSQL", "Greenplum", "AlloyDB", "Citus", "CockroachDB", "PGlite"
+    ]
+
+    static func forDatabaseType(_ databaseTypeId: String) -> SQLExportEncodingDeclaration {
+        switch SqlDialect.from(databaseTypeId: databaseTypeId) {
         case .mysql:
             return mysql
+        case .postgres where typesAcceptingSetClientEncoding.contains(databaseTypeId):
+            return postgres
         default:
             return .empty
         }
@@ -38,5 +44,14 @@ internal struct SQLExportEncodingDeclaration: Equatable {
         /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 
         """
+    )
+
+    private static let postgres = SQLExportEncodingDeclaration(
+        prologue: """
+        SET client_encoding = 'UTF8';
+
+
+        """,
+        epilogue: ""
     )
 }

--- a/Plugins/SQLExportPlugin/SQLExportPlugin.swift
+++ b/Plugins/SQLExportPlugin/SQLExportPlugin.swift
@@ -142,7 +142,7 @@ final class SQLExportPlugin: ExportFormatPlugin, SettablePlugin, @unchecked Send
         let writer = try SQLExportFileWriter(
             destination: actualDestination,
             splitSizeMegabytes: splitSize,
-            encodingDeclaration: .forDialect(SqlDialect.from(databaseTypeId: dataSource.databaseTypeId))
+            encodingDeclaration: .forDatabaseType(dataSource.databaseTypeId)
         )
         var committed = false
         defer {

--- a/TableProMobile/TableProMobile/Drivers/PostgreSQLConnectionString.swift
+++ b/TableProMobile/TableProMobile/Drivers/PostgreSQLConnectionString.swift
@@ -2,6 +2,7 @@ import Foundation
 
 nonisolated enum PostgreSQLConnectionString {
     static let connectTimeoutSeconds = 10
+    static let clientEncoding = "UTF8"
 
     static func build(
         host: String,
@@ -19,6 +20,7 @@ nonisolated enum PostgreSQLConnectionString {
             ("password", password),
             ("connect_timeout", String(connectTimeoutSeconds)),
             ("sslmode", ssl.postgresSSLMode),
+            ("client_encoding", clientEncoding),
         ]
 
         if let caPath = ssl.existingCACertificatePath {

--- a/TableProMobile/TableProMobileTests/Drivers/PostgreSQLConnectionStringTests.swift
+++ b/TableProMobile/TableProMobileTests/Drivers/PostgreSQLConnectionStringTests.swift
@@ -34,6 +34,11 @@ struct PostgreSQLConnectionStringTests {
         #expect(connStr.contains("sslmode='disable'"))
     }
 
+    @Test("the session is pinned to UTF8 in the startup packet, whatever the database's encoding")
+    func pinsClientEncoding() {
+        #expect(build(ssl: .disabled).contains("client_encoding='UTF8'"))
+    }
+
     @Test("a client certificate and key reach libpq as sslcert and sslkey")
     func clientCertificateIsSent() {
         let certPath = temporaryFile()

--- a/TableProTests/Plugins/LibPQCellDecodingTests.swift
+++ b/TableProTests/Plugins/LibPQCellDecodingTests.swift
@@ -1,0 +1,61 @@
+//
+//  LibPQCellDecodingTests.swift
+//  TableProTests
+//
+
+import Foundation
+import TableProPluginKit
+import Testing
+
+@Suite("LibPQCellDecoding")
+struct LibPQCellDecodingTests {
+    private static let textOid: UInt32 = 25
+    private static let booleanOid: UInt32 = 16
+    private static let byteaOid: UInt32 = 17
+
+    private func decode(_ bytes: [UInt8], oid: UInt32 = textOid) -> PluginCellValue {
+        bytes.withUnsafeBytes { LibPQCellDecoding.value(from: $0, oid: oid) }
+    }
+
+    @Test("UTF-8 text decodes as written")
+    func utf8Text() {
+        #expect(decode(Array("メール café".utf8)) == .text("メール café"))
+    }
+
+    @Test("Bytes that are not UTF-8 become replacement characters, never Latin 1 guesses")
+    func invalidUTF8IsNotFabricated() {
+        let eucJPMail: [UInt8] = [0xA5, 0xE1, 0xA1, 0xBC, 0xA5, 0xEB]
+        guard case .text(let text) = decode(eucJPMail) else {
+            Issue.record("expected text")
+            return
+        }
+        #expect(text.contains("\u{FFFD}"))
+        #expect(text != "¥á¡¼¥ë")
+    }
+
+    @Test("A Latin 1 byte on its own is a replacement character, not é")
+    func latin1ByteIsReplaced() {
+        #expect(decode([0x63, 0x61, 0x66, 0xE9]) == .text("caf\u{FFFD}"))
+    }
+
+    @Test("Empty text stays empty")
+    func emptyText() {
+        #expect(decode([]) == .text(""))
+    }
+
+    @Test("Boolean t and f read as true and false")
+    func booleans() {
+        #expect(decode(Array("t".utf8), oid: Self.booleanOid) == .text("true"))
+        #expect(decode(Array("f".utf8), oid: Self.booleanOid) == .text("false"))
+    }
+
+    @Test("bytea hex decodes to its bytes")
+    func byteaHex() {
+        #expect(decode(Array("\\xdeadbeef".utf8), oid: Self.byteaOid) == .bytes(Data([0xDE, 0xAD, 0xBE, 0xEF])))
+    }
+
+    @Test("A bytea value that is not in a bytea format stays text")
+    func byteaFallsBackToText() {
+        #expect(decode(Array("\\xzz".utf8), oid: Self.byteaOid) == .text("\\xzz"))
+    }
+}

--- a/TableProTests/Plugins/LibPQConnectionStringTests.swift
+++ b/TableProTests/Plugins/LibPQConnectionStringTests.swift
@@ -1,0 +1,111 @@
+//
+//  LibPQConnectionStringTests.swift
+//  TableProTests
+//
+
+import Foundation
+import TableProPluginKit
+import Testing
+
+@Suite("LibPQConnectionString")
+struct LibPQConnectionStringTests {
+    private func build(
+        user: String = "postgres",
+        password: String? = "hunter2",
+        sslConfig: SSLConfiguration = SSLConfiguration(),
+        options: String? = nil
+    ) -> String {
+        LibPQConnectionString.build(
+            host: "db.example.com",
+            port: 5_432,
+            user: user,
+            password: password,
+            database: "app",
+            sslConfig: sslConfig,
+            options: options
+        )
+    }
+
+    @Test("The base parameters are always present")
+    func baseParameters() {
+        let conninfo = build()
+
+        #expect(conninfo.contains("host='db.example.com'"))
+        #expect(conninfo.contains("port='5432'"))
+        #expect(conninfo.contains("dbname='app'"))
+        #expect(conninfo.contains("user='postgres'"))
+        #expect(conninfo.contains("password='hunter2'"))
+        #expect(conninfo.contains("sslmode='disable'"))
+    }
+
+    @Test("The session is pinned to UTF8 in the startup packet, so RESET ALL and DISCARD ALL keep it")
+    func pinsClientEncoding() {
+        #expect(build().contains("client_encoding='UTF8'"))
+    }
+
+    @Test("Connection options still reach the server, after the pinned encoding")
+    func optionsFollowTheEncoding() {
+        let conninfo = build(options: "--cluster=my-cluster -c search_path=app")
+
+        #expect(conninfo.hasSuffix("client_encoding='UTF8' options='--cluster=my-cluster -c search_path=app'"))
+    }
+
+    @Test("A client_encoding in the connection options rides along in options, where the server applies it first")
+    func clientEncodingInOptionsStaysInOptions() {
+        let conninfo = build(options: "-c client_encoding=LATIN1")
+
+        #expect(conninfo.contains("client_encoding='UTF8'"))
+        #expect(conninfo.contains("options='-c client_encoding=LATIN1'"))
+    }
+
+    @Test("An empty user, password or options is left out")
+    func emptyValuesAreOmitted() {
+        let conninfo = build(user: "", password: "", options: "")
+
+        #expect(!conninfo.contains("user="))
+        #expect(!conninfo.contains("password="))
+        #expect(!conninfo.contains("options="))
+        #expect(conninfo.contains("client_encoding='UTF8'"))
+    }
+
+    @Test("A CA certificate is sent only when the mode verifies it")
+    func caOnlyWhenVerifying() {
+        let requiring = build(sslConfig: SSLConfiguration(mode: .required, caCertificatePath: "/ca.pem"))
+        #expect(!requiring.contains("sslrootcert"))
+
+        let verifying = build(sslConfig: SSLConfiguration(mode: .verifyCa, caCertificatePath: "/ca.pem"))
+        #expect(verifying.contains("sslmode='verify-ca'"))
+        #expect(verifying.contains("sslrootcert='/ca.pem'"))
+    }
+
+    @Test("A client certificate and key reach libpq as sslcert and sslkey")
+    func clientCertificateIsSent() {
+        let conninfo = build(sslConfig: SSLConfiguration(
+            mode: .required,
+            clientCertificatePath: "/client.pem",
+            clientKeyPath: "/client.key"
+        ))
+
+        #expect(conninfo.contains("sslcert='/client.pem'"))
+        #expect(conninfo.contains("sslkey='/client.key'"))
+    }
+
+    @Test("Quotes and backslashes in values are escaped")
+    func escapesValues() {
+        let conninfo = build(user: "o'brien", password: "back\\slash", options: "-c application_name='x'")
+
+        #expect(conninfo.contains("user='o\\'brien'"))
+        #expect(conninfo.contains("password='back\\\\slash'"))
+        #expect(conninfo.contains("options='-c application_name=\\'x\\''"))
+    }
+
+    @Test("UTF8 and its PostgreSQL 8.0 name UNICODE both count as the pinned encoding")
+    func recognizesReportedEncoding() {
+        #expect(LibPQConnectionString.isClientEncoding(reportedByServer: "UTF8"))
+        #expect(LibPQConnectionString.isClientEncoding(reportedByServer: "UNICODE"))
+        #expect(LibPQConnectionString.isClientEncoding(reportedByServer: "utf8"))
+        #expect(!LibPQConnectionString.isClientEncoding(reportedByServer: "EUC_JP"))
+        #expect(!LibPQConnectionString.isClientEncoding(reportedByServer: "SQL_ASCII"))
+        #expect(!LibPQConnectionString.isClientEncoding(reportedByServer: nil))
+    }
+}

--- a/TableProTests/Plugins/SQLExportEncodingTests.swift
+++ b/TableProTests/Plugins/SQLExportEncodingTests.swift
@@ -18,27 +18,60 @@ struct SQLExportEncodingTests {
 
     @Test("A MySQL dump declares utf8mb4 the way mysqldump does, and puts the session back")
     func mysqlDeclaresUTF8MB4() {
-        let declaration = SQLExportEncodingDeclaration.forDialect(.mysql)
-        #expect(declaration.prologue.contains("/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;"))
-        #expect(declaration.prologue.contains("/*!40101 SET NAMES utf8 */;"))
-        #expect(declaration.prologue.contains("/*!50503 SET NAMES utf8mb4 */;"))
-        #expect(declaration.epilogue.contains("/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;"))
-        #expect(declaration.epilogue.contains("/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;"))
-        #expect(declaration.epilogue.contains("/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;"))
+        for typeId in ["MySQL", "MariaDB", "TiDB"] {
+            let declaration = SQLExportEncodingDeclaration.forDatabaseType(typeId)
+            #expect(declaration.prologue.contains("/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;"))
+            #expect(declaration.prologue.contains("/*!40101 SET NAMES utf8 */;"))
+            #expect(declaration.prologue.contains("/*!50503 SET NAMES utf8mb4 */;"))
+            #expect(declaration.epilogue.contains("/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;"))
+            #expect(declaration.epilogue.contains("/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;"))
+            #expect(declaration.epilogue.contains("/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;"))
+        }
     }
 
-    @Test("Other dialects write no declaration")
-    func otherDialectsDeclareNothing() {
-        for dialect: SqlDialect in [.sqlite, .generic, .postgres] {
-            #expect(SQLExportEncodingDeclaration.forDialect(dialect) == .empty)
+    @Test("A PostgreSQL dump declares UTF8 the way pg_dump does, on every engine that accepts the statement")
+    func postgresDeclaresUTF8() {
+        for typeId in ["PostgreSQL", "Greenplum", "AlloyDB", "Citus", "CockroachDB", "PGlite"] {
+            let declaration = SQLExportEncodingDeclaration.forDatabaseType(typeId)
+            #expect(declaration.prologue == "SET client_encoding = 'UTF8';\n\n", "\(typeId)")
+            #expect(declaration.epilogue.isEmpty, "\(typeId)")
         }
+    }
+
+    @Test("Redshift gets no declaration, because it does not document client_encoding as settable")
+    func redshiftDeclaresNothing() {
+        #expect(SQLExportEncodingDeclaration.forDatabaseType("Redshift") == .empty)
+    }
+
+    @Test("Other engines write no declaration")
+    func otherEnginesDeclareNothing() {
+        for typeId in ["SQLite", "DuckDB", "Oracle", "MSSQL", "SomeFuturePlugin"] {
+            #expect(SQLExportEncodingDeclaration.forDatabaseType(typeId) == .empty, "\(typeId)")
+        }
+    }
+
+    @Test("A PostgreSQL dump opens with the declaration and ends with the last statement")
+    func postgresDumpIsPrefixed() throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let declaration = SQLExportEncodingDeclaration.forDatabaseType("PostgreSQL")
+
+        let destination = directory.appendingPathComponent("dump.sql")
+        let writer = try SQLExportFileWriter(
+            destination: destination, splitSizeMegabytes: 0, encodingDeclaration: declaration
+        )
+        try writer.write("INSERT INTO \"t\" VALUES ('メール');\n")
+        try writer.commit()
+
+        let dump = try String(contentsOf: destination, encoding: .utf8)
+        #expect(dump == "SET client_encoding = 'UTF8';\n\nINSERT INTO \"t\" VALUES ('メール');\n")
     }
 
     @Test("An unsplit dump opens with the declaration and closes by restoring the session")
     func unsplitDumpIsWrapped() throws {
         let directory = try temporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
-        let declaration = SQLExportEncodingDeclaration.forDialect(.mysql)
+        let declaration = SQLExportEncodingDeclaration.forDatabaseType("MySQL")
 
         let destination = directory.appendingPathComponent("dump.sql")
         let writer = try SQLExportFileWriter(
@@ -51,11 +84,15 @@ struct SQLExportEncodingTests {
         #expect(dump == declaration.prologue + "INSERT INTO `t` VALUES ('メール');\n" + declaration.epilogue)
     }
 
-    @Test("Every part of a split dump carries its own declaration, so each restores on its own")
-    func everyPartIsWrapped() throws {
+    @Test(
+        "Every part of a split dump carries its own declaration, so each restores on its own",
+        arguments: ["MySQL", "PostgreSQL"]
+    )
+    func everyPartIsWrapped(databaseTypeId: String) throws {
         let directory = try temporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
-        let declaration = SQLExportEncodingDeclaration.forDialect(.mysql)
+        let declaration = SQLExportEncodingDeclaration.forDatabaseType(databaseTypeId)
+        #expect(declaration != .empty)
 
         let destination = directory.appendingPathComponent("dump.sql")
         let writer = try SQLExportFileWriter(
@@ -79,7 +116,7 @@ struct SQLExportEncodingTests {
     func epilogueCountsTowardTheCap() throws {
         let directory = try temporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
-        let declaration = SQLExportEncodingDeclaration.forDialect(.mysql)
+        let declaration = SQLExportEncodingDeclaration.forDatabaseType("MySQL")
         let cap = 1_024 * 1_024
 
         let destination = directory.appendingPathComponent("dump.sql")
@@ -106,7 +143,7 @@ struct SQLExportEncodingTests {
         let destination = directory.appendingPathComponent("dump.sql")
         let writer = try SQLExportFileWriter(
             destination: destination, splitSizeMegabytes: 1,
-            encodingDeclaration: .forDialect(.mysql)
+            encodingDeclaration: .forDatabaseType("MySQL")
         )
         try writer.write(String(repeating: "y", count: 2 * 1_024 * 1_024) + ";\n")
         let parts = try writer.commit()

--- a/docs/databases/postgresql.mdx
+++ b/docs/databases/postgresql.mdx
@@ -70,6 +70,10 @@ Enums, composites, domains and ranges are listed under **Types** in each schema,
 
 PostgreSQL has no in-place `USE`, so a tab bound to a database other than the connection's active one runs on a second connection opened for that database. It shares no temp tables, session variables, or open transaction with the query editor on the main connection: keep a multi-statement transaction or a `CREATE TEMP TABLE` on tabs bound to one database. Binding itself is on [Tabs](/features/tabs#where-a-tab-points).
 
+## Text encoding
+
+Sessions run in `UTF8` whatever encoding the database was created with, and the server converts text both ways. Japanese in an `EUC_JP` database or accented names in a `LATIN1` one read and save intact, and stay that way after `RESET ALL` or `DISCARD ALL` in a query tab. A `-c client_encoding=…` in **Connection Options** is overridden; other settings there still apply.
+
 ## Tools
 
 `EXPLAIN` and `EXPLAIN ANALYZE` run with `FORMAT JSON` and render as a plan diagram or tree. See [EXPLAIN Visualization](/features/explain-visualization). **Database > Users & Roles** shows where each privilege comes from before you grant or revoke it. **Backup Dump** and **Restore Dump** shell out to your local `pg_dump` and `pg_restore`; see [Backup & Restore](/features/backup-restore).
@@ -89,5 +93,7 @@ New connections default to **Preferred** (libpq `sslmode=prefer`): TLS first, pl
 **Connection refused**: check the server is running, that `listen_addresses` in `postgresql.conf` covers remote connections, and that the firewall allows port 5432.
 
 **FATAL: password authentication failed for user "…"**: the role and password are checked against `pg_hba.conf`. Confirm the method on the matching line (`scram-sha-256` or `md5` for passwords, `trust` for local dev), and that the line matches the host you are connecting from.
+
+**ERROR: invalid byte sequence for encoding "UTF8": 0x…**: the database's encoding is `SQL_ASCII`, which stores bytes without checking them, and a value in the result is not UTF-8. Run `SHOW server_encoding` to confirm. Move the data to a `UTF8` database: dump it with `pg_dump --encoding=` and the encoding the text was written in, such as `EUC_JP` or `WIN1252`, then restore that dump into a database created with `ENCODING 'UTF8'`.
 
 **A Postgres-compatible engine loads no tables**: wire-compatible engines connect under the PostgreSQL type, and the catalogs they omit are probed for rather than assumed. An engine without `pg_matviews` still lists its tables; object kinds it does not expose will not appear at all.

--- a/docs/features/import-export.mdx
+++ b/docs/features/import-export.mdx
@@ -133,7 +133,15 @@ As SQL, a results export writes `INSERT` statements only. A result set is the ou
 
     Splitting writes `dump.part1.sql`, `dump.part2.sql` and so on, rotating between statements so no part ends mid-`INSERT`. Restore the parts in order. A gzipped export is one file, so the two settings do not combine and the summary says so.
 
-    A MySQL or MariaDB dump is UTF-8 and says so: every part opens with `SET NAMES utf8mb4` and ends by putting the session's character set back, as `mysqldump` does. `mysql < dump.sql` then restores Japanese, emoji and other non-Latin text intact, even from a client whose default is Latin 1.
+    A dump is UTF-8 and says so in every part, the way the engine's own dump tool does:
+
+    | Engine | Each part opens with |
+    |---|---|
+    | MySQL, MariaDB | `SET NAMES utf8mb4`, and ends by putting the session's character set back |
+    | PostgreSQL, CockroachDB, PGlite | `SET client_encoding = 'UTF8';` |
+    | Amazon Redshift | Nothing. Set `PGCLIENTENCODING=UTF8` before restoring it into a database that is not UTF-8 |
+
+    `mysql < dump.sql` and `psql < dump.sql` then restore Japanese, emoji and other non-Latin text intact, even into a `LATIN1` or `EUC_JP` database or from a client whose default is Latin 1.
 
     One snapshot opens `START TRANSACTION WITH CONSISTENT SNAPSHOT` on MySQL, `BEGIN ISOLATION LEVEL REPEATABLE READ` on PostgreSQL, and a deferred transaction on SQLite. It holds that transaction open for the whole export.
 

--- a/project.yml
+++ b/project.yml
@@ -508,6 +508,8 @@ targets:
       - Plugins/MSSQLDriverPlugin/MSSQLCheckConstraintDefinition.swift
       - Plugins/PostgreSQLDriverPlugin/ColumnQueryShape.swift
       - Plugins/PostgreSQLDriverPlugin/LibPQByteaDecoder.swift
+      - Plugins/PostgreSQLDriverPlugin/LibPQCellDecoding.swift
+      - Plugins/PostgreSQLDriverPlugin/LibPQConnectionString.swift
       - Plugins/PostgreSQLDriverPlugin/LibPQPluginError.swift
       - Plugins/PostgreSQLDriverPlugin/LibPQSSLMapping.swift
       - Plugins/PostgreSQLDriverPlugin/PostGISSpatialRewrite.swift

--- a/scripts/check-postgres-client-encoding.sh
+++ b/scripts/check-postgres-client-encoding.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+#
+# Check the server facts the PostgreSQL driver and SQL export rely on for text encoding.
+#
+# The macOS and iOS drivers put client_encoding=UTF8 in the libpq connection string instead of
+# running SET client_encoding after connect, because a value from the startup packet is the
+# session's reset value and survives RESET ALL and DISCARD ALL, while a SET does not. SQL export
+# opens a PostgreSQL-family dump with SET client_encoding = 'UTF8', which only helps if the engine
+# accepts that statement. This asks a real server both questions, then restores a UTF-8 dump into
+# LATIN1 and EUC_JP databases through psql reading stdin, where psql leaves the client encoding at
+# the database's own, and checks the bytes that were stored.
+#
+# Usage:
+#   scripts/check-postgres-client-encoding.sh [host] [port] [user] [database]
+#
+# Needs psql. The password, if any, comes from PGPASSWORD. Point it at CockroachDB, PGlite or any
+# other PostgreSQL-compatible engine to check the first two facts there; the restore check is
+# skipped on an engine that cannot create and connect to a LATIN1 or EUC_JP database, which
+# includes both of those. Exits non-zero on a failure.
+
+set -uo pipefail
+
+HOST="${1:-127.0.0.1}"
+PORT="${2:-5432}"
+USER_NAME="${3:-postgres}"
+DATABASE="${4:-postgres}"
+
+command -v psql > /dev/null || {
+    echo "psql not found" >&2
+    exit 3
+}
+
+unset PGCLIENTENCODING
+BASE="host=$HOST port=$PORT user=$USER_NAME sslmode=prefer connect_timeout=10"
+PSQL=(psql -X -A -t -v ON_ERROR_STOP=1)
+
+if ! "${PSQL[@]}" "$BASE dbname=$DATABASE" -c "SELECT 1" > /dev/null 2>&1; then
+    echo "no PostgreSQL at $HOST:$PORT for $USER_NAME" >&2
+    exit 3
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+failures=0
+
+check() {
+    local label=$1 expected=$2 actual=$3
+    if [ "$expected" = "$actual" ]; then
+        echo "ok    $label"
+    else
+        echo "FAIL  $label: expected '$expected', got '$actual'"
+        failures=$((failures + 1))
+    fi
+}
+
+pinned="$BASE dbname=$DATABASE client_encoding=UTF8"
+check "startup client_encoding=UTF8" "UTF8" "$("${PSQL[@]}" "$pinned" -c "SHOW client_encoding" 2>&1)"
+check "UTF8 after RESET ALL" "UTF8" "$("${PSQL[@]}" "$pinned" -c "RESET ALL" -c "SHOW client_encoding" 2>&1 | tail -1)"
+check "UTF8 after DISCARD ALL" "UTF8" "$("${PSQL[@]}" "$pinned" -c "DISCARD ALL" -c "SHOW client_encoding" 2>&1 | tail -1)"
+check "SET client_encoding = 'UTF8' accepted" "SET" \
+    "$(psql -X -v ON_ERROR_STOP=1 "$BASE dbname=$DATABASE" -c "SET client_encoding = 'UTF8'" 2>&1)"
+
+restore_check() {
+    local encoding=$1 text=$2 expected_hex=$3 db
+    db="tablepro_encoding_probe_$(echo "$encoding" | tr '[:upper:]' '[:lower:]')"
+    "${PSQL[@]}" "$BASE dbname=$DATABASE" -c "DROP DATABASE IF EXISTS $db" > /dev/null 2>&1
+    if ! "${PSQL[@]}" "$BASE dbname=$DATABASE" \
+        -c "CREATE DATABASE $db ENCODING '$encoding' LC_COLLATE 'C' LC_CTYPE 'C' TEMPLATE template0" \
+        > /dev/null 2>&1; then
+        echo "skip  $encoding restore: the server cannot create a $encoding database"
+        return
+    fi
+    local reached
+    reached=$("${PSQL[@]}" "$BASE dbname=$db" -c "SHOW server_encoding" 2>&1)
+    if [ "$reached" != "$encoding" ]; then
+        echo "skip  $encoding restore: connecting to $db reached a $reached database"
+        "${PSQL[@]}" "$BASE dbname=$DATABASE" -c "DROP DATABASE IF EXISTS $db" > /dev/null 2>&1
+        return
+    fi
+
+    printf "SET client_encoding = 'UTF8';\n\nCREATE TABLE t (v text);\nINSERT INTO t VALUES ('%s');\n" "$text" \
+        > "$WORK/dump.sql"
+    local output
+    output=$("${PSQL[@]}" "$BASE dbname=$db" < "$WORK/dump.sql" 2>&1)
+    local stored
+    stored=$("${PSQL[@]}" "$BASE dbname=$db" -c "SELECT encode(convert_to(v, '$encoding'), 'hex') FROM t" 2>&1)
+    check "$encoding restore of a UTF-8 dump through stdin" "$expected_hex" "${stored:-$output}"
+
+    local session
+    session=$("${PSQL[@]}" "$BASE dbname=$db client_encoding=UTF8" -c "RESET ALL" -c "SELECT v FROM t" 2>&1 | tail -1)
+    check "$encoding read through a UTF8-pinned session after RESET ALL" "$text" "$session"
+
+    "${PSQL[@]}" "$BASE dbname=$DATABASE" -c "DROP DATABASE IF EXISTS $db" > /dev/null 2>&1
+}
+
+restore_check LATIN1 "café" "636166e9"
+restore_check EUC_JP "メール" "a5e1a1bca5eb"
+
+if [ "$failures" -gt 0 ]; then
+    echo "$failures check(s) failed"
+    exit 1
+fi
+echo "all checks passed"


### PR DESCRIPTION
Follow-up to #2740, found while investigating #2725. It was written stacked on #2740; that PR merged while this was in progress, so this is rebased onto `main` and uses the `SQLExportEncodingDeclaration` it added. The PostgreSQL drivers have the same defect class as the MySQL one: a session encoding that is not pinned in a way that survives, and a decode that guesses.

## Root cause

1. **macOS.** `LibPQPluginConnection` ran `SET client_encoding TO 'UTF8'` through `PQexec` after connect and ignored the result. The connection string never carried `client_encoding`, so the session's reset value was the database's own encoding. A `RESET ALL` or `DISCARD ALL` in a query tab put the session back on `EUC_JP` or `LATIN1`. The app kept sending UTF-8 and decoding UTF-8, and when that failed it decoded as ISO-8859-1, which turned EUC-JP bytes into `¥á¡¼¥ë`.
2. **iOS.** `PostgreSQLConnectionString` had no `client_encoding` and the driver never set one, so every session on a non-UTF-8 database ran in the database's encoding from the first statement.
3. **SQL export.** A PostgreSQL-family dump had no `SET client_encoding = 'UTF8';`, which `pg_dump` writes. `psql db < dump.sql` (stdin not a terminal) uses the database's encoding as the client encoding, so a UTF-8 dump restored into a `LATIN1` database was stored double-encoded, and into `EUC_JP` it failed.

## Fix

- `LibPQConnectionString` (new, pure) builds the libpq conninfo and always adds `client_encoding='UTF8'`. A startup-packet value becomes the session's reset value, so `RESET ALL` and `DISCARD ALL` keep it.
- The post-connect `SET` is gone. It had no job left: the startup packet sets the same parameter, with higher standing. In its place, one log line if the server's reported `client_encoding` is not `UTF8` (or `UNICODE`, PostgreSQL 8.0's name for it, which Redshift descends from), so a pooler that drops the parameter is diagnosable.
- **Connection Options** still reach the server. PostgreSQL applies the `options` switches first and the startup parameters after, so `-c client_encoding=LATIN1` there is overridden, the same outcome the old `SET` produced, and `-c search_path=…` and the rest still apply. Documented.
- `LibPQCellDecoding` (new, pure) holds the cell decode. Invalid UTF-8 now becomes U+FFFD, the choice #2740 made for MySQL, instead of an ISO-8859-1 guess. With the session pinned the server either converts text to UTF-8 or refuses the query, so the fallback no longer runs on a healthy connection.
- iOS: the same `client_encoding='UTF8'` in `PostgreSQLConnectionString`. The iOS decode stays `String(cString:)`, which already replaces ill-formed UTF-8 with U+FFFD. The `U+187C` in the original finding was a valid UTF-8 sequence inside the EUC-JP bytes, not a guess; no decoder can avoid that, pinning the session does.
- SQL export: `SQLExportEncodingDeclaration.forDatabaseType(_:)` replaces `forDialect(_:)`, because the dialect cannot tell Redshift from PostgreSQL. PostgreSQL, Greenplum, AlloyDB, Citus, CockroachDB and PGlite dumps open every split part with `SET client_encoding = 'UTF8';` and no epilogue, as `pg_dump` does. Redshift gets none: its `SET` docs do not list `client_encoding`.
- `scripts/check-postgres-client-encoding.sh [host] [port] [user] [database]` checks the server facts this hard-codes: the startup value survives `RESET ALL` and `DISCARD ALL`, `SET client_encoding = 'UTF8'` is accepted, and a UTF-8 dump with the prologue restores byte-exact into `LATIN1` and `EUC_JP` through `psql` reading stdin. I checked it fails when the prologue is removed (LATIN1 stores `636166c3a9`, EUC_JP errors).

## SQL_ASCII databases (behaviour kept, documented)

A `SQL_ASCII` database stores bytes unchecked. Under a UTF8 session the server validates what it sends, so a query that reaches a non-UTF-8 value fails with `invalid byte sequence for encoding "UTF8": 0x…`. That was already the macOS behaviour until a `RESET ALL`; it is now the behaviour on both platforms, always. Rows holding valid UTF-8 read normally. `docs/databases/postgresql.mdx` gives the migration path (`pg_dump --encoding=<real encoding>` into a `UTF8` database). Two alternatives need a product decision and are not in this PR:

- Detect `server_encoding = SQL_ASCII` and switch that session to `client_encoding = SQL_ASCII`, decoding bytes as UTF-8 with U+FFFD. Readable, but an edit writes the U+FFFD back and corrupts the value.
- A per-connection encoding option (like #2740's MySQL **Encoding**) that names the real encoding of a `SQL_ASCII` database, decoding and encoding with it client-side.

On iOS this is a visible change for that one case: before, a non-UTF-8 value in a `SQL_ASCII` database showed as replacement characters; now the query fails with the server's error.

## Measured

PostgreSQL 17.11 throwaway cluster. macOS rows come from a swiftc harness running the real `PostgreSQLDriverPlugin` sources (before = #2740's head `3e3bed2c0`, whose PostgreSQL driver matches `main` apart from #2739's SQLSTATE field; after = this branch, re-run after the rebase with identical output). iOS rows come from a harness compiling the real `PostgreSQLConnectionString.swift` and reading cells with `String(cString:)` exactly as `PostgreSQLDriver` does, against the same libpq.

| Scenario | Before | After |
|---|---|---|
| macOS, `EUC_JP` db, `RESET ALL` then `SHOW client_encoding` | `EUC_JP` | `UTF8` |
| macOS, `EUC_JP` db, `RESET ALL` then read `メール` | `¥á¡¼¥ë` | `メール` |
| macOS, `EUC_JP` db, `RESET ALL` then `INSERT … 'メール'` | `invalid byte sequence for encoding "EUC_JP": 0xe3 0x83` | OK, reads back `メール` |
| macOS, `EUC_JP` db, `DISCARD ALL` then `SHOW client_encoding` | `EUC_JP` | `UTF8` |
| macOS, `LATIN1` db, `RESET ALL` then `UPDATE … 'café'`, stored bytes | `636166c3a9` (`cafÃ©`), shown as `café` | `636166e9` |
| macOS, `LATIN1` db, `RESET ALL` then `WHERE v = 'Müller'` | 0 rows | 1 row |
| macOS, Connection Options `-c client_encoding=LATIN1`, after `RESET ALL` | `LATIN1` | `UTF8` |
| macOS, Connection Options `-c search_path=pg_catalog` | `pg_catalog` | `pg_catalog` |
| macOS, `SQL_ASCII` db, EUC-JP bytes | error, then `¥á¡¼¥ë` after `RESET ALL` | error, before and after `RESET ALL` |
| iOS, `EUC_JP` db, `SHOW client_encoding` | `EUC_JP` | `UTF8` |
| iOS, `EUC_JP` db, read `メール` | `U+FFFD U+187C U+FFFD U+FFFD` | `メール` |
| iOS, `EUC_JP` db, `INSERT … 'メール'` | `invalid byte sequence for encoding "EUC_JP": 0xe3 0x83` | OK |
| iOS, `LATIN1` db, `UPDATE … 'café'`, stored bytes | `636166c3a9` | `636166e9` |
| iOS, `LATIN1` db, `WHERE v = 'Müller'` / read `Müller` | 0 rows / `M�ller` | 1 row / `Müller` |
| iOS, `SQL_ASCII` db, EUC-JP bytes | `U+FFFD U+187C U+FFFD U+FFFD` | `invalid byte sequence for encoding "UTF8": 0xa5` |
| Export restore via `psql < dump.sql` into `LATIN1`, `café` | `636166c3a9` | `636166e9` |
| Export restore via `psql < dump.sql` into `EUC_JP`, `メール` | error | `a5e1a1bca5eb` |

Engines that receive the new startup parameter or statement:

| Engine | Startup `client_encoding=UTF8` | `SET client_encoding = 'UTF8'` | Evidence |
|---|---|---|---|
| PostgreSQL 17.11 | accepted, survives `RESET ALL` / `DISCARD ALL` | accepted | probe script |
| PGlite 0.5.8 (`pglite-socket`) | accepted, survives both | accepted | probe script |
| CockroachDB | accepted | accepted, UTF8 is the only value | [session variables](https://docs.cockroachlabs.com/docs/stable/session-variables) |
| Redshift | accepted: Amazon's own JDBC driver sends it in every StartupPacket ([aws/amazon-redshift-jdbc-driver#6](https://github.com/aws/amazon-redshift-jdbc-driver/issues/6)) | not documented, so not emitted ([SET](https://docs.aws.amazon.com/redshift/latest/dg/r_SET.html)) | docs |

## Verification

- `verify.sh build` (TablePro, bundled PostgreSQL and SQL export plugins): PASS.
- `verify.sh test LibPQConnectionStringTests LibPQCellDecodingTests SQLExportEncodingTests LibPQSSLMappingTests LibPQByteaDecoderHexTests`: 43 of 43, `** TEST SUCCEEDED **`.
- `swiftlint lint --strict` on every changed Swift file: clean except three violations already on the base (`number_separator` on two existing `5432` lines in `PostgreSQLConnectionStringTests.swift`, `function_parameter_count` in `SQLExportPlugin.swift`).
- `verify.sh docs` and both docs scripts in the worktree: PASS. `shellcheck --severity=warning` on the probe script: clean.
- **TableProMobile could not be built or tested on this machine.** Both `build` and `build-for-testing` for `generic/platform=iOS Simulator` stop in `OracleNIO` on the Xcode beta toolchain defect `unknown attribute 'usableFromInlinenonisolated'` in a `@TaskLocal` expansion, before any TablePro source compiles. The iOS change is two lines in the conninfo builder and one test; the builder itself compiled and ran in the iOS harness above. CI runs the iOS suite.

## Review

Codex is out of credits. A separate review agent read the whole diff, including `LibPQPluginConnection.swift` after the rebase over #2739, and found nothing at high confidence. I also self-reviewed it.

## Found, not fixed here

- A PostgreSQL export writes string literals with only `'` doubled, which assumes `standard_conforming_strings = on`. `pg_dump` also writes `SET standard_conforming_strings = on;`. Restoring into a server configured with it `off` reads a backslash in a value as an escape. Same prologue, different setting, so left for its own change.
- A user's own `SET client_encoding = 'LATIN1'` in a query tab still leaves the driver sending and decoding UTF-8 until reconnect, so reads show U+FFFD and writes are stored double-encoded. The app decodes by its own session contract rather than following a mid-session change, the same choice #2740 made for `SET NAMES`.
- iOS still runs `SET standard_conforming_strings = on` after connect, which `RESET ALL` undoes on a server whose default is `off`.

https://claude.ai/code/session_01U7kkDGsR4M4v9NWiycc97U
