### PR TITLE
docs(changelog): scope the foreign key label fix to engines with a schema layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,7 +150,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Garbled non-ASCII text on PostgreSQL databases not encoded in UTF-8 after `RESET ALL` or `DISCARD ALL`.
 - Garbled or double-encoded non-ASCII text on iOS with PostgreSQL databases not encoded in UTF-8.
 - Garbled non-ASCII text when restoring a PostgreSQL SQL export into a database not encoded in UTF-8.
-- Display As formats and foreign key labels lost on a rename, and kept with column layouts after deleting a connection.
+- Display As formats lost on a rename, and kept with column layouts after deleting a connection.
 
 ### Security
 


### PR DESCRIPTION
#2746's Fixed entry claims foreign key labels survive a rename. They do on PostgreSQL, SQL Server and Oracle, and they do not on MySQL or MariaDB: the picker keys a label through `ForeignKeyLookupService.tableScope`, which puts `REFERENCED_TABLE_SCHEMA` (a database name on MySQL) in the schema slot, so its key disagrees with the scope every other per-table store uses and the rename never finds it.

Fixing that means choosing what the target scope is on an engine with no schema layer, deciding what a cross-database reference resolves to, and migrating labels already saved, so it belongs in its own change. This drops the claim from the entry until then.

Display As formats and the column layout purge are unaffected and stay in the line.