### PR TITLE
fix(plugins): decode every SQL import chunk in the file's own encoding and byte order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Warnings in the SQL editor for full-width punctuation, curly quotes and non-ASCII spaces. (#2717)
 - Highlight rules that color data grid rows or cells by value. (#2723)
 - **Encoding** option for MySQL and MariaDB connections, with **UTF-8 via Latin 1** for databases written through a Latin 1 client. (#2725)
+- UTF-16 LE, UTF-16 BE and Windows-1252 in the SQL import encoding menu.
 
 ### Changed
 
@@ -43,6 +44,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Data grid ignoring the theme's background, text, alternate row, NULL, boolean and row number colors.
+- Text past the first 64 KB of a UTF-16 SQL import arriving byte-swapped.
+- SQL import failing on a file whose encoding is not UTF-8 when a character lands on a 64 KB boundary.
 - Garbled non-Latin text saved from iPhone and iPad to MySQL servers that force a Latin 1 session. (#2725)
 - **Encoding** ignored on iPhone and iPad by a MySQL connection synced from the Mac. (#2725)
 - Binary MySQL columns shown as text on iPhone and iPad, and searched with `LIKE`.

--- a/TablePro/Core/Utilities/SQL/SQLChunkDecoder.swift
+++ b/TablePro/Core/Utilities/SQL/SQLChunkDecoder.swift
@@ -1,0 +1,154 @@
+//
+//  SQLChunkDecoder.swift
+//  TablePro
+//
+
+import Foundation
+
+/// Turns a file's bytes into text one chunk at a time, holding back whatever runs off the end of
+/// a chunk until the next one arrives.
+///
+/// `String(data:encoding:)` is the whole of Foundation's decoding API and it has no way to report
+/// a partial character, so three measured behaviours have to be worked around rather than caught.
+///
+/// A chunk of UTF-16 carrying no byte order mark decodes as big-endian. The mark is at the start
+/// of the file, so only the first chunk has one, and every chunk after it in a little-endian file
+/// came back byte-swapped: a UTF-16 dump over 64 KiB imported as CJK from its first chunk
+/// boundary on, with nothing raised. The byte order is therefore settled once, from the mark, and
+/// every chunk after that is decoded with the explicit variant. Stripping the mark becomes this
+/// type's job at the same time, because only the `.utf16` spelling consumes one.
+///
+/// A chunk holding an odd number of UTF-16 bytes decodes the even part and drops the last byte
+/// without failing, so the alignment is held back here rather than left for the decoder to
+/// notice.
+///
+/// A UTF-16 surrogate pair split across a boundary fails the whole chunk, as does a partial UTF-8
+/// sequence, so a chunk that will not decode gives its last few bytes back to the next one. How
+/// many is derived from the encoding rather than assumed: only UTF-8 was handled before, so a
+/// character split across a boundary in any other multi-byte encoding failed the import outright.
+struct SQLChunkDecoder {
+    private let declaredEncoding: String.Encoding
+    private var resolvedEncoding: String.Encoding?
+    private var unitSize = 1
+    private var maximumTrim = 0
+    private var pendingTail = Data()
+
+    var hasPendingBytes: Bool { !pendingTail.isEmpty }
+
+    init(encoding: String.Encoding) {
+        declaredEncoding = encoding
+    }
+
+    mutating func decode(_ rawData: Data) -> String? {
+        var data = pendingTail
+        data.append(rawData)
+        pendingTail.removeAll(keepingCapacity: true)
+
+        let encoding = resolveIfNeeded(startingWith: &data)
+
+        var carried = Data()
+        let misalignment = data.count % unitSize
+        if misalignment > 0 {
+            carried = Data(data.suffix(misalignment))
+            data = Data(data.prefix(data.count - misalignment))
+        }
+
+        if let decoded = String(data: data, encoding: encoding) {
+            pendingTail = carried
+            return decoded
+        }
+
+        var trim = unitSize
+        while trim <= maximumTrim && data.count >= trim {
+            let head = Data(data.prefix(data.count - trim))
+            if head.isEmpty {
+                pendingTail = data + carried
+                return ""
+            }
+            if let decoded = String(data: head, encoding: encoding) {
+                pendingTail = Data(data.suffix(trim)) + carried
+                return decoded
+            }
+            trim += unitSize
+        }
+        return nil
+    }
+
+    private mutating func resolveIfNeeded(startingWith data: inout Data) -> String.Encoding {
+        if let resolvedEncoding { return resolvedEncoding }
+
+        let resolution = Self.resolve(declaredEncoding, startingWith: data)
+        resolvedEncoding = resolution.encoding
+        unitSize = Self.unitSize(of: resolution.encoding)
+        maximumTrim = Self.maximumTrim(of: resolution.encoding, unitSize: unitSize)
+        if resolution.byteOrderMarkLength > 0, data.count >= resolution.byteOrderMarkLength {
+            data = Data(data.dropFirst(resolution.byteOrderMarkLength))
+        }
+        return resolution.encoding
+    }
+
+    private struct Resolution {
+        let encoding: String.Encoding
+        let byteOrderMarkLength: Int
+    }
+
+    private static let utf16LittleEndianMark: [UInt8] = [0xFF, 0xFE]
+    private static let utf16BigEndianMark: [UInt8] = [0xFE, 0xFF]
+    private static let utf32LittleEndianMark: [UInt8] = [0xFF, 0xFE, 0x00, 0x00]
+    private static let utf32BigEndianMark: [UInt8] = [0x00, 0x00, 0xFE, 0xFF]
+
+    /// `.utf8` is absent on purpose: Foundation consumes a UTF-8 mark itself, measured.
+    private static func resolve(_ encoding: String.Encoding, startingWith data: Data) -> Resolution {
+        switch encoding {
+        case .utf16:
+            if data.starts(with: utf16LittleEndianMark) {
+                return Resolution(encoding: .utf16LittleEndian, byteOrderMarkLength: 2)
+            }
+            if data.starts(with: utf16BigEndianMark) {
+                return Resolution(encoding: .utf16BigEndian, byteOrderMarkLength: 2)
+            }
+            return Resolution(encoding: .utf16BigEndian, byteOrderMarkLength: 0)
+        case .utf16LittleEndian:
+            return Resolution(encoding: encoding, byteOrderMarkLength: data.starts(with: utf16LittleEndianMark) ? 2 : 0)
+        case .utf16BigEndian:
+            return Resolution(encoding: encoding, byteOrderMarkLength: data.starts(with: utf16BigEndianMark) ? 2 : 0)
+        case .utf32:
+            if data.starts(with: utf32LittleEndianMark) {
+                return Resolution(encoding: .utf32LittleEndian, byteOrderMarkLength: 4)
+            }
+            if data.starts(with: utf32BigEndianMark) {
+                return Resolution(encoding: .utf32BigEndian, byteOrderMarkLength: 4)
+            }
+            return Resolution(encoding: .utf32BigEndian, byteOrderMarkLength: 0)
+        case .utf32LittleEndian:
+            return Resolution(encoding: encoding, byteOrderMarkLength: data.starts(with: utf32LittleEndianMark) ? 4 : 0)
+        case .utf32BigEndian:
+            return Resolution(encoding: encoding, byteOrderMarkLength: data.starts(with: utf32BigEndianMark) ? 4 : 0)
+        default:
+            return Resolution(encoding: encoding, byteOrderMarkLength: 0)
+        }
+    }
+
+    private static func unitSize(of encoding: String.Encoding) -> Int {
+        switch encoding {
+        case .utf16, .utf16LittleEndian, .utf16BigEndian:
+            return 2
+        case .utf32, .utf32LittleEndian, .utf32BigEndian:
+            return 4
+        default:
+            return 1
+        }
+    }
+
+    /// `CFStringGetMaximumSizeForEncoding` counts bytes per UTF-16 code unit, so it is asked for
+    /// two of them: that is one Unicode scalar, which is the largest thing a boundary can cut in
+    /// half. It over-reports for several encodings, which costs a decode attempt that fails and
+    /// never loses a byte, since a trimmed byte goes back on the front of the next chunk.
+    private static func maximumTrim(of encoding: String.Encoding, unitSize: Int) -> Int {
+        let cfEncoding = CFStringConvertNSStringEncodingToEncoding(encoding.rawValue)
+        guard cfEncoding != kCFStringEncodingInvalidId else { return 0 }
+        let perScalar = Int(CFStringGetMaximumSizeForEncoding(2, cfEncoding))
+        guard perScalar > unitSize else { return 0 }
+        return min(perScalar, 8) - unitSize
+    }
+}

--- a/TablePro/Core/Utilities/SQL/SQLFileParser.swift
+++ b/TablePro/Core/Utilities/SQL/SQLFileParser.swift
@@ -417,31 +417,6 @@ final class SQLFileParser: Sendable {
         return StepResult(advanced: true, deferred: false)
     }
 
-    private static func decodeChunkOrCarryTail(
-        rawData: Data,
-        pendingTail: inout Data,
-        encoding: String.Encoding
-    ) -> String? {
-        var data = pendingTail
-        data.append(rawData)
-        pendingTail.removeAll(keepingCapacity: true)
-
-        if let decoded = String(data: data, encoding: encoding) {
-            return decoded
-        }
-
-        guard encoding == .utf8 else { return nil }
-
-        for trim in 1...3 where data.count > trim {
-            let head = data.prefix(data.count - trim)
-            if let decoded = String(data: head, encoding: .utf8) {
-                pendingTail = Data(data.suffix(trim))
-                return decoded
-            }
-        }
-        return nil
-    }
-
     func parseFile(
         url: URL,
         encoding: String.Encoding,
@@ -463,7 +438,7 @@ final class SQLFileParser: Sendable {
         private var fileHandle: FileHandle?
         private var ctx: ParserContext
         private let nsBuffer = NSMutableString()
-        private var pendingTail = Data()
+        private var decoder: SQLChunkDecoder
         private var emitIndex = 0
         private var finished = false
 
@@ -471,6 +446,7 @@ final class SQLFileParser: Sendable {
             self.url = url
             self.encoding = encoding
             self.dialect = dialect
+            self.decoder = SQLChunkDecoder(encoding: encoding)
             self.ctx = ParserContext(
                 dialect: dialect,
                 currentStatement: countOnly ? nil : NSMutableString()
@@ -515,7 +491,7 @@ final class SQLFileParser: Sendable {
             let handle = try openFileIfNeeded()
             let rawData = handle.readData(ofLength: chunkSize)
 
-            if rawData.isEmpty && pendingTail.isEmpty {
+            if rawData.isEmpty && !decoder.hasPendingBytes {
                 emitTrailingStatement()
                 finished = true
                 closeFile()
@@ -523,15 +499,13 @@ final class SQLFileParser: Sendable {
             }
 
             let isFinalChunk = rawData.isEmpty
-            guard let chunk = SQLFileParser.decodeChunkOrCarryTail(
-                rawData: rawData, pendingTail: &pendingTail, encoding: encoding
-            ) else {
+            guard let chunk = decoder.decode(rawData) else {
                 throw DecompressionError.fileReadFailed(
                     "Failed to decode file with \(encoding.description) encoding"
                 )
             }
 
-            if isFinalChunk && !pendingTail.isEmpty {
+            if isFinalChunk && decoder.hasPendingBytes {
                 throw DecompressionError.fileReadFailed(
                     "Trailing bytes did not form a valid \(encoding.description) sequence at end of file"
                 )

--- a/TablePro/Models/Export/ImportModels.swift
+++ b/TablePro/Models/Export/ImportModels.swift
@@ -9,25 +9,45 @@ import Foundation
 
 // MARK: - Import Encoding Options
 
-/// Available text encodings for import
+/// The text encodings the SQL import dialog offers, matching the list the CSV inspector already
+/// offers in `CSVPropertyOptions.encodings`.
+///
+/// The raw value is the key the last choice is stored under, so it stays put; `label` is what the
+/// menu shows. Latin-1 and Windows-1252 are both here because they disagree over 0x80 to 0x9F,
+/// which is where a dump written by MySQL keeps its curly quotes, en dashes and euro sign: read
+/// as Latin-1 they arrive as C1 control characters instead.
 enum ImportEncoding: String, CaseIterable, Identifiable {
     case utf8 = "UTF-8"
     case utf16 = "UTF-16"
+    case utf16LittleEndian = "UTF-16LE"
+    case utf16BigEndian = "UTF-16BE"
     case latin1 = "Latin1"
+    case windows1252 = "Windows-1252"
     case ascii = "ASCII"
 
     var id: String { rawValue }
 
+    var label: String {
+        switch self {
+        case .utf8: return "UTF-8"
+        case .utf16: return "UTF-16"
+        case .utf16LittleEndian: return "UTF-16 LE"
+        case .utf16BigEndian: return "UTF-16 BE"
+        case .latin1: return "Latin-1"
+        case .windows1252: return "Windows-1252"
+        case .ascii: return "ASCII"
+        }
+    }
+
     var encoding: String.Encoding {
         switch self {
-        case .utf8:
-            return .utf8
-        case .utf16:
-            return .utf16
-        case .latin1:
-            return .isoLatin1
-        case .ascii:
-            return .ascii
+        case .utf8: return .utf8
+        case .utf16: return .utf16
+        case .utf16LittleEndian: return .utf16LittleEndian
+        case .utf16BigEndian: return .utf16BigEndian
+        case .latin1: return .isoLatin1
+        case .windows1252: return .windowsCP1252
+        case .ascii: return .ascii
         }
     }
 }

--- a/TablePro/Views/Import/ImportDialog.swift
+++ b/TablePro/Views/Import/ImportDialog.swift
@@ -279,7 +279,7 @@ struct ImportDialog: View {
 
                     Picker(String(localized: "Encoding"), selection: $selectedEncoding) {
                         ForEach(ImportEncoding.allCases) { enc in
-                            Text(enc.rawValue).tag(enc)
+                            Text(enc.label).tag(enc)
                         }
                     }
                     .pickerStyle(.menu)
@@ -421,11 +421,12 @@ struct ImportDialog: View {
             let maxPreviewSize = 5 * 1_024 * 1_024
             let previewData = handle.readData(ofLength: maxPreviewSize)
 
-            if let preview = String(data: previewData, encoding: selectedEncoding.encoding) {
+            var decoder = SQLChunkDecoder(encoding: selectedEncoding.encoding)
+            if let preview = decoder.decode(previewData) {
                 filePreview = preview
                 hasPreviewError = false
             } else {
-                filePreview = String(format: String(localized: "Failed to load preview using encoding: %@. Try selecting a different text encoding."), selectedEncoding.rawValue)
+                filePreview = String(format: String(localized: "Failed to load preview using encoding: %@. Try selecting a different text encoding."), selectedEncoding.label)
                 hasPreviewError = true
             }
         } catch {

--- a/TableProTests/Core/Utilities/SQL/SQLChunkDecoderTests.swift
+++ b/TableProTests/Core/Utilities/SQL/SQLChunkDecoderTests.swift
@@ -1,0 +1,112 @@
+//
+//  SQLChunkDecoderTests.swift
+//  TableProTests
+//
+
+import Foundation
+import Testing
+
+@testable import TablePro
+
+@Suite("SQL chunk decoding")
+struct SQLChunkDecoderTests {
+    private func decodeInChunks(_ data: Data, encoding: String.Encoding, chunk size: Int) -> String? {
+        var decoder = SQLChunkDecoder(encoding: encoding)
+        var text = ""
+        var offset = 0
+        while offset < data.count {
+            let end = min(offset + size, data.count)
+            guard let piece = decoder.decode(data.subdata(in: offset..<end)) else { return nil }
+            text += piece
+            offset = end
+        }
+        return decoder.hasPendingBytes ? nil : text
+    }
+
+    /// The byte order mark is at the start of the file, so only the first chunk carries one, and
+    /// a chunk of UTF-16 without one decodes as big-endian. Every chunk after the first in a
+    /// little-endian file therefore came back byte-swapped, and a dump over 64 KiB imported as
+    /// CJK from its first boundary on with nothing raised.
+    @Test("A UTF-16 file keeps its byte order past the first chunk")
+    func utf16KeepsItsByteOrder() throws {
+        let text = "SELECT 'a';\nSELECT 'b';\nSELECT 'c';\n"
+        for encoding in [String.Encoding.utf16LittleEndian, .utf16BigEndian] {
+            let mark: [UInt8] = encoding == .utf16LittleEndian ? [0xFF, 0xFE] : [0xFE, 0xFF]
+            let data = try Data(mark) + #require(text.data(using: encoding))
+            #expect(decodeInChunks(data, encoding: .utf16, chunk: 8) == text, "\(encoding)")
+            #expect(decodeInChunks(data, encoding: encoding, chunk: 8) == text, "\(encoding)")
+        }
+    }
+
+    /// Without a mark there is nothing to read the order from, and big-endian is what Foundation
+    /// itself assumes.
+    @Test("UTF-16 with no mark stays big-endian, and an explicit choice is honoured")
+    func utf16WithoutAMark() throws {
+        let text = "SELECT 1;"
+        let bigEndian = try #require(text.data(using: .utf16BigEndian))
+        let littleEndian = try #require(text.data(using: .utf16LittleEndian))
+        #expect(decodeInChunks(bigEndian, encoding: .utf16, chunk: 6) == text)
+        #expect(decodeInChunks(littleEndian, encoding: .utf16LittleEndian, chunk: 6) == text)
+    }
+
+    /// A mark left in the text is a zero-width no-break space in front of the first statement,
+    /// which the server answers with a syntax error. Only the `.utf16` spelling drops one.
+    @Test("A byte order mark never reaches the text")
+    func markIsStripped() throws {
+        let data = try Data([0xFF, 0xFE]) + #require("SELECT 1;".data(using: .utf16LittleEndian))
+        for encoding in [String.Encoding.utf16, .utf16LittleEndian] {
+            let decoded = decodeInChunks(data, encoding: encoding, chunk: 4096)
+            #expect(decoded == "SELECT 1;", "\(encoding)")
+        }
+    }
+
+    /// A chunk holding an odd number of UTF-16 bytes decodes the even part and drops the last
+    /// byte without failing, so the alignment has to be held back rather than noticed.
+    @Test("An odd chunk boundary loses no byte")
+    func oddBoundariesLoseNothing() throws {
+        let text = "SELECT 'abcdefgh';"
+        let data = try #require(text.data(using: .utf16LittleEndian))
+        for size in [1, 3, 5, 7, 9] {
+            #expect(decodeInChunks(data, encoding: .utf16LittleEndian, chunk: size) == text, "chunk \(size)")
+        }
+    }
+
+    @Test("A character split across a boundary survives in every encoding the dialog offers")
+    func splitCharactersSurvive() throws {
+        let text = "SELECT 'メール 😀 café';"
+        for encoding in [String.Encoding.utf8, .utf16, .utf16LittleEndian, .utf16BigEndian] {
+            let mark: Data = encoding == .utf16 ? Data([0xFF, 0xFE]) : Data()
+            let body = encoding == .utf16 ? text.data(using: .utf16LittleEndian) : text.data(using: encoding)
+            let data = try mark + #require(body)
+            for size in [2, 3, 5, 7, 11] {
+                #expect(decodeInChunks(data, encoding: encoding, chunk: size) == text, "\(encoding) chunk \(size)")
+            }
+        }
+    }
+
+    /// Shift JIS is not in the import menu, and the decoder must not be the reason it could never
+    /// be: only UTF-8 carried a partial character across a boundary before.
+    @Test("A multi-byte encoding outside the menu is carried too")
+    func otherMultiByteEncodingsAreCarried() throws {
+        let text = "SELECT '日本語';"
+        let data = try #require(text.data(using: .shiftJIS))
+        for size in [1, 3, 5] {
+            #expect(decodeInChunks(data, encoding: .shiftJIS, chunk: size) == text, "chunk \(size)")
+        }
+    }
+
+    /// Latin-1 and Windows-1252 disagree over 0x80 to 0x9F, which is where a MySQL dump keeps its
+    /// curly quotes and its euro sign.
+    @Test("Latin-1 and Windows-1252 decode the C1 range differently")
+    func singleByteEncodingsDiffer() {
+        let data = Data([0x27, 0x80, 0x92, 0x27])
+        #expect(decodeInChunks(data, encoding: .isoLatin1, chunk: 1) == "'\u{80}\u{92}'")
+        #expect(decodeInChunks(data, encoding: .windowsCP1252, chunk: 1) == "'€’'")
+    }
+
+    @Test("Bytes that decode in no chunking fail rather than being dropped")
+    func undecodableBytesFail() {
+        let data = Data([0x53, 0xC3, 0x28, 0x54])
+        #expect(decodeInChunks(data, encoding: .utf8, chunk: 4096) == nil)
+    }
+}

--- a/TableProTests/Core/Utilities/SQL/SQLFileParserTests.swift
+++ b/TableProTests/Core/Utilities/SQL/SQLFileParserTests.swift
@@ -280,4 +280,46 @@ struct SQLFileParserTests {
         #expect(SqlDialect.from(databaseTypeId: "Oracle") == .generic)
         #expect(SqlDialect.from(databaseTypeId: "Unknown Whatever") == .generic)
     }
+
+    private static func parse(_ data: Data, encoding: String.Encoding) async throws -> [String] {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString + ".sql")
+        try data.write(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        var statements: [String] = []
+        let parser = SQLFileParser()
+        for try await (stmt, _) in parser.parseFile(url: url, encoding: encoding, dialect: .mysql) {
+            statements.append(stmt)
+        }
+        return statements
+    }
+
+    /// The parser reads 64 KiB at a time, and a chunk of UTF-16 without a byte order mark decodes
+    /// as big-endian, so every statement past the first boundary used to arrive byte-swapped: a
+    /// dump this size imported as CJK from 64 KiB on, with nothing raised.
+    @Test("A UTF-16 dump larger than one chunk parses to the statements it holds")
+    func utf16DumpLargerThanOneChunk() async throws {
+        let lines = (0..<4_000).map { "INSERT INTO t (a) VALUES ('メール \($0)');" }
+        let sql = lines.joined(separator: "\n") + "\n"
+        let body = try #require(sql.data(using: .utf16LittleEndian))
+        #expect(body.count > 65_536 * 2)
+
+        let withMark = try await Self.parse(Data([0xFF, 0xFE]) + body, encoding: .utf16)
+        #expect(withMark == lines.map { String($0.dropLast()) })
+
+        let withoutMark = try await Self.parse(body, encoding: .utf16LittleEndian)
+        #expect(withoutMark == lines.map { String($0.dropLast()) })
+    }
+
+    /// A multi-byte character landing on a chunk boundary is the ordinary case in a dump of
+    /// non-Latin text, and only UTF-8 used to carry one across.
+    @Test("A Shift JIS dump larger than one chunk parses to the statements it holds")
+    func shiftJISDumpLargerThanOneChunk() async throws {
+        let lines = (0..<4_000).map { "INSERT INTO t (a) VALUES ('日本語 \($0)');" }
+        let sql = lines.joined(separator: "\n") + "\n"
+        let body = try #require(sql.data(using: .shiftJIS))
+        #expect(body.count > 65_536)
+        #expect(try await Self.parse(body, encoding: .shiftJIS) == lines.map { String($0.dropLast()) })
+    }
 }

--- a/docs/features/import-export.mdx
+++ b/docs/features/import-export.mdx
@@ -270,7 +270,7 @@ Select a row in the data grid and press `Cmd+V` to paste tabular data straight i
 | Option | What it does | Default |
 |--------|-------------|---------|
 | On error | Stop and Rollback, Stop and Commit, or Skip and Continue | Stop and Rollback |
-| Encoding | UTF-8, UTF-16, Latin1, or ASCII | UTF-8 |
+| Encoding | UTF-8, UTF-16, UTF-16 LE, UTF-16 BE, Latin-1, Windows-1252, or ASCII | UTF-8 |
 | Wrap in transaction | Runs every statement inside one transaction. Dimmed in Skip and Continue | Yes |
 | Disable foreign key checks | Suspends constraint checks for the import | Yes |
 
@@ -279,6 +279,8 @@ Select a row in the data grid and press `Cmd+V` to paste tabular data straight i
 | **Stop and Rollback** | Stops there. With the transaction on, everything rolls back |
 | **Stop and Commit** | Stops there, keeping what already succeeded |
 | **Skip and Continue** | Logs it and carries on, including a line the parser cannot read. No transaction |
+
+**UTF-16** reads the byte order from the mark at the start of the file and falls back to big-endian, which is what a file with no mark means. Pick **UTF-16 LE** or **UTF-16 BE** for a file that has no mark and is not big-endian. Latin-1 and Windows-1252 differ over the bytes `0x80` to `0x9F`: a dump written by MySQL keeps its curly quotes, en dashes and euro sign there, so Windows-1252 is the one to pick for it.
 
 Skip and Continue collects up to 1,000 failures with their line numbers and messages, and the summary counts successes against failures behind a **Copy Details** button. **Save Report…** writes them all to a CSV with a line, a statement and the database's own error per row, so a large import's failures can be sorted and searched rather than scrolled. A stop shows the line, the database's own message, and the failing statement, with the dialog still open behind it, ready for a changed setting and another run.
 


### PR DESCRIPTION
Two defects in SQL import, found while investigating #2725. Neither is that issue and neither has an issue of its own.

## What was wrong

The parser reads the file 64 KiB at a time and turned each chunk into text with `String(data:encoding:)`. That call cannot report a partial character, and the code worked around it for UTF-8 alone.

**A UTF-16 file was byte-swapped past its first chunk.** Measured: a chunk of UTF-16 with no byte order mark decodes as big-endian. The mark is at the start of the file, so only the first chunk has one. A UTF-16 LE dump over 64 KiB therefore imported correctly up to the boundary and as CJK from there on, with nothing raised. A 100 KB dump of English text inserts rows full of `卅䕌䕃` past the 64 KiB mark.

Two more UTF-16 failures in the same place, both measured: a chunk holding an odd number of bytes decodes the even part and drops the last byte without failing, and a surrogate pair split across the boundary fails the whole chunk with no tail carried, which ends the import with "Failed to decode file with Unicode (UTF-16) encoding".

**Any other multi-byte encoding failed on a split character.** The tail carry was `guard encoding == .utf8 else { return nil }`, so a Shift JIS or EUC-JP dump whose character landed on a boundary ended the import outright.

The encoding menu also offered one Latin 1, `.isoLatin1`. MySQL writes curly quotes, en dashes and the euro sign in `0x80` to `0x9F`, which ISO Latin 1 maps to C1 control characters: measured, `0x92` reads as U+0092 where Windows-1252 gives U+2019. Every such character in a latin1 dump was imported as an invisible control character.

## The fix

`SQLChunkDecoder` (new) owns the chunk-to-text step and the parser holds one:

- The byte order is resolved once, from the mark on the first chunk, and every chunk after that is decoded with the explicit `.utf16LittleEndian` or `.utf16BigEndian` variant. With no mark it stays big-endian, which is what Foundation itself assumes.
- The mark is stripped here, because only the `.utf16` spelling consumes one and the explicit variants leave it in the text, where it is a zero-width no-break space in front of the first statement.
- Bytes that do not fill a whole code unit are held back before the decode rather than left for it to drop.
- A chunk that will not decode gives its last few bytes to the next one, in any encoding. How many comes from `CFStringGetMaximumSizeForEncoding` for one Unicode scalar, so nothing is hard-coded per encoding.

The import menu now lists UTF-16 LE, UTF-16 BE and Windows-1252 alongside what it had, matching the list the CSV inspector already offers. `ImportEncoding`'s raw values stay as they were, since they are the key the last choice is stored under, and a separate `label` supplies the menu text. The file preview goes through the same decoder, so a preview no longer reports a bad encoding for a good file whose 5 MB cut lands mid-character.

## Verification

- **Build:** PASS (`build-TablePro-001703.log`).
- **Tests:** PASS, 28 cases in `SQLChunkDecoderTests` and `SQLFileParserTests` (`test-SQLChunkDecoderTests-002447.log`). Two of them build a dump over 64 KiB, one UTF-16 and one Shift JIS, write it to a temp file and parse it through `SQLFileParser` end to end; both fail on `main`.
- **Lint:** PASS, 0 violations. **Docs:** PASS.
- Every encoding claim in the PR was measured with a swiftc probe against Foundation on this machine rather than taken from the documentation, including the big-endian default, the silently dropped odd byte, and the Latin-1 versus Windows-1252 C1 range.

## Tests

`SQLChunkDecoderTests` feeds the same bytes through the decoder at chunk sizes of 1, 2, 3, 5, 7 and 11 so every boundary inside a character is hit: byte order past the first chunk, a mark never reaching the text, an odd boundary losing no byte, a split character in UTF-8 and all three UTF-16 spellings, Shift JIS, the Latin-1 versus Windows-1252 difference, and bytes that decode in no chunking failing rather than being dropped.
