### PR TITLE
fix(datagrid): carry every per-table setting through a rename and a connection delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Garbled non-ASCII text on PostgreSQL databases not encoded in UTF-8 after `RESET ALL` or `DISCARD ALL`.
 - Garbled or double-encoded non-ASCII text on iOS with PostgreSQL databases not encoded in UTF-8.
 - Garbled non-ASCII text when restoring a PostgreSQL SQL export into a database not encoded in UTF-8.
+- Display As formats and foreign key labels lost on a rename, and kept with column layouts after deleting a connection.
 
 ### Security
 

--- a/Packages/TableProCore/Sources/TableProSyncTransport/SyncMetadataStorage.swift
+++ b/Packages/TableProCore/Sources/TableProSyncTransport/SyncMetadataStorage.swift
@@ -73,9 +73,14 @@ public final class SyncMetadataStorage: @unchecked Sendable {
     }
 
     public func removeDirty(_ id: String, type: SyncRecordType) {
-        var ids = dirtyIds(for: type)
-        ids.remove(id)
-        saveDirtyIds(ids, for: type)
+        removeDirty([id], type: type)
+    }
+
+    public func removeDirty(_ ids: [String], type: SyncRecordType) {
+        guard !ids.isEmpty else { return }
+        var current = dirtyIds(for: type)
+        current.subtract(ids)
+        saveDirtyIds(current, for: type)
     }
 
     public func clearDirty(type: SyncRecordType) {
@@ -95,8 +100,13 @@ public final class SyncMetadataStorage: @unchecked Sendable {
     }
 
     public func addTombstone(_ id: String, type: SyncRecordType) {
+        addTombstones([id], type: type)
+    }
+
+    public func addTombstones(_ ids: [String], type: SyncRecordType) {
+        guard !ids.isEmpty else { return }
         var current = tombstones(for: type)
-        current.append(Tombstone(id: id))
+        current.append(contentsOf: ids.map { Tombstone(id: $0) })
         saveTombstones(current, for: type)
     }
 

--- a/TablePro/Core/Storage/ColumnLayoutPersister.swift
+++ b/TablePro/Core/Storage/ColumnLayoutPersister.swift
@@ -8,7 +8,7 @@ import os
 import TableProSyncTransport
 
 @MainActor
-final class FileColumnLayoutPersister: ColumnLayoutPersisting {
+final class FileColumnLayoutPersister: ColumnLayoutPersisting, TableScopedSettingsStore {
     static let shared: FileColumnLayoutPersister = {
         let persister = FileColumnLayoutPersister()
         persister.performScopeMigration()
@@ -131,20 +131,23 @@ final class FileColumnLayoutPersister: ColumnLayoutPersisting {
     /// Persisted before either sync marker is written, because `markDeleted` posts a change
     /// notification that can start a sync, and a sync reading the old file would put the entry
     /// back under the name that has gone.
-    func rename(from oldKey: ColumnLayoutTableKey, to newKey: ColumnLayoutTableKey) {
-        var entries = loadEntries(for: oldKey.connectionId)
-        guard let entry = entries.removeValue(forKey: oldKey.storageKey) else { return }
-        entries[newKey.storageKey] = entry
-        cache[oldKey.connectionId] = entries
-        writeEntries(entries, for: oldKey.connectionId)
-        syncTracker.markDirty(.settings, id: Self.syncCategory(for: newKey.storageKey))
-        syncTracker.markDeleted(.settings, id: Self.syncCategory(for: oldKey.storageKey))
+    func renameTable(from oldScope: TableScope, to newScope: TableScope) {
+        let oldKey = oldScope.storageComponent
+        let newKey = newScope.storageComponent
+        guard oldKey != newKey else { return }
+        var entries = loadEntries(for: oldScope.connectionId)
+        guard let entry = entries.removeValue(forKey: oldKey) else { return }
+        entries[newKey] = entry
+        cache[oldScope.connectionId] = entries
+        writeEntries(entries, for: oldScope.connectionId)
+        syncTracker.markDirty(.settings, id: Self.syncCategory(for: newKey))
+        syncTracker.markDeleted(.settings, id: Self.syncCategory(for: oldKey))
     }
 
     /// Moves every table's saved layout from one container to another. Same prefix rewrite as the
     /// filter store, and for the same reason: the tables that have a layout are whatever the user
     /// has opened over the life of the connection, not what is loaded now.
-    func renameScope(
+    func renameContainer(
         connectionId: UUID,
         fromDatabase: String,
         fromSchema: String?,
@@ -172,6 +175,16 @@ final class FileColumnLayoutPersister: ColumnLayoutPersisting {
             syncTracker.markDirty(.settings, id: Self.syncCategory(for: newPrefix + key.dropFirst(oldPrefix.count)))
             syncTracker.markDeleted(.settings, id: Self.syncCategory(for: key))
         }
+    }
+
+    func purgeConnections(_ connectionIds: Set<UUID>) {
+        var deletedCategories: [String] = []
+        for connectionId in connectionIds {
+            deletedCategories += loadEntries(for: connectionId).keys.map(Self.syncCategory(for:))
+            cache[connectionId] = [:]
+            removeFile(for: connectionId)
+        }
+        syncTracker.markDeleted(.settings, ids: deletedCategories)
     }
 
     func clear(for key: ColumnLayoutTableKey) {

--- a/TablePro/Core/Storage/ConnectionLocalState.swift
+++ b/TablePro/Core/Storage/ConnectionLocalState.swift
@@ -22,7 +22,8 @@ internal enum ConnectionLocalState {
     internal static func purge(
         connectionIds: Set<UUID>,
         origin: Origin,
-        appSettings: AppSettingsStorage = .shared
+        appSettings: AppSettingsStorage = .shared,
+        tableScopedStores: [any TableScopedSettingsStore] = TableScopedSettingsRegistry.stores
     ) {
         guard !connectionIds.isEmpty else { return }
 
@@ -37,8 +38,9 @@ internal enum ConnectionLocalState {
             QueryInsightsPreferencesStorage.remove(for: connectionId)
         }
 
-        FilterSettingsStorage.shared.removeFilters(for: connectionIds)
-        HighlightRuleStorage.shared.removeRules(for: connectionIds)
+        for store in tableScopedStores {
+            store.purgeConnections(connectionIds)
+        }
         DatabaseTreeFilterStorage.shared.removeFilters(for: connectionIds)
         RecentlyClosedTabStore.shared.removeEntries(for: connectionIds)
         WorkspaceRailOrderStore.shared.removeEntries(for: connectionIds)

--- a/TablePro/Core/Storage/FilterSettingsStorage.swift
+++ b/TablePro/Core/Storage/FilterSettingsStorage.swift
@@ -75,7 +75,7 @@ struct FilterSettings: Codable, Equatable {
 }
 
 @MainActor
-final class FilterSettingsStorage {
+final class FilterSettingsStorage: TableScopedSettingsStore {
     static let shared = FilterSettingsStorage()
     nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "FilterSettingsStorage")
 
@@ -84,6 +84,7 @@ final class FilterSettingsStorage {
     private static let migrationCompleteKey = "com.TablePro.filterStateMigrationComplete"
     private static let compositeKeyMigrationKey = "com.TablePro.filterStateCompositeKeyMigrationComplete"
     private static let settingsKey = "com.TablePro.filter.settings"
+    private static let browseKeySuffix = ".browse"
 
     private let defaults: UserDefaults
 
@@ -257,38 +258,31 @@ final class FilterSettingsStorage {
 
     /// Moves a table's saved filters onto its new name. A rename keeps the columns the filters
     /// name, so the working set is still valid; leaving it behind would silently drop it.
-    func renameLastFilters(
-        from oldTableName: String,
-        to newTableName: String,
-        connectionId: UUID,
-        databaseName: String,
-        schemaName: String?
-    ) {
-        let oldKey = compositeKey(
-            tableName: oldTableName, connectionId: connectionId,
-            databaseName: databaseName, schemaName: schemaName
-        )
-        let newKey = compositeKey(
-            tableName: newTableName, connectionId: connectionId,
-            databaseName: databaseName, schemaName: schemaName
-        )
+    func renameTable(from oldScope: TableScope, to newScope: TableScope) {
+        let oldKey = oldScope.storageComponent
+        let newKey = newScope.storageComponent
         guard oldKey != newKey else { return }
-        if let cached = lastFiltersCache.removeValue(forKey: oldKey) {
-            lastFiltersCache[newKey] = cached
+        let oldBrowseKey = oldKey + Self.browseKeySuffix
+        let newBrowseKey = newKey + Self.browseKeySuffix
+        lastFiltersCache[newKey] = lastFiltersCache.removeValue(forKey: oldKey)
+        browseSearchCache[newBrowseKey] = browseSearchCache.removeValue(forKey: oldBrowseKey)
+
+        let moves = [(oldKey, newKey), (oldBrowseKey, newBrowseKey)].map { source, destination in
+            (fileURL(forKey: source), fileURL(forKey: destination))
         }
-        let source = fileURL(forKey: oldKey)
-        let destination = fileURL(forKey: newKey)
         ioQueue.async {
-            guard FileManager.default.fileExists(atPath: source.path) else { return }
-            try? FileManager.default.removeItem(at: destination)
-            try? FileManager.default.moveItem(at: source, to: destination)
+            let fm = FileManager.default
+            for (source, destination) in moves where fm.fileExists(atPath: source.path) {
+                try? fm.removeItem(at: destination)
+                try? fm.moveItem(at: source, to: destination)
+            }
         }
     }
 
     /// Moves every table's saved filters from one container to another, by rewriting the part of
     /// each key that names the container. Keyed by prefix rather than by walking the table list,
     /// because that list is loaded lazily and a table nobody opened this session still has a file.
-    func renameScope(
+    func renameContainer(
         connectionId: UUID,
         fromDatabase: String,
         fromSchema: String?,
@@ -303,10 +297,8 @@ final class FilterSettingsStorage {
         )
         guard oldPrefix != newPrefix else { return }
 
-        for key in lastFiltersCache.keys where key.hasPrefix(oldPrefix) {
-            let moved = newPrefix + key.dropFirst(oldPrefix.count)
-            lastFiltersCache[moved] = lastFiltersCache.removeValue(forKey: key)
-        }
+        lastFiltersCache = Self.rekeyed(lastFiltersCache, fromPrefix: oldPrefix, toPrefix: newPrefix)
+        browseSearchCache = Self.rekeyed(browseSearchCache, fromPrefix: oldPrefix, toPrefix: newPrefix)
 
         let directory = filterStateDirectory
         ioQueue.async {
@@ -410,20 +402,13 @@ final class FilterSettingsStorage {
             connectionId: connectionId,
             databaseName: databaseName,
             schemaName: schemaName
-        ) + ".browse"
+        ) + Self.browseKeySuffix
     }
 
-    func removeFilters(for connectionId: UUID) {
-        removeFilters(for: [connectionId])
-    }
-
-    func removeFilters(for connectionIds: Set<UUID>) {
+    func purgeConnections(_ connectionIds: Set<UUID>) {
         guard !connectionIds.isEmpty else { return }
 
-        let encodedPrefixes = connectionIds.map { id in
-            let idString = id.uuidString
-            return (idString.addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? idString) + "."
-        }
+        let encodedPrefixes = connectionIds.map { TableScope.storagePrefix(connectionId: $0) }
         let matchesConnection: (String) -> Bool = { name in
             encodedPrefixes.contains { name.hasPrefix($0) }
         }
@@ -443,6 +428,18 @@ final class FilterSettingsStorage {
                 Self.logger.error("Failed to enumerate filter state directory: \(error.localizedDescription)")
             }
         }
+    }
+
+    private static func rekeyed<Value>(
+        _ cache: [String: Value],
+        fromPrefix oldPrefix: String,
+        toPrefix newPrefix: String
+    ) -> [String: Value] {
+        var rekeyed = cache
+        for key in cache.keys where key.hasPrefix(oldPrefix) {
+            rekeyed[newPrefix + key.dropFirst(oldPrefix.count)] = rekeyed.removeValue(forKey: key)
+        }
+        return rekeyed
     }
 
     private func fileURL(forKey key: String) -> URL {

--- a/TablePro/Core/Storage/ForeignKeyLabelColumnStore.swift
+++ b/TablePro/Core/Storage/ForeignKeyLabelColumnStore.swift
@@ -12,8 +12,10 @@ import Foundation
 /// setting it once for `users` is what a user means by remembering it. Device-local, so this needs
 /// no CloudKit record type.
 @MainActor
-internal final class ForeignKeyLabelColumnStore {
+internal final class ForeignKeyLabelColumnStore: TableScopedSettingsStore {
     static let shared = ForeignKeyLabelColumnStore()
+
+    private static let keyPrefix = PreferenceKeys.foreignKeyLabelColumnPrefix
 
     private let store: KeyValueStore
 
@@ -35,5 +37,33 @@ internal final class ForeignKeyLabelColumnStore {
             return
         }
         store.setDataValue(Data(name.utf8), forKey: PreferenceKeys.foreignKeyLabelColumn(scope).name)
+    }
+
+    func renameTable(from oldScope: TableScope, to newScope: TableScope) {
+        store.moveValue(
+            fromKey: PreferenceKeys.foreignKeyLabelColumn(oldScope).name,
+            toKey: PreferenceKeys.foreignKeyLabelColumn(newScope).name
+        )
+    }
+
+    func renameContainer(
+        connectionId: UUID,
+        fromDatabase: String,
+        fromSchema: String?,
+        toDatabase: String,
+        toSchema: String?
+    ) {
+        store.moveValues(
+            withPrefix: Self.keyPrefix
+                + TableScope.storagePrefix(connectionId: connectionId, database: fromDatabase, schema: fromSchema),
+            toPrefix: Self.keyPrefix
+                + TableScope.storagePrefix(connectionId: connectionId, database: toDatabase, schema: toSchema)
+        )
+    }
+
+    func purgeConnections(_ connectionIds: Set<UUID>) {
+        for connectionId in connectionIds {
+            store.removeValues(withPrefix: Self.keyPrefix + TableScope.storagePrefix(connectionId: connectionId))
+        }
     }
 }

--- a/TablePro/Core/Storage/HighlightRuleStorage.swift
+++ b/TablePro/Core/Storage/HighlightRuleStorage.swift
@@ -9,7 +9,7 @@ import os
 
 @MainActor
 @Observable
-final class HighlightRuleStorage {
+final class HighlightRuleStorage: TableScopedSettingsStore {
     static let shared = HighlightRuleStorage()
 
     nonisolated private static let logger = Logger(
@@ -53,7 +53,7 @@ final class HighlightRuleStorage {
         commit(entries, for: scope.connectionId)
     }
 
-    func rename(from oldScope: TableScope, to newScope: TableScope) {
+    func renameTable(from oldScope: TableScope, to newScope: TableScope) {
         guard oldScope.storageComponent != newScope.storageComponent else { return }
         var entries = loadEntries(for: oldScope.connectionId)
         guard let moving = entries.removeValue(forKey: oldScope.storageComponent) else { return }
@@ -61,7 +61,7 @@ final class HighlightRuleStorage {
         commit(entries, for: oldScope.connectionId)
     }
 
-    func renameScope(
+    func renameContainer(
         connectionId: UUID,
         fromDatabase: String,
         fromSchema: String?,
@@ -81,11 +81,12 @@ final class HighlightRuleStorage {
         commit(entries, for: connectionId)
     }
 
-    func removeRules(for connectionIds: Set<UUID>) {
+    func purgeConnections(_ connectionIds: Set<UUID>) {
         guard !connectionIds.isEmpty else { return }
         for connectionId in connectionIds {
             cache[connectionId] = [:]
             removeFile(at: fileURL(for: connectionId))
+            removeFile(at: unreadableFileURL(for: connectionId))
         }
         revision &+= 1
     }
@@ -122,7 +123,7 @@ final class HighlightRuleStorage {
             Self.logger.error(
                 "Unreadable highlight rules for \(connectionId, privacy: .public): \(error.localizedDescription, privacy: .public)"
             )
-            preserveUnreadableFile(at: url)
+            preserveUnreadableFile(for: connectionId)
             cache[connectionId] = [:]
             return [:]
         }
@@ -139,12 +140,12 @@ final class HighlightRuleStorage {
         }
     }
 
-    private func preserveUnreadableFile(at url: URL) {
-        let preserved = url.deletingPathExtension().appendingPathExtension("unreadable.json")
+    private func preserveUnreadableFile(for connectionId: UUID) {
+        let preserved = unreadableFileURL(for: connectionId)
         let fileManager = FileManager.default
         try? fileManager.removeItem(at: preserved)
         do {
-            try fileManager.moveItem(at: url, to: preserved)
+            try fileManager.moveItem(at: fileURL(for: connectionId), to: preserved)
         } catch {
             Self.logger.error("Failed to set aside unreadable highlight rules: \(error.localizedDescription, privacy: .public)")
         }
@@ -157,6 +158,10 @@ final class HighlightRuleStorage {
         } catch {
             Self.logger.error("Failed to remove highlight rules file: \(error.localizedDescription, privacy: .public)")
         }
+    }
+
+    private func unreadableFileURL(for connectionId: UUID) -> URL {
+        storageDirectory.appendingPathComponent("\(connectionId.uuidString).unreadable.json")
     }
 
     private func fileURL(for connectionId: UUID) -> URL {

--- a/TablePro/Core/Storage/Preferences/KeyValueStore.swift
+++ b/TablePro/Core/Storage/Preferences/KeyValueStore.swift
@@ -8,6 +8,28 @@ import Foundation
 protocol KeyValueStore: AnyObject, Sendable {
     func dataValue(forKey key: String) -> Data?
     func setDataValue(_ data: Data?, forKey key: String)
+    func keys(withPrefix prefix: String) -> [String]
+}
+
+internal extension KeyValueStore {
+    func moveValue(fromKey oldKey: String, toKey newKey: String) {
+        guard oldKey != newKey, let data = dataValue(forKey: oldKey) else { return }
+        setDataValue(data, forKey: newKey)
+        setDataValue(nil, forKey: oldKey)
+    }
+
+    func moveValues(withPrefix oldPrefix: String, toPrefix newPrefix: String) {
+        guard oldPrefix != newPrefix else { return }
+        for key in keys(withPrefix: oldPrefix) {
+            moveValue(fromKey: key, toKey: newPrefix + key.dropFirst(oldPrefix.count))
+        }
+    }
+
+    func removeValues(withPrefix prefix: String) {
+        for key in keys(withPrefix: prefix) {
+            setDataValue(nil, forKey: key)
+        }
+    }
 }
 
 extension UserDefaults: KeyValueStore {
@@ -21,5 +43,9 @@ extension UserDefaults: KeyValueStore {
             return
         }
         set(data, forKey: key)
+    }
+
+    func keys(withPrefix prefix: String) -> [String] {
+        dictionaryRepresentation().keys.filter { $0.hasPrefix(prefix) }
     }
 }

--- a/TablePro/Core/Storage/Preferences/PreferenceKeys.swift
+++ b/TablePro/Core/Storage/Preferences/PreferenceKeys.swift
@@ -28,8 +28,11 @@ enum PreferenceKeys {
         lastBackupDirectory.name,
     ]
 
+    static let columnDisplayFormatsPrefix = "com.TablePro.columns.displayFormat."
+    static let foreignKeyLabelColumnPrefix = "com.TablePro.foreignKey.labelColumn."
+
     static func columnDisplayFormats(_ scope: TableScope) -> DefaultsKey<[String: ValueDisplayFormat]> {
-        DefaultsKey("com.TablePro.columns.displayFormat." + scope.storageComponent)
+        DefaultsKey(columnDisplayFormatsPrefix + scope.storageComponent)
     }
 
     static func recentTables(connectionId: UUID) -> DefaultsKey<[RecentTableEntry]> {
@@ -37,6 +40,6 @@ enum PreferenceKeys {
     }
 
     static func foreignKeyLabelColumn(_ scope: TableScope) -> DefaultsKey<String> {
-        DefaultsKey("com.TablePro.foreignKey.labelColumn." + scope.storageComponent)
+        DefaultsKey(foreignKeyLabelColumnPrefix + scope.storageComponent)
     }
 }

--- a/TablePro/Core/Storage/Preferences/TableScope.swift
+++ b/TablePro/Core/Storage/Preferences/TableScope.swift
@@ -31,6 +31,10 @@ struct TableScope: Hashable, Codable, Sendable {
         return encode(parts) + "."
     }
 
+    static func storagePrefix(connectionId: UUID) -> String {
+        encode([connectionId.uuidString]) + "."
+    }
+
     private static func encode(_ parts: [String]) -> String {
         parts
             .map { $0.addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? $0 }

--- a/TablePro/Core/Storage/TableScopedSettingsStore.swift
+++ b/TablePro/Core/Storage/TableScopedSettingsStore.swift
@@ -1,0 +1,32 @@
+//
+//  TableScopedSettingsStore.swift
+//  TablePro
+//
+
+import Foundation
+
+@MainActor
+internal protocol TableScopedSettingsStore: AnyObject {
+    func renameTable(from oldScope: TableScope, to newScope: TableScope)
+    func renameContainer(
+        connectionId: UUID,
+        fromDatabase: String,
+        fromSchema: String?,
+        toDatabase: String,
+        toSchema: String?
+    )
+    func purgeConnections(_ connectionIds: Set<UUID>)
+}
+
+@MainActor
+internal enum TableScopedSettingsRegistry {
+    internal static var stores: [any TableScopedSettingsStore] {
+        [
+            FilterSettingsStorage.shared,
+            FileColumnLayoutPersister.shared,
+            HighlightRuleStorage.shared,
+            ValueDisplayFormatStorage.shared,
+            ForeignKeyLabelColumnStore.shared
+        ]
+    }
+}

--- a/TablePro/Core/Storage/ValueDisplayFormatStorage.swift
+++ b/TablePro/Core/Storage/ValueDisplayFormatStorage.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 @MainActor
-internal final class ValueDisplayFormatStorage {
+internal final class ValueDisplayFormatStorage: TableScopedSettingsStore {
     static let shared = ValueDisplayFormatStorage()
 
     private let store: KeyValueStore
@@ -38,6 +38,37 @@ internal final class ValueDisplayFormatStorage {
         removeLegacy(for: scope)
     }
 
+    func renameTable(from oldScope: TableScope, to newScope: TableScope) {
+        let oldKey = PreferenceKeys.columnDisplayFormats(oldScope).name
+        if store.dataValue(forKey: oldKey) == nil {
+            migrateLegacy(for: oldScope)
+        }
+        store.moveValue(fromKey: oldKey, toKey: PreferenceKeys.columnDisplayFormats(newScope).name)
+    }
+
+    func renameContainer(
+        connectionId: UUID,
+        fromDatabase: String,
+        fromSchema: String?,
+        toDatabase: String,
+        toSchema: String?
+    ) {
+        store.moveValues(
+            withPrefix: Self.keyPrefix
+                + TableScope.storagePrefix(connectionId: connectionId, database: fromDatabase, schema: fromSchema),
+            toPrefix: Self.keyPrefix
+                + TableScope.storagePrefix(connectionId: connectionId, database: toDatabase, schema: toSchema)
+        )
+    }
+
+    func purgeConnections(_ connectionIds: Set<UUID>) {
+        for connectionId in connectionIds {
+            store.removeValues(withPrefix: Self.keyPrefix + TableScope.storagePrefix(connectionId: connectionId))
+            store.removeValues(withPrefix: Self.legacyKeyPrefix(for: connectionId))
+        }
+    }
+
+    @discardableResult
     private func migrateLegacy(for scope: TableScope) -> [String: ValueDisplayFormat]? {
         let legacyKey = Self.legacyKey(for: scope)
         guard let data = store.dataValue(forKey: legacyKey),
@@ -56,7 +87,13 @@ internal final class ValueDisplayFormatStorage {
         store.setDataValue(nil, forKey: Self.legacyKey(for: scope))
     }
 
+    private static let keyPrefix = PreferenceKeys.columnDisplayFormatsPrefix
+
     private static func legacyKey(for scope: TableScope) -> String {
-        "com.TablePro.columns.displayFormat.\(scope.connectionId.uuidString).\(scope.table)"
+        legacyKeyPrefix(for: scope.connectionId) + scope.table
+    }
+
+    private static func legacyKeyPrefix(for connectionId: UUID) -> String {
+        "\(keyPrefix)\(connectionId.uuidString)."
     }
 }

--- a/TablePro/Core/Sync/SyncChangeTracker.swift
+++ b/TablePro/Core/Sync/SyncChangeTracker.swift
@@ -61,6 +61,14 @@ final class SyncChangeTracker: Sendable {
         postChangeNotification()
     }
 
+    func markDeleted(_ type: SyncRecordType, ids: [String]) {
+        guard !isSuppressed, !ids.isEmpty else { return }
+        metadataStorage.removeDirty(ids, type: type)
+        metadataStorage.addTombstones(ids, type: type)
+        Self.logger.trace("Marked deleted: \(type.rawValue) x\(ids.count)")
+        postChangeNotification()
+    }
+
     // MARK: - Query
 
     func dirtyRecords(for type: SyncRecordType) -> Set<String> {

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+RenameAdoption.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+RenameAdoption.swift
@@ -83,26 +83,12 @@ extension MainContentCoordinator {
         database: String,
         schema: String?
     ) {
-        FilterSettingsStorage.shared.renameLastFilters(
-            from: oldName,
-            to: newName,
-            connectionId: connectionId,
-            databaseName: database,
-            schemaName: schema
-        )
-        FileColumnLayoutPersister.shared.rename(
-            from: ColumnLayoutTableKey(
-                connectionId: connectionId, databaseName: database, schemaName: schema, tableName: oldName
-            ),
-            to: ColumnLayoutTableKey(
-                connectionId: connectionId, databaseName: database, schemaName: schema, tableName: newName
-            )
-        )
         let scopedDatabase = database.isEmpty ? nil : database
-        HighlightRuleStorage.shared.rename(
-            from: TableScope(connectionId: connectionId, database: scopedDatabase, schema: schema, table: oldName),
-            to: TableScope(connectionId: connectionId, database: scopedDatabase, schema: schema, table: newName)
-        )
+        let oldScope = TableScope(connectionId: connectionId, database: scopedDatabase, schema: schema, table: oldName)
+        let newScope = TableScope(connectionId: connectionId, database: scopedDatabase, schema: schema, table: newName)
+        for store in TableScopedSettingsRegistry.stores {
+            store.renameTable(from: oldScope, to: newScope)
+        }
     }
 
     private func moveFavorite(_ ref: DatabaseTreeTableRef, to newName: String, database: String?) {
@@ -136,18 +122,12 @@ extension MainContentCoordinator {
         retargetPendingOperations(
             database: database, schema: schema, toDatabase: toDatabase, toSchema: toSchema
         )
-        FilterSettingsStorage.shared.renameScope(
-            connectionId: connectionId, fromDatabase: database, fromSchema: schema,
-            toDatabase: toDatabase, toSchema: toSchema
-        )
-        FileColumnLayoutPersister.shared.renameScope(
-            connectionId: connectionId, fromDatabase: database, fromSchema: schema,
-            toDatabase: toDatabase, toSchema: toSchema
-        )
-        HighlightRuleStorage.shared.renameScope(
-            connectionId: connectionId, fromDatabase: database, fromSchema: schema,
-            toDatabase: toDatabase, toSchema: toSchema
-        )
+        for store in TableScopedSettingsRegistry.stores {
+            store.renameContainer(
+                connectionId: connectionId, fromDatabase: database, fromSchema: schema,
+                toDatabase: toDatabase, toSchema: toSchema
+            )
+        }
         retargetFavoriteTables(
             database: database, schema: schema, toDatabase: toDatabase, toSchema: toSchema
         )

--- a/TableProTests/Core/Storage/ColumnLayoutSyncTests.swift
+++ b/TableProTests/Core/Storage/ColumnLayoutSyncTests.swift
@@ -19,6 +19,21 @@ struct ColumnLayoutSyncTests {
         return (FileColumnLayoutPersister(storageDirectory: directory, syncTracker: tracker), tracker)
     }
 
+    private func makeTrackedPersister() throws -> (FileColumnLayoutPersister, SyncMetadataStorage, URL) {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cl-sync-\(UUID().uuidString)", isDirectory: true)
+        let meta = try #require(UserDefaults(suiteName: "cl-sync-meta-\(UUID().uuidString)"))
+        let metadata = SyncMetadataStorage(userDefaults: meta)
+        let tracker = SyncChangeTracker(metadataStorage: metadata)
+        return (FileColumnLayoutPersister(storageDirectory: directory, syncTracker: tracker), metadata, directory)
+    }
+
+    private func layout(_ widths: [String: CGFloat]) -> ColumnLayoutState {
+        var state = ColumnLayoutState()
+        state.columnWidths = widths
+        return state
+    }
+
     private func key() -> ColumnLayoutTableKey {
         ColumnLayoutTableKey(connectionId: UUID(), databaseName: "shop", schemaName: "public", tableName: "orders")
     }
@@ -53,6 +68,68 @@ struct ColumnLayoutSyncTests {
         #expect(target.load(for: tableKey)?.columnWidths == ["id": 80, "created_at": 176])
         #expect(target.load(for: tableKey)?.columnContentWidths == ["id": 80, "created_at": 160])
         #expect(target.load(for: tableKey)?.columnOrder == ["id", "created_at"])
+    }
+
+    @Test("Deleting a connection removes its layout file and tombstones every layout it held")
+    func purgeConnectionsRemovesFileAndTombstones() throws {
+        let (persister, metadata, directory) = try makeTrackedPersister()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let connectionId = UUID()
+        let orders = ColumnLayoutTableKey(
+            connectionId: connectionId, databaseName: "shop", schemaName: "public", tableName: "orders"
+        )
+        let items = ColumnLayoutTableKey(
+            connectionId: connectionId, databaseName: "shop", schemaName: "public", tableName: "items"
+        )
+        let kept = ColumnLayoutTableKey(
+            connectionId: UUID(), databaseName: "shop", schemaName: "public", tableName: "orders"
+        )
+        persister.save(layout(["id": 80]), for: orders)
+        persister.save(layout(["id": 90]), for: items)
+        persister.save(layout(["id": 70]), for: kept)
+
+        persister.purgeConnections([connectionId])
+
+        let file = directory.appendingPathComponent("\(connectionId.uuidString).json")
+        #expect(!FileManager.default.fileExists(atPath: file.path))
+        #expect(persister.load(for: orders) == nil)
+        #expect(persister.load(for: items) == nil)
+        #expect(persister.load(for: kept)?.columnWidths == ["id": 70])
+
+        let tombstones = Set(metadata.tombstones(for: .settings).map(\.id))
+        #expect(tombstones == [
+            FileColumnLayoutPersister.syncCategory(for: orders.storageKey),
+            FileColumnLayoutPersister.syncCategory(for: items.storageKey)
+        ])
+        #expect(!metadata.dirtyIds(for: .settings).contains(FileColumnLayoutPersister.syncCategory(for: orders.storageKey)))
+    }
+
+    @Test("A table rename moves its layout, tombstones the old record and marks the new one dirty")
+    func renameTableMovesLayoutAndSyncsIt() throws {
+        let (persister, metadata, directory) = try makeTrackedPersister()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let connectionId = UUID()
+        let old = TableScope(connectionId: connectionId, database: "shop", schema: "public", table: "orders")
+        let new = TableScope(connectionId: connectionId, database: "shop", schema: "public", table: "purchases")
+        let archive = ColumnLayoutTableKey(
+            connectionId: connectionId, databaseName: "shop", schemaName: "public", tableName: "orders_archive"
+        )
+        let oldKey = ColumnLayoutTableKey(
+            connectionId: connectionId, databaseName: "shop", schemaName: "public", tableName: "orders"
+        )
+        let newKey = ColumnLayoutTableKey(
+            connectionId: connectionId, databaseName: "shop", schemaName: "public", tableName: "purchases"
+        )
+        persister.save(layout(["id": 80]), for: oldKey)
+        persister.save(layout(["id": 60]), for: archive)
+
+        persister.renameTable(from: old, to: new)
+
+        #expect(persister.load(for: oldKey) == nil)
+        #expect(persister.load(for: newKey)?.columnWidths == ["id": 80])
+        #expect(persister.load(for: archive)?.columnWidths == ["id": 60])
+        #expect(metadata.tombstones(for: .settings).map(\.id) == [FileColumnLayoutPersister.syncCategory(for: oldKey.storageKey)])
+        #expect(metadata.dirtyIds(for: .settings).contains(FileColumnLayoutPersister.syncCategory(for: newKey.storageKey)))
     }
 
     @Test("The sync category carries the columnLayout prefix")

--- a/TableProTests/Core/Storage/FilterSettingsStorageTests.swift
+++ b/TableProTests/Core/Storage/FilterSettingsStorageTests.swift
@@ -131,7 +131,7 @@ struct FilterSettingsStorageTests {
             keptFilters, for: "users", connectionId: keptConnection, databaseName: "db", schemaName: nil
         )
 
-        storage.removeFilters(for: deletedConnection)
+        storage.purgeConnections([deletedConnection])
         storage.waitForPendingDiskWrites()
 
         #expect(
@@ -158,7 +158,7 @@ struct FilterSettingsStorageTests {
             )
         }
 
-        storage.removeFilters(for: [first, second])
+        storage.purgeConnections([first, second])
         storage.waitForPendingDiskWrites()
 
         #expect(storage.loadLastFilters(for: "users", connectionId: first, databaseName: "db", schemaName: nil).isEmpty)
@@ -184,7 +184,7 @@ struct FilterSettingsStorageTests {
             for: "users", connectionId: connectionId, databaseName: "db", schemaName: nil
         )
 
-        storage.removeFilters(for: connectionId)
+        storage.purgeConnections([connectionId])
         storage.waitForPendingDiskWrites()
 
         let fresh = FilterSettingsStorage(filterStateDirectory: directory, defaults: defaults)
@@ -394,5 +394,85 @@ struct FilterSettingsStorageTests {
         )
         #expect(state.filters == filters)
         #expect(state.logicMode == .and)
+    }
+
+    @Test("A table rename moves its filters and browse search and leaves a longer name alone")
+    func renameTableMovesFiltersAndBrowseSearch() throws {
+        let defaults = try #require(UserDefaults(suiteName: "FilterSettingsStorageTests-\(UUID().uuidString)"))
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("FilterSettingsStorageTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let connectionId = UUID()
+        let filters = [TestFixtures.makeTableFilter(column: "email", value: "a@b.com")]
+        let archiveFilters = [TestFixtures.makeTableFilter(column: "id", value: "1")]
+        let search = BrowseSearchState(pattern: "user:*", typeScope: "hash")
+
+        let storage = FilterSettingsStorage(filterStateDirectory: directory, defaults: defaults)
+        storage.saveLastFilters(filters, for: "users", connectionId: connectionId, databaseName: "db", schemaName: nil)
+        storage.saveLastFilters(
+            archiveFilters, for: "users_archive", connectionId: connectionId, databaseName: "db", schemaName: nil
+        )
+        storage.saveBrowseSearch(search, for: "users", connectionId: connectionId, databaseName: "db", schemaName: nil)
+
+        storage.renameTable(
+            from: TableScope(connectionId: connectionId, database: "db", schema: nil, table: "users"),
+            to: TableScope(connectionId: connectionId, database: "db", schema: nil, table: "members")
+        )
+        storage.waitForPendingDiskWrites()
+
+        for reader in [storage, FilterSettingsStorage(filterStateDirectory: directory, defaults: defaults)] {
+            #expect(
+                reader.loadLastFilters(for: "members", connectionId: connectionId, databaseName: "db", schemaName: nil)
+                    == filters
+            )
+            #expect(
+                reader.loadBrowseSearch(for: "members", connectionId: connectionId, databaseName: "db", schemaName: nil)
+                    == search
+            )
+            #expect(
+                reader.loadLastFilters(for: "users", connectionId: connectionId, databaseName: "db", schemaName: nil)
+                    .isEmpty
+            )
+            #expect(
+                reader.loadLastFilters(
+                    for: "users_archive", connectionId: connectionId, databaseName: "db", schemaName: nil
+                ) == archiveFilters
+            )
+        }
+    }
+
+    @Test("A schema rename moves browse search along with the filters")
+    func renameContainerMovesBrowseSearch() throws {
+        let defaults = try #require(UserDefaults(suiteName: "FilterSettingsStorageTests-\(UUID().uuidString)"))
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("FilterSettingsStorageTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let connectionId = UUID()
+        let filters = [TestFixtures.makeTableFilter(column: "email", value: "a@b.com")]
+        let search = BrowseSearchState(pattern: "user:*", typeScope: "hash")
+
+        let storage = FilterSettingsStorage(filterStateDirectory: directory, defaults: defaults)
+        storage.saveLastFilters(filters, for: "users", connectionId: connectionId, databaseName: "db", schemaName: "app")
+        storage.saveBrowseSearch(search, for: "users", connectionId: connectionId, databaseName: "db", schemaName: "app")
+
+        storage.renameContainer(
+            connectionId: connectionId, fromDatabase: "db", fromSchema: "app", toDatabase: "db", toSchema: "core"
+        )
+        storage.waitForPendingDiskWrites()
+
+        for reader in [storage, FilterSettingsStorage(filterStateDirectory: directory, defaults: defaults)] {
+            #expect(
+                reader.loadLastFilters(for: "users", connectionId: connectionId, databaseName: "db", schemaName: "core")
+                    == filters
+            )
+            #expect(
+                reader.loadBrowseSearch(for: "users", connectionId: connectionId, databaseName: "db", schemaName: "core")
+                    == search
+            )
+            #expect(
+                !reader.loadBrowseSearch(for: "users", connectionId: connectionId, databaseName: "db", schemaName: "app")
+                    .isActive
+            )
+        }
     }
 }

--- a/TableProTests/Core/Storage/HighlightRuleStorageTests.swift
+++ b/TableProTests/Core/Storage/HighlightRuleStorageTests.swift
@@ -55,7 +55,7 @@ struct HighlightRuleStorageTests {
         let rules = [HighlightRule(columnName: "status", value: "paid")]
         storage.setRules(rules, for: scope(table: "orders"))
 
-        storage.rename(from: scope(table: "orders"), to: scope(table: "purchases"))
+        storage.renameTable(from: scope(table: "orders"), to: scope(table: "purchases"))
 
         let reloaded = HighlightRuleStorage(storageDirectory: directory)
         #expect(reloaded.rules(for: scope(table: "orders")).isEmpty)
@@ -69,7 +69,7 @@ struct HighlightRuleStorageTests {
         storage.setRules(rules, for: scope(table: "orders"))
         storage.setRules(rules, for: scope(table: "items"))
 
-        storage.renameScope(
+        storage.renameContainer(
             connectionId: connectionId, fromDatabase: "shop", fromSchema: "public",
             toDatabase: "shop", toSchema: "sales"
         )
@@ -84,10 +84,24 @@ struct HighlightRuleStorageTests {
         let storage = HighlightRuleStorage(storageDirectory: directory)
         storage.setRules([HighlightRule(columnName: "status", value: "paid")], for: scope(table: "orders"))
 
-        storage.removeRules(for: [connectionId])
+        storage.purgeConnections([connectionId])
 
         #expect(storage.rules(for: scope(table: "orders")).isEmpty)
         #expect(!FileManager.default.fileExists(atPath: fileURL.path))
+    }
+
+    @Test("Deleting a connection removes a set-aside unreadable file too")
+    func purgeRemovesUnreadableFile() throws {
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try Data("{ not json".utf8).write(to: fileURL)
+        let storage = HighlightRuleStorage(storageDirectory: directory)
+        _ = storage.rules(for: scope(table: "orders"))
+        let preserved = directory.appendingPathComponent("\(connectionId.uuidString).unreadable.json")
+        #expect(FileManager.default.fileExists(atPath: preserved.path))
+
+        storage.purgeConnections([connectionId])
+
+        #expect(!FileManager.default.fileExists(atPath: preserved.path))
     }
 
     @Test("Every change moves the observed revision")

--- a/TableProTests/Core/Storage/TableScopedSettingsRegistryTests.swift
+++ b/TableProTests/Core/Storage/TableScopedSettingsRegistryTests.swift
@@ -1,0 +1,134 @@
+//
+//  TableScopedSettingsRegistryTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("Table-scoped settings registry")
+@MainActor
+struct TableScopedSettingsRegistryTests {
+    @MainActor
+    private final class RecordingStore: TableScopedSettingsStore {
+        private(set) var purgedConnectionIds: [Set<UUID>] = []
+
+        func renameTable(from oldScope: TableScope, to newScope: TableScope) {}
+
+        func renameContainer(
+            connectionId: UUID,
+            fromDatabase: String,
+            fromSchema: String?,
+            toDatabase: String,
+            toSchema: String?
+        ) {}
+
+        func purgeConnections(_ connectionIds: Set<UUID>) {
+            purgedConnectionIds.append(connectionIds)
+        }
+    }
+
+    @Test("Deleting a connection purges every table-scoped store once with every id")
+    func connectionPurgeReachesEveryStore() {
+        let first = RecordingStore()
+        let second = RecordingStore()
+        let deleted: Set<UUID> = [UUID(), UUID()]
+
+        ConnectionLocalState.purge(connectionIds: deleted, origin: .remote, tableScopedStores: [first, second])
+
+        #expect(first.purgedConnectionIds == [deleted])
+        #expect(second.purgedConnectionIds == [deleted])
+    }
+
+    @Test("An empty delete purges nothing")
+    func emptyPurgeReachesNoStore() {
+        let store = RecordingStore()
+
+        ConnectionLocalState.purge(connectionIds: [], origin: .remote, tableScopedStores: [store])
+
+        #expect(store.purgedConnectionIds.isEmpty)
+    }
+
+    @Test("Every store keyed by a table scope conforms and is registered")
+    func everyTableScopedStoreIsRegistered() throws {
+        let root = try Self.repoRoot()
+        let storageDirectory = root.appendingPathComponent("TablePro/Core/Storage", isDirectory: true)
+        let registry = try String(
+            contentsOf: storageDirectory.appendingPathComponent("TableScopedSettingsStore.swift"),
+            encoding: .utf8
+        )
+
+        let keyUsage = try NSRegularExpression(pattern: #"\b(TableScope|CompositeStorageKey|ColumnLayoutTableKey)\b"#)
+        let classDeclaration = try NSRegularExpression(pattern: #"\bclass\s+([A-Z]\w*)"#)
+        var storeTypes: Set<String> = []
+        for text in try Self.swiftSources(under: storageDirectory) where Self.matches(keyUsage, in: text) {
+            storeTypes.formUnion(Self.captures(classDeclaration, in: text))
+        }
+
+        let conformance = try NSRegularExpression(
+            pattern: #"\b(?:class|extension)\s+([A-Z]\w*)\s*:[^{]*\bTableScopedSettingsStore\b"#
+        )
+        var conformingTypes: Set<String> = []
+        for text in try Self.swiftSources(under: root.appendingPathComponent("TablePro", isDirectory: true)) {
+            conformingTypes.formUnion(Self.captures(conformance, in: text))
+        }
+
+        #expect(storeTypes.isSuperset(of: [
+            "FilterSettingsStorage",
+            "FileColumnLayoutPersister",
+            "HighlightRuleStorage",
+            "ValueDisplayFormatStorage",
+            "ForeignKeyLabelColumnStore"
+        ]))
+        let unconformed = storeTypes.subtracting(conformingTypes)
+        #expect(
+            unconformed.isEmpty,
+            "A store keyed by table scope must conform to TableScopedSettingsStore: \(unconformed.sorted())"
+        )
+        let unregistered = storeTypes.filter { !registry.contains("\($0).shared") }
+        #expect(
+            unregistered.isEmpty,
+            "A table-scoped store must be listed in TableScopedSettingsRegistry.stores: \(unregistered.sorted())"
+        )
+    }
+
+    private static func matches(_ regex: NSRegularExpression, in text: String) -> Bool {
+        regex.firstMatch(in: text, range: NSRange(text.startIndex..., in: text)) != nil
+    }
+
+    private static func captures(_ regex: NSRegularExpression, in text: String) -> Set<String> {
+        let matches = regex.matches(in: text, range: NSRange(text.startIndex..., in: text))
+        return Set(matches.compactMap { match in
+            Range(match.range(at: 1), in: text).map { String(text[$0]) }
+        })
+    }
+
+    private static func swiftSources(under directory: URL) throws -> [String] {
+        guard let enumerator = FileManager.default.enumerator(
+            at: directory,
+            includingPropertiesForKeys: [.isRegularFileKey]
+        ) else { return [] }
+
+        var sources: [String] = []
+        for case let url as URL in enumerator where url.pathExtension == "swift" {
+            sources.append(try String(contentsOf: url, encoding: .utf8))
+        }
+        return sources
+    }
+
+    private static func repoRoot() throws -> URL {
+        var directory = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        for _ in 0 ..< 12 {
+            if FileManager.default.fileExists(atPath: directory.appendingPathComponent("TablePro.xcodeproj").path) {
+                return directory
+            }
+            directory = directory.deletingLastPathComponent()
+        }
+        throw GuardError.repoRootNotFound
+    }
+
+    private enum GuardError: Error {
+        case repoRootNotFound
+    }
+}

--- a/TableProTests/Core/Storage/ValueDisplayFormatStorageTests.swift
+++ b/TableProTests/Core/Storage/ValueDisplayFormatStorageTests.swift
@@ -87,4 +87,100 @@ struct ValueDisplayFormatStorageTests {
         #expect(defaults.data(forKey: legacyKey) == nil)
         #expect(defaults.data(forKey: PreferenceKeys.columnDisplayFormats(target).name) != nil)
     }
+
+    @Test("A table rename moves its formats and leaves a longer name alone")
+    func renameTableMovesOnlyThatTable() throws {
+        let (storage, _) = try makeStorage()
+        let conn = UUID()
+        let other = UUID()
+        storage.save(["id": .uuid], for: scope("public", connectionId: conn))
+        storage.save(["ref": .json], for: scope("public", connectionId: conn, table: "orders_archive"))
+        storage.save(["id": .json], for: scope("public", connectionId: other))
+
+        storage.renameTable(
+            from: scope("public", connectionId: conn),
+            to: scope("public", connectionId: conn, table: "purchases")
+        )
+
+        #expect(storage.load(for: scope("public", connectionId: conn)) == nil)
+        #expect(storage.load(for: scope("public", connectionId: conn, table: "purchases")) == ["id": .uuid])
+        #expect(storage.load(for: scope("public", connectionId: conn, table: "orders_archive")) == ["ref": .json])
+        #expect(storage.load(for: scope("public", connectionId: other)) == ["id": .json])
+    }
+
+    @Test("A table rename carries formats still stored under the legacy key")
+    func renameTableMigratesLegacy() throws {
+        let (storage, defaults) = try makeStorage()
+        let conn = UUID()
+        let legacyKey = "com.TablePro.columns.displayFormat.\(conn.uuidString).orders"
+        defaults.set(try JSONEncoder().encode(["id": ValueDisplayFormat.uuid]), forKey: legacyKey)
+
+        storage.renameTable(
+            from: scope("public", connectionId: conn),
+            to: scope("public", connectionId: conn, table: "purchases")
+        )
+
+        #expect(defaults.data(forKey: legacyKey) == nil)
+        #expect(storage.load(for: scope("public", connectionId: conn, table: "purchases")) == ["id": .uuid])
+        #expect(storage.load(for: scope("public", connectionId: conn)) == nil)
+    }
+
+    @Test("A schema rename moves every table in it and nothing outside it")
+    func renameContainerMovesTheSchema() throws {
+        let (storage, _) = try makeStorage()
+        let conn = UUID()
+        let other = UUID()
+        storage.save(["id": .uuid], for: scope("public", connectionId: conn))
+        storage.save(["ref": .json], for: scope("public", connectionId: conn, table: "items"))
+        storage.save(["id": .json], for: scope("public_old", connectionId: conn))
+        storage.save(["id": .uuid], for: scope("public", connectionId: other))
+
+        storage.renameContainer(
+            connectionId: conn, fromDatabase: "shop", fromSchema: "public", toDatabase: "shop", toSchema: "sales"
+        )
+
+        #expect(storage.load(for: scope("sales", connectionId: conn)) == ["id": .uuid])
+        #expect(storage.load(for: scope("sales", connectionId: conn, table: "items")) == ["ref": .json])
+        #expect(storage.load(for: scope("public", connectionId: conn)) == nil)
+        #expect(storage.load(for: scope("public_old", connectionId: conn)) == ["id": .json])
+        #expect(storage.load(for: scope("public", connectionId: other)) == ["id": .uuid])
+    }
+
+    @Test("A database rename moves every schema in it")
+    func renameDatabaseMovesEverySchema() throws {
+        let (storage, _) = try makeStorage()
+        let conn = UUID()
+        storage.save(["id": .uuid], for: scope("public", connectionId: conn))
+        storage.save(["id": .json], for: scope("archive", connectionId: conn))
+        let longerName = TableScope(connectionId: conn, database: "shopping", schema: "public", table: "orders")
+        storage.save(["id": .text], for: longerName)
+
+        storage.renameContainer(
+            connectionId: conn, fromDatabase: "shop", fromSchema: nil, toDatabase: "store", toSchema: nil
+        )
+
+        let moved = TableScope(connectionId: conn, database: "store", schema: "public", table: "orders")
+        let movedArchive = TableScope(connectionId: conn, database: "store", schema: "archive", table: "orders")
+        #expect(storage.load(for: moved) == ["id": .uuid])
+        #expect(storage.load(for: movedArchive) == ["id": .json])
+        #expect(storage.load(for: longerName) == ["id": .text])
+        #expect(storage.load(for: scope("public", connectionId: conn)) == nil)
+    }
+
+    @Test("Deleting a connection removes its formats, legacy keys included, and keeps the rest")
+    func purgeConnectionsRemovesOnlyThatConnection() throws {
+        let (storage, defaults) = try makeStorage()
+        let conn = UUID()
+        let other = UUID()
+        let legacyKey = "com.TablePro.columns.displayFormat.\(conn.uuidString).customers"
+        defaults.set(try JSONEncoder().encode(["id": ValueDisplayFormat.uuid]), forKey: legacyKey)
+        storage.save(["id": .uuid], for: scope("public", connectionId: conn))
+        storage.save(["id": .json], for: scope("public", connectionId: other))
+
+        storage.purgeConnections([conn])
+
+        #expect(defaults.data(forKey: PreferenceKeys.columnDisplayFormats(scope("public", connectionId: conn)).name) == nil)
+        #expect(defaults.data(forKey: legacyKey) == nil)
+        #expect(storage.load(for: scope("public", connectionId: other)) == ["id": .json])
+    }
 }

--- a/TableProTests/Core/Sync/SyncChangeTrackerTests.swift
+++ b/TableProTests/Core/Sync/SyncChangeTrackerTests.swift
@@ -4,8 +4,8 @@
 //
 
 import Foundation
-import Testing
 import TableProSyncTransport
+import Testing
 
 @testable import TablePro
 
@@ -15,9 +15,9 @@ struct SyncChangeTrackerTests {
     private let metadata: SyncMetadataStorage
     private let tracker: SyncChangeTracker
 
-    init() {
+    init() throws {
         let unique = UUID().uuidString
-        let syncDefaults = UserDefaults(suiteName: "com.TablePro.tests.SyncChangeTracker.\(unique)")!
+        let syncDefaults = try #require(UserDefaults(suiteName: "com.TablePro.tests.SyncChangeTracker.\(unique)"))
         metadata = SyncMetadataStorage(userDefaults: syncDefaults)
         tracker = SyncChangeTracker(metadataStorage: metadata)
     }
@@ -47,6 +47,34 @@ struct SyncChangeTrackerTests {
 
         #expect(!tracker.dirtyRecords(for: .connection).contains("conn-1"))
         #expect(metadata.tombstones(for: .connection).contains { $0.id == "conn-1" })
+    }
+
+    @Test("markDeleted with multiple ids clears each dirty flag and tombstones each id once")
+    func markDeletedMultiple() {
+        tracker.markDirty(.settings, ids: ["a", "b", "kept"])
+        tracker.markDeleted(.settings, ids: ["a", "b"])
+
+        #expect(tracker.dirtyRecords(for: .settings) == ["kept"])
+        #expect(metadata.tombstones(for: .settings).map(\.id).sorted() == ["a", "b"])
+    }
+
+    @Test("markDeleted with an empty id list records nothing")
+    func markDeletedEmptyIsNoop() {
+        tracker.markDirty(.settings, id: "kept")
+        tracker.markDeleted(.settings, ids: [])
+
+        #expect(tracker.dirtyRecords(for: .settings) == ["kept"])
+        #expect(metadata.tombstones(for: .settings).isEmpty)
+    }
+
+    @Test("Suppression makes a batch markDeleted a no-op")
+    func suppressionDisablesBatchDelete() {
+        tracker.markDirty(.settings, id: "a")
+        tracker.isSuppressed = true
+        tracker.markDeleted(.settings, ids: ["a"])
+
+        #expect(tracker.dirtyRecords(for: .settings) == ["a"])
+        #expect(metadata.tombstones(for: .settings).isEmpty)
     }
 
     @Test("Suppression makes markDirty and markDeleted no-ops")

--- a/TableProTests/Storage/ForeignKeyLabelColumnStoreTests.swift
+++ b/TableProTests/Storage/ForeignKeyLabelColumnStoreTests.swift
@@ -76,4 +76,79 @@ struct ForeignKeyLabelColumnStoreTests {
         #expect(store.labelColumn(for: target) == "full name")
         #expect(store.labelColumn(for: scope(connectionId: target.connectionId)) == nil)
     }
+
+    @Test("A table rename moves its choice and leaves a longer name alone")
+    func renameTableMovesOnlyThatTable() throws {
+        let store = try makeStore()
+        let connection = UUID()
+        let other = UUID()
+        store.setLabelColumn("Name", for: scope(connectionId: connection))
+        store.setLabelColumn("Title", for: scope(connectionId: connection, table: "Artist_archive"))
+        store.setLabelColumn("Code", for: scope(connectionId: other))
+
+        store.renameTable(
+            from: scope(connectionId: connection),
+            to: scope(connectionId: connection, table: "Performer")
+        )
+
+        #expect(store.labelColumn(for: scope(connectionId: connection)) == nil)
+        #expect(store.labelColumn(for: scope(connectionId: connection, table: "Performer")) == "Name")
+        #expect(store.labelColumn(for: scope(connectionId: connection, table: "Artist_archive")) == "Title")
+        #expect(store.labelColumn(for: scope(connectionId: other)) == "Code")
+    }
+
+    @Test("A schema rename moves every table in it and nothing outside it")
+    func renameContainerMovesTheSchema() throws {
+        let store = try makeStore()
+        let connection = UUID()
+        let other = UUID()
+        store.setLabelColumn("Name", for: scope(connectionId: connection, schema: "music"))
+        store.setLabelColumn("Title", for: scope(connectionId: connection, schema: "music", table: "Album"))
+        store.setLabelColumn("Code", for: scope(connectionId: connection, schema: "music_old"))
+        store.setLabelColumn("Email", for: scope(connectionId: other, schema: "music"))
+
+        store.renameContainer(
+            connectionId: connection, fromDatabase: "chinook", fromSchema: "music",
+            toDatabase: "chinook", toSchema: "catalog"
+        )
+
+        #expect(store.labelColumn(for: scope(connectionId: connection, schema: "catalog")) == "Name")
+        #expect(store.labelColumn(for: scope(connectionId: connection, schema: "catalog", table: "Album")) == "Title")
+        #expect(store.labelColumn(for: scope(connectionId: connection, schema: "music")) == nil)
+        #expect(store.labelColumn(for: scope(connectionId: connection, schema: "music_old")) == "Code")
+        #expect(store.labelColumn(for: scope(connectionId: other, schema: "music")) == "Email")
+    }
+
+    @Test("A database rename moves its tables and leaves a longer database name alone")
+    func renameDatabaseMovesItsTables() throws {
+        let store = try makeStore()
+        let connection = UUID()
+        store.setLabelColumn("Name", for: scope(connectionId: connection))
+        store.setLabelColumn("Title", for: scope(connectionId: connection, database: "chinook_backup"))
+
+        store.renameContainer(
+            connectionId: connection, fromDatabase: "chinook", fromSchema: nil,
+            toDatabase: "music", toSchema: nil
+        )
+
+        #expect(store.labelColumn(for: scope(connectionId: connection, database: "music")) == "Name")
+        #expect(store.labelColumn(for: scope(connectionId: connection)) == nil)
+        #expect(store.labelColumn(for: scope(connectionId: connection, database: "chinook_backup")) == "Title")
+    }
+
+    @Test("Deleting a connection removes its choices and keeps every other connection's")
+    func purgeConnectionsRemovesOnlyThatConnection() throws {
+        let store = try makeStore()
+        let connection = UUID()
+        let other = UUID()
+        store.setLabelColumn("Name", for: scope(connectionId: connection))
+        store.setLabelColumn("Title", for: scope(connectionId: connection, table: "Album"))
+        store.setLabelColumn("Code", for: scope(connectionId: other))
+
+        store.purgeConnections([connection])
+
+        #expect(store.labelColumn(for: scope(connectionId: connection)) == nil)
+        #expect(store.labelColumn(for: scope(connectionId: connection, table: "Album")) == nil)
+        #expect(store.labelColumn(for: scope(connectionId: other)) == "Code")
+    }
 }


### PR DESCRIPTION
## Summary

Five stores keep settings keyed by connection, database, schema and table. Each one had to be wired by hand into three lifecycle events: a table rename, a database or schema rename, and a connection delete. Two were wired into none of them.

| Store | Table rename | Container rename | Connection delete |
| --- | --- | --- | --- |
| `FilterSettingsStorage` | yes, but the browse search stayed behind | yes | yes |
| `FileColumnLayoutPersister` | yes | yes | **no**: file and synced records left behind |
| `HighlightRuleStorage` | yes | yes | yes, but the `.unreadable.json` copy stayed |
| `ValueDisplayFormatStorage` (Display As) | **no** | **no** | **no** |
| `ForeignKeyLabelColumnStore` | **no** | **no** | **no** |

So a Display As format or a foreign key label was lost on any rename and outlived the connection it belonged to. A deleted connection's column layouts stayed on disk and in iCloud.

## Fix

- New `TableScopedSettingsStore` protocol (`renameTable`, `renameContainer`, `purgeConnections`) and `TableScopedSettingsRegistry.stores`, which lists all five shared instances.
- `movePerTableSettings`, `retargetContainer` and `ConnectionLocalState.purge` loop over the registry, so a new store is wired into all three events by being registered.
- Existing methods that already had the protocol's shape are renamed, not wrapped, so each operation has one entry point: `renameLastFilters`/`renameScope`/`removeFilters(for:)`, `rename`/`renameScope` on the layout persister, and `rename`/`renameScope`/`removeRules` on highlight rules. Every caller and test is updated.
- The two `UserDefaults` stores conform through new `KeyValueStore.keys(withPrefix:)` plus `moveValue`/`moveValues`/`removeValues` helpers, and `TableScope.storagePrefix(connectionId:)`. A table rename moves one exact key, so `orders_archive` is untouched when `orders` is renamed. The container prefix ends in a separator, so `shopping` is untouched when `shop` is renamed.
- Display As: purge also removes the pre-scope legacy keys, and a table rename carries a legacy key over to the new name.
- Column layout purge deletes every purged connection's file first, then tombstones all of their records in one call, per the sync delete ordering rule. That call is a new batch `SyncChangeTracker.markDeleted(_:ids:)`, backed by `SyncMetadataStorage.removeDirty(_ ids:)` and `addTombstones`. It does one read-modify-write and posts one change notification, where 300 saved layouts would otherwise post 300 notifications and rewrite a growing tombstone list 300 times. On a delete that arrived from iCloud, the tracker is already suppressed inside `applyRemoteChanges`, so no tombstones are pushed back.
- A table rename now moves the saved browse search too. It only moved on a container rename before.
- A layout rename where the old and new names match is a no-op. Before, it wrote a tombstone for a live record.

Highlight rules (#2738) are on main as `8a9ed73a3`, so they conform here. The purge fix for their unreadable file needs no CHANGELOG line because the feature is unreleased.

Import and export are not affected: `ConnectionExportEnvelope` carries connections, groups, tags and credentials only.

## Known gap, not fixed here: foreign key labels on MySQL and MariaDB

The foreign key picker keys its label through `ForeignKeyLookupService.tableScope(from:reference:)`, which puts `referencedSchema` in the schema slot. On MySQL that value is `REFERENCED_TABLE_SCHEMA`, which is the database name, so a label is saved under `(db: shop, schema: shop, table: users)`. A table rename builds `(db: shop, schema: nil, table: users)`, the same scope every other per-table store uses, so the label key is not found and the label is still lost. A database rename rewrites the prefix but leaves `schema: shop`, so the picker then looks under `store.store`.

The fix is to make the label key the referenced table's own scope, which needs a rule for engines whose "schema" is a database (and for cross-database references), plus a migration for labels already saved. That is a change to the picker's key, not to the lifecycle wiring, so it is left for a follow-up. PostgreSQL, SQL Server, Oracle and other engines with a real schema layer are fixed by this PR.

## Tests

- `ValueDisplayFormatStorageTests`, `ForeignKeyLabelColumnStoreTests`: table, schema and database rename, purge, and the longer-name traps (`orders_archive`, `public_old`, `shopping`, `chinook_backup`). Display As also covers legacy key migration on rename and legacy key removal on purge.
- `FilterSettingsStorageTests`: a table rename moves filters and browse search, read back from a fresh instance. A schema rename moves browse search.
- `ColumnLayoutSyncTests`: purge removes the file, leaves other connections alone, and tombstones exactly the purged records. A rename tombstones the old record and marks the new one dirty.
- `HighlightRuleStorageTests`: purge removes the unreadable file.
- `SyncChangeTrackerTests`: a batch `markDeleted` clears each dirty flag and tombstones each id once, an empty batch does nothing, and suppression makes it a no-op.
- New `TableScopedSettingsRegistryTests`: purge reaches every store once with every id, an empty purge reaches none, and a source scan of `TablePro/Core/Storage` fails if a class keyed by `TableScope`, `CompositeStorageKey` or `ColumnLayoutTableKey` does not conform or is not registered.

No UI test: the behaviour is storage bookkeeping, covered at the store and registry level.

Build passes. The nine affected suites run 102 cases, all passing: `ValueDisplayFormatStorageTests`, `ForeignKeyLabelColumnStoreTests`, `FilterSettingsStorageTests`, `HighlightRuleStorageTests`, `ColumnLayoutSyncTests`, `FileColumnLayoutPersisterTests`, `TableScopedSettingsRegistryTests`, `TableScopeTests` and `SyncChangeTrackerTests`. SwiftLint strict is clean over all 20 changed files, the test target and `Packages/` included.
