### PR TITLE
fix(export): report a restore into an older PostgreSQL server as complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Line and paragraph separators (U+2028, U+2029) shown as line breaks the database does not see. (#2717)
 - Stop on Cloudflare D1, libSQL and Trino cancelling a sidebar read instead of the running query.
 - Numeric-looking filter values sent unquoted to text columns when a table first opens or after a foreign key jump.
+- Restore reported as failed after a complete restore into a PostgreSQL server older than `pg_restore`.
 - Garbled non-Latin text saved to MySQL and MariaDB servers that force a Latin 1 session. (#2725)
 - Garbled non-Latin text when restoring a MySQL or MariaDB SQL export through a Latin 1 client. (#2725)
 - Curly quotes, € and other Windows-1252 symbols shown as invisible characters after `SET NAMES latin1`.

--- a/TablePro/Core/Database/NativeDumpBatch.swift
+++ b/TablePro/Core/Database/NativeDumpBatch.swift
@@ -195,7 +195,7 @@ final class NativeDumpBatch {
             case .running(_, _, let bytes, let total):
                 state.bytesProcessed = bytes
                 state.totalBytes = total ?? state.totalBytes
-            case .finished(_, _, let bytes):
+            case .finished(_, _, let bytes, _):
                 record(item, .succeeded(bytes: bytes))
                 return
             case .failed(let message, _):

--- a/TablePro/Core/Database/NativeDumpDescriptor.swift
+++ b/TablePro/Core/Database/NativeDumpDescriptor.swift
@@ -122,6 +122,10 @@ struct NativeDumpDescriptor: Sendable {
         /// from the binary's name, which is what `buildCommand` used to do.
         let needsCredentialsFile: Bool
 
+        internal let restoreExitPolicy: NativeDumpExitPolicy
+
+        internal let requiresUntranslatedMessages: Bool
+
         let backupArguments: @Sendable (Request) -> [String]
         let restoreArguments: @Sendable (Request) -> [String]
         let environment: @Sendable (Request) -> [String: String]
@@ -134,6 +138,8 @@ struct NativeDumpDescriptor: Sendable {
             restoreDelivery: OutputDelivery,
             exposesPasswordInArguments: Bool = false,
             needsCredentialsFile: Bool = false,
+            restoreExitPolicy: NativeDumpExitPolicy = .zeroExitOnly,
+            requiresUntranslatedMessages: Bool = false,
             backupArguments: @escaping @Sendable (Request) -> [String],
             restoreArguments: @escaping @Sendable (Request) -> [String],
             environment: @escaping @Sendable (Request) -> [String: String] = { _ in [:] }
@@ -145,6 +151,8 @@ struct NativeDumpDescriptor: Sendable {
             self.restoreDelivery = restoreDelivery
             self.exposesPasswordInArguments = exposesPasswordInArguments
             self.needsCredentialsFile = needsCredentialsFile
+            self.restoreExitPolicy = restoreExitPolicy
+            self.requiresUntranslatedMessages = requiresUntranslatedMessages
             self.backupArguments = backupArguments
             self.restoreArguments = restoreArguments
             self.environment = environment
@@ -160,6 +168,10 @@ struct NativeDumpDescriptor: Sendable {
 
         func delivery(for kind: NativeDumpKind) -> OutputDelivery {
             kind == .backup ? backupDelivery : restoreDelivery
+        }
+
+        internal func exitPolicy(for kind: NativeDumpKind) -> NativeDumpExitPolicy {
+            kind == .backup ? .zeroExitOnly : restoreExitPolicy
         }
     }
 

--- a/TablePro/Core/Database/NativeDumpRegistry.swift
+++ b/TablePro/Core/Database/NativeDumpRegistry.swift
@@ -79,6 +79,8 @@ enum NativeDumpRegistry {
                     installHint: String(localized: "Install it with `brew install libpq` and link it."),
                     backupDelivery: .toolWritesFile,
                     restoreDelivery: .toolWritesFile,
+                    restoreExitPolicy: .toleratesUnrecognizedSessionSettings,
+                    requiresUntranslatedMessages: true,
                     backupArguments: { request in
                         connectionFlags(request)
                             + ["-Fc", "-d", request.database]

--- a/TablePro/Core/Database/NativeDumpService.swift
+++ b/TablePro/Core/Database/NativeDumpService.swift
@@ -26,7 +26,7 @@ enum NativeDumpState: Equatable {
     case idle
     case running(database: String, fileURL: URL, bytesProcessed: Int64, totalBytes: Int64?)
     case cancelling
-    case finished(database: String, fileURL: URL, bytesProcessed: Int64)
+    case finished(database: String, fileURL: URL, bytesProcessed: Int64, skippedSettings: [String] = [])
     /// A restore that fails part way through has already replayed some of the dump, and the
     /// target is left in whatever state that reached. A backup writes only to its own file, which
     /// is removed, so nothing of the user's is touched.
@@ -64,6 +64,20 @@ enum NativeDumpError: LocalizedError, Equatable {
     }
 }
 
+internal enum NativeDumpExitPolicy: Equatable, Sendable {
+    case zeroExitOnly
+    case toleratesUnrecognizedSessionSettings
+
+    internal func skippedSettings(exitCode: Int32, stderr: String) -> [String]? {
+        switch self {
+        case .zeroExitOnly:
+            return nil
+        case .toleratesUnrecognizedSessionSettings:
+            return PostgresRestoreDiagnostics.skippedSessionSettings(exitCode: exitCode, stderr: stderr)
+        }
+    }
+}
+
 /// Parameters for a single backup or restore subprocess.
 struct NativeDumpCommand: Equatable {
     let executable: URL
@@ -87,6 +101,8 @@ struct NativeDumpCommand: Equatable {
     /// takes standard output and writes it out.
     let isRestore: Bool
 
+    internal let exitPolicy: NativeDumpExitPolicy
+
     init(
         executable: URL,
         arguments: [String],
@@ -95,7 +111,8 @@ struct NativeDumpCommand: Equatable {
         delivery: NativeDumpDescriptor.OutputDelivery = .toolWritesFile,
         redirectedFileURL: URL? = nil,
         temporaryCredentialsFileURL: URL? = nil,
-        isRestore: Bool = false
+        isRestore: Bool = false,
+        exitPolicy: NativeDumpExitPolicy = .zeroExitOnly
     ) {
         self.executable = executable
         self.arguments = arguments
@@ -105,6 +122,7 @@ struct NativeDumpCommand: Equatable {
         self.redirectedFileURL = redirectedFileURL
         self.temporaryCredentialsFileURL = temporaryCredentialsFileURL
         self.isRestore = isRestore
+        self.exitPolicy = exitPolicy
     }
 }
 
@@ -122,6 +140,13 @@ struct NativeDumpStatementJob: Sendable, Equatable {
 enum NativeDumpJob {
     case process(NativeDumpCommand)
     case statements(NativeDumpStatementJob)
+}
+
+internal extension NativeDumpJob {
+    var exitPolicy: NativeDumpExitPolicy {
+        guard case .process(let command) = self else { return .zeroExitOnly }
+        return command.exitPolicy
+    }
 }
 
 /// Captured terminal state of a finished/cancelled run.
@@ -305,6 +330,7 @@ final class NativeDumpService {
         let runner = runnerFactory(job)
         try runner.start()
         self.runner = runner
+        let exitPolicy = job.exitPolicy
 
         setState(.running(database: database, fileURL: fileURL, bytesProcessed: 0, totalBytes: totalBytesEstimate))
         if kind == .backup {
@@ -313,7 +339,7 @@ final class NativeDumpService {
 
         Task { @MainActor [weak self] in
             guard let result = await self?.runner?.result else { return }
-            self?.handleTermination(result: result, database: database, fileURL: fileURL)
+            self?.handleTermination(result: result, database: database, fileURL: fileURL, exitPolicy: exitPolicy)
         }
     }
 
@@ -389,6 +415,9 @@ final class NativeDumpService {
         var arguments = tool.arguments(for: kind, request: request)
         var environment = minimalEnvironment()
         environment.merge(tool.environment(request)) { _, new in new }
+        if tool.requiresUntranslatedMessages {
+            environment = untranslatedMessagesEnvironment(environment)
+        }
 
         var credentialsFileURL: URL?
         if tool.needsCredentialsFile,
@@ -408,7 +437,8 @@ final class NativeDumpService {
             delivery: delivery,
             redirectedFileURL: delivery == .standardOutput ? request.fileURL : nil,
             temporaryCredentialsFileURL: credentialsFileURL,
-            isRestore: kind == .restore
+            isRestore: kind == .restore,
+            exitPolicy: tool.exitPolicy(for: kind)
         )
     }
 
@@ -440,6 +470,17 @@ final class NativeDumpService {
         "PATH", "HOME", "USER", "LOGNAME", "SHELL", "TMPDIR", "LANG", "LC_ALL"
     ]
 
+    nonisolated internal static let untranslatedMessagesLocale = "C"
+
+    nonisolated internal static func untranslatedMessagesEnvironment(_ environment: [String: String]) -> [String: String] {
+        var result = environment
+        if let everyCategory = result.removeValue(forKey: "LC_ALL"), result["LC_CTYPE"] == nil {
+            result["LC_CTYPE"] = everyCategory
+        }
+        result["LC_MESSAGES"] = untranslatedMessagesLocale
+        return result
+    }
+
     nonisolated static func minimalEnvironment() -> [String: String] {
         let parent = ProcessInfo.processInfo.environment
         var env: [String: String] = [:]
@@ -454,7 +495,8 @@ final class NativeDumpService {
     private func handleTermination(
         result: NativeDumpRunResult,
         database: String,
-        fileURL: URL
+        fileURL: URL,
+        exitPolicy: NativeDumpExitPolicy
     ) {
         byteSizeTask?.cancel()
         byteSizeTask = nil
@@ -472,6 +514,23 @@ final class NativeDumpService {
         if result.exitCode == 0 {
             setState(.finished(database: database, fileURL: fileURL, bytesProcessed: writtenBytes))
             Self.logger.info("\(self.toolName, privacy: .public) finished bytes=\(writtenBytes) db=\(database, privacy: .public)")
+            return
+        }
+
+        if let skipped = exitPolicy.skippedSettings(exitCode: result.exitCode, stderr: result.stderr) {
+            setState(.finished(
+                database: database,
+                fileURL: fileURL,
+                bytesProcessed: writtenBytes,
+                skippedSettings: skipped
+            ))
+            let settings = skipped.joined(separator: ",")
+            Self.logger.notice(
+                """
+                \(self.toolName, privacy: .public) finished skipping settings=\(settings, privacy: .public) \
+                db=\(database, privacy: .public)
+                """
+            )
             return
         }
 

--- a/TablePro/Core/Database/PostgresRestoreDiagnostics.swift
+++ b/TablePro/Core/Database/PostgresRestoreDiagnostics.swift
@@ -1,0 +1,121 @@
+//
+//  PostgresRestoreDiagnostics.swift
+//  TablePro
+//
+
+import Foundation
+
+internal enum PostgresRestoreDiagnostics {
+    private static let errorsIgnoredExitCode: Int32 = 1
+    private static let errorsIgnoredPrefix = "pg_restore: warning: errors ignored on restore: "
+    private static let phaseContextLines: Set<String> = [
+        "pg_restore: while INITIALIZING:",
+        "pg_restore: while PROCESSING TOC:"
+    ]
+    private static let tocEntryContextPrefix = "pg_restore: from TOC entry "
+    private static let executeQueryPrefix = "pg_restore: error: could not execute query: "
+    private static let couldNotSetPrefix = "pg_restore: error: could not set "
+    private static let setCommandPrefix = "Command was: SET "
+    private static let unrecognizedParameterPrefix = "ERROR:  unrecognized configuration parameter \""
+
+    internal static func skippedSessionSettings(exitCode: Int32, stderr: String) -> [String]? {
+        guard exitCode == errorsIgnoredExitCode else { return nil }
+        let lines = stderr
+            .split(whereSeparator: \.isNewline)
+            .map(String.init)
+            .filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
+        guard let summary = lines.last,
+              let reportedErrorCount = errorsIgnoredCount(summary),
+              let skipped = rejectedSettings(in: lines.dropLast()),
+              !skipped.isEmpty,
+              skipped.count == reportedErrorCount
+        else { return nil }
+        return uniqued(skipped)
+    }
+
+    private static func rejectedSettings(in lines: ArraySlice<String>) -> [String]? {
+        var settings: [String] = []
+        var remaining = lines
+        while let line = remaining.popFirst() {
+            if isContext(line) { continue }
+            if let setting = couldNotSetSetting(line) {
+                settings.append(setting)
+                continue
+            }
+            guard let command = remaining.popFirst(),
+                  let setting = rejectedSetCommandSetting(error: line, command: command)
+            else { return nil }
+            settings.append(setting)
+        }
+        return settings
+    }
+
+    private static func isContext(_ line: String) -> Bool {
+        phaseContextLines.contains(line) || line.hasPrefix(tocEntryContextPrefix)
+    }
+
+    private static func errorsIgnoredCount(_ line: String) -> Int? {
+        guard line.hasPrefix(errorsIgnoredPrefix) else { return nil }
+        return Int(line.dropFirst(errorsIgnoredPrefix.count))
+    }
+
+    private static func couldNotSetSetting(_ line: String) -> String? {
+        guard line.hasPrefix(couldNotSetPrefix) else { return nil }
+        let remainder = line.dropFirst(couldNotSetPrefix.count)
+        let quoted = remainder.first == "\""
+        let nameStart = quoted ? remainder.index(after: remainder.startIndex) : remainder.startIndex
+        let separator = quoted ? "\": " : ": "
+        guard let separatorRange = remainder[nameStart...].range(of: separator) else { return nil }
+        let setting = String(remainder[nameStart..<separatorRange.lowerBound])
+        let serverMessage = String(remainder[separatorRange.upperBound...])
+        guard isSettingName(setting), unrecognizedParameter(in: serverMessage) == setting else { return nil }
+        return setting
+    }
+
+    private static func rejectedSetCommandSetting(error: String, command: String) -> String? {
+        guard error.hasPrefix(executeQueryPrefix),
+              let setting = unrecognizedParameter(in: String(error.dropFirst(executeQueryPrefix.count)))
+        else { return nil }
+        let assignment = setCommandPrefix + setting + " = "
+        guard command.hasPrefix(assignment), command.hasSuffix(";") else { return nil }
+        let value = command.dropFirst(assignment.count).dropLast()
+        guard isSingleValue(value) else { return nil }
+        return setting
+    }
+
+    private static func unrecognizedParameter(in serverMessage: String) -> String? {
+        guard serverMessage.hasPrefix(unrecognizedParameterPrefix), serverMessage.hasSuffix("\"") else { return nil }
+        let name = String(serverMessage.dropFirst(unrecognizedParameterPrefix.count).dropLast())
+        return isSettingName(name) ? name : nil
+    }
+
+    private static func isSettingName(_ name: String) -> Bool {
+        !name.isEmpty && name.allSatisfy { character in
+            character == "_" || character == "." || (character.isASCII && (character.isLetter || character.isNumber))
+        }
+    }
+
+    private static func isSingleValue(_ value: Substring) -> Bool {
+        guard value.first == "'" else {
+            return !value.isEmpty && value.allSatisfy { character in
+                character.isASCII && (character.isLetter || character.isNumber || "_.+-".contains(character))
+            }
+        }
+        return isQuotedLiteral(value)
+    }
+
+    private static func isQuotedLiteral(_ value: Substring) -> Bool {
+        guard value.count >= 2, value.first == "'", value.last == "'" else { return false }
+        var inner = value.dropFirst().dropLast()
+        while let character = inner.popFirst() {
+            guard character == "'" else { continue }
+            guard inner.popFirst() == "'" else { return false }
+        }
+        return true
+    }
+
+    private static func uniqued(_ settings: [String]) -> [String] {
+        var seen: Set<String> = []
+        return settings.filter { seen.insert($0).inserted }
+    }
+}

--- a/TablePro/Resources/Localizable.xcstrings
+++ b/TablePro/Resources/Localizable.xcstrings
@@ -142543,6 +142543,74 @@
         }
       }
     },
+    "Skipped settings this server does not recognize: %@." : {
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 서버가 인식하지 못하는 설정을 건너뛰었습니다: %@."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bu sunucunun tanımadığı ayarlar atlandı: %@."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đã bỏ qua các thiết lập mà máy chủ này không nhận ra: %@."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已跳过此服务器无法识别的设置：%@。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已略過此伺服器無法辨識的設定：%@。"
+          }
+        }
+      }
+    },
+    "Skipped the %@ setting, which this server does not recognize." : {
+      "localizations" : {
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 서버가 인식하지 못하는 %@ 설정을 건너뛰었습니다."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bu sunucunun tanımadığı %@ ayarı atlandı."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đã bỏ qua thiết lập %@ mà máy chủ này không nhận ra."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已跳过此服务器无法识别的 %@ 设置。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已略過此伺服器無法辨識的 %@ 設定。"
+          }
+        }
+      }
+    },
     "Skips foreign key constraint checks for this operation" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/TablePro/Views/Backup/BackupResultSheet.swift
+++ b/TablePro/Views/Backup/BackupResultSheet.swift
@@ -15,7 +15,7 @@ struct BackupResultSheet: View {
 
     enum Outcome {
         case backupSuccess(database: String, destination: URL, bytes: Int64)
-        case restoreSuccess(database: String, source: URL)
+        case restoreSuccess(database: String, source: URL, skippedSettings: [String])
         /// A run over several databases, where one failing does not stop the rest, so the sheet
         /// reports every database rather than one verdict for the batch.
         case batch(outcomes: [NativeDumpBatchOutcome], directory: URL)
@@ -84,16 +84,32 @@ struct BackupResultSheet: View {
             scrollingDetail(message)
         case .batch(let outcomes, let directory):
             scrollingDetail(Self.batchDetail(outcomes, directory: directory))
-        default:
-            if let detail {
-                Text(detail)
+        case .restoreSuccess(_, _, let skippedSettings):
+            summaryDetail
+            if let note = Self.skippedSettingsNote(skippedSettings) {
+                Text(note)
                     .font(.callout)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
-                    .lineLimit(6)
+                    .fixedSize(horizontal: false, vertical: true)
                     .frame(maxWidth: .infinity, alignment: .center)
                     .textSelection(.enabled)
             }
+        default:
+            summaryDetail
+        }
+    }
+
+    @ViewBuilder
+    private var summaryDetail: some View {
+        if let detail {
+            Text(detail)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .lineLimit(6)
+                .frame(maxWidth: .infinity, alignment: .center)
+                .textSelection(.enabled)
         }
     }
 
@@ -179,7 +195,7 @@ struct BackupResultSheet: View {
                 database,
                 destination.path
             )
-        case .restoreSuccess(let database, let source):
+        case .restoreSuccess(let database, let source, _):
             return String(
                 format: String(localized: "Restored \u{201C}%@\u{201D} from %@"),
                 database,
@@ -196,6 +212,20 @@ struct BackupResultSheet: View {
         case .batch(let outcomes, let directory):
             return Self.batchDetail(outcomes, directory: directory)
         }
+    }
+
+    internal static func skippedSettingsNote(_ settings: [String]) -> String? {
+        guard let first = settings.first else { return nil }
+        guard settings.count > 1 else {
+            return String(
+                format: String(localized: "Skipped the %@ setting, which this server does not recognize."),
+                first
+            )
+        }
+        return String(
+            format: String(localized: "Skipped settings this server does not recognize: %@."),
+            settings.formatted(.list(type: .and))
+        )
     }
 
     /// One line per database, so a run where the second of three failed says which one and keeps
@@ -242,7 +272,21 @@ struct BackupResultSheet: View {
         kind: .restore,
         outcome: .restoreSuccess(
             database: "production",
-            source: URL(fileURLWithPath: "/Users/me/Desktop/production.dump")
+            source: URL(fileURLWithPath: "/Users/me/Desktop/production.dump"),
+            skippedSettings: []
+        ),
+        onClose: {},
+        onShowInFinder: nil
+    )
+}
+
+#Preview("Restore Success With Skipped Settings") {
+    BackupResultSheet(
+        kind: .restore,
+        outcome: .restoreSuccess(
+            database: "production",
+            source: URL(fileURLWithPath: "/Users/me/Desktop/production.dump"),
+            skippedSettings: ["idle_in_transaction_session_timeout", "transaction_timeout"]
         ),
         onClose: {},
         onShowInFinder: nil

--- a/TablePro/Views/Backup/RestoreDatabaseFlow.swift
+++ b/TablePro/Views/Backup/RestoreDatabaseFlow.swift
@@ -20,7 +20,7 @@ struct RestoreDatabaseFlow: View {
         case resolvingTarget
         case pickDatabase
         case running(database: String)
-        case finished(database: String)
+        case finished(database: String, skippedSettings: [String])
         case failed(message: String, targetMayBeModified: Bool)
         case cancelled
     }
@@ -41,10 +41,11 @@ struct RestoreDatabaseFlow: View {
                     isCancelling: service.state == .cancelling,
                     onCancel: { service.cancel() }
                 )
-            case .finished(let database):
+            case .finished(let database, let skippedSettings):
                 BackupResultSheet(
                     kind: .restore,
-                    outcome: .restoreSuccess(database: database, source: sourceURL),
+                    outcome: .restoreSuccess(
+                        database: database, source: sourceURL, skippedSettings: skippedSettings),
                     onClose: { isPresented = false },
                     onShowInFinder: nil
                 )
@@ -152,8 +153,8 @@ struct RestoreDatabaseFlow: View {
         switch state {
         case .running(let database, _, _, _):
             phase = .running(database: database)
-        case .finished(let database, _, _):
-            phase = .finished(database: database)
+        case .finished(let database, _, _, let skippedSettings):
+            phase = .finished(database: database, skippedSettings: skippedSettings)
         case .failed(let message, let targetMayBeModified):
             phase = .failed(message: message, targetMayBeModified: targetMayBeModified)
         case .cancelled:

--- a/TableProTests/Database/NativeDumpBatchTests.swift
+++ b/TableProTests/Database/NativeDumpBatchTests.swift
@@ -56,7 +56,7 @@ private final class FakeDumpService: NativeDumpRunning {
     }
 
     private func substituted(_ state: NativeDumpState, database: String, fileURL: URL) -> NativeDumpState {
-        guard case .finished(_, _, let bytes) = state else { return state }
+        guard case .finished(_, _, let bytes, _) = state else { return state }
         return .finished(database: database, fileURL: fileURL, bytesProcessed: bytes)
     }
 

--- a/TableProTests/Database/NativeDumpServiceTests.swift
+++ b/TableProTests/Database/NativeDumpServiceTests.swift
@@ -98,6 +98,92 @@ struct NativeDumpServiceCommandTests {
         #expect(!command.arguments.contains("-f"))
     }
 
+    @Test("pg_restore tolerates unrecognized session settings; pg_dump does not")
+    func postgresExitPolicies() throws {
+        let restore = try NativeDumpService.buildCommand(
+            kind: .restore,
+            tool: postgresTool,
+            executable: URL(fileURLWithPath: "/usr/bin/pg_restore"),
+            request: request(connection: connection(), fileURL: URL(fileURLWithPath: "/tmp/sales.dump"))
+        )
+        let backup = try NativeDumpService.buildCommand(
+            kind: .backup,
+            tool: postgresTool,
+            executable: URL(fileURLWithPath: "/usr/bin/pg_dump"),
+            request: request(connection: connection(), fileURL: URL(fileURLWithPath: "/tmp/sales.dump"))
+        )
+        #expect(restore.exitPolicy == .toleratesUnrecognizedSessionSettings)
+        #expect(backup.exitPolicy == .zeroExitOnly)
+    }
+
+    @Test("Every other engine's restore keeps the strict exit policy")
+    func otherEnginesStayStrict() throws {
+        for type in [DatabaseType.mysql, .mongodb, .sqlite, .mssql] {
+            let tool = try #require(NativeDumpRegistry.descriptor(for: type)?.commandLineTool)
+            #expect(tool.exitPolicy(for: .restore) == .zeroExitOnly)
+            #expect(tool.exitPolicy(for: .backup) == .zeroExitOnly)
+        }
+    }
+
+    @Test("A job the engine runs for itself never tolerates a failure")
+    func statementJobsStayStrict() {
+        let job = NativeDumpJob.statements(
+            NativeDumpStatementJob(
+                statements: ["SELECT 1"],
+                cleanupStatements: [],
+                scope: DatabaseScope(connectionId: UUID(), database: "sales", schema: nil)
+            )
+        )
+        #expect(job.exitPolicy == .zeroExitOnly)
+    }
+
+    @Test("pg_dump and pg_restore print untranslated messages")
+    func postgresToolsPrintUntranslatedMessages() throws {
+        for kind in [NativeDumpKind.backup, .restore] {
+            let command = try NativeDumpService.buildCommand(
+                kind: kind,
+                tool: postgresTool,
+                executable: URL(fileURLWithPath: "/usr/bin/pg_restore"),
+                request: request(connection: connection(), fileURL: URL(fileURLWithPath: "/tmp/sales.dump"))
+            )
+            #expect(command.environment["LC_MESSAGES"] == "C")
+            #expect(command.environment["LC_ALL"] == nil)
+        }
+    }
+
+    @Test("Other engines' tools keep the user's message language")
+    func otherToolsKeepTheirLanguage() throws {
+        let tool = try #require(NativeDumpRegistry.descriptor(for: .mysql)?.commandLineTool)
+        #expect(!tool.requiresUntranslatedMessages)
+    }
+
+    @Test("LC_ALL moves to LC_CTYPE so character handling survives, and messages become untranslated")
+    func untranslatedMessagesMovesLcAll() {
+        let environment = NativeDumpService.untranslatedMessagesEnvironment(
+            ["LANG": "fr_FR.UTF-8", "LC_ALL": "fr_FR.UTF-8", "PATH": "/usr/bin"]
+        )
+        #expect(environment == [
+            "LANG": "fr_FR.UTF-8",
+            "LC_CTYPE": "fr_FR.UTF-8",
+            "LC_MESSAGES": "C",
+            "PATH": "/usr/bin"
+        ])
+    }
+
+    @Test("An LC_CTYPE already present is kept over LC_ALL")
+    func untranslatedMessagesKeepsLcCtype() {
+        let environment = NativeDumpService.untranslatedMessagesEnvironment(
+            ["LC_ALL": "fr_FR.UTF-8", "LC_CTYPE": "de_DE.UTF-8"]
+        )
+        #expect(environment == ["LC_CTYPE": "de_DE.UTF-8", "LC_MESSAGES": "C"])
+    }
+
+    @Test("Without LC_ALL only LC_MESSAGES is added")
+    func untranslatedMessagesWithoutLcAll() {
+        let environment = NativeDumpService.untranslatedMessagesEnvironment(["LANG": "ko_KR.UTF-8"])
+        #expect(environment == ["LANG": "ko_KR.UTF-8", "LC_MESSAGES": "C"])
+    }
+
     @Test("empty host falls back to 127.0.0.1")
     func hostFallback() throws {
         let command = try NativeDumpService.buildCommand(
@@ -191,7 +277,7 @@ struct NativeDumpServiceCommandTests {
             )
         )
         let allowed: Set<String> = [
-            "PATH", "HOME", "USER", "LOGNAME", "SHELL", "TMPDIR", "LANG", "LC_ALL",
+            "PATH", "HOME", "USER", "LOGNAME", "SHELL", "TMPDIR", "LANG", "LC_CTYPE", "LC_MESSAGES",
             "PGPASSWORD", "PGSSLMODE"
         ]
         let unexpected = Set(command.environment.keys).subtracting(allowed)
@@ -257,15 +343,101 @@ private final class FakeDumpRunner: NativeDumpRunner, @unchecked Sendable {
 @Suite("NativeDumpService state machine", .serialized)
 @MainActor
 struct NativeDumpServiceStateMachineTests {
-    private func fakeJob() -> NativeDumpJob {
+    private func fakeJob(exitPolicy: NativeDumpExitPolicy = .zeroExitOnly) -> NativeDumpJob {
         .process(
             NativeDumpCommand(
                 executable: URL(fileURLWithPath: "/usr/bin/true"),
                 arguments: [],
                 environment: [:],
-                stderrByteCap: 64_000
+                stderrByteCap: 64_000,
+                exitPolicy: exitPolicy
             )
         )
+    }
+
+    private static let skippedSettingsStderr = """
+        pg_restore: error: could not execute query: ERROR:  unrecognized configuration parameter "transaction_timeout"
+        Command was: SET transaction_timeout = 0;
+        pg_restore: warning: errors ignored on restore: 1
+        """
+
+    @Test("A restore whose only errors are unrecognized settings finishes and names them")
+    func restoreFinishesSkippingSettings() async throws {
+        let runner = FakeDumpRunner()
+        let service = service(kind: .restore, runner: runner)
+        let updates = service.stateUpdates()
+
+        try service.run(
+            job: fakeJob(exitPolicy: .toleratesUnrecognizedSessionSettings),
+            database: "sales",
+            fileURL: URL(fileURLWithPath: "/tmp/test-skipped.dump")
+        )
+        runner.finish(.init(exitCode: 1, stderr: Self.skippedSettingsStderr, wasCancelled: false))
+        let finalState = try await firstMatching(updates) {
+            switch $0 {
+            case .finished, .failed: return true
+            default: return false
+            }
+        }
+
+        guard case .finished(let db, _, _, let skipped) = finalState else {
+            Issue.record("expected finished, got \(finalState)")
+            return
+        }
+        #expect(db == "sales")
+        #expect(skipped == ["transaction_timeout"])
+    }
+
+    @Test("The same output under the strict policy is still a failure")
+    func strictPolicyStillFails() async throws {
+        let runner = FakeDumpRunner()
+        let service = service(kind: .restore, runner: runner)
+        let updates = service.stateUpdates()
+
+        try service.run(
+            job: fakeJob(),
+            database: "sales",
+            fileURL: URL(fileURLWithPath: "/tmp/test-strict.dump")
+        )
+        runner.finish(.init(exitCode: 1, stderr: Self.skippedSettingsStderr, wasCancelled: false))
+        let finalState = try await firstMatching(updates) {
+            switch $0 {
+            case .finished, .failed: return true
+            default: return false
+            }
+        }
+
+        guard case .failed(let message, let targetMayBeModified) = finalState else {
+            Issue.record("expected failed, got \(finalState)")
+            return
+        }
+        #expect(message == Self.skippedSettingsStderr)
+        #expect(targetMayBeModified)
+    }
+
+    @Test("A real error under the tolerant policy is still a failure")
+    func tolerantPolicyRealError() async throws {
+        let runner = FakeDumpRunner()
+        let service = service(kind: .restore, runner: runner)
+        let updates = service.stateUpdates()
+
+        try service.run(
+            job: fakeJob(exitPolicy: .toleratesUnrecognizedSessionSettings),
+            database: "sales",
+            fileURL: URL(fileURLWithPath: "/tmp/test-real-error.dump")
+        )
+        runner.finish(.init(exitCode: 1, stderr: "FATAL: connection refused", wasCancelled: false))
+        let finalState = try await firstMatching(updates) {
+            switch $0 {
+            case .finished, .failed: return true
+            default: return false
+            }
+        }
+
+        guard case .failed = finalState else {
+            Issue.record("expected failed, got \(finalState)")
+            return
+        }
     }
 
     private func service(kind: NativeDumpKind, runner: FakeDumpRunner) -> NativeDumpService {
@@ -299,7 +471,7 @@ struct NativeDumpServiceStateMachineTests {
         runner.finish(.init(exitCode: 0, stderr: "", wasCancelled: false))
         let finalState = try await firstMatching(updates) { if case .finished = $0 { return true }; return false }
 
-        if case .finished(let db, _, _) = finalState {
+        if case .finished(let db, _, _, _) = finalState {
             #expect(db == "sales")
         } else {
             Issue.record("expected finished, got \(finalState)")

--- a/TableProTests/Database/PostgresRestoreDiagnosticsTests.swift
+++ b/TableProTests/Database/PostgresRestoreDiagnosticsTests.swift
@@ -1,0 +1,287 @@
+import Foundation
+import Testing
+
+@testable import TablePro
+
+@Suite("PostgresRestoreDiagnostics")
+struct PostgresRestoreDiagnosticsTests {
+    private static let pgRestore17IntoServer92 = """
+        pg_restore: error: could not execute query: ERROR:  unrecognized configuration parameter "lock_timeout"
+        Command was: SET lock_timeout = 0;
+        pg_restore: error: could not execute query: ERROR:  unrecognized configuration parameter "idle_in_transaction_session_timeout"
+        Command was: SET idle_in_transaction_session_timeout = 0;
+        pg_restore: error: could not execute query: ERROR:  unrecognized configuration parameter "transaction_timeout"
+        Command was: SET transaction_timeout = 0;
+        pg_restore: error: could not execute query: ERROR:  unrecognized configuration parameter "row_security"
+        Command was: SET row_security = off;
+        pg_restore: warning: errors ignored on restore: 4
+        """
+
+    private static let pgRestore17IntoServer12 = """
+        pg_restore: error: could not execute query: ERROR:  unrecognized configuration parameter "transaction_timeout"
+        Command was: SET transaction_timeout = 0;
+        pg_restore: warning: errors ignored on restore: 1
+        """
+
+    private static let pgRestore17ArchiveFrom17IntoServer96 = """
+        pg_restore: error: could not execute query: ERROR:  unrecognized configuration parameter "transaction_timeout"
+        Command was: SET transaction_timeout = 0;
+        pg_restore: error: could not set "default_table_access_method": ERROR:  unrecognized configuration parameter "default_table_access_method"
+        pg_restore: warning: errors ignored on restore: 2
+        """
+
+    private static let pgRestore17SequenceDumpIntoServer96 = """
+        pg_restore: error: could not execute query: ERROR:  unrecognized configuration parameter "transaction_timeout"
+        Command was: SET transaction_timeout = 0;
+        pg_restore: error: could not set "default_table_access_method": ERROR:  unrecognized configuration parameter "default_table_access_method"
+        pg_restore: error: could not execute query: ERROR:  syntax error at or near "AS"
+        LINE 2:     AS integer
+                    ^
+        Command was: CREATE SEQUENCE public.t_id_seq
+            AS integer
+            START WITH 1
+            INCREMENT BY 1
+            NO MINVALUE
+            NO MAXVALUE
+            CACHE 1;
+
+
+        pg_restore: error: could not execute query: ERROR:  relation "public.t_id_seq" does not exist
+        Command was: ALTER SEQUENCE public.t_id_seq OWNED BY public.t.id;
+
+
+        pg_restore: error: could not execute query: ERROR:  relation "public.t_id_seq" does not exist
+        Command was: ALTER TABLE ONLY public.t ALTER COLUMN id SET DEFAULT nextval('public.t_id_seq'::regclass);
+
+
+        pg_restore: error: could not execute query: ERROR:  relation "public.t_id_seq" does not exist
+        LINE 1: SELECT pg_catalog.setval('public.t_id_seq', 3, true);
+                                         ^
+        Command was: SELECT pg_catalog.setval('public.t_id_seq', 3, true);
+
+
+        pg_restore: warning: errors ignored on restore: 6
+        """
+
+    private static let pgRestore12InitializingIntoServer93 = """
+        pg_restore: while INITIALIZING:
+        pg_restore: error: could not execute query: ERROR:  unrecognized configuration parameter "idle_in_transaction_session_timeout"
+        Command was: SET idle_in_transaction_session_timeout = 0;
+        pg_restore: error: could not execute query: ERROR:  unrecognized configuration parameter "row_security"
+        Command was: SET row_security = off;
+        pg_restore: warning: errors ignored on restore: 2
+        """
+
+    private static let pgRestore12ProcessingTocIntoServer96 = """
+        pg_restore: while PROCESSING TOC:
+        pg_restore: from TOC entry 202; 1259 19993 TABLE t postgres
+        pg_restore: error: could not set default_table_access_method: ERROR:  unrecognized configuration parameter "default_table_access_method"
+        pg_restore: warning: errors ignored on restore: 1
+        """
+
+    private static let pgRestore12BothPhasesIntoServer93 = """
+        pg_restore: while INITIALIZING:
+        pg_restore: error: could not execute query: ERROR:  unrecognized configuration parameter "idle_in_transaction_session_timeout"
+        Command was: SET idle_in_transaction_session_timeout = 0;
+        pg_restore: error: could not execute query: ERROR:  unrecognized configuration parameter "row_security"
+        Command was: SET row_security = off;
+        pg_restore: while PROCESSING TOC:
+        pg_restore: from TOC entry 202; 1259 19993 TABLE t postgres
+        pg_restore: error: could not set default_table_access_method: ERROR:  unrecognized configuration parameter "default_table_access_method"
+        pg_restore: warning: errors ignored on restore: 3
+        """
+
+    private static let pgRestore11IntoServer93 = """
+        pg_restore: [archiver (db)] Error while INITIALIZING:
+        pg_restore: [archiver (db)] could not execute query: ERROR:  unrecognized configuration parameter "idle_in_transaction_session_timeout"
+            Command was: SET idle_in_transaction_session_timeout = 0;
+
+        pg_restore: [archiver (db)] could not execute query: ERROR:  unrecognized configuration parameter "row_security"
+            Command was: SET row_security = off;
+
+        WARNING: errors ignored on restore: 2
+        """
+
+    private static let pgRestore17FrenchLocaleIntoServer12 = """
+        pg_restore: erreur : could not execute query: ERROR:  unrecognized configuration parameter "transaction_timeout"
+        La commande était : SET transaction_timeout = 0;
+        pg_restore: attention : erreurs ignorées lors de la restauration : 1
+        """
+
+    private static func skipped(_ stderr: String, exitCode: Int32 = 1) -> [String]? {
+        PostgresRestoreDiagnostics.skippedSessionSettings(exitCode: exitCode, stderr: stderr)
+    }
+
+    @Test("A same-server round trip with pg_restore 17 on 9.2 skips four settings")
+    func roundTripOnServer92() {
+        #expect(Self.skipped(Self.pgRestore17IntoServer92) == [
+            "lock_timeout", "idle_in_transaction_session_timeout", "transaction_timeout", "row_security"
+        ])
+    }
+
+    @Test("pg_restore 17 on a 12 server skips transaction_timeout alone")
+    func roundTripOnServer12() {
+        #expect(Self.skipped(Self.pgRestore17IntoServer12) == ["transaction_timeout"])
+    }
+
+    @Test("pg_restore 17's quoted could not set form counts as a skipped setting")
+    func quotedCouldNotSetForm() {
+        #expect(Self.skipped(Self.pgRestore17ArchiveFrom17IntoServer96) == [
+            "transaction_timeout", "default_table_access_method"
+        ])
+    }
+
+    @Test("pg_restore 12 prefixes the preamble with a while INITIALIZING context line")
+    func pgRestore12InitializingContext() {
+        #expect(Self.skipped(Self.pgRestore12InitializingIntoServer93) == [
+            "idle_in_transaction_session_timeout", "row_security"
+        ])
+    }
+
+    @Test("pg_restore 12 sets the table access method per TOC entry, unquoted")
+    func pgRestore12ProcessingTocContext() {
+        #expect(Self.skipped(Self.pgRestore12ProcessingTocIntoServer96) == ["default_table_access_method"])
+    }
+
+    @Test("pg_restore 12 with errors in both phases")
+    func pgRestore12BothPhases() {
+        #expect(Self.skipped(Self.pgRestore12BothPhasesIntoServer93) == [
+            "idle_in_transaction_session_timeout", "row_security", "default_table_access_method"
+        ])
+    }
+
+    @Test("pg_restore 11 and older use another format and are not second-guessed")
+    func pgRestore11FailsSafe() {
+        #expect(Self.skipped(Self.pgRestore11IntoServer93) == nil)
+    }
+
+    @Test("Translated client messages are not second-guessed")
+    func translatedClientMessages() {
+        #expect(Self.skipped(Self.pgRestore17FrenchLocaleIntoServer12) == nil)
+    }
+
+    @Test("A real object error among skipped settings is still a failure")
+    func realErrorAmongSkippedSettings() {
+        #expect(Self.skipped(Self.pgRestore17SequenceDumpIntoServer96) == nil)
+    }
+
+    @Test("Empty output with a failing exit is a failure")
+    func emptyStderr() {
+        #expect(Self.skipped("") == nil)
+    }
+
+    @Test("Only exit code 1, the errors-ignored code, is ever tolerated")
+    func otherExitCodes() {
+        #expect(Self.skipped(Self.pgRestore17IntoServer12, exitCode: 0) == nil)
+        #expect(Self.skipped(Self.pgRestore17IntoServer12, exitCode: 2) == nil)
+    }
+
+    @Test("A count that disagrees with the errors shown means output was lost")
+    func truncatedOutput() {
+        let lines = Self.pgRestore17IntoServer92.split(separator: "\n", omittingEmptySubsequences: false)
+        #expect(Self.skipped(lines.dropFirst(2).joined(separator: "\n")) == nil)
+    }
+
+    @Test("A missing errors-ignored summary is a failure")
+    func missingSummary() {
+        let lines = Self.pgRestore17IntoServer12.split(separator: "\n", omittingEmptySubsequences: false)
+        #expect(Self.skipped(lines.dropLast().joined(separator: "\n")) == nil)
+    }
+
+    @Test("Anything after the summary is a failure, context lines included")
+    func outputAfterSummary() {
+        #expect(Self.skipped(Self.pgRestore17IntoServer12 + "\npg_restore: error: could not execute query: ERROR:  boom") == nil)
+        #expect(Self.skipped(Self.pgRestore17IntoServer12 + "\npg_restore: while INITIALIZING:") == nil)
+    }
+
+    @Test("The same setting rejected twice is named once")
+    func duplicateSettingNamedOnce() {
+        let stderr = """
+            pg_restore: error: could not execute query: ERROR:  unrecognized configuration parameter "transaction_timeout"
+            Command was: SET transaction_timeout = 0;
+            pg_restore: error: could not execute query: ERROR:  unrecognized configuration parameter "transaction_timeout"
+            Command was: SET transaction_timeout = 0;
+            pg_restore: warning: errors ignored on restore: 2
+            """
+        #expect(Self.skipped(stderr) == ["transaction_timeout"])
+    }
+
+    @Test("A rejected SET naming a different parameter than the error is a failure")
+    func mismatchedSetParameter() {
+        let stderr = """
+            pg_restore: error: could not execute query: ERROR:  unrecognized configuration parameter "row_security"
+            Command was: SET transaction_timeout = 0;
+            pg_restore: warning: errors ignored on restore: 1
+            """
+        #expect(Self.skipped(stderr) == nil)
+    }
+
+    @Test("A could not set line naming a different parameter than the error is a failure")
+    func mismatchedCouldNotSetParameter() {
+        let quoted = """
+            pg_restore: error: could not set "default_table_access_method": ERROR:  unrecognized configuration parameter "row_security"
+            pg_restore: warning: errors ignored on restore: 1
+            """
+        let unquoted = """
+            pg_restore: error: could not set default_table_access_method: ERROR:  unrecognized configuration parameter "row_security"
+            pg_restore: warning: errors ignored on restore: 1
+            """
+        #expect(Self.skipped(quoted) == nil)
+        #expect(Self.skipped(unquoted) == nil)
+    }
+
+    @Test("A command carrying a second statement is not a skipped setting")
+    func multiStatementCommand() {
+        let stderr = """
+            pg_restore: error: could not execute query: ERROR:  unrecognized configuration parameter "bogus"
+            Command was: SET bogus = 1; CREATE TABLE t(id int);
+            pg_restore: warning: errors ignored on restore: 1
+            """
+        #expect(Self.skipped(stderr) == nil)
+    }
+
+    @Test("A quoted value is one value, and a quote that ends early is not")
+    func quotedValues() {
+        let quoted = """
+            pg_restore: error: could not execute query: ERROR:  unrecognized configuration parameter "bogus"
+            Command was: SET bogus = 'it''s fine';
+            pg_restore: warning: errors ignored on restore: 1
+            """
+        let escaping = """
+            pg_restore: error: could not execute query: ERROR:  unrecognized configuration parameter "bogus"
+            Command was: SET bogus = 'a'; DROP TABLE t; SELECT 'b';
+            pg_restore: warning: errors ignored on restore: 1
+            """
+        #expect(Self.skipped(quoted) == ["bogus"])
+        #expect(Self.skipped(escaping) == nil)
+    }
+
+    @Test("A SET rejected for a bad value rather than an unknown parameter is a failure")
+    func invalidValue() {
+        let stderr = """
+            pg_restore: error: could not execute query: ERROR:  invalid value for parameter "client_encoding": "LATIN9X"
+            Command was: SET client_encoding = 'LATIN9X';
+            pg_restore: warning: errors ignored on restore: 1
+            """
+        #expect(Self.skipped(stderr) == nil)
+    }
+
+    @Test("A connection failure is a failure")
+    func connectionFailure() {
+        let stderr = """
+            pg_restore: error: connection to server at "127.0.0.1", port 5432 failed: Connection refused
+            \tIs the server running on that host and accepting TCP/IP connections?
+            """
+        #expect(Self.skipped(stderr) == nil)
+    }
+
+    @Test("A server that reports errors in another language is not second-guessed")
+    func localizedServerMessage() {
+        let stderr = """
+            pg_restore: error: could not execute query: ERROR:  paramètre de configuration « transaction_timeout » non reconnu
+            Command was: SET transaction_timeout = 0;
+            pg_restore: warning: errors ignored on restore: 1
+            """
+        #expect(Self.skipped(stderr) == nil)
+    }
+}

--- a/TableProTests/Views/Backup/BackupResultSheetSkippedSettingsTests.swift
+++ b/TableProTests/Views/Backup/BackupResultSheetSkippedSettingsTests.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Testing
+
+@testable import TablePro
+
+@Suite("BackupResultSheet skipped settings note")
+struct BackupResultSheetSkippedSettingsTests {
+    @Test("No note when nothing was skipped")
+    func noSettings() {
+        #expect(BackupResultSheet.skippedSettingsNote([]) == nil)
+    }
+
+    @Test("One setting is named on its own")
+    func oneSetting() {
+        let note = BackupResultSheet.skippedSettingsNote(["transaction_timeout"])
+        #expect(note?.contains("transaction_timeout") == true)
+    }
+
+    @Test("Every setting is named, however many there are")
+    func severalSettings() {
+        let settings = [
+            "lock_timeout", "idle_in_transaction_session_timeout", "transaction_timeout",
+            "row_security", "default_table_access_method"
+        ]
+        let note = BackupResultSheet.skippedSettingsNote(settings)
+        for setting in settings {
+            #expect(note?.contains(setting) == true)
+        }
+    }
+}

--- a/docs/features/backup-restore.mdx
+++ b/docs/features/backup-restore.mdx
@@ -138,3 +138,5 @@ A non-zero exit shows the last 64 KB of the tool's stderr in a scrollable monosp
 | An authentication failure | The password goes through the environment or a config file rather than a prompt, so this is the account or the database. Check that the role can log in |
 | Objects that conflict with the dump | Restore into a fresh database, or drop the conflicting objects first |
 | *"a single transaction can only write to a single attached database"* | A DuckDB query tab has an open transaction that has already written. Commit or roll it back, then run the backup again |
+
+One non-zero exit is not a failure. A `pg_restore` newer than the server sets parameters the server does not have, such as `transaction_timeout` on anything before PostgreSQL 17, and exits 1 after restoring everything. When those are its only errors, the restore reports complete and names the settings the server skipped. Any other error in the same run still fails it. So does a server whose `lc_messages` is not English, because its errors cannot be read.


### PR DESCRIPTION
Found while investigating #2734.

## Problem

Restore Dump reports **Restore Dump Failed** with the "partial state" warning after a restore that put back every object and row, whenever `pg_restore` is newer than the server. That is the usual setup: Homebrew's `libpq` is 17 or 18, and a backup and restore on the same PostgreSQL 16 server hits it.

## Root cause

`pg_restore` sends a fixed preamble of `SET` statements for its own version before it restores anything: `lock_timeout` (9.3), `row_security` (9.5), `idle_in_transaction_session_timeout` (9.6), `transaction_timeout` (17). It also sets `default_table_access_method` (12) for each table. A server that lacks one rejects it with `unrecognized configuration parameter`. `pg_restore` does not stop on errors by default, so it restores everything, prints `errors ignored on restore: N` and exits 1. `NativeDumpService.handleTermination` treated every non-zero exit as a failed restore.

## Fix

- `PostgresRestoreDiagnostics`, a pure parser over `pg_restore`'s stderr. It returns the skipped setting names only when all of this holds:
  - the exit code is 1;
  - the last line is `errors ignored on restore: N`, and nothing follows it;
  - every error before it is a rejected session setting, in one of these forms:
    - `could not execute query` followed by `Command was: SET <name> = <value>;`, where the value is a single bare token or one single-quoted literal (`''` escapes allowed), so a line carrying a second statement is never accepted;
    - `could not set "<name>":` (pg_restore 17 and later) or `could not set <name>:` (12 to 16);
  - the server message names that same parameter as unrecognized;
  - N equals the number of those errors.

  `while INITIALIZING:`, `while PROCESSING TOC:` and `from TOC entry ...` context lines are skipped. Anything else returns `nil`, and the run fails exactly as before.
- **Untranslated tool messages.** Homebrew's `libpq` is built with NLS, so `LANG=fr_FR.UTF-8` turns `error:` into `erreur :` and `Command was:` into `La commande était :`. The PostgreSQL tools are now spawned with `LC_MESSAGES=C`. `LC_ALL` would override that, so it is removed and its value moved to `LC_CTYPE` when `LC_CTYPE` is not already set, which keeps character handling as it was. Measured: `LANG=fr_FR.UTF-8` and `LC_ALL=fr_FR.UTF-8` both print French. With `LC_MESSAGES=C` and `LC_ALL` moved to `LC_CTYPE`, the output is English and a `café_missing` database name prints intact. Only `pg_dump` and `pg_restore` are affected; the other engines' tools keep the user's language.
- `NativeDumpExitPolicy` is carried as data on `NativeDumpCommand` and captured per run. `CommandLineTool.exitPolicy(for:)` sits next to `delivery(for:)`. Only the PostgreSQL restore opts in; backups, engine-statement jobs, MySQL, MongoDB, SQLite and SQL Server stay strict.
- `NativeDumpState.finished` carries `skippedSettings`. The result sheet says **Restore Dump Complete** and adds a line naming every skipped setting, below the summary and with no line limit.
- The two new strings are in `Localizable.xcstrings` with ko, tr, vi, zh-Hans and zh-Hant translations; `localization.py verify` round-trips cleanly.

**Still a failure, on purpose:**
- A server whose `lc_messages` is not English. The server message cannot be matched, and changing `lc_messages` needs a superuser.
- pg_restore 11 and older. They print `pg_restore: [archiver (db)] ...`, an indented `Command was:` and `WARNING: errors ignored on restore: N`. 11 is past end of life. A fixture pins this behaviour.

## Measured

pg_dump and pg_restore 17.11 (Homebrew), pg_restore 18.6 (Homebrew libpq), and pg_restore 12.22 and 11 (Debian containers), against PostgreSQL 9.1, 9.2, 9.3, 9.5, 9.6, 10, 12 and 17. Row counts, views and comments were checked after each restore.

| Run | Exit | Errors | Everything restored | Verdict now |
|---|---|---|---|---|
| pg_dump 17 + pg_restore 17, same server, 9.2 | 1 | 4 SETs | yes | complete, 4 settings skipped |
| same, 9.3 / 9.5 | 1 | 3 / 2 SETs | yes | complete |
| same, 9.6 / 10 / 12 | 1 | `transaction_timeout` | yes | complete |
| same, 17 | 0 | none | yes | complete |
| pg_restore 18 into 12 | 1 | `transaction_timeout` | yes | complete |
| pg_restore 18 into 17 | 0 | none | yes | complete |
| pg_restore 12 into 9.3 (`while INITIALIZING:`) | 1 | 2 SETs | yes | complete |
| pg_restore 12, 12 archive, into 9.6 (`while PROCESSING TOC:`, unquoted `could not set`) | 1 | 1 | yes | complete |
| pg_restore 12, 12 archive, into 9.3 (both phases) | 1 | 3 | yes | complete |
| 17 archive without sequences into 9.6 (quoted `could not set`) | 1 | 2 | yes | complete |
| pg_restore 17 under `LANG=fr_FR.UTF-8`, no fix | 1 | 1, in French | yes | failed (the fix sets `LC_MESSAGES=C`) |
| pg_restore 11 into 9.3 | 1 | 2 SETs, legacy format | yes | failed (fail safe) |
| 17 archive with a serial column into 9.6 and 9.1 (`CREATE SEQUENCE ... AS integer` fails) | 1 | SETs plus real DDL errors | no, sequence missing | **failed** |

A swiftc probe ran the parser over every captured stderr file and over the edge cases below before the tests were written. The results matched the table.

## Tests

- `PostgresRestoreDiagnosticsTests`: every captured stderr, embedded verbatim, including pg_restore 12's two context forms, pg_restore 11 (nil) and the French client output (nil). It also covers:
  - the same setting rejected twice (named once);
  - mismatched parameter names in both `could not set` spellings;
  - a multi-statement `Command was:`;
  - a quoted value, and a quote that ends early;
  - a bad value, a connection failure and a localized server message;
  - a missing summary, output lost from the start, and output after the summary (a context line included);
  - exit codes 0 and 2.
- `NativeDumpServiceTests`:
  - the PostgreSQL restore command tolerates skipped settings, and its backup does not;
  - every other engine stays strict, and so do engine-statement jobs;
  - `pg_dump` and `pg_restore` get `LC_MESSAGES=C` and no `LC_ALL`, and MySQL keeps the user's language;
  - the `LC_ALL`-to-`LC_CTYPE` rewrite, including an existing `LC_CTYPE`;
  - the state machine finishes with skipped settings under the tolerant policy, fails on the same output under the strict one, and fails on a real error under the tolerant one.
- `BackupResultSheetSkippedSettingsTests` (now under `TableProTests/Views/Backup`): the one-setting note, and five settings all named.

## Not automated

The result sheet change is detail text in an existing sheet, and the restore flow needs a live PostgreSQL server and a `pg_restore` binary, so it has no UI test. Before and after screenshots of the result sheet are pending. The app was not launched from this branch, because other sessions were running UI tests on the same machine.

## Not in scope

Restoring a dump from a newer server into an older one (the last table row) still fails, correctly. PostgreSQL does not support loading a newer server's dump into an older one, and the sequence really is missing.

## Verification

- Build: PASS. Tests: `PostgresRestoreDiagnosticsTests`, `BackupResultSheetSkippedSettingsTests`, `NativeDumpServiceCommandTests`, `NativeDumpServiceStateMachineTests`, `NativeDumpBatchTests`, `NativeDumpRegistryTests`, 74 of 74 passed.
- Lint clean on the changed files; both docs checks pass.
- Review: Codex was unavailable (usage limit), so this was reviewed with the `code-review` skill. Its findings are applied: the tools now run with English messages so the classifier works in any locale, a multi-statement `Command was:` line no longer counts as a skipped setting, pg_restore 12 to 16 output shapes are accepted with captured fixtures, the exit policy is per job, the result sheet shows every skipped setting, and the new strings are in the catalog.
- Screenshots of the result sheet are pending; no UI test covers this flow because it needs a live server and a `pg_restore` binary.
