### PR TITLE
feat(plugins): refresh materialized views, show view DDL and edit object comments (#2726)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Warnings in the SQL editor for full-width punctuation, curly quotes and non-ASCII spaces. (#2717)
 - Highlight rules that color data grid rows or cells by value. (#2723)
 - **Encoding** option for MySQL and MariaDB connections, with **UTF-8 via Latin 1** for databases written through a Latin 1 client. (#2725)
+- **Refresh Materialized View…** on PostgreSQL, with a concurrent refresh where the view qualifies. (#2726)
+- **Show DDL** and **Copy DDL** for views and materialized views. (#2726)
+- **Edit Comment…** for PostgreSQL tables, views, materialized views and foreign tables. (#2726)
 
 ### Changed
 
@@ -151,10 +154,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Garbled or double-encoded non-ASCII text on iOS with PostgreSQL databases not encoded in UTF-8.
 - Garbled non-ASCII text when restoring a PostgreSQL SQL export into a database not encoded in UTF-8.
 - Display As formats and foreign key labels lost on a rename, and kept with column layouts after deleting a connection.
+- PostgreSQL view definitions without `security_barrier`, `security_invoker` or the check option. (#2726)
+- PostgreSQL view definitions that bind to another schema's tables when run elsewhere. (#2726)
+- `CREATE TABLE` in Structure > DDL for a PostgreSQL view or materialized view. (#2726)
+- **Edit View Definition** in the Database menu opening a same-named view from the browsed schema. (#2726)
+- **Edit View Definition** enabled in the Database menu on a read-only connection. (#2726)
+- Enum types and sequences written in front of a PostgreSQL view's DDL. (#2726)
 
 ### Security
 
 - BigQuery Google sign-in accepting an authorization response without PKCE or a state check.
+- PostgreSQL comment and password literals escaped by quote doubling alone, which a backslash can break out of. (#2726)
 
 ## [0.73.0] - 2026-09-09
 

--- a/Plugins/BeancountDriverPlugin/Info.plist
+++ b/Plugins/BeancountDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>25</integer>
+	<integer>26</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Beancount</string>

--- a/Plugins/BigQueryDriverPlugin/Info.plist
+++ b/Plugins/BigQueryDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>25</integer>
+	<integer>26</integer>
 </dict>
 </plist>

--- a/Plugins/CSVExportPlugin/Info.plist
+++ b/Plugins/CSVExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>25</integer>
+	<integer>26</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>csv</string>

--- a/Plugins/CSVImportPlugin/Info.plist
+++ b/Plugins/CSVImportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>25</integer>
+	<integer>26</integer>
 	<key>TableProProvidesImportFormatIds</key>
 	<array>
 		<string>csv</string>

--- a/Plugins/CassandraDriverPlugin/Info.plist
+++ b/Plugins/CassandraDriverPlugin/Info.plist
@@ -21,6 +21,6 @@
 	<key>NSPrincipalClass</key>
 	<string>$(PRODUCT_MODULE_NAME).CassandraPlugin</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>25</integer>
+	<integer>26</integer>
 </dict>
 </plist>

--- a/Plugins/ClickHouseDriverPlugin/Info.plist
+++ b/Plugins/ClickHouseDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>25</integer>
+	<integer>26</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>ClickHouse</string>

--- a/Plugins/CloudflareD1DriverPlugin/Info.plist
+++ b/Plugins/CloudflareD1DriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>25</integer>
+	<integer>26</integer>
 </dict>
 </plist>

--- a/Plugins/CloudflareR2SQLDriverPlugin/Info.plist
+++ b/Plugins/CloudflareR2SQLDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>25</integer>
+	<integer>26</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Cloudflare R2 SQL</string>

--- a/Plugins/DamengDriverPlugin/Info.plist
+++ b/Plugins/DamengDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>25</integer>
+	<integer>26</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Dameng</string>

--- a/Plugins/DuckDBDriverPlugin/Info.plist
+++ b/Plugins/DuckDBDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>25</integer>
+	<integer>26</integer>
 </dict>
 </plist>

--- a/Plugins/DynamoDBDriverPlugin/Info.plist
+++ b/Plugins/DynamoDBDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>25</integer>
+	<integer>26</integer>
 </dict>
 </plist>

--- a/Plugins/ElasticsearchDriverPlugin/Info.plist
+++ b/Plugins/ElasticsearchDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.53.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>25</integer>
+	<integer>26</integer>
 </dict>
 </plist>

--- a/Plugins/EtcdDriverPlugin/Info.plist
+++ b/Plugins/EtcdDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>25</integer>
+	<integer>26</integer>
 </dict>
 </plist>

--- a/Plugins/HTMLExportPlugin/Info.plist
+++ b/Plugins/HTMLExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>25</integer>
+	<integer>26</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>html</string>

--- a/Plugins/JSONExportPlugin/Info.plist
+++ b/Plugins/JSONExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>25</integer>
+	<integer>26</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>json</string>

--- a/Plugins/JSONImportPlugin/Info.plist
+++ b/Plugins/JSONImportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>25</integer>
+	<integer>26</integer>
 	<key>TableProProvidesImportFormatIds</key>
 	<array>
 		<string>json</string>

--- a/Plugins/KafkaDriverPlugin/Info.plist
+++ b/Plugins/KafkaDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>25</integer>
+	<integer>26</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Kafka</string>

--- a/Plugins/LibSQLDriverPlugin/Info.plist
+++ b/Plugins/LibSQLDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>25</integer>
+	<integer>26</integer>
 </dict>
 </plist>

--- a/Plugins/MQLExportPlugin/Info.plist
+++ b/Plugins/MQLExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>25</integer>
+	<integer>26</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>mql</string>

--- a/Plugins/MSSQLDriverPlugin/Info.plist
+++ b/Plugins/MSSQLDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>25</integer>
+	<integer>26</integer>
 </dict>
 </plist>

--- a/Plugins/MarkdownExportPlugin/Info.plist
+++ b/Plugins/MarkdownExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>25</integer>
+	<integer>26</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>md</string>

--- a/Plugins/MongoDBDriverPlugin/Info.plist
+++ b/Plugins/MongoDBDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>25</integer>
+	<integer>26</integer>
 </dict>
 </plist>

--- a/Plugins/MySQLDriverPlugin/Info.plist
+++ b/Plugins/MySQLDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>25</integer>
+	<integer>26</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>MySQL</string>

--- a/Plugins/OracleDriverPlugin/Info.plist
+++ b/Plugins/OracleDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>25</integer>
+	<integer>26</integer>
 </dict>
 </plist>

--- a/Plugins/ParquetExportPlugin/Info.plist
+++ b/Plugins/ParquetExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>25</integer>
+	<integer>26</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>parquet</string>

--- a/Plugins/PostgreSQLDriverPlugin/Info.plist
+++ b/Plugins/PostgreSQLDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>25</integer>
+	<integer>26</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>PostgreSQL</string>

--- a/Plugins/PostgreSQLDriverPlugin/LibPQDriverCore.swift
+++ b/Plugins/PostgreSQLDriverPlugin/LibPQDriverCore.swift
@@ -27,6 +27,7 @@ final class LibPQDriverCore: @unchecked Sendable {
 
     var serverVersion: String? { libpqConnection?.serverVersion() }
     var serverVersionNumber: Int32 { libpqConnection?.serverVersionNumber() ?? 0 }
+    var isInsideTransactionBlock: Bool { libpqConnection?.isInsideTransactionBlock ?? false }
 
     init(
         config: DriverConnectionConfig,

--- a/Plugins/PostgreSQLDriverPlugin/LibPQPluginConnection.swift
+++ b/Plugins/PostgreSQLDriverPlugin/LibPQPluginConnection.swift
@@ -514,6 +514,22 @@ final class LibPQPluginConnection: @unchecked Sendable {
         _cachedServerVersionNumber
     }
 
+    /// Whether the session is inside a transaction block, including one a failed statement has
+    /// aborted. A statement sent now joins that block rather than running on its own.
+    ///
+    /// Read on the connection's own queue, like every other libpq call here: one `PGconn` may not
+    /// be used from two threads at once, and the lock alone guards the pointer rather than the call.
+    var isInsideTransactionBlock: Bool {
+        stateLock.lock()
+        let conn = self.conn
+        stateLock.unlock()
+        guard let conn else { return false }
+        return queue.sync {
+            let status = PQtransactionStatus(conn)
+            return status == PQTRANS_INTRANS || status == PQTRANS_INERROR
+        }
+    }
+
     func currentDatabase() -> String {
         database
     }

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver+PrincipalSQL.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver+PrincipalSQL.swift
@@ -13,7 +13,7 @@ extension PostgreSQLPluginDriver {
         options.append(contentsOf: attributeKeywords(definition.attributes))
 
         if let password = definition.password, !password.isEmpty {
-            options.append("PASSWORD '\(escapeStringLiteral(password))'")
+            options.append("PASSWORD \(PostgreSQLObjectQueries.quoteLiteral(password))")
         }
         if let limit = definition.connectionLimit {
             options.append("CONNECTION LIMIT \(limit)")
@@ -24,7 +24,7 @@ extension PostgreSQLPluginDriver {
             "GRANT \(quoteIdentifier($0)) TO \(role)"
         })
         if let comment = definition.comment, !comment.isEmpty {
-            statements.append("COMMENT ON ROLE \(role) IS '\(escapeStringLiteral(comment))'")
+            statements.append("COMMENT ON ROLE \(role) IS \(PostgreSQLRelationSQL.commentValue(comment))")
         }
         return statements
     }
@@ -51,9 +51,7 @@ extension PostgreSQLPluginDriver {
         statements.append(contentsOf: membershipStatements(old: old, new: new, role: role))
 
         if old.comment != new.comment {
-            let comment = new.comment ?? ""
-            let value = comment.isEmpty ? "NULL" : "'\(escapeStringLiteral(comment))'"
-            statements.append("COMMENT ON ROLE \(role) IS \(value)")
+            statements.append("COMMENT ON ROLE \(role) IS \(PostgreSQLRelationSQL.commentValue(new.comment))")
         }
         if old.ref.name != new.ref.name {
             statements.append("ALTER ROLE \(role) RENAME TO \(quoteIdentifier(new.ref.name))")
@@ -63,7 +61,7 @@ extension PostgreSQLPluginDriver {
 
     func generateSetPasswordSQL(principal: PluginPrincipalRef, password: String) -> [String]? {
         let role = quoteIdentifier(principal.name)
-        return ["ALTER ROLE \(role) WITH PASSWORD '\(escapeStringLiteral(password))'"]
+        return ["ALTER ROLE \(role) WITH PASSWORD \(PostgreSQLObjectQueries.quoteLiteral(password))"]
     }
 
     func generateDropPrincipalSQL(

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver+Views.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver+Views.swift
@@ -1,0 +1,91 @@
+//
+//  PostgreSQLPluginDriver+Views.swift
+//  PostgreSQLDriverPlugin
+//
+
+import Foundation
+import TableProPluginKit
+
+extension PostgreSQLPluginDriver {
+    /// `pg_views` and `pg_matviews` return the query alone, so the definition this used to build
+    /// from them lost the view's options and check option, and read the body under the connection's
+    /// own search path. The statement is now rebuilt from the catalog with every name qualified.
+    func fetchViewDefinition(view: String, schema: String?) async throws -> String {
+        let resolvedSchema = schema ?? core.currentSchema
+        let query = PostgreSQLViewDefinition.catalogQuery(name: view, schema: resolvedSchema)
+        let result = try await executeQualifiedRead(query)
+        guard let row = result.rows.first,
+              let catalogRow = PostgreSQLViewDefinition.parse(row: row.map(\.asText))
+        else {
+            throw LibPQPluginError(message: "Failed to fetch definition for view '\(view)'", sqlState: nil, detail: nil)
+        }
+        return PostgreSQLViewDefinition.statement(name: view, schema: resolvedSchema, row: catalogRow)
+    }
+
+    func objectCommentStatement(name: String, objectType: String, schema: String?, comment: String?) -> String? {
+        PostgreSQLRelationSQL.commentStatement(
+            name: name,
+            schema: schema ?? core.currentSchema,
+            objectType: objectType,
+            comment: comment
+        )
+    }
+
+    func refreshMaterializedViewStatement(name: String, schema: String?, concurrently: Bool) -> String? {
+        PostgreSQLRelationSQL.refreshStatement(
+            name: name,
+            schema: schema ?? core.currentSchema,
+            concurrently: concurrently
+        )
+    }
+
+    func concurrentRefreshAvailability(
+        materializedView: String,
+        schema: String?
+    ) async throws -> PluginConcurrentRefreshAvailability? {
+        let query = PostgreSQLRelationSQL.concurrentRefreshQuery(
+            name: materializedView,
+            schema: schema ?? core.currentSchema
+        )
+        let result = try await execute(query: query)
+        guard let row = result.rows.first, row.count >= 2 else {
+            throw LibPQPluginError(
+                message: "Materialized view '\(materializedView)' was not found",
+                sqlState: nil,
+                detail: nil
+            )
+        }
+        return PostgreSQLRelationSQL.concurrentRefreshAvailability(
+            isPopulated: row[0].asText == "1",
+            hasUsableUniqueIndex: row[1].asText == "1"
+        )
+    }
+
+    /// Reads with `search_path` emptied so every name the server deparses comes back qualified.
+    ///
+    /// A pooled connection is never inside a transaction, and there the prefix and the read form
+    /// one implicit transaction that restores the path as it ends. PGlite has no pool, so its reads
+    /// share the connection a query tab may have left inside `BEGIN`; the prefix would then outlive
+    /// the read and every later unqualified name in that tab would fail. A savepoint scopes it there.
+    private func executeQualifiedRead(_ query: String) async throws -> PluginQueryResult {
+        let statement = PostgreSQLViewDefinition.qualifiedReadPrefix + query
+        guard core.isInsideTransactionBlock else {
+            return try await execute(query: statement)
+        }
+        let savepoint = "tablepro_qualified_read"
+        _ = try await execute(query: "SAVEPOINT \(savepoint)")
+        /// The rollback is best effort on both paths. It undoes a `SET LOCAL` in a transaction that
+        /// is about to end anyway, so a connection lost between the read and the rollback has taken
+        /// the whole transaction with it, and reporting that instead of the definition just read
+        /// would lose the answer to a failure that no longer matters.
+        let release = "ROLLBACK TO SAVEPOINT \(savepoint); RELEASE SAVEPOINT \(savepoint)"
+        do {
+            let result = try await execute(query: statement)
+            _ = try? await execute(query: release)
+            return result
+        } catch {
+            _ = try? await execute(query: release)
+            throw error
+        }
+    }
+}

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver.swift
@@ -529,7 +529,8 @@ class PostgreSQLPluginDriver: LibPQBackedDriver, @unchecked Sendable {
                   WHEN a.atthasdef \(defaultGuard)
                     THEN ' DEFAULT ' || pg_get_expr(d.adbin, d.adrelid)
                   ELSE ''
-                END
+                END,
+                c.relkind::text
             FROM pg_attribute a
             JOIN pg_class c ON c.oid = a.attrelid
             JOIN pg_namespace n ON n.oid = c.relnamespace
@@ -558,6 +559,14 @@ class PostgreSQLPluginDriver: LibPQBackedDriver, @unchecked Sendable {
         async let constraintsResult = execute(query: constraintsQuery)
 
         let (cols, cons) = try await (columnsResult, constraintsResult)
+
+        /// `pg_attribute` covers views and materialized views as well as tables, so a view reached
+        /// here as a `CREATE TABLE` of its columns. The Structure tab's DDL and every other caller
+        /// that asks for a relation's DDL by name get the view's own statement instead.
+        if let relkind = cols.rows.first?[safe: 1]?.asText,
+           PostgreSQLViewDefinition.kind(forRelkind: relkind) != nil {
+            return try await fetchViewDefinition(view: table, schema: resolvedSchema)
+        }
 
         let columnDefs = cols.rows.compactMap { $0[0].asText }
         guard !columnDefs.isEmpty else {
@@ -599,37 +608,6 @@ class PostgreSQLPluginDriver: LibPQBackedDriver, @unchecked Sendable {
             """
         let result = try await execute(query: query)
         return result.rows.compactMap { $0[0].asText }
-    }
-
-    func fetchViewDefinition(view: String, schema: String?) async throws -> String {
-        let schemaLiteral = escapeLiteral(schema ?? core.currentSchema)
-        let query = """
-            SELECT 'CREATE OR REPLACE VIEW ' || quote_ident(schemaname) || '.' || quote_ident(viewname) || ' AS ' || E'\\n' || definition AS ddl
-            FROM pg_views
-            WHERE viewname = '\(escapeLiteral(view))'
-              AND schemaname = '\(schemaLiteral)'
-            """
-        let result = try await execute(query: query)
-        if let firstRow = result.rows.first, let ddl = firstRow[0].asText {
-            return ddl
-        }
-
-        /// `pg_views` excludes materialized views, so a name that is one reaches here with no rows.
-        /// Falling through to `fetchTableDDL` instead, which succeeds on a matview because
-        /// `pg_class` and `pg_attribute` both cover one, put a `CREATE TABLE` in the dump under a
-        /// `DROP MATERIALIZED VIEW` and restored an empty ordinary table.
-        let matview = """
-            SELECT 'CREATE MATERIALIZED VIEW ' || quote_ident(schemaname) || '.' || quote_ident(matviewname)
-                   || ' AS ' || E'\\n' || definition AS ddl
-            FROM pg_matviews
-            WHERE matviewname = '\(escapeLiteral(view))'
-              AND schemaname = '\(schemaLiteral)'
-            """
-        let matviewResult = try await execute(query: matview)
-        guard let row = matviewResult.rows.first, let ddl = row[0].asText else {
-            throw LibPQPluginError(message: "Failed to fetch definition for view '\(view)'", sqlState: nil, detail: nil)
-        }
-        return ddl
     }
 
     func fetchTableMetadata(table: String, schema: String?) async throws -> PluginTableMetadata {
@@ -730,6 +708,11 @@ class PostgreSQLPluginDriver: LibPQBackedDriver, @unchecked Sendable {
         }
     }
 
+    /// The kinds `fetchTableDDL` writes a `CREATE TABLE` for. A view's DDL is its own statement, so
+    /// the enum types and sequences its columns happen to use are not a preamble to it: written in
+    /// front of a `CREATE VIEW` they recreated objects the view only reads.
+    private static let relkindsCreatedByTableDDL = "('r', 'p', 'f')"
+
     func fetchDependentTypes(table: String, schema: String?) async throws -> [(name: String, labels: [String])] {
         let safeTable = escapeLiteral(table)
         let schemaLiteral = escapeLiteral(schema ?? core.currentSchema)
@@ -743,6 +726,7 @@ class PostgreSQLPluginDriver: LibPQBackedDriver, @unchecked Sendable {
             JOIN pg_enum e ON e.enumtypid = t.oid
             WHERE c.relname = '\(safeTable)'
               AND n.nspname = '\(schemaLiteral)'
+              AND c.relkind IN \(Self.relkindsCreatedByTableDDL)
               AND a.attnum > 0
               AND NOT a.attisdropped
             GROUP BY t.typname
@@ -778,6 +762,7 @@ class PostgreSQLPluginDriver: LibPQBackedDriver, @unchecked Sendable {
                  AND pg_get_expr(ad.adbin, ad.adrelid) LIKE '%' || quote_ident(s.sequencename) || '%'
             WHERE c.relname = '\(safeTable)'
               AND n.nspname = '\(schemaLiteral)'
+              AND c.relkind IN \(Self.relkindsCreatedByTableDDL)
               AND pg_get_expr(ad.adbin, ad.adrelid) LIKE '%nextval%'
             """
         let result = try await execute(query: query)
@@ -1317,7 +1302,7 @@ class PostgreSQLPluginDriver: LibPQBackedDriver, @unchecked Sendable {
         }
 
         if let newComment = newColumn.comment, !newComment.isEmpty, newColumn.comment != oldColumn.comment {
-            stmts.append("COMMENT ON COLUMN \(qt).\(colName) IS '\(escapeLiteral(newComment))'")
+            stmts.append("COMMENT ON COLUMN \(qt).\(colName) IS \(PostgreSQLRelationSQL.commentValue(newComment))")
         } else if oldColumn.comment != nil && (newColumn.comment == nil || newColumn.comment?.isEmpty == true) {
             stmts.append("COMMENT ON COLUMN \(qt).\(colName) IS NULL")
         }

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLRelationSQL.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLRelationSQL.swift
@@ -1,0 +1,95 @@
+//
+//  PostgreSQLRelationSQL.swift
+//  PostgreSQLDriverPlugin
+//
+//  Statements that act on one table-like relation by name: comments and materialized view
+//  refreshes. Pure, so it is testable without a server.
+//
+
+import Foundation
+import TableProPluginKit
+
+public enum PostgreSQLRelationSQL {
+    /// The keyword `COMMENT ON` needs for each relation kind. PostgreSQL checks it against the
+    /// relation's `relkind` and refuses a mismatch: `COMMENT ON TABLE` on a view fails with
+    /// "is not a table", and `COMMENT ON VIEW` on a materialized view with "is not a view".
+    public static func commentKeyword(forObjectType objectType: String) -> String? {
+        switch objectType.uppercased() {
+        case "TABLE", "PARTITIONED TABLE":
+            return "TABLE"
+        case "VIEW":
+            return "VIEW"
+        case "MATERIALIZED VIEW":
+            return "MATERIALIZED VIEW"
+        case "FOREIGN TABLE":
+            return "FOREIGN TABLE"
+        default:
+            return nil
+        }
+    }
+
+    /// `COMMENT` takes a literal and nothing else, so the value is quoted here rather than bound. The
+    /// quoting reads the same whatever `standard_conforming_strings` is set to.
+    public static func commentStatement(
+        name: String,
+        schema: String,
+        objectType: String,
+        comment: String?
+    ) -> String? {
+        guard let keyword = commentKeyword(forObjectType: objectType) else { return nil }
+        let target = PostgreSQLObjectQueries.qualifiedName(schema: schema, name: name)
+        return "COMMENT ON \(keyword) \(target) IS \(commentValue(comment))"
+    }
+
+    public static func commentValue(_ comment: String?) -> String {
+        guard let comment, !comment.isEmpty else { return "NULL" }
+        return PostgreSQLObjectQueries.quoteLiteral(comment)
+    }
+
+    public static func refreshStatement(name: String, schema: String, concurrently: Bool) -> String {
+        let target = PostgreSQLObjectQueries.qualifiedName(schema: schema, name: name)
+        return concurrently
+            ? "REFRESH MATERIALIZED VIEW CONCURRENTLY \(target)"
+            : "REFRESH MATERIALIZED VIEW \(target)"
+    }
+
+    /// A concurrent refresh diffs the new result against the stored rows through a unique index,
+    /// so it needs one the server can use for every row: valid, immediate, on plain columns and
+    /// without a predicate. It also needs rows to diff against, which an unpopulated view lacks.
+    /// Measured on PostgreSQL 17 against every index shape `scripts/check-postgres-matview-refresh.sh`
+    /// builds; that script re-checks the predicate against a live server.
+    public static func concurrentRefreshQuery(name: String, schema: String) -> String {
+        """
+        SELECT
+            CASE WHEN c.relispopulated THEN 1 ELSE 0 END,
+            CASE WHEN EXISTS (
+                SELECT 1
+                FROM pg_catalog.pg_index i
+                JOIN pg_catalog.pg_class ic ON ic.oid = i.indexrelid
+                JOIN pg_catalog.pg_am am ON am.oid = ic.relam
+                WHERE i.indrelid = c.oid
+                  AND i.indisunique
+                  AND i.indimmediate
+                  AND i.indisvalid
+                  AND i.indpred IS NULL
+                  AND i.indexprs IS NULL
+                  AND am.amname = 'btree'
+            ) THEN 1 ELSE 0 END
+        FROM pg_catalog.pg_class c
+        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        WHERE c.relkind = 'm'
+          AND n.nspname = \(PostgreSQLObjectQueries.quoteLiteral(schema))
+          AND c.relname = \(PostgreSQLObjectQueries.quoteLiteral(name))
+        """
+    }
+
+    /// Population is checked first: an unpopulated view is refused even when its index is fine, and
+    /// the fix the user needs is a plain refresh, not a new index.
+    public static func concurrentRefreshAvailability(
+        isPopulated: Bool,
+        hasUsableUniqueIndex: Bool
+    ) -> PluginConcurrentRefreshAvailability {
+        guard isPopulated else { return .requiresPopulatedView }
+        return hasUsableUniqueIndex ? .available : .requiresUniqueIndex
+    }
+}

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLViewDefinition.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLViewDefinition.swift
@@ -1,0 +1,169 @@
+//
+//  PostgreSQLViewDefinition.swift
+//  PostgreSQLDriverPlugin
+//
+//  Rebuilds the CREATE statement of a view or materialized view from the catalog. Pure, so it is
+//  testable without a server.
+//
+
+import Foundation
+
+public enum PostgreSQLViewDefinition {
+    public enum Kind: Equatable, Sendable {
+        case view
+        case materializedView
+    }
+
+    /// Everything the statement is rebuilt from. `pg_get_viewdef` returns the query alone, so the
+    /// view's options, its check option, and a materialized view's access method and tablespace
+    /// each come from their own catalog column.
+    public struct CatalogRow: Equatable, Sendable {
+        public let kind: Kind
+        public let query: String
+        public let options: [String]
+        public let accessMethod: String?
+        public let tablespace: String?
+
+        public init(kind: Kind, query: String, options: [String], accessMethod: String?, tablespace: String?) {
+            self.kind = kind
+            self.query = query
+            self.options = options
+            self.accessMethod = accessMethod
+            self.tablespace = tablespace
+        }
+    }
+
+    /// Run with `search_path` emptied first (see `qualifiedReadPrefix`). `pg_get_viewdef` writes a
+    /// table name bare whenever the reading session could resolve it without its schema, and the
+    /// scoped connection this runs on has its path set to the view's own schema, so the body came
+    /// back naming `orders` rather than `sales.orders`. Run anywhere else, that text silently bound
+    /// to whichever `orders` the new session found first.
+    public static func catalogQuery(name: String, schema: String) -> String {
+        """
+        SELECT
+            c.relkind::text,
+            pg_catalog.pg_get_viewdef(c.oid, true),
+            pg_catalog.array_to_json(c.reloptions)::text,
+            am.amname::text,
+            ts.spcname::text
+        FROM pg_catalog.pg_class c
+        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        LEFT JOIN pg_catalog.pg_am am ON am.oid = c.relam
+        LEFT JOIN pg_catalog.pg_tablespace ts ON ts.oid = c.reltablespace
+        WHERE c.relkind IN ('v', 'm')
+          AND n.nspname = \(PostgreSQLObjectQueries.quoteLiteral(schema))
+          AND c.relname = \(PostgreSQLObjectQueries.quoteLiteral(name))
+        """
+    }
+
+    /// `SET LOCAL` lasts only as long as the transaction it runs in. Sent in the same query string
+    /// as the read, the pair is one implicit transaction, so the path is back to what it was as
+    /// soon as the read returns. Inside a transaction the caller already holds, it would last until
+    /// that transaction ends, which is why the driver wraps the read in a savepoint there.
+    public static let qualifiedReadPrefix = "SET LOCAL search_path = ''; "
+
+    public static func parse(row: [String?]) -> CatalogRow? {
+        guard row.count >= 5,
+              let relkind = row[0],
+              let query = row[1],
+              let kind = kind(forRelkind: relkind)
+        else { return nil }
+        return CatalogRow(
+            kind: kind,
+            query: query,
+            options: options(fromJSON: row[2]),
+            accessMethod: row[3]?.nilIfBlank,
+            tablespace: row[4]?.nilIfBlank
+        )
+    }
+
+    public static func kind(forRelkind relkind: String) -> Kind? {
+        switch relkind {
+        case "v": return .view
+        case "m": return .materializedView
+        default: return nil
+        }
+    }
+
+    /// Read as JSON rather than as array text, because an option value may itself hold a comma or
+    /// a quote and splitting `{a=1,b=2}` on commas would cut it in two.
+    public static func options(fromJSON json: String?) -> [String] {
+        guard let data = json?.data(using: .utf8),
+              let decoded = try? JSONDecoder().decode([String].self, from: data)
+        else { return [] }
+        return decoded
+    }
+
+    public static func statement(name: String, schema: String, row: CatalogRow) -> String {
+        let target = PostgreSQLObjectQueries.qualifiedName(schema: schema, name: name)
+        let body = trimmedQuery(row.query)
+        switch row.kind {
+        case .view:
+            return viewStatement(target: target, body: body, options: row.options)
+        case .materializedView:
+            return materializedViewStatement(target: target, body: body, row: row)
+        }
+    }
+
+    /// `CREATE OR REPLACE VIEW` resets every option the statement leaves out, so running a
+    /// definition that dropped `security_barrier`, `security_invoker` or the check option quietly
+    /// turned a restricted view into an unrestricted one. The check option is stored as a
+    /// reloption but written as its own clause after the query, the way `pg_dump` writes it.
+    private static func viewStatement(target: String, body: String, options: [String]) -> String {
+        let parsed = options.map(splitOption)
+        let checkOption = parsed.first { $0.name == "check_option" }?.value
+        let storage = parsed.filter { $0.name != "check_option" }
+        var header = "CREATE OR REPLACE VIEW \(target)"
+        if let withClause = withClause(storage) {
+            header += " \(withClause)"
+        }
+        var statement = "\(header) AS\n\(body)"
+        if let checkOption, !checkOption.isEmpty {
+            statement += "\n  WITH \(checkOption.uppercased()) CHECK OPTION"
+        }
+        return statement + ";"
+    }
+
+    /// The access method is written only when it is not the default, because `USING` does not
+    /// exist before PostgreSQL 12 and `heap` is what every server creates without it.
+    private static func materializedViewStatement(target: String, body: String, row: CatalogRow) -> String {
+        var header = "CREATE MATERIALIZED VIEW \(target)"
+        if let accessMethod = row.accessMethod, accessMethod != "heap" {
+            header += " USING \(PostgreSQLObjectQueries.quoteIdentifier(accessMethod))"
+        }
+        if let withClause = withClause(row.options.map(splitOption)) {
+            header += " \(withClause)"
+        }
+        if let tablespace = row.tablespace {
+            header += " TABLESPACE \(PostgreSQLObjectQueries.quoteIdentifier(tablespace))"
+        }
+        return "\(header) AS\n\(body);"
+    }
+
+    private static func withClause(_ options: [(name: String, value: String)]) -> String? {
+        guard !options.isEmpty else { return nil }
+        let rendered = options.map { "\($0.name)=\(PostgreSQLObjectQueries.quoteLiteral($0.value))" }
+        return "WITH (\(rendered.joined(separator: ", ")))"
+    }
+
+    private static func splitOption(_ option: String) -> (name: String, value: String) {
+        guard let separator = option.firstIndex(of: "=") else { return (option, "") }
+        return (String(option[..<separator]), String(option[option.index(after: separator)...]))
+    }
+
+    /// `pg_get_viewdef` ends the query with its own semicolon, and the check option has to go
+    /// before it.
+    private static func trimmedQuery(_ query: String) -> String {
+        var trimmed = Substring(query)
+        while let last = trimmed.last, last.isWhitespace || last == ";" {
+            trimmed = trimmed.dropLast()
+        }
+        return String(trimmed)
+    }
+}
+
+private extension String {
+    var nilIfBlank: String? {
+        trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : self
+    }
+}

--- a/Plugins/RedisDriverPlugin/Info.plist
+++ b/Plugins/RedisDriverPlugin/Info.plist
@@ -21,7 +21,7 @@
 	<key>NSPrincipalClass</key>
 	<string>$(PRODUCT_MODULE_NAME).RedisPlugin</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>25</integer>
+	<integer>26</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Redis</string>

--- a/Plugins/SQLExportPlugin/Info.plist
+++ b/Plugins/SQLExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>25</integer>
+	<integer>26</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>sql</string>

--- a/Plugins/SQLImportPlugin/Info.plist
+++ b/Plugins/SQLImportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>25</integer>
+	<integer>26</integer>
 	<key>TableProProvidesImportFormatIds</key>
 	<array>
 		<string>sql</string>

--- a/Plugins/SQLiteDriverPlugin/Info.plist
+++ b/Plugins/SQLiteDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>25</integer>
+	<integer>26</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>SQLite</string>

--- a/Plugins/SnowflakeDriverPlugin/Info.plist
+++ b/Plugins/SnowflakeDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.48.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>25</integer>
+	<integer>26</integer>
 </dict>
 </plist>

--- a/Plugins/SpannerDriverPlugin/Info.plist
+++ b/Plugins/SpannerDriverPlugin/Info.plist
@@ -5,7 +5,7 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>25</integer>
+	<integer>26</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Spanner</string>

--- a/Plugins/SurrealDBDriverPlugin/Info.plist
+++ b/Plugins/SurrealDBDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>25</integer>
+	<integer>26</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>SurrealDB</string>

--- a/Plugins/TableProPluginKit/PluginConcurrentRefreshAvailability.swift
+++ b/Plugins/TableProPluginKit/PluginConcurrentRefreshAvailability.swift
@@ -1,0 +1,17 @@
+//
+//  PluginConcurrentRefreshAvailability.swift
+//  TableProPluginKit
+//
+
+import Foundation
+
+/// Whether one materialized view can be refreshed without blocking the sessions reading it.
+///
+/// The answer depends on the view, not only on the engine: PostgreSQL refuses a concurrent refresh
+/// of a view that has no usable unique index or has never been populated, and the prompt says which
+/// rather than offering an option the server will reject.
+public enum PluginConcurrentRefreshAvailability: String, Sendable, Equatable {
+    case available
+    case requiresUniqueIndex
+    case requiresPopulatedView
+}

--- a/Plugins/TableProPluginKit/PluginDatabaseDriver.swift
+++ b/Plugins/TableProPluginKit/PluginDatabaseDriver.swift
@@ -337,6 +337,23 @@ public protocol PluginDatabaseDriver: AnyObject, Sendable {
     /// namespaces out and say so rather than emitting DDL the server will reject.
     func createSchemaStatement(name: String) -> String?
 
+    /// Sets or clears the comment on a table-like object. `objectType` is the object's type as the
+    /// table listing reported it, because engines that key the statement on the kind refuse the
+    /// wrong keyword: PostgreSQL answers `COMMENT ON TABLE` on a view with "is not a table". A nil
+    /// or empty comment removes it. Return nil for a kind the engine cannot comment on.
+    func objectCommentStatement(name: String, objectType: String, schema: String?, comment: String?) -> String?
+
+    /// The statement that recomputes a materialized view's stored rows. Return nil where the engine
+    /// has no materialized views or keeps them current on its own.
+    func refreshMaterializedViewStatement(name: String, schema: String?, concurrently: Bool) -> String?
+
+    /// Whether this view can be refreshed without blocking its readers. Return nil where the engine
+    /// has no such refresh, so the option is not offered at all.
+    func concurrentRefreshAvailability(
+        materializedView: String,
+        schema: String?
+    ) async throws -> PluginConcurrentRefreshAvailability?
+
     // Maintenance operations (optional — return nil if not supported)
     func supportedMaintenanceOperations() -> [String]?
     func maintenanceStatements(operation: String, table: String?, schema: String?, options: [String: String]) -> [String]?
@@ -776,6 +793,19 @@ public extension PluginDatabaseDriver {
     func foreignKeyDisableStatements() -> [String]? { nil }
     func foreignKeyEnableStatements() -> [String]? { nil }
     func createSchemaStatement(name: String) -> String? { nil }
+
+    func objectCommentStatement(name: String, objectType: String, schema: String?, comment: String?) -> String? {
+        nil
+    }
+
+    func refreshMaterializedViewStatement(name: String, schema: String?, concurrently: Bool) -> String? { nil }
+
+    func concurrentRefreshAvailability(
+        materializedView: String,
+        schema: String?
+    ) async throws -> PluginConcurrentRefreshAvailability? {
+        nil
+    }
 
     func supportedMaintenanceOperations() -> [String]? { nil }
     func maintenanceStatements(operation: String, table: String?, schema: String?, options: [String: String]) -> [String]? { nil }

--- a/Plugins/TeradataDriverPlugin/Info.plist
+++ b/Plugins/TeradataDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>25</integer>
+	<integer>26</integer>
 </dict>
 </plist>

--- a/Plugins/TrinoDriverPlugin/Info.plist
+++ b/Plugins/TrinoDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>25</integer>
+	<integer>26</integer>
 </dict>
 </plist>

--- a/Plugins/TypesenseDriverPlugin/Info.plist
+++ b/Plugins/TypesenseDriverPlugin/Info.plist
@@ -5,7 +5,7 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.73.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>25</integer>
+	<integer>26</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Typesense</string>

--- a/Plugins/XLSXExportPlugin/Info.plist
+++ b/Plugins/XLSXExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>25</integer>
+	<integer>26</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>xlsx</string>

--- a/Plugins/XLSXImportPlugin/Info.plist
+++ b/Plugins/XLSXImportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>25</integer>
+	<integer>26</integer>
 	<key>TableProProvidesImportFormatIds</key>
 	<array>
 		<string>xlsx</string>

--- a/Plugins/XMLExportPlugin/Info.plist
+++ b/Plugins/XMLExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>25</integer>
+	<integer>26</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>xml</string>

--- a/TablePro/Core/Database/DatabaseDriver.swift
+++ b/TablePro/Core/Database/DatabaseDriver.swift
@@ -243,6 +243,19 @@ protocol DatabaseDriver: AnyObject, Sendable {
     /// Generates SQL statements for a maintenance operation.
     func maintenanceStatements(operation: String, table: String?, options: [String: String]) -> [String]?
 
+    // MARK: - Object Comments and Materialized Views
+
+    /// Nil for an object kind the engine cannot comment on. Takes the object's own schema, never
+    /// the connection's current one, because the object named may live anywhere in the tree.
+    func objectCommentStatement(name: String, objectType: String, schema: String?, comment: String?) -> String?
+
+    func refreshMaterializedViewStatement(name: String, schema: String?, concurrently: Bool) -> String?
+
+    func concurrentRefreshAvailability(
+        materializedView: String,
+        schema: String?
+    ) async throws -> PluginConcurrentRefreshAvailability?
+
     // MARK: - Query Cancellation
 
     /// Cancel the currently running query, if any.
@@ -551,6 +564,19 @@ extension DatabaseDriver {
 
     func supportedMaintenanceOperations() -> [String]? { nil }
     func maintenanceStatements(operation: String, table: String?, options: [String: String]) -> [String]? { nil }
+
+    func objectCommentStatement(name: String, objectType: String, schema: String?, comment: String?) -> String? {
+        nil
+    }
+
+    func refreshMaterializedViewStatement(name: String, schema: String?, concurrently: Bool) -> String? { nil }
+
+    func concurrentRefreshAvailability(
+        materializedView: String,
+        schema: String?
+    ) async throws -> PluginConcurrentRefreshAvailability? {
+        nil
+    }
 
     /// Default: no schema support (MySQL/SQLite don't use schemas in the same way)
     func fetchSchemas() async throws -> [String] { [] }

--- a/TablePro/Core/Database/DatabaseObjectToolEligibility.swift
+++ b/TablePro/Core/Database/DatabaseObjectToolEligibility.swift
@@ -1,0 +1,53 @@
+//
+//  DatabaseObjectToolEligibility.swift
+//  TablePro
+//
+
+import Foundation
+
+/// Which of the per-object commands (Show DDL, Copy DDL, Refresh Materialized View, Edit Comment)
+/// apply to a row. The sidebar and the menu bar ask the same functions, so the two can never offer
+/// a command to a different set of objects; the sidebar omits what the menu bar disables.
+enum DatabaseObjectToolEligibility {
+    /// What the connection's driver can do, read once per menu build rather than per item.
+    ///
+    /// Derived by asking the driver's own statement hooks, so a driver cannot declare a capability
+    /// it has no statement for.
+    struct Support: Equatable {
+        var canRefreshMaterializedViews = false
+        var commentableTypes: Set<TableInfo.TableType> = []
+
+        static let none = Support()
+
+        @MainActor
+        static func of(_ driver: DatabaseDriver?) -> Support {
+            guard let driver else { return .none }
+            let commentable = TableInfo.TableType.allCases.filter { type in
+                driver.objectCommentStatement(name: "t", objectType: type.rawValue, schema: "s", comment: nil) != nil
+            }
+            return Support(
+                canRefreshMaterializedViews: driver.refreshMaterializedViewStatement(
+                    name: "t", schema: "s", concurrently: false
+                ) != nil,
+                commentableTypes: Set(commentable)
+            )
+        }
+    }
+
+    /// A view's source is its definition rather than its columns, which is what the DDL viewer
+    /// shows. Offered read-only too: reading a definition changes nothing.
+    static func canShowDDL(_ type: TableInfo.TableType?) -> Bool {
+        guard let type else { return false }
+        return DatabaseObjectKind(tableType: type) != nil
+    }
+
+    static func canRefresh(_ type: TableInfo.TableType?, support: Support, isReadOnly: Bool) -> Bool {
+        guard !isReadOnly, type == .materializedView else { return false }
+        return support.canRefreshMaterializedViews
+    }
+
+    static func canEditComment(_ type: TableInfo.TableType?, support: Support, isReadOnly: Bool) -> Bool {
+        guard !isReadOnly, let type else { return false }
+        return support.commentableTypes.contains(type)
+    }
+}

--- a/TablePro/Core/Database/MaterializedViewRefreshing.swift
+++ b/TablePro/Core/Database/MaterializedViewRefreshing.swift
@@ -1,0 +1,55 @@
+//
+//  MaterializedViewRefreshing.swift
+//  TablePro
+//
+//  Recomputes a materialized view's rows through the execution gate.
+//
+
+import Combine
+import Foundation
+import TableProPluginKit
+
+@MainActor
+enum MaterializedViewRefreshing {
+    /// Nil where the engine has no refresh that leaves readers alone, so the prompt offers no
+    /// option at all rather than one that is always off.
+    static func concurrentRefreshAvailability(
+        of target: DatabaseObjectTarget
+    ) async throws -> PluginConcurrentRefreshAvailability? {
+        let name = target.name
+        let schema = target.schema
+        return try await DatabaseManager.shared.withMetadataDriver(scope: target.scope) { driver in
+            try await driver.concurrentRefreshAvailability(materializedView: name, schema: schema)
+        }
+    }
+
+    /// Runs on its own connection wherever the engine has one to give, never inside a transaction a
+    /// query tab left open: a plain refresh holds an exclusive lock on the view until the
+    /// transaction it runs in ends, which inside the user's would be until they committed.
+    static func refresh(
+        _ target: DatabaseObjectTarget,
+        concurrently: Bool,
+        connection: DatabaseConnection,
+        gate: any ExecutionGate = ExecutionGateProvider.shared
+    ) async throws {
+        guard let driver = DatabaseManager.shared.driver(for: connection.id) else {
+            throw DatabaseObjectCommandError.notConnected
+        }
+        guard let sql = driver.refreshMaterializedViewStatement(
+            name: target.name,
+            schema: target.schema,
+            concurrently: concurrently
+        ) else {
+            throw DatabaseObjectCommandError.unsupported
+        }
+        try await DatabaseObjectCommandRunner.run(
+            sql,
+            on: target,
+            connection: connection,
+            kind: .maintenance,
+            operationDescription: String(localized: "Refresh Materialized View"),
+            gate: gate
+        )
+        AppCommands.shared.objectChanged.send(target.change(.rows))
+    }
+}

--- a/TablePro/Core/Database/ObjectCommentEditing.swift
+++ b/TablePro/Core/Database/ObjectCommentEditing.swift
@@ -1,0 +1,127 @@
+//
+//  ObjectCommentEditing.swift
+//  TablePro
+//
+//  Sets or clears the comment on a table, view, materialized view or foreign table through the
+//  execution gate.
+//
+
+import Combine
+import Foundation
+import TableProPluginKit
+
+enum DatabaseObjectCommandError: LocalizedError, Equatable {
+    case notConnected
+    case unsupported
+    case denied(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .notConnected: String(localized: "Not connected to database")
+        case .unsupported: String(localized: "This database cannot run this command on this object")
+        case let .denied(reason): reason
+        }
+    }
+}
+
+@MainActor
+enum ObjectCommentEditing {
+    /// The current comment, read fresh rather than taken from the sidebar's listing, which may
+    /// predate a change made in another window or another app.
+    static func currentComment(of target: DatabaseObjectTarget) async throws -> String? {
+        let name = target.name
+        let metadata = try await DatabaseManager.shared.withMetadataDriver(scope: target.scope) { driver in
+            try await driver.fetchTableMetadata(tableName: name)
+        }
+        return metadata.comment
+    }
+
+    static func statement(for comment: String?, on target: DatabaseObjectTarget, driver: DatabaseDriver) -> String? {
+        driver.objectCommentStatement(
+            name: target.name,
+            objectType: target.type.rawValue,
+            schema: target.schema,
+            comment: comment
+        )
+    }
+
+    /// Runs on the schema change route, like every other statement the app writes on the user's
+    /// behalf: on the session driver it would join a transaction a query tab left open and be
+    /// undone by that tab's rollback.
+    static func setComment(
+        _ comment: String?,
+        on target: DatabaseObjectTarget,
+        connection: DatabaseConnection,
+        gate: any ExecutionGate = ExecutionGateProvider.shared
+    ) async throws {
+        guard let driver = DatabaseManager.shared.driver(for: connection.id) else {
+            throw DatabaseObjectCommandError.notConnected
+        }
+        guard let sql = statement(for: comment, on: target, driver: driver) else {
+            throw DatabaseObjectCommandError.unsupported
+        }
+        try await DatabaseObjectCommandRunner.run(
+            sql,
+            on: target,
+            connection: connection,
+            kind: .schemaMutation,
+            operationDescription: String(localized: "Edit Comment"),
+            gate: gate
+        )
+        AppCommands.shared.objectChanged.send(target.change(.comment))
+    }
+}
+
+/// The part every object command shares: authorize, run on a lease no Stop can reach, record it.
+@MainActor
+enum DatabaseObjectCommandRunner {
+    static func run(
+        _ sql: String,
+        on target: DatabaseObjectTarget,
+        connection: DatabaseConnection,
+        kind: OperationKind,
+        operationDescription: String,
+        gate: any ExecutionGate
+    ) async throws {
+        let decision = await gate.authorize(
+            OperationRequest(
+                connectionId: connection.id,
+                databaseType: connection.type,
+                sql: sql,
+                kind: kind,
+                caller: .userInterface,
+                capabilities: .interactiveUser,
+                operationDescription: operationDescription
+            )
+        )
+        guard case .authorized = decision else {
+            throw DatabaseObjectCommandError.denied(
+                decision.deniedReason ?? String(localized: "Operation not permitted")
+            )
+        }
+
+        let scope = target.scope
+        let startedAt = Date()
+        try await DatabaseManager.shared.withScopedDriver(
+            scope: scope,
+            route: DatabaseManager.shared.schemaChangeRoute(for: scope),
+            cancellation: .protectedWrite
+        ) { driver in
+            _ = try await driver.execute(query: sql)
+        }
+
+        await DatabaseManager.shared.historyRecorder.record(
+            QueryHistoryRecordRequest(
+                query: sql,
+                connectionId: connection.id,
+                databaseName: scope.database,
+                databaseType: connection.type,
+                schemaName: scope.schema,
+                source: .structureDDL,
+                executionTime: Date().timeIntervalSince(startedAt),
+                rowCount: -1,
+                wasSuccessful: true
+            )
+        )
+    }
+}

--- a/TablePro/Core/Database/TableDDLComposer.swift
+++ b/TablePro/Core/Database/TableDDLComposer.swift
@@ -26,4 +26,34 @@ internal enum TableDDLComposer {
         }
         return composed + "\n\n" + statements.joined(separator: "\n")
     }
+
+    /// One object's whole definition, read on a driver already pinned to its scope. The Structure
+    /// tab's DDL, Show DDL and Copy DDL all come through here, so the three can never disagree about
+    /// the same object. `includesDependencies` adds the sequences and enum types the table's columns
+    /// use, which the Structure tab writes first so its text runs on its own.
+    internal static func fetchDDL(
+        for table: String,
+        using driver: DatabaseDriver,
+        includesDependencies: Bool
+    ) async throws -> String {
+        let preamble = includesDependencies ? try await dependencyPreamble(for: table, using: driver) : ""
+        let baseDDL = try await driver.fetchTableDDL(table: table)
+        let indexDDL = (try? await driver.fetchIndexDDL(table: table)) ?? []
+        return compose(tableDDL: baseDDL, indexDDL: indexDDL, preamble: preamble)
+    }
+
+    private static func dependencyPreamble(for table: String, using driver: DatabaseDriver) async throws -> String {
+        let sequences = try await driver.fetchDependentSequences(forTable: table)
+        let enumTypes = try await driver.fetchDependentTypes(forTable: table)
+        var preamble = ""
+        for sequence in sequences {
+            preamble += sequence.ddl + "\n\n"
+        }
+        for enumType in enumTypes {
+            let quotedName = "\"\(enumType.name.replacingOccurrences(of: "\"", with: "\"\""))\""
+            let quotedLabels = enumType.labels.map { "'\(SQLEscaping.escapeStringLiteral($0))'" }
+            preamble += "CREATE TYPE \(quotedName) AS ENUM (\(quotedLabels.joined(separator: ", ")));\n"
+        }
+        return preamble
+    }
 }

--- a/TablePro/Core/Events/AppCommands.swift
+++ b/TablePro/Core/Events/AppCommands.swift
@@ -31,6 +31,32 @@ struct DataRefreshRequest: Sendable, Equatable {
     }
 }
 
+/// A change to one named object, addressed by name rather than by scope.
+///
+/// `DataRefreshRequest` reloads whichever tab each window has selected in the scope, whatever table
+/// it shows, and asks the user to discard its edits first. A change that touches one object has no
+/// business interrupting a tab on another, and the tabs that do show it are reloaded whether they
+/// are in front or not.
+struct DatabaseObjectChange: Sendable, Equatable {
+    enum Kind: Sendable, Equatable {
+        /// The object's rows were recomputed, as a materialized view refresh does.
+        case rows
+        /// The object's comment changed.
+        case comment
+    }
+
+    let connectionId: UUID
+    let scope: DatabaseScope
+    let name: String
+    let kind: Kind
+
+    /// Whether a tab's table is this object. Schema is compared as the tab stores it, which is the
+    /// resolved schema for an engine that has them and nil for one that does not.
+    func matches(tableName: String?, databaseName: String, schemaName: String?) -> Bool {
+        tableName == name && databaseName == scope.database && schemaName == scope.schema
+    }
+}
+
 @MainActor
 final class AppCommands {
     static let shared = AppCommands()
@@ -38,6 +64,7 @@ final class AppCommands {
     // MARK: - Refresh
 
     let refreshData = PassthroughSubject<DataRefreshRequest, Never>()
+    let objectChanged = PassthroughSubject<DatabaseObjectChange, Never>()
     let refreshPrincipals = PassthroughSubject<UUID, Never>()
 
     // MARK: - File / Connection Import-Export

--- a/TablePro/Core/MCP/MCPConnectionBridge+Schema.swift
+++ b/TablePro/Core/MCP/MCPConnectionBridge+Schema.swift
@@ -98,17 +98,13 @@ extension MCPConnectionBridge {
     /// The table's own statement plus the indexes it does not declare, because a caller asking for
     /// a table's DDL wants what recreates it, not the half the export replays first.
     static func composedTableDDL(driver: DatabaseDriver, table: String) async -> String? {
-        guard let base = try? await driver.fetchTableDDL(table: table) else { return nil }
-        let indexes = (try? await driver.fetchIndexDDL(table: table)) ?? []
-        return TableDDLComposer.compose(tableDDL: base, indexDDL: indexes)
+        try? await TableDDLComposer.fetchDDL(for: table, using: driver, includesDependencies: false)
     }
 
     func getTableDDL(scope: DatabaseScope, table: String) async throws -> JsonValue {
         try await ensureConnected(scope.connectionId)
         let ddl = try await DatabaseManager.shared.withMetadataDriver(scope: scope) { driver in
-            let base = try await driver.fetchTableDDL(table: table)
-            let indexes = (try? await driver.fetchIndexDDL(table: table)) ?? []
-            return TableDDLComposer.compose(tableDDL: base, indexDDL: indexes)
+            try await TableDDLComposer.fetchDDL(for: table, using: driver, includesDependencies: false)
         }
         return .object([
             "table": .string(table),

--- a/TablePro/Core/Menu/DatabaseMenuBuilder.swift
+++ b/TablePro/Core/Menu/DatabaseMenuBuilder.swift
@@ -67,6 +67,24 @@ enum DatabaseMenuBuilder {
                 String(localized: "Edit View Definition…"),
                 action: #selector(MainSplitViewController.editViewDefinition(_:))
             ),
+            /// The sidebar's own per-object commands, mirrored so each is reachable from the menu
+            /// bar and the keyboard, and spelled exactly as the sidebar spells them.
+            MenuItemFactory.item(
+                String(localized: "Show DDL"),
+                action: #selector(MainSplitViewController.showObjectDDL(_:))
+            ),
+            MenuItemFactory.item(
+                String(localized: "Copy DDL"),
+                action: #selector(MainSplitViewController.copyObjectDDL(_:))
+            ),
+            MenuItemFactory.item(
+                String(localized: "Refresh Materialized View…"),
+                action: #selector(MainSplitViewController.refreshMaterializedView(_:))
+            ),
+            MenuItemFactory.item(
+                String(localized: "Edit Comment…"),
+                action: #selector(MainSplitViewController.editObjectComment(_:))
+            ),
             schemaSubmenu(),
             sessionContextSubmenu(),
             safeModeSubmenu(),

--- a/TablePro/Core/Plugins/PluginDriverAdapter.swift
+++ b/TablePro/Core/Plugins/PluginDriverAdapter.swift
@@ -766,6 +766,23 @@ final class PluginDriverAdapter: DatabaseDriver, SchemaSwitchable, DatabaseRepor
         pluginDriver.maintenanceStatements(operation: operation, table: table, schema: pluginDriver.currentSchema, options: options)
     }
 
+    // MARK: - Object Comments and Materialized Views
+
+    func objectCommentStatement(name: String, objectType: String, schema: String?, comment: String?) -> String? {
+        pluginDriver.objectCommentStatement(name: name, objectType: objectType, schema: schema, comment: comment)
+    }
+
+    func refreshMaterializedViewStatement(name: String, schema: String?, concurrently: Bool) -> String? {
+        pluginDriver.refreshMaterializedViewStatement(name: name, schema: schema, concurrently: concurrently)
+    }
+
+    func concurrentRefreshAvailability(
+        materializedView: String,
+        schema: String?
+    ) async throws -> PluginConcurrentRefreshAvailability? {
+        try await pluginDriver.concurrentRefreshAvailability(materializedView: materializedView, schema: schema)
+    }
+
     // MARK: - All Tables Metadata SQL
 
     func allTablesMetadataSQL(schema: String?) -> String? {

--- a/TablePro/Core/Plugins/PluginManager.swift
+++ b/TablePro/Core/Plugins/PluginManager.swift
@@ -14,6 +14,10 @@ import TableProPluginKit
 @MainActor @Observable
 final class PluginManager {
     static let shared = PluginManager(userDefaults: AppStorageEnvironment.shared.defaults)
+    /// Raised to 26 for `objectCommentStatement`, `refreshMaterializedViewStatement` and
+    /// `concurrentRefreshAvailability` on `PluginDatabaseDriver`, plus the
+    /// `PluginConcurrentRefreshAvailability` the last one answers with.
+    ///
     /// Raised to 23 for `releasableResourceCommandTitle` and `releaseIdleResource` on
     /// `PluginDatabaseDriver`, plus the `PluginResourceRelease` they answer with. Together they let
     /// a driver hand back a resource its session is holding without ending the session. DuckDB is
@@ -37,7 +41,7 @@ final class PluginManager {
     /// rebuilt CassandraDriver for the v20 requirements it implements none of. Left at 20, such a
     /// plugin passes `validateBundleVersions` in a shipped v20 app and then fails
     /// `Bundle.loadAndReturnError`; at 21 that app refuses it and says to update.
-    nonisolated static let currentPluginKitVersion = 25
+    nonisolated static let currentPluginKitVersion = 26
 
     /// Still 19, so every plugin already published for the previous release keeps loading.
     nonisolated static let minimumCompatiblePluginKitVersion = 19

--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController+DatabaseMenuActions.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController+DatabaseMenuActions.swift
@@ -88,6 +88,22 @@ extension MainSplitViewController {
         commandActions?.editViewDefinition()
     }
 
+    @objc func showObjectDDL(_ sender: Any?) {
+        commandActions?.showObjectDDL()
+    }
+
+    @objc func copyObjectDDL(_ sender: Any?) {
+        commandActions?.copyObjectDDL()
+    }
+
+    @objc func refreshMaterializedView(_ sender: Any?) {
+        commandActions?.refreshMaterializedView()
+    }
+
+    @objc func editObjectComment(_ sender: Any?) {
+        commandActions?.editObjectComment()
+    }
+
     @objc func runMaintenanceOperation(_ sender: Any?) {
         guard let operation = (sender as? NSMenuItem)?.representedObject as? String else { return }
         commandActions?.runMaintenanceOperation(operation)

--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController+MenuValidation.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController+MenuValidation.swift
@@ -68,6 +68,9 @@ struct MenuValidationContext: Equatable {
     var canReleaseFileLock = false
     var canShowTableStructure = false
     var canEditViewDefinition = false
+    var canShowObjectDDL = false
+    var canRefreshMaterializedView = false
+    var canEditObjectComment = false
     var canCreateDatabase = false
     var canCopyObjects = false
     var canDuplicateDatabase = false
@@ -229,10 +232,13 @@ extension MainSplitViewController: NSMenuItemValidation {
             return context.canCopyObjects
         case #selector(duplicateCurrentDatabase(_:)):
             return context.canDuplicateDatabase
-        case #selector(showTableStructure(_:)):
-            return context.isConnected && context.canShowTableStructure
-        case #selector(editViewDefinition(_:)):
-            return context.isConnected && context.canEditViewDefinition
+        case #selector(showTableStructure(_:)),
+             #selector(editViewDefinition(_:)),
+             #selector(showObjectDDL(_:)),
+             #selector(copyObjectDDL(_:)),
+             #selector(refreshMaterializedView(_:)),
+             #selector(editObjectComment(_:)):
+            return objectCommandIsEnabled(selector, context: context)
         case #selector(runMaintenanceOperation(_:)):
             return context.isConnected && context.hasMaintenanceOperations
         case #selector(switchToSchema(_:)):
@@ -284,6 +290,27 @@ extension MainSplitViewController: NSMenuItemValidation {
         }
     }
 
+    /// The commands that act on the object selected in the sidebar. They answer on the same facts
+    /// the sidebar's own contextual menu reads, so a command the sidebar omits is dimmed here rather
+    /// than enabled over an object it cannot act on.
+    private static func objectCommandIsEnabled(_ selector: Selector, context: MenuValidationContext) -> Bool {
+        guard context.isConnected else { return false }
+        switch selector {
+        case #selector(showTableStructure(_:)):
+            return context.canShowTableStructure
+        case #selector(editViewDefinition(_:)):
+            return !context.isReadOnly && context.canEditViewDefinition
+        case #selector(showObjectDDL(_:)), #selector(copyObjectDDL(_:)):
+            return context.canShowObjectDDL
+        case #selector(refreshMaterializedView(_:)):
+            return context.canRefreshMaterializedView
+        case #selector(editObjectComment(_:)):
+            return context.canEditObjectComment
+        default:
+            return false
+        }
+    }
+
     /// The workspace-rail facts come from the window in both branches. They are true of the window,
     /// not of the connection it happens to be showing, and reading them off a connection that has
     /// no coordinator left disabled the only menu route to the window's other connections.
@@ -329,6 +356,9 @@ extension MainSplitViewController: NSMenuItemValidation {
             canReleaseFileLock: canReleaseFileLock,
             canShowTableStructure: actions.canShowTableStructure,
             canEditViewDefinition: actions.canEditViewDefinition,
+            canShowObjectDDL: actions.canShowObjectDDL,
+            canRefreshMaterializedView: actions.canRefreshMaterializedView,
+            canEditObjectComment: actions.canEditObjectComment,
             canCreateDatabase: actions.canCreateDatabase,
             canCopyObjects: actions.canCopyObjects,
             canDuplicateDatabase: actions.canDuplicateDatabase,

--- a/TablePro/Models/Database/DatabaseObjectTarget.swift
+++ b/TablePro/Models/Database/DatabaseObjectTarget.swift
@@ -1,0 +1,28 @@
+//
+//  DatabaseObjectTarget.swift
+//  TablePro
+//
+
+import Foundation
+
+/// One table-like object a command acts on, with the scope its statement runs in.
+///
+/// The scope comes from the object's own database and schema, never from where the sidebar or the
+/// selected tab happens to point, so a command raised on a view in another schema cannot act on a
+/// same-named view in the browsed one.
+struct DatabaseObjectTarget: Equatable, Sendable {
+    let name: String
+    let type: TableInfo.TableType
+    let schema: String?
+    let scope: DatabaseScope
+
+    /// How the object is named to the user: its schema and its name, as the sidebar shows them.
+    var qualifiedName: String {
+        guard let schema, !schema.isEmpty else { return name }
+        return "\(schema).\(name)"
+    }
+
+    func change(_ kind: DatabaseObjectChange.Kind) -> DatabaseObjectChange {
+        DatabaseObjectChange(connectionId: scope.connectionId, scope: scope, name: name, kind: kind)
+    }
+}

--- a/TablePro/Models/Database/MaterializedViewRefreshPrompt.swift
+++ b/TablePro/Models/Database/MaterializedViewRefreshPrompt.swift
@@ -1,0 +1,89 @@
+//
+//  MaterializedViewRefreshPrompt.swift
+//  TablePro
+//
+
+import Foundation
+import TableProPluginKit
+
+/// What the Refresh Materialized View confirmation says, kept apart from the alert so it can be
+/// asserted without presenting one.
+///
+/// The option to refresh without blocking readers is shown only where the engine has one, and it is
+/// enabled only for a view the server will accept it for. Offering it on engine version alone is how
+/// other clients ended up with a checkbox the server then refuses.
+internal struct MaterializedViewRefreshPrompt: Equatable {
+    internal let qualifiedName: String
+    /// Nil when the engine has no concurrent refresh at all.
+    internal let availability: PluginConcurrentRefreshAvailability?
+    /// The check failed, so whether the view qualifies is not known. The option is shown disabled
+    /// rather than left out, so the user is not told the engine lacks it.
+    internal let availabilityCheckFailed: Bool
+
+    internal init(
+        qualifiedName: String,
+        availability: PluginConcurrentRefreshAvailability?,
+        availabilityCheckFailed: Bool = false
+    ) {
+        self.qualifiedName = qualifiedName
+        self.availability = availability
+        self.availabilityCheckFailed = availabilityCheckFailed
+    }
+
+    internal var messageText: String {
+        String(format: String(localized: "Refresh the materialized view “%@”?"), qualifiedName)
+    }
+
+    internal var informativeText: String {
+        String(
+            localized: """
+            The view's query runs again and replaces its stored rows. A plain refresh stops other \
+            sessions from reading the view until it finishes.
+            """
+        )
+    }
+
+    internal var confirmButtonTitle: String {
+        String(localized: "Refresh")
+    }
+
+    internal var cancelButtonTitle: String {
+        String(localized: "Cancel")
+    }
+
+    internal var showsConcurrentOption: Bool {
+        availability != nil || availabilityCheckFailed
+    }
+
+    internal var isConcurrentOptionEnabled: Bool {
+        availability == .available
+    }
+
+    internal var concurrentOptionTitle: String {
+        String(localized: "Refresh concurrently")
+    }
+
+    internal var concurrentOptionDescription: String {
+        if availabilityCheckFailed {
+            return String(localized: "Couldn't check whether this view can be refreshed concurrently.")
+        }
+        switch availability {
+        case .available:
+            return String(localized: "Other sessions keep reading the view. Slower, because the new rows are compared with the old ones.")
+        case .requiresUniqueIndex:
+            return String(localized: "Needs a valid unique index on the view's columns, with no WHERE clause and no expressions.")
+        case .requiresPopulatedView:
+            return String(localized: "Available once the view holds rows. Refresh it once without this option first.")
+        case .none:
+            return ""
+        @unknown default:
+            return String(localized: "This view can't be refreshed concurrently.")
+        }
+    }
+
+    /// Only honoured while the option is enabled, so a stale checkbox can never ask the server for
+    /// a refresh it has already said it would refuse.
+    internal func refreshesConcurrently(checkboxIsOn: Bool) -> Bool {
+        isConcurrentOptionEnabled && checkboxIsOn
+    }
+}

--- a/TablePro/Models/Database/ObjectCommentDraft.swift
+++ b/TablePro/Models/Database/ObjectCommentDraft.swift
@@ -1,0 +1,39 @@
+//
+//  ObjectCommentDraft.swift
+//  TablePro
+//
+
+import Foundation
+
+/// The text in the Edit Comment sheet and what saving it would write.
+///
+/// A comment that is empty or only whitespace is removed rather than stored, which is what an empty
+/// field means to the person clearing it and what PostgreSQL itself does with an empty string.
+internal struct ObjectCommentDraft: Equatable {
+    internal let original: String?
+    internal var text: String
+
+    internal init(original: String?) {
+        let normalized = Self.normalized(original)
+        self.original = normalized
+        self.text = normalized ?? ""
+    }
+
+    /// Nil removes the comment.
+    internal var commentToSave: String? {
+        Self.normalized(text)
+    }
+
+    internal var hasChanges: Bool {
+        commentToSave != original
+    }
+
+    internal var removesComment: Bool {
+        original != nil && commentToSave == nil
+    }
+
+    private static func normalized(_ comment: String?) -> String? {
+        guard let comment, !comment.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+        return comment
+    }
+}

--- a/TablePro/Models/Query/DatabaseObjectRef.swift
+++ b/TablePro/Models/Query/DatabaseObjectRef.swift
@@ -2,7 +2,7 @@
 //  DatabaseObjectRef.swift
 //  TablePro
 //
-//  Everything needed to find one routine, trigger or type again and read its source.
+//  Everything needed to find one routine, trigger, type or view again and read its source.
 //
 
 import Foundation
@@ -12,13 +12,26 @@ enum DatabaseObjectKind: String, Codable, Sendable, Hashable {
     case function
     case trigger
     case userType
+    case view
+    case materializedView
 
     var sidebarObjectKind: SidebarObjectKind {
         switch self {
-        case .procedure: return .procedure
-        case .function:  return .function
-        case .trigger:   return .trigger
-        case .userType:  return .type
+        case .procedure:        return .procedure
+        case .function:         return .function
+        case .trigger:          return .trigger
+        case .userType:         return .type
+        case .view:             return .view
+        case .materializedView: return .materializedView
+        }
+    }
+
+    /// The kind a table listing row opens as, or nil for a row whose source is its table DDL.
+    init?(tableType: TableInfo.TableType) {
+        switch tableType {
+        case .view: self = .view
+        case .materializedView: self = .materializedView
+        case .table, .foreignTable, .systemTable, .partitionedTable, .externalTable: return nil
         }
     }
 
@@ -100,6 +113,12 @@ struct DatabaseObjectRef: Hashable, Codable, Sendable {
         )
     }
 
+    /// A view or materialized view, whose source is read the way the Structure tab reads it.
+    init?(relation table: TableInfo, database: String, schema: String?) {
+        guard let kind = DatabaseObjectKind(tableType: table.type) else { return nil }
+        self.init(kind: kind, name: table.name, database: database, schema: schema)
+    }
+
     init(userType: UserDefinedTypeInfo, database: String) {
         self.init(
             kind: .userType,
@@ -122,7 +141,7 @@ struct DatabaseObjectRef: Hashable, Codable, Sendable {
         case .trigger:
             guard let table, !table.isEmpty else { return qualifiedName }
             return String(format: String(localized: "%1$@ on %2$@"), qualifiedName, table)
-        case .userType:
+        case .userType, .view, .materializedView:
             return qualifiedName
         }
     }
@@ -171,7 +190,7 @@ struct DatabaseObjectRef: Hashable, Codable, Sendable {
                 argumentSignature: argumentSignature,
                 identity: identity
             )
-        case .trigger, .userType:
+        case .trigger, .userType, .view, .materializedView:
             return nil
         }
     }

--- a/TablePro/Models/Query/QueryResult.swift
+++ b/TablePro/Models/Query/QueryResult.swift
@@ -120,7 +120,7 @@ struct TableInfo: Identifiable, Hashable, Sendable {
     let schema: String?
     let comment: String?
 
-    enum TableType: String, Sendable {
+    enum TableType: String, Sendable, CaseIterable {
         case table = "TABLE"
         case view = "VIEW"
         case materializedView = "MATERIALIZED VIEW"

--- a/TablePro/Models/Query/QueryTabManager.swift
+++ b/TablePro/Models/Query/QueryTabManager.swift
@@ -420,6 +420,8 @@ final class QueryTabManager {
         case .function:  format = String(localized: "Function: %@")
         case .trigger:   format = String(localized: "Trigger: %@")
         case .userType:  format = String(localized: "Type: %@")
+        case .view:      format = String(localized: "View: %@")
+        case .materializedView: format = String(localized: "Materialized View: %@")
         }
         return String(format: format, objectRef.displayIdentity)
     }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+DatabaseObjectTools.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+DatabaseObjectTools.swift
@@ -1,0 +1,157 @@
+//
+//  MainContentCoordinator+DatabaseObjectTools.swift
+//  TablePro
+//
+//  Copy DDL, Refresh Materialized View and Edit Comment on one table-like object.
+//
+
+import AppKit
+import Foundation
+import os
+import TableProPluginKit
+
+extension MainContentCoordinator {
+    private static let objectToolsLogger = Logger(subsystem: "com.TablePro", category: "DatabaseObjectTools")
+
+    /// The object a sidebar row or the menu bar's selection names, scoped to its own database and
+    /// schema. A row whose database is nil belongs to the database being browsed.
+    func objectTarget(for ref: DatabaseTreeTableRef) -> DatabaseObjectTarget? {
+        guard let scope = services.databaseManager.resolvedScope(
+            database: ref.database,
+            schema: ref.qualifyingSchema,
+            for: connectionId
+        ) else { return nil }
+        return DatabaseObjectTarget(
+            name: ref.table.name,
+            type: ref.table.type,
+            schema: scope.schema ?? ref.qualifyingSchema,
+            scope: scope
+        )
+    }
+
+    // MARK: - Copy DDL
+
+    /// The same text the DDL viewer and the Structure tab's DDL show, read in the object's own scope.
+    func copyDDL(of ref: DatabaseTreeTableRef) {
+        guard let target = objectTarget(for: ref) else { return }
+        let name = target.name
+        Task {
+            do {
+                let ddl = try await services.databaseManager.withMetadataDriver(scope: target.scope) { driver in
+                    try await TableDDLComposer.fetchDDL(for: name, using: driver, includesDependencies: true)
+                }
+                ClipboardService.shared.writeText(ddl)
+            } catch {
+                Self.objectToolsLogger.error("Copy DDL failed: \(error.localizedDescription, privacy: .public)")
+                AlertHelper.showErrorSheet(
+                    title: String(localized: "Couldn't Copy DDL"),
+                    message: error.localizedDescription,
+                    window: contentWindow
+                )
+            }
+        }
+    }
+
+    // MARK: - Refresh Materialized View
+
+    func refreshMaterializedView(_ ref: DatabaseTreeTableRef) {
+        guard !safeModeLevel.blocksAllWrites, let target = objectTarget(for: ref) else { return }
+        Task {
+            let prompt = await refreshPrompt(for: target)
+            MaterializedViewRefreshAlert.present(prompt: prompt, window: contentWindow) { [weak self] concurrently in
+                guard let self, let concurrently else { return }
+                self.runMaterializedViewRefresh(target, concurrently: concurrently)
+            }
+        }
+    }
+
+    /// A failed check still asks the question: the refresh itself does not depend on it, and a
+    /// server that could not answer the catalog read will say why when the refresh runs.
+    private func refreshPrompt(for target: DatabaseObjectTarget) async -> MaterializedViewRefreshPrompt {
+        do {
+            let availability = try await MaterializedViewRefreshing.concurrentRefreshAvailability(of: target)
+            return MaterializedViewRefreshPrompt(qualifiedName: target.qualifiedName, availability: availability)
+        } catch {
+            Self.objectToolsLogger.error(
+                "Concurrent refresh check failed: \(error.localizedDescription, privacy: .public)"
+            )
+            return MaterializedViewRefreshPrompt(
+                qualifiedName: target.qualifiedName,
+                availability: nil,
+                availabilityCheckFailed: true
+            )
+        }
+    }
+
+    private func runMaterializedViewRefresh(_ target: DatabaseObjectTarget, concurrently: Bool) {
+        Task {
+            do {
+                try await MaterializedViewRefreshing.refresh(target, concurrently: concurrently, connection: connection)
+                AlertHelper.showInfoSheet(
+                    title: String(localized: "Materialized View Refreshed"),
+                    message: String(format: String(localized: "“%@” now holds the current result of its query."), target.qualifiedName),
+                    window: contentWindow
+                )
+            } catch {
+                AlertHelper.showErrorSheet(
+                    title: String(localized: "Couldn't Refresh Materialized View"),
+                    message: error.localizedDescription,
+                    window: contentWindow
+                )
+            }
+        }
+    }
+
+    // MARK: - Edit Comment
+
+    func editComment(of ref: DatabaseTreeTableRef) {
+        guard !safeModeLevel.blocksAllWrites, let target = objectTarget(for: ref) else { return }
+        activeSheet = .editObjectComment(target)
+    }
+
+    // MARK: - Object Changes
+
+    /// Brings every tab showing the changed object up to date, and no other tab. The selected one
+    /// reloads now, asking first if it holds edits; a background one drops its rows so it reloads
+    /// when it is next shown.
+    ///
+    /// The selected tab goes through `handleRefresh`, the entry Cmd+R uses, rather than straight to
+    /// the data reload: that one refuses to run while the Structure pane is in front and refreshes
+    /// the structure instead, and a tab excluded from the eviction loop for being selected would
+    /// otherwise keep its rows with nothing left to reload them.
+    func applyObjectChange(
+        _ change: DatabaseObjectChange,
+        hasPendingTableOps: Bool,
+        onDiscard: @escaping () -> Void
+    ) {
+        guard change.connectionId == connectionId else { return }
+        let showing = tabManager.tabs.filter { tab in
+            tab.tabType == .table && change.matches(
+                tableName: tab.tableContext.tableName,
+                databaseName: tab.tableContext.resolvedDatabaseName(browsing: browseDatabaseName),
+                schemaName: tab.tableContext.schemaName
+            )
+        }
+        let selected = tabManager.selectedTab.flatMap { tab in showing.contains { $0.id == tab.id } ? tab : nil }
+
+        switch change.kind {
+        case .rows:
+            for tab in showing where tab.id != selected?.id {
+                evictReloadableTableRows(for: tab.id)
+            }
+            if selected != nil {
+                handleRefresh(hasPendingTableOps: hasPendingTableOps, onDiscard: onDiscard)
+            }
+        case .comment:
+            for tab in showing {
+                tableMetadataCache.removeValue(forKey: tab.id)
+            }
+            if let selected, let tableName = selected.tableContext.tableName {
+                Task { await loadTableMetadata(tableName: tableName, for: selected) }
+            }
+            if change.scope.database == browseDatabaseName {
+                Task { await refreshTables() }
+            }
+        }
+    }
+}

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+SidebarActions.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+SidebarActions.swift
@@ -134,33 +134,47 @@ extension MainContentCoordinator {
         WindowManager.shared.openTab(payload: payload)
     }
 
-    func editViewDefinition(_ viewName: String) {
+    /// Reads the view the row names, in the database and schema the row names, and opens the query
+    /// tab there. It used to read through the browse scope with the name alone, so a view selected
+    /// in another schema opened the definition of a same-named view in the browsed one, and running
+    /// it replaced that other view.
+    func editViewDefinition(_ ref: DatabaseTreeTableRef) {
+        guard let target = objectTarget(for: ref) else { return }
+        let viewName = ref.table.name
         Task {
+            let query: String
             do {
-                let definition = try await DatabaseManager.shared.withBrowseMetadataDriver(connectionId: self.connection.id) { driver in
+                query = try await DatabaseManager.shared.withMetadataDriver(scope: target.scope) { driver in
                     try await driver.fetchViewDefinition(view: viewName)
                 }
-
-                let payload = EditorTabPayload(
-                    connectionId: connection.id,
-                    tabType: .query,
-                    initialQuery: definition
-                )
-                WindowManager.shared.openTab(payload: payload)
             } catch {
-                let driver = DatabaseManager.shared.driver(for: self.connection.id)
-                let template = driver?.editViewFallbackTemplate(viewName: viewName)
-                    ?? "CREATE OR REPLACE VIEW \(viewName) AS\nSELECT * FROM table_name;"
-                let fallbackSQL = "-- Could not fetch view definition: \(error.localizedDescription)\n\(template)"
-
-                let payload = EditorTabPayload(
-                    connectionId: connection.id,
-                    tabType: .query,
-                    initialQuery: fallbackSQL
+                query = Self.viewDefinitionFallback(
+                    viewName: viewName,
+                    error: error,
+                    driver: DatabaseManager.shared.driver(for: self.connection.id)
                 )
-                WindowManager.shared.openTab(payload: payload)
             }
+            WindowManager.shared.openTab(payload: EditorTabPayload(
+                connectionId: connection.id,
+                tabType: .query,
+                databaseName: target.scope.database,
+                schemaName: target.scope.schema,
+                initialQuery: query
+            ))
         }
+    }
+
+    /// Every line of the error is commented out. A driver error can span several lines, and only the
+    /// first used to be, so the rest landed in the query tab as SQL.
+    static func viewDefinitionFallback(viewName: String, error: Error, driver: DatabaseDriver?) -> String {
+        let template = driver?.editViewFallbackTemplate(viewName: viewName)
+            ?? "CREATE OR REPLACE VIEW \(viewName) AS\nSELECT * FROM table_name;"
+        let reason = error.localizedDescription
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map { "-- \($0)" }
+            .joined(separator: "\n")
+        let heading = "-- " + String(localized: "Could not fetch the view definition:")
+        return "\(heading)\n\(reason)\n\(template)"
     }
 
     // MARK: - Export/Import

--- a/TablePro/Views/Main/MainContentCommandActions+DatabaseObjects.swift
+++ b/TablePro/Views/Main/MainContentCommandActions+DatabaseObjects.swift
@@ -25,8 +25,59 @@ extension MainContentCommandActions {
     }
 
     func editViewDefinition() {
-        guard let object = selectedObject, object.type == .view else { return }
-        coordinator?.editViewDefinition(object.name)
+        guard let ref = selectedObjectRef, ref.table.type == .view else { return }
+        coordinator?.editViewDefinition(ref)
+    }
+
+    var canShowObjectDDL: Bool {
+        DatabaseObjectToolEligibility.canShowDDL(selectedObject?.type)
+    }
+
+    func showObjectDDL() {
+        guard let ref = selectedObjectRef,
+              let objectRef = DatabaseObjectRef(
+                  relation: ref.table,
+                  database: ref.database ?? "",
+                  schema: ref.qualifyingSchema
+              )
+        else { return }
+        coordinator?.showObjectSource(objectRef)
+    }
+
+    func copyObjectDDL() {
+        guard let ref = selectedObjectRef, canShowObjectDDL else { return }
+        coordinator?.copyDDL(of: ref)
+    }
+
+    var canRefreshMaterializedView: Bool {
+        DatabaseObjectToolEligibility.canRefresh(
+            selectedObject?.type,
+            support: objectToolSupport,
+            isReadOnly: isReadOnly
+        )
+    }
+
+    func refreshMaterializedView() {
+        guard let ref = selectedObjectRef, canRefreshMaterializedView else { return }
+        coordinator?.refreshMaterializedView(ref)
+    }
+
+    var canEditObjectComment: Bool {
+        DatabaseObjectToolEligibility.canEditComment(
+            selectedObject?.type,
+            support: objectToolSupport,
+            isReadOnly: isReadOnly
+        )
+    }
+
+    func editObjectComment() {
+        guard let ref = selectedObjectRef, canEditObjectComment else { return }
+        coordinator?.editComment(of: ref)
+    }
+
+    private var objectToolSupport: DatabaseObjectToolEligibility.Support {
+        guard let connectionId = coordinator?.connectionId else { return .none }
+        return .of(DatabaseManager.shared.driver(for: connectionId))
     }
 
     var maintenanceOperations: [String] {

--- a/TablePro/Views/Main/MainContentCommandActions.swift
+++ b/TablePro/Views/Main/MainContentCommandActions.swift
@@ -501,12 +501,20 @@ final class MainContentCommandActions {
         TableOperationEligibility.canTruncate(selectedTables.wrappedValue)
     }
 
+    /// The one selected object with the database and schema it lives in, or nil when the selection
+    /// is empty or spans several. A command that acts on the object takes this rather than the bare
+    /// `TableInfo`, which names no database, so it reaches the object the user selected even while
+    /// the browser points at another database or schema.
+    var selectedObjectRef: DatabaseTreeTableRef? {
+        let selection = selectedTables.wrappedValue
+        guard selection.count == 1 else { return nil }
+        return selection.first
+    }
+
     /// The one selected object, or nil when the selection is empty or spans several.
     /// Commands that open a single object need this rather than `hasTableSelection`.
     var selectedObject: TableInfo? {
-        let selection = selectedTables.wrappedValue
-        guard selection.count == 1 else { return nil }
-        return selection.first?.table
+        selectedObjectRef?.table
     }
 
     var hasQueryText: Bool {
@@ -1463,6 +1471,19 @@ final class MainContentCommandActions {
                 if request.reachesBrowsedDatabase(coordinator.browseDatabaseName) {
                     Task { await coordinator.refreshTables() }
                 }
+            }
+            .store(in: &eventCancellables)
+
+        AppCommands.shared.objectChanged
+            .receive(on: RunLoop.main)
+            .sink { [weak self] change in
+                guard let self, change.connectionId == self.connection.id,
+                      let coordinator = self.coordinator else { return }
+                coordinator.applyObjectChange(
+                    change,
+                    hasPendingTableOps: self.hasPendingTableOps,
+                    onDiscard: { [weak self] in self?.clearPendingTableOps() }
+                )
             }
             .store(in: &eventCancellables)
     }

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -70,6 +70,10 @@ enum ActiveSheet: Identifiable {
     /// This is the rule the sidebar's other destructive commands already keep by carrying their ref.
     case maintenance(operation: String, tableName: String, database: String?, schema: String?)
     case createDatabase
+    /// The object's own database and schema travel in the target, for the reason `.maintenance`
+    /// carries them: the comment is written to the object the user right-clicked, not to a
+    /// same-named one wherever the browser points by the time Save is pressed.
+    case editObjectComment(DatabaseObjectTarget)
     /// Copying carries the whole launch request, because the source database, the source schema
     /// and the objects the user right-clicked are all part of what the sheet opens onto, and the
     /// object browser may be pointed somewhere else by the time the sheet appears.
@@ -92,6 +96,8 @@ enum ActiveSheet: Identifiable {
         case .maintenance(let operation, let tableName, let database, let schema):
             "maintenance-\(operation)-\(database ?? "")-\(schema ?? "")-\(tableName)"
         case .createDatabase: "createDatabase"
+        case .editObjectComment(let target):
+            "editObjectComment-\(target.scope.database)-\(target.scope.schema ?? "")-\(target.name)"
         case .copyObjects(let launch): "copyObjects-\(launch.id)"
         case .rewind: "rewind"
         case .tableRebuildReview: "tableRebuildReview"

--- a/TablePro/Views/Main/MainContentView.swift
+++ b/TablePro/Views/Main/MainContentView.swift
@@ -205,6 +205,8 @@ struct MainContentView: View {
             )
         case .copyObjects(let launch):
             CopyObjectsSheet(launch: launch, connection: connection)
+        case .editObjectComment(let target):
+            ObjectCommentSheet(target: target, connection: connection)
         case .exportDialog, .exportQueryResults, .importDialog, .rowImport,
              .transferTables, .backupDatabase, .restoreDatabase, .serverSideExport:
             transferSheetContent(for: sheet, dismiss: dismissBinding)

--- a/TablePro/Views/ObjectSource/ObjectSourceTabView.swift
+++ b/TablePro/Views/ObjectSource/ObjectSourceTabView.swift
@@ -2,7 +2,7 @@
 //  ObjectSourceTabView.swift
 //  TablePro
 //
-//  Tab showing the source of one stored procedure, function, trigger or user-defined type.
+//  Tab showing the source of one stored procedure, function, trigger, user-defined type or view.
 //
 
 import SwiftUI
@@ -107,6 +107,13 @@ final class ObjectSourceLoader {
                     enumLabels: fetched.enumLabels,
                     userType: fetched
                 )
+            case .view, .materializedView:
+                let source = try await TableDDLComposer.fetchDDL(
+                    for: objectRef.name,
+                    using: driver,
+                    includesDependencies: true
+                )
+                return Fetched(source: source, attributes: objectRef.attributes, enumLabels: [], userType: nil)
             }
         }
     }

--- a/TablePro/Views/Sidebar/DatabaseTreeOutlineCoordinator+Commands.swift
+++ b/TablePro/Views/Sidebar/DatabaseTreeOutlineCoordinator+Commands.swift
@@ -29,8 +29,14 @@ extension DatabaseTreeOutlineCoordinator {
             }
         case .editViewDefinition(let ref):
             activateThen(ref) { [weak self] in
-                self?.mainCoordinator?.editViewDefinition(ref.table.name)
+                self?.mainCoordinator?.editViewDefinition(ref)
             }
+        case .copyDDL(let ref):
+            mainCoordinator?.copyDDL(of: ref)
+        case .refreshMaterializedView(let ref):
+            mainCoordinator?.refreshMaterializedView(ref)
+        case .editComment(let ref):
+            mainCoordinator?.editComment(of: ref)
         case .showStructure(let ref):
             activateThen(ref) { [weak self] in
                 self?.mainCoordinator?.openTableTab(

--- a/TablePro/Views/Sidebar/DatabaseTreeOutlineCoordinator+Menu.swift
+++ b/TablePro/Views/Sidebar/DatabaseTreeOutlineCoordinator+Menu.swift
@@ -86,7 +86,8 @@ extension DatabaseTreeOutlineCoordinator: NSMenuDelegate {
                 isReadOnly: mainCoordinator?.safeModeLevel.blocksAllWrites ?? false
             ),
             canBackUp: backupIsAvailable(),
-            canCreateType: DatabaseManager.shared.driver(for: connectionId)?.createTypeTemplate(schema: nil) != nil
+            canCreateType: DatabaseManager.shared.driver(for: connectionId)?.createTypeTemplate(schema: nil) != nil,
+            objectToolSupport: .of(DatabaseManager.shared.driver(for: connectionId))
         )
     }
 

--- a/TablePro/Views/Sidebar/MaterializedViewRefreshAlert.swift
+++ b/TablePro/Views/Sidebar/MaterializedViewRefreshAlert.swift
@@ -1,0 +1,80 @@
+//
+//  MaterializedViewRefreshAlert.swift
+//  TablePro
+//
+
+import AppKit
+
+/// An informational alert, not a destructive one: the user chose this command on purpose and a
+/// refresh loses nothing, so the confirming button keeps Return, which the HIG reserves taking away
+/// for an action people did not deliberately choose.
+@MainActor
+internal enum MaterializedViewRefreshAlert {
+    private static let accessoryWidth: CGFloat = 300
+    private static let descriptionIndent: CGFloat = 20
+
+    /// - Parameter completion: nil when cancelled, otherwise whether to refresh concurrently.
+    internal static func present(
+        prompt: MaterializedViewRefreshPrompt,
+        window: NSWindow?,
+        completion: @escaping @MainActor (Bool?) -> Void
+    ) {
+        let alert = NSAlert()
+        alert.messageText = prompt.messageText
+        alert.informativeText = prompt.informativeText
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: prompt.confirmButtonTitle)
+        AlertHelper.addCancelButton(to: alert, title: prompt.cancelButtonTitle)
+
+        let checkbox = prompt.showsConcurrentOption ? concurrentCheckbox(prompt: prompt) : nil
+        if let checkbox {
+            alert.accessoryView = accessoryView(checkbox: checkbox, description: prompt.concurrentOptionDescription)
+            alert.layout()
+        }
+
+        AlertHelper.present(alert, in: window) { response in
+            guard response == .alertFirstButtonReturn else {
+                completion(nil)
+                return
+            }
+            completion(prompt.refreshesConcurrently(checkboxIsOn: checkbox?.state == .on))
+        }
+    }
+
+    private static func concurrentCheckbox(prompt: MaterializedViewRefreshPrompt) -> NSButton {
+        let button = NSButton(checkboxWithTitle: prompt.concurrentOptionTitle, target: nil, action: nil)
+        button.state = .off
+        button.isEnabled = prompt.isConcurrentOptionEnabled
+        button.setAccessibilityIdentifier("refresh-materialized-view-concurrently")
+        if !prompt.isConcurrentOptionEnabled {
+            button.toolTip = prompt.concurrentOptionDescription
+            button.setAccessibilityHelp(prompt.concurrentOptionDescription)
+        }
+        return button
+    }
+
+    private static func accessoryView(checkbox: NSButton, description: String) -> NSView {
+        let label = NSTextField(wrappingLabelWithString: description)
+        label.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
+        label.textColor = .secondaryLabelColor
+        label.preferredMaxLayoutWidth = accessoryWidth - descriptionIndent
+
+        let indented = NSStackView(views: [label])
+        indented.orientation = .horizontal
+        indented.alignment = .top
+        indented.edgeInsets = NSEdgeInsets(top: 0, left: descriptionIndent, bottom: 0, right: 0)
+
+        let rows: [NSView] = [checkbox, indented]
+        let stack = NSStackView(views: rows)
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = 6
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        for row in rows {
+            row.widthAnchor.constraint(equalToConstant: accessoryWidth).isActive = true
+        }
+        stack.layoutSubtreeIfNeeded()
+        stack.frame = NSRect(origin: .zero, size: stack.fittingSize)
+        return stack
+    }
+}

--- a/TablePro/Views/Sidebar/Menu/DatabaseTreeMenuContext.swift
+++ b/TablePro/Views/Sidebar/Menu/DatabaseTreeMenuContext.swift
@@ -51,4 +51,6 @@ internal struct DatabaseTreeMenuContext {
     internal var canBackUp: Bool = false
     /// Whether the driver can offer a CREATE TYPE template. Read-only mode still hides the item.
     internal var canCreateType: Bool = false
+    /// Which materialized-view and comment commands the driver has statements for.
+    internal var objectToolSupport: DatabaseObjectToolEligibility.Support = .none
 }

--- a/TablePro/Views/Sidebar/Menu/DatabaseTreeMenuSpec.swift
+++ b/TablePro/Views/Sidebar/Menu/DatabaseTreeMenuSpec.swift
@@ -91,10 +91,19 @@ internal enum DatabaseTreeMenuSpec {
             .command(String(localized: "Open in New Tab"), .openInNewTab(ref)),
             .command(String(localized: "Show Structure"), .showStructure(ref))
         ]
+        if let objectRef = sourceObjectRef(for: ref) {
+            items.append(.command(String(localized: "Show DDL"), .showObjectSource(objectRef)))
+        }
         if SidebarContextMenuLogic.isView(clickedTable: ref.table), !context.isReadOnly {
             items.append(.command(String(localized: "Edit View Definition"), .editViewDefinition(ref)))
         }
         return items
+    }
+
+    /// A view's source opens in the read-only DDL viewer, addressed by the row's own database and
+    /// schema so it reads the view the user clicked rather than a same-named one where the browser is.
+    private static func sourceObjectRef(for ref: DatabaseTreeTableRef) -> DatabaseObjectRef? {
+        DatabaseObjectRef(relation: ref.table, database: ref.database ?? "", schema: ref.qualifyingSchema)
     }
 
     private static func noteItems(
@@ -103,15 +112,17 @@ internal enum DatabaseTreeMenuSpec {
         context: DatabaseTreeMenuContext
     ) -> [DatabaseTreeMenuItem] {
         let names = targets.map(\.table.name).sorted()
-        return [
-            .command(copyNamesTitle(count: names.count), .copyTableNames(names)),
-            .command(
-                context.isFavorite
-                    ? String(localized: "Remove from Favorites")
-                    : String(localized: "Add to Favorites"),
-                .toggleFavorite(ref)
-            )
-        ]
+        var items: [DatabaseTreeMenuItem] = [.command(copyNamesTitle(count: names.count), .copyTableNames(names))]
+        if DatabaseObjectToolEligibility.canShowDDL(ref.table.type) {
+            items.append(.command(String(localized: "Copy DDL"), .copyDDL(ref)))
+        }
+        items.append(.command(
+            context.isFavorite
+                ? String(localized: "Remove from Favorites")
+                : String(localized: "Add to Favorites"),
+            .toggleFavorite(ref)
+        ))
+        return items
     }
 
     /// Everything that moves the object's data somewhere else, in the order the work usually runs:
@@ -140,6 +151,14 @@ internal enum DatabaseTreeMenuSpec {
                 .copyObjectsTo(objects: copySelections(for: sameScope), ref: ref)
             ))
         }
+        /// Beside Maintenance, the other command that runs a server operation on the object's data.
+        if DatabaseObjectToolEligibility.canRefresh(
+            ref.table.type,
+            support: context.objectToolSupport,
+            isReadOnly: context.isReadOnly
+        ) {
+            items.append(.command(String(localized: "Refresh Materialized View…"), .refreshMaterializedView(ref)))
+        }
         if SidebarContextMenuLogic.maintenanceGroupEnabled(
             isReadOnly: context.isReadOnly,
             hasSelection: true,
@@ -165,6 +184,13 @@ internal enum DatabaseTreeMenuSpec {
     ) -> [DatabaseTreeMenuItem] {
         guard !context.isReadOnly else { return [] }
         var items: [DatabaseTreeMenuItem] = []
+        if DatabaseObjectToolEligibility.canEditComment(
+            ref.table.type,
+            support: context.objectToolSupport,
+            isReadOnly: context.isReadOnly
+        ) {
+            items.append(.command(String(localized: "Edit Comment…"), .editComment(ref)))
+        }
         if ObjectRenameEligibility.canRename(table: ref.table, context: context.renameEligibility) {
             items.append(.command(String(localized: "Rename"), .beginRenameTable(ref: ref, isRecentRow: isRecentRow)))
         }

--- a/TablePro/Views/Sidebar/Menu/SidebarMenuCommand.swift
+++ b/TablePro/Views/Sidebar/Menu/SidebarMenuCommand.swift
@@ -23,6 +23,9 @@ internal enum SidebarMenuCommand: Equatable {
     case showAllDatabases
     case openInNewTab(DatabaseTreeTableRef)
     case editViewDefinition(DatabaseTreeTableRef)
+    case copyDDL(DatabaseTreeTableRef)
+    case refreshMaterializedView(DatabaseTreeTableRef)
+    case editComment(DatabaseTreeTableRef)
     case showStructure(DatabaseTreeTableRef)
     case showERDiagram
     case copyTableNames([String])

--- a/TablePro/Views/Sidebar/ObjectCommentSheet.swift
+++ b/TablePro/Views/Sidebar/ObjectCommentSheet.swift
@@ -1,0 +1,157 @@
+//
+//  ObjectCommentSheet.swift
+//  TablePro
+//
+
+import os
+import SwiftUI
+
+/// Edits the comment on one table, view, materialized view or foreign table.
+///
+/// A sheet with an explicit Save rather than a field that commits on its own: the write is a
+/// statement against the server, and a popover or an inspector field that saves when it loses
+/// focus would run it on a stray click.
+struct ObjectCommentSheet: View {
+    private static let logger = Logger(subsystem: "com.TablePro", category: "ObjectCommentSheet")
+
+    private enum Phase: Equatable {
+        case loading
+        case editing
+        case saving
+        case loadFailed(String)
+    }
+
+    @Environment(\.dismiss) private var dismiss
+
+    let target: DatabaseObjectTarget
+    let connection: DatabaseConnection
+
+    @State private var draft = ObjectCommentDraft(original: nil)
+    @State private var phase: Phase = .loading
+    @State private var saveError: String?
+    @FocusState private var isEditorFocused: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            Divider()
+            content
+                .padding(20)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            Divider()
+            buttonBar
+        }
+        .frame(width: 480, height: 320)
+        .task { await load() }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("Edit Comment")
+                .font(.headline)
+            Text(target.qualifiedName)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .textSelection(.enabled)
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 14)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch phase {
+        case .loading:
+            ProgressView()
+                .controlSize(.small)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        case .loadFailed(let message):
+            ContentUnavailableView {
+                Label("Comment Unavailable", systemImage: "exclamationmark.triangle")
+            } description: {
+                Text(message)
+            } actions: {
+                Button("Try Again") {
+                    Task { await load() }
+                }
+            }
+        case .editing, .saving:
+            editor
+        }
+    }
+
+    private var editor: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            TextEditor(text: $draft.text)
+                .font(ThemeEngine.shared.valueFontSwiftUI)
+                .focused($isEditorFocused)
+                .disabled(phase == .saving)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 4)
+                        .stroke(Color(nsColor: .separatorColor))
+                )
+                .accessibilityLabel(String(localized: "Comment"))
+                .accessibilityIdentifier("object-comment-editor")
+            if let saveError {
+                Text(saveError)
+                    .font(.callout)
+                    .foregroundStyle(.red)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .textSelection(.enabled)
+            } else {
+                Text("Leave the comment empty to remove it.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var buttonBar: some View {
+        HStack {
+            if phase == .saving {
+                ProgressView()
+                    .controlSize(.small)
+            }
+            Spacer()
+            Button(String(localized: "Cancel")) {
+                dismiss()
+            }
+            .keyboardShortcut(.cancelAction)
+            Button(draft.removesComment ? String(localized: "Remove Comment") : String(localized: "Save")) {
+                Task { await save() }
+            }
+            .keyboardShortcut(.defaultAction)
+            .disabled(phase != .editing || !draft.hasChanges)
+            .accessibilityIdentifier("object-comment-save")
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 14)
+    }
+
+    private func load() async {
+        phase = .loading
+        do {
+            let comment = try await ObjectCommentEditing.currentComment(of: target)
+            draft = ObjectCommentDraft(original: comment)
+            phase = .editing
+            isEditorFocused = true
+        } catch {
+            Self.logger.error("Failed to read comment: \(error.localizedDescription, privacy: .public)")
+            phase = .loadFailed(error.localizedDescription)
+        }
+    }
+
+    private func save() async {
+        phase = .saving
+        saveError = nil
+        do {
+            try await ObjectCommentEditing.setComment(draft.commentToSave, on: target, connection: connection)
+            dismiss()
+        } catch {
+            saveError = error.localizedDescription
+            phase = .editing
+        }
+    }
+}

--- a/TablePro/Views/Structure/TableStructureView+DataLoading.swift
+++ b/TablePro/Views/Structure/TableStructureView+DataLoading.swift
@@ -70,21 +70,7 @@ extension TableStructureView {
             case .ddl:
                 let table = tableName
                 ddlStatement = try await structureLoader.perform { driver in
-                    let sequences = try await driver.fetchDependentSequences(forTable: table)
-                    let enumTypes = try await driver.fetchDependentTypes(forTable: table)
-                    let baseDDL = try await driver.fetchTableDDL(table: table)
-                    let indexDDL = (try? await driver.fetchIndexDDL(table: table)) ?? []
-                    var preamble = ""
-                    for seq in sequences {
-                        preamble += seq.ddl + "\n\n"
-                    }
-                    for enumType in enumTypes {
-                        let quotedName = "\"\(enumType.name.replacingOccurrences(of: "\"", with: "\"\""))\""
-                        let quotedLabels = enumType.labels.map { "'\(SQLEscaping.escapeStringLiteral($0))'" }
-                        preamble += "CREATE TYPE \(quotedName) AS ENUM (\(quotedLabels.joined(separator: ", ")));\n"
-                    }
-                    return TableDDLComposer.compose(
-                        tableDDL: baseDDL, indexDDL: indexDDL, preamble: preamble)
+                    try await TableDDLComposer.fetchDDL(for: table, using: driver, includesDependencies: true)
                 }
             case .triggers:
                 do {

--- a/TableProTests/Core/Menu/MainMenuBuilderTests.swift
+++ b/TableProTests/Core/Menu/MainMenuBuilderTests.swift
@@ -637,6 +637,45 @@ struct MainMenuValidationTests {
         #expect(enabled(#selector(MainSplitViewController.editViewDefinition(_:)), context))
     }
 
+    /// The sidebar hides Edit View Definition on a read-only connection. The menu bar used to leave
+    /// it enabled, so it opened the definition and the save then failed at the gate.
+    @Test("Editing a view definition is disabled on a read-only connection")
+    func editViewDefinitionNeedsWriteAccess() {
+        var context = MenuValidationContext()
+        context.isConnected = true
+        context.canEditViewDefinition = true
+        #expect(enabled(#selector(MainSplitViewController.editViewDefinition(_:)), context))
+        context.isReadOnly = true
+        #expect(!enabled(#selector(MainSplitViewController.editViewDefinition(_:)), context))
+    }
+
+    /// Reading a definition writes nothing, so these stay available on a read-only connection,
+    /// exactly as the sidebar offers them there.
+    @Test("Show DDL and Copy DDL need a view and survive read-only")
+    func ddlCommandsFollowTheSelectedObject() {
+        var context = MenuValidationContext()
+        context.isConnected = true
+        #expect(!enabled(#selector(MainSplitViewController.showObjectDDL(_:)), context))
+        #expect(!enabled(#selector(MainSplitViewController.copyObjectDDL(_:)), context))
+        context.canShowObjectDDL = true
+        #expect(enabled(#selector(MainSplitViewController.showObjectDDL(_:)), context))
+        #expect(enabled(#selector(MainSplitViewController.copyObjectDDL(_:)), context))
+        context.isReadOnly = true
+        #expect(enabled(#selector(MainSplitViewController.showObjectDDL(_:)), context))
+    }
+
+    @Test("Refresh and Edit Comment need the driver and the object to support them")
+    func refreshAndCommentNeedSupport() {
+        var context = MenuValidationContext()
+        context.isConnected = true
+        #expect(!enabled(#selector(MainSplitViewController.refreshMaterializedView(_:)), context))
+        #expect(!enabled(#selector(MainSplitViewController.editObjectComment(_:)), context))
+        context.canRefreshMaterializedView = true
+        context.canEditObjectComment = true
+        #expect(enabled(#selector(MainSplitViewController.refreshMaterializedView(_:)), context))
+        #expect(enabled(#selector(MainSplitViewController.editObjectComment(_:)), context))
+    }
+
     @Test("Maintenance stays disabled when the driver offers no operations")
     func maintenanceNeedsOperations() {
         var context = MenuValidationContext()

--- a/TableProTests/Models/DatabaseObjectToolsTests.swift
+++ b/TableProTests/Models/DatabaseObjectToolsTests.swift
@@ -1,0 +1,217 @@
+//
+//  DatabaseObjectToolsTests.swift
+//  TableProTests
+//
+
+import Foundation
+import TableProPluginKit
+import Testing
+
+@testable import TablePro
+
+@Suite("Per-object command eligibility")
+struct DatabaseObjectToolEligibilityTests {
+    private let support = DatabaseObjectToolEligibility.Support(
+        canRefreshMaterializedViews: true,
+        commentableTypes: [.table, .partitionedTable, .view, .materializedView, .foreignTable]
+    )
+
+    @Test("A view's source is its definition, so only the view kinds show DDL")
+    func ddlIsViewOnly() {
+        #expect(DatabaseObjectToolEligibility.canShowDDL(.view))
+        #expect(DatabaseObjectToolEligibility.canShowDDL(.materializedView))
+        for type in [TableInfo.TableType.table, .partitionedTable, .foreignTable, .systemTable, .externalTable] {
+            #expect(!DatabaseObjectToolEligibility.canShowDDL(type))
+        }
+        #expect(!DatabaseObjectToolEligibility.canShowDDL(nil))
+    }
+
+    @Test("Refresh needs a materialized view, a driver statement and write access")
+    func refreshRequirements() {
+        #expect(DatabaseObjectToolEligibility.canRefresh(.materializedView, support: support, isReadOnly: false))
+        #expect(!DatabaseObjectToolEligibility.canRefresh(.materializedView, support: support, isReadOnly: true))
+        #expect(!DatabaseObjectToolEligibility.canRefresh(.view, support: support, isReadOnly: false))
+        #expect(!DatabaseObjectToolEligibility.canRefresh(.materializedView, support: .none, isReadOnly: false))
+        #expect(!DatabaseObjectToolEligibility.canRefresh(nil, support: support, isReadOnly: false))
+    }
+
+    @Test("Editing a comment follows the kinds the driver can comment on")
+    func commentRequirements() {
+        #expect(DatabaseObjectToolEligibility.canEditComment(.table, support: support, isReadOnly: false))
+        #expect(DatabaseObjectToolEligibility.canEditComment(.materializedView, support: support, isReadOnly: false))
+        #expect(!DatabaseObjectToolEligibility.canEditComment(.externalTable, support: support, isReadOnly: false))
+        #expect(!DatabaseObjectToolEligibility.canEditComment(.table, support: support, isReadOnly: true))
+        #expect(!DatabaseObjectToolEligibility.canEditComment(.table, support: .none, isReadOnly: false))
+    }
+}
+
+@Suite("Materialized view refresh prompt")
+struct MaterializedViewRefreshPromptTests {
+    private func prompt(
+        _ availability: PluginConcurrentRefreshAvailability?,
+        checkFailed: Bool = false
+    ) -> MaterializedViewRefreshPrompt {
+        MaterializedViewRefreshPrompt(
+            qualifiedName: "sales.mv",
+            availability: availability,
+            availabilityCheckFailed: checkFailed
+        )
+    }
+
+    @Test("The prompt names the view it is about")
+    func promptNamesTheView() {
+        #expect(prompt(.available).messageText.contains("sales.mv"))
+        #expect(prompt(.available).confirmButtonTitle == String(localized: "Refresh"))
+    }
+
+    /// The informative text has to warn about the lock, because a plain refresh holds an exclusive
+    /// lock on the view for its whole duration.
+    @Test("The prompt says a plain refresh blocks readers")
+    func promptWarnsAboutReaders() {
+        #expect(prompt(.available).informativeText.lowercased().contains("other sessions"))
+    }
+
+    @Test("The concurrent option is enabled only for a view the server would accept")
+    func concurrentOptionEnablement() {
+        #expect(prompt(.available).isConcurrentOptionEnabled)
+        #expect(!prompt(.requiresUniqueIndex).isConcurrentOptionEnabled)
+        #expect(!prompt(.requiresPopulatedView).isConcurrentOptionEnabled)
+        #expect(!prompt(nil).isConcurrentOptionEnabled)
+    }
+
+    /// An engine with no concurrent refresh shows no option at all. A check that failed shows it
+    /// disabled with its reason, rather than implying the engine lacks it.
+    @Test("The option is absent for an engine without one and present when the check failed")
+    func optionVisibility() {
+        #expect(prompt(.available).showsConcurrentOption)
+        #expect(prompt(.requiresUniqueIndex).showsConcurrentOption)
+        #expect(!prompt(nil).showsConcurrentOption)
+        #expect(prompt(nil, checkFailed: true).showsConcurrentOption)
+        #expect(!prompt(nil, checkFailed: true).isConcurrentOptionEnabled)
+    }
+
+    @Test("Each unavailable reason explains itself")
+    func reasonsAreExplained() {
+        #expect(prompt(.requiresUniqueIndex).concurrentOptionDescription.contains("unique index"))
+        #expect(prompt(.requiresPopulatedView).concurrentOptionDescription.contains("rows"))
+        #expect(!prompt(nil, checkFailed: true).concurrentOptionDescription.isEmpty)
+        #expect(prompt(nil).concurrentOptionDescription.isEmpty)
+    }
+
+    /// A checkbox left on by a previous state cannot ask for a refresh the server has already said
+    /// it would refuse.
+    @Test("A checked box is honoured only while the option is enabled")
+    func checkboxIsGated() {
+        #expect(prompt(.available).refreshesConcurrently(checkboxIsOn: true))
+        #expect(!prompt(.available).refreshesConcurrently(checkboxIsOn: false))
+        #expect(!prompt(.requiresUniqueIndex).refreshesConcurrently(checkboxIsOn: true))
+        #expect(!prompt(nil, checkFailed: true).refreshesConcurrently(checkboxIsOn: true))
+    }
+}
+
+@Suite("Object comment draft")
+struct ObjectCommentDraftTests {
+    @Test("A draft starts from the stored comment")
+    func startsFromStoredComment() {
+        let draft = ObjectCommentDraft(original: "daily totals")
+
+        #expect(draft.text == "daily totals")
+        #expect(!draft.hasChanges)
+        #expect(draft.commentToSave == "daily totals")
+        #expect(!draft.removesComment)
+    }
+
+    @Test("An object with no comment starts empty and has nothing to save")
+    func startsEmptyWithoutComment() {
+        let draft = ObjectCommentDraft(original: nil)
+
+        #expect(draft.text.isEmpty)
+        #expect(!draft.hasChanges)
+        #expect(draft.commentToSave == nil)
+        #expect(!draft.removesComment)
+    }
+
+    /// Clearing the field means removing the comment, which is the same thing PostgreSQL does with
+    /// an empty string.
+    @Test("Emptying the field removes the comment", arguments: ["", "   ", "\n\t"])
+    func emptyingRemovesTheComment(text: String) {
+        var draft = ObjectCommentDraft(original: "daily totals")
+        draft.text = text
+
+        #expect(draft.commentToSave == nil)
+        #expect(draft.hasChanges)
+        #expect(draft.removesComment)
+    }
+
+    @Test("Whitespace around a stored comment does not count as a change")
+    func whitespaceOnlyOriginalIsNoComment() {
+        let draft = ObjectCommentDraft(original: "   ")
+
+        #expect(draft.commentToSave == nil)
+        #expect(!draft.hasChanges)
+    }
+
+    @Test("Editing the text is a change, and multiple lines are kept")
+    func editingIsAChange() {
+        var draft = ObjectCommentDraft(original: "one")
+        draft.text = "one\ntwo"
+
+        #expect(draft.hasChanges)
+        #expect(draft.commentToSave == "one\ntwo")
+        #expect(!draft.removesComment)
+    }
+}
+
+@MainActor
+@Suite("Object source refs for views")
+struct DatabaseObjectRefViewKindTests {
+    private func table(_ name: String, type: TableInfo.TableType) -> TableInfo {
+        TableInfo(name: name, type: type, rowCount: nil, schema: "sales")
+    }
+
+    @Test("A view and a materialized view open as object source, other kinds do not")
+    func kindFromTableType() {
+        #expect(DatabaseObjectKind(tableType: .view) == .view)
+        #expect(DatabaseObjectKind(tableType: .materializedView) == .materializedView)
+        for type in [TableInfo.TableType.table, .partitionedTable, .foreignTable, .systemTable, .externalTable] {
+            #expect(DatabaseObjectKind(tableType: type) == nil)
+        }
+    }
+
+    @Test("A ref built from a listing row carries the object's own database and schema")
+    func refCarriesScope() {
+        let ref = DatabaseObjectRef(relation: table("mv", type: .materializedView), database: "app", schema: "sales")
+
+        #expect(ref?.kind == .materializedView)
+        #expect(ref?.database == "app")
+        #expect(ref?.schema == "sales")
+        #expect(ref?.qualifiedName == "sales.mv")
+        #expect(ref?.displayIdentity == "sales.mv")
+        #expect(DatabaseObjectRef(relation: table("users", type: .table), database: "app", schema: "sales") == nil)
+    }
+
+    @Test("The view kinds map to their sidebar kind and survive a round trip")
+    func kindsRoundTrip() throws {
+        #expect(DatabaseObjectKind.view.sidebarObjectKind == .view)
+        #expect(DatabaseObjectKind.materializedView.sidebarObjectKind == .materializedView)
+
+        for kind in [DatabaseObjectKind.view, .materializedView] {
+            let ref = DatabaseObjectRef(kind: kind, name: "mv", database: "app", schema: "sales")
+            let decoded = try JSONDecoder().decode(
+                DatabaseObjectRef.self,
+                from: try JSONEncoder().encode(ref)
+            )
+            #expect(decoded == ref)
+        }
+    }
+
+    @Test("The tab title names the kind")
+    func tabTitleNamesTheKind() {
+        let view = DatabaseObjectRef(kind: .view, name: "vw", database: "app", schema: "sales")
+        let matview = DatabaseObjectRef(kind: .materializedView, name: "mv", database: "app", schema: "sales")
+
+        #expect(QueryTabManager.objectSourceTitle(for: view).contains("sales.vw"))
+        #expect(QueryTabManager.objectSourceTitle(for: matview).contains("sales.mv"))
+        #expect(QueryTabManager.objectSourceTitle(for: view) != QueryTabManager.objectSourceTitle(for: matview))
+    }
+}

--- a/TableProTests/Plugins/PostgreSQLRelationSQLTests.swift
+++ b/TableProTests/Plugins/PostgreSQLRelationSQLTests.swift
@@ -1,0 +1,131 @@
+//
+//  PostgreSQLRelationSQLTests.swift
+//  TableProTests
+//
+//  Tests for PostgreSQLRelationSQL (compiled via project.yml from PostgreSQLDriverPlugin). The
+//  expectations come from PostgreSQL 17.11: COMMENT ON checks its keyword against the relation's
+//  relkind, and CONCURRENTLY is refused for a view with no usable unique index or no rows.
+//
+
+import Foundation
+import TableProPluginKit
+import Testing
+
+@Suite("PostgreSQL relation statements")
+struct PostgreSQLRelationSQLTests {
+    // MARK: - Comments
+
+    @Test("The COMMENT keyword follows the object kind", arguments: [
+        ("TABLE", "TABLE"),
+        ("PARTITIONED TABLE", "TABLE"),
+        ("VIEW", "VIEW"),
+        ("MATERIALIZED VIEW", "MATERIALIZED VIEW"),
+        ("FOREIGN TABLE", "FOREIGN TABLE")
+    ])
+    func commentKeywordFollowsKind(objectType: String, keyword: String) {
+        #expect(PostgreSQLRelationSQL.commentKeyword(forObjectType: objectType) == keyword)
+    }
+
+    /// `COMMENT ON TABLE` on a view fails with "is not a table", so a kind with no keyword of its
+    /// own produces no statement rather than one the server refuses.
+    @Test("A kind PostgreSQL cannot comment on produces no statement", arguments: [
+        "SYSTEM TABLE", "EXTERNAL TABLE", "SEQUENCE", ""
+    ])
+    func unsupportedKindsProduceNoStatement(objectType: String) {
+        #expect(PostgreSQLRelationSQL.commentKeyword(forObjectType: objectType) == nil)
+        #expect(PostgreSQLRelationSQL.commentStatement(
+            name: "t", schema: "s", objectType: objectType, comment: "x"
+        ) == nil)
+    }
+
+    @Test("A comment statement qualifies and quotes the object")
+    func commentStatementQualifies() {
+        let sql = PostgreSQLRelationSQL.commentStatement(
+            name: "Mat \"View\" X",
+            schema: "My \"Odd\" Schema",
+            objectType: "MATERIALIZED VIEW",
+            comment: "it's here"
+        )
+
+        #expect(sql == "COMMENT ON MATERIALIZED VIEW \"My \"\"Odd\"\" Schema\".\"Mat \"\"View\"\" X\" IS 'it''s here'")
+    }
+
+    /// Quote doubling alone is injectable when `standard_conforming_strings` is off, where a
+    /// trailing backslash eats the closing quote. A value holding one is written as an E'' string.
+    @Test("A comment with a backslash is written as an E-string")
+    func backslashCommentUsesEString() {
+        let sql = PostgreSQLRelationSQL.commentStatement(
+            name: "t", schema: "s", objectType: "TABLE", comment: #"Path C:\temp\"#
+        )
+
+        #expect(sql == #"COMMENT ON TABLE "s"."t" IS E'Path C:\\temp\\'"#)
+    }
+
+    @Test("An empty or missing comment clears it")
+    func emptyCommentClears() {
+        #expect(PostgreSQLRelationSQL.commentValue(nil) == "NULL")
+        #expect(PostgreSQLRelationSQL.commentValue("") == "NULL")
+        #expect(PostgreSQLRelationSQL.commentStatement(
+            name: "t", schema: "s", objectType: "TABLE", comment: nil
+        ) == "COMMENT ON TABLE \"s\".\"t\" IS NULL")
+    }
+
+    /// Whitespace is a value here. Deciding that a field holding only spaces means "remove the
+    /// comment" belongs to the sheet, which normalizes before asking for a statement.
+    @Test("Whitespace is quoted rather than treated as a clear")
+    func whitespaceCommentIsStored() {
+        #expect(PostgreSQLRelationSQL.commentValue("   ") == "'   '")
+    }
+
+    // MARK: - Refresh
+
+    @Test("Refresh qualifies the view and adds CONCURRENTLY only when asked")
+    func refreshStatementShape() {
+        #expect(PostgreSQLRelationSQL.refreshStatement(name: "mv", schema: "sales", concurrently: false)
+            == "REFRESH MATERIALIZED VIEW \"sales\".\"mv\"")
+        #expect(PostgreSQLRelationSQL.refreshStatement(name: "mv", schema: "sales", concurrently: true)
+            == "REFRESH MATERIALIZED VIEW CONCURRENTLY \"sales\".\"mv\"")
+    }
+
+    @Test("Refresh quotes a name that needs it")
+    func refreshQuotesNames() {
+        #expect(PostgreSQLRelationSQL.refreshStatement(
+            name: "MV \"Totals\"", schema: "Sales Q1", concurrently: false
+        ) == "REFRESH MATERIALIZED VIEW \"Sales Q1\".\"MV \"\"Totals\"\"\"")
+    }
+
+    /// The predicate measured against every index shape on PostgreSQL 17.11:
+    /// `scripts/check-postgres-matview-refresh.sh` re-runs that comparison against a live server.
+    @Test("The eligibility query tests exactly what the server requires")
+    func eligibilityQueryPredicate() {
+        let sql = PostgreSQLRelationSQL.concurrentRefreshQuery(name: "mv", schema: "sales")
+
+        #expect(sql.contains("c.relispopulated"))
+        #expect(sql.contains("i.indisunique"))
+        #expect(sql.contains("i.indimmediate"))
+        #expect(sql.contains("i.indisvalid"))
+        #expect(sql.contains("i.indpred IS NULL"))
+        #expect(sql.contains("i.indexprs IS NULL"))
+        #expect(sql.contains("c.relkind = 'm'"))
+        #expect(sql.contains("n.nspname = 'sales'"))
+        #expect(sql.contains("c.relname = 'mv'"))
+    }
+
+    /// An unpopulated view is refused whatever its indexes are, and the fix for it is a plain
+    /// refresh rather than a new index, so population is reported first.
+    @Test("Population is reported before the index requirement")
+    func populationTakesPrecedence() {
+        #expect(PostgreSQLRelationSQL.concurrentRefreshAvailability(
+            isPopulated: false, hasUsableUniqueIndex: true
+        ) == .requiresPopulatedView)
+        #expect(PostgreSQLRelationSQL.concurrentRefreshAvailability(
+            isPopulated: false, hasUsableUniqueIndex: false
+        ) == .requiresPopulatedView)
+        #expect(PostgreSQLRelationSQL.concurrentRefreshAvailability(
+            isPopulated: true, hasUsableUniqueIndex: false
+        ) == .requiresUniqueIndex)
+        #expect(PostgreSQLRelationSQL.concurrentRefreshAvailability(
+            isPopulated: true, hasUsableUniqueIndex: true
+        ) == .available)
+    }
+}

--- a/TableProTests/Plugins/PostgreSQLViewDefinitionTests.swift
+++ b/TableProTests/Plugins/PostgreSQLViewDefinitionTests.swift
@@ -1,0 +1,189 @@
+//
+//  PostgreSQLViewDefinitionTests.swift
+//  TableProTests
+//
+//  Tests for PostgreSQLViewDefinition (compiled via project.yml from PostgreSQLDriverPlugin).
+//  The catalog values below are what PostgreSQL 17.11 returns for the objects described.
+//
+
+import Foundation
+import Testing
+
+@Suite("PostgreSQL view definition")
+struct PostgreSQLViewDefinitionTests {
+    private let body = " SELECT id,\n    v\n   FROM sales.orders\n  WHERE (id > 0);"
+
+    private func row(
+        kind: PostgreSQLViewDefinition.Kind,
+        options: [String] = [],
+        accessMethod: String? = nil,
+        tablespace: String? = nil
+    ) -> PostgreSQLViewDefinition.CatalogRow {
+        PostgreSQLViewDefinition.CatalogRow(
+            kind: kind,
+            query: body,
+            options: options,
+            accessMethod: accessMethod,
+            tablespace: tablespace
+        )
+    }
+
+    // MARK: - Views
+
+    @Test("A plain view is a CREATE OR REPLACE VIEW ending in one semicolon")
+    func plainView() {
+        let sql = PostgreSQLViewDefinition.statement(name: "vw", schema: "sales", row: row(kind: .view))
+
+        #expect(sql == """
+            CREATE OR REPLACE VIEW "sales"."vw" AS
+             SELECT id,
+                v
+               FROM sales.orders
+              WHERE (id > 0);
+            """)
+        #expect(!sql.hasSuffix(";;"))
+    }
+
+    /// `CREATE OR REPLACE VIEW` replaces the options it does not name, so a definition that left
+    /// these out turned a `security_barrier` or `security_invoker` view into an unrestricted one and
+    /// dropped its check option. Measured on 17.11: reloptions went to NULL and a role with rights
+    /// on the view alone could then read the base table through it.
+    @Test("A view keeps its options and its check option")
+    func viewKeepsOptionsAndCheckOption() {
+        let sql = PostgreSQLViewDefinition.statement(
+            name: "vw",
+            schema: "sales",
+            row: row(
+                kind: .view,
+                options: ["security_barrier=true", "security_invoker=true", "check_option=cascaded"]
+            )
+        )
+
+        #expect(sql.hasPrefix(
+            "CREATE OR REPLACE VIEW \"sales\".\"vw\" WITH (security_barrier='true', security_invoker='true') AS"
+        ))
+        #expect(sql.hasSuffix("\n  WITH CASCADED CHECK OPTION;"))
+        #expect(!sql.contains("check_option"))
+    }
+
+    @Test("A local check option is named as such")
+    func localCheckOption() {
+        let sql = PostgreSQLViewDefinition.statement(
+            name: "vw", schema: "sales", row: row(kind: .view, options: ["check_option=local"])
+        )
+
+        #expect(sql.hasSuffix("\n  WITH LOCAL CHECK OPTION;"))
+        #expect(!sql.contains("WITH ("))
+    }
+
+    // MARK: - Materialized views
+
+    @Test("A materialized view is a CREATE MATERIALIZED VIEW")
+    func plainMaterializedView() {
+        let sql = PostgreSQLViewDefinition.statement(
+            name: "mv", schema: "sales", row: row(kind: .materializedView, accessMethod: "heap")
+        )
+
+        #expect(sql.hasPrefix("CREATE MATERIALIZED VIEW \"sales\".\"mv\" AS\n"))
+        #expect(sql.hasSuffix(";"))
+    }
+
+    /// `USING` does not exist before PostgreSQL 12 and `heap` is what a server creates without it,
+    /// so it is written only for a view that is actually stored another way.
+    @Test("Only a non-default access method is written")
+    func accessMethodOnlyWhenNotHeap() {
+        let sql = PostgreSQLViewDefinition.statement(
+            name: "mv",
+            schema: "sales",
+            row: row(kind: .materializedView, accessMethod: "columnar", tablespace: "fast")
+        )
+
+        #expect(sql.hasPrefix("CREATE MATERIALIZED VIEW \"sales\".\"mv\" USING \"columnar\" TABLESPACE \"fast\" AS\n"))
+    }
+
+    @Test("A materialized view keeps its storage parameters")
+    func materializedViewKeepsStorageParameters() {
+        let sql = PostgreSQLViewDefinition.statement(
+            name: "mv", schema: "sales", row: row(kind: .materializedView, options: ["fillfactor=70"])
+        )
+
+        #expect(sql.contains("WITH (fillfactor='70')"))
+    }
+
+    /// Population is the view's data state rather than part of its definition. Writing `WITH NO
+    /// DATA` into it would make two otherwise identical views compare as different and have schema
+    /// sync drop and recreate one, losing its rows.
+    @Test("Population state is not part of the statement")
+    func populationIsNotInTheStatement() {
+        let sql = PostgreSQLViewDefinition.statement(
+            name: "mv", schema: "sales", row: row(kind: .materializedView)
+        )
+
+        #expect(!sql.contains("WITH NO DATA"))
+        #expect(!sql.contains("WITH DATA"))
+    }
+
+    // MARK: - Catalog parsing
+
+    @Test("relkind selects the kind, and anything else is not a view")
+    func relkindMapping() {
+        #expect(PostgreSQLViewDefinition.kind(forRelkind: "v") == .view)
+        #expect(PostgreSQLViewDefinition.kind(forRelkind: "m") == .materializedView)
+        for relkind in ["r", "p", "f", "i", "S", "t", ""] {
+            #expect(PostgreSQLViewDefinition.kind(forRelkind: relkind) == nil)
+        }
+    }
+
+    /// Read as JSON rather than by splitting the array text, because an option value may hold a
+    /// comma or a quote of its own.
+    @Test("Options are parsed from JSON, commas inside a value included")
+    func optionsParsedFromJSON() {
+        #expect(PostgreSQLViewDefinition.options(fromJSON: #"["security_barrier=true"]"#) == ["security_barrier=true"])
+        #expect(PostgreSQLViewDefinition.options(fromJSON: #"["toast.autovacuum_enabled=false","fillfactor=70"]"#)
+            == ["toast.autovacuum_enabled=false", "fillfactor=70"])
+        #expect(PostgreSQLViewDefinition.options(fromJSON: #"["note=a, b"]"#) == ["note=a, b"])
+        #expect(PostgreSQLViewDefinition.options(fromJSON: nil).isEmpty)
+        #expect(PostgreSQLViewDefinition.options(fromJSON: "").isEmpty)
+    }
+
+    @Test("A catalog row parses into the kind, query, options and storage")
+    func parseRow() {
+        let parsed = PostgreSQLViewDefinition.parse(row: [
+            "m", body, #"["fillfactor=70"]"#, "heap", "fast"
+        ])
+
+        #expect(parsed?.kind == .materializedView)
+        #expect(parsed?.query == body)
+        #expect(parsed?.options == ["fillfactor=70"])
+        #expect(parsed?.accessMethod == "heap")
+        #expect(parsed?.tablespace == "fast")
+    }
+
+    @Test("A row for something that is not a view parses to nothing")
+    func parseRejectsOtherKinds() {
+        #expect(PostgreSQLViewDefinition.parse(row: ["r", body, nil, nil, nil]) == nil)
+        #expect(PostgreSQLViewDefinition.parse(row: [nil, nil, nil, nil, nil]) == nil)
+        #expect(PostgreSQLViewDefinition.parse(row: ["v", body]) == nil)
+    }
+
+    /// The body is read with `search_path` emptied, so every name in it is qualified and the text
+    /// binds to the same tables wherever it is run.
+    @Test("The catalog query empties the search path and addresses the view by schema and name")
+    func catalogQueryIsQualifiedAndScoped() {
+        let query = PostgreSQLViewDefinition.catalogQuery(name: "vw", schema: "sales")
+
+        #expect(PostgreSQLViewDefinition.qualifiedReadPrefix == "SET LOCAL search_path = ''; ")
+        #expect(query.contains("pg_catalog.pg_get_viewdef(c.oid, true)"))
+        #expect(query.contains("n.nspname = 'sales'"))
+        #expect(query.contains("c.relname = 'vw'"))
+        #expect(query.contains("c.relkind IN ('v', 'm')"))
+    }
+
+    @Test("A name that needs quoting is quoted, and a literal that needs escaping is escaped")
+    func catalogQueryQuotesIdentifiers() {
+        let query = PostgreSQLViewDefinition.catalogQuery(name: "it's", schema: "My \"Odd\" Schema")
+
+        #expect(query.contains("c.relname = 'it''s'"))
+        #expect(query.contains("n.nspname = 'My \"Odd\" Schema'"))
+    }
+}

--- a/TableProTests/Views/Sidebar/DatabaseTreeMenuSpecTests.swift
+++ b/TableProTests/Views/Sidebar/DatabaseTreeMenuSpecTests.swift
@@ -34,7 +34,8 @@ struct DatabaseTreeMenuSpecTests {
         supportsRename: Bool = true,
         canCopyObjects: Bool = true,
         canDuplicateDatabase: Bool = true,
-        canCreateType: Bool = false
+        canCreateType: Bool = false,
+        objectToolSupport: DatabaseObjectToolEligibility.Support = .none
     ) -> DatabaseTreeMenuContext {
         DatabaseTreeMenuContext(
             clicked: clicked,
@@ -78,7 +79,17 @@ struct DatabaseTreeMenuSpecTests {
             hasDatabaseFilter: hasDatabaseFilter,
             canCopyObjects: canCopyObjects,
             canDuplicateDatabase: canDuplicateDatabase,
-            canCreateType: canCreateType
+            canCreateType: canCreateType,
+            objectToolSupport: objectToolSupport
+        )
+    }
+
+    /// What the PostgreSQL driver answers: every table-like kind can be commented on, and a
+    /// materialized view can be refreshed.
+    private var postgresSupport: DatabaseObjectToolEligibility.Support {
+        DatabaseObjectToolEligibility.Support(
+            canRefreshMaterializedViews: true,
+            commentableTypes: [.table, .partitionedTable, .view, .materializedView, .foreignTable]
         )
     }
 
@@ -378,6 +389,89 @@ struct DatabaseTreeMenuSpecTests {
             .contains(.editViewDefinition(view)))
         #expect(!commands(DatabaseTreeMenuSpec.sections(for: context(clicked: .table(table))))
             .contains(.editViewDefinition(table)))
+    }
+
+    @Test("Show DDL and Copy DDL are offered for a view and a materialized view, and not for a table")
+    func showAndCopyDDLAreViewOnly() {
+        let view = tableRef("active_users", type: .view)
+        let matview = tableRef("sales_totals", type: .materializedView)
+        let table = tableRef("users")
+
+        for ref in [view, matview] {
+            let issued = commands(DatabaseTreeMenuSpec.sections(for: context(clicked: .table(ref))))
+            #expect(issued.contains(.copyDDL(ref)))
+            #expect(issued.contains { command in
+                guard case .showObjectSource(let objectRef) = command else { return false }
+                return objectRef.name == ref.table.name && objectRef.schema == "public" && objectRef.database == "app"
+            })
+        }
+
+        let tableCommands = commands(DatabaseTreeMenuSpec.sections(for: context(clicked: .table(table))))
+        #expect(!tableCommands.contains(.copyDDL(table)))
+        #expect(!tableCommands.contains { command in
+            if case .showObjectSource = command { return true }
+            return false
+        })
+    }
+
+    /// Reading a definition writes nothing, so a read-only connection still offers it. Editing the
+    /// definition is the command that disappears.
+    @Test("Read-only keeps Show DDL and Copy DDL")
+    func readOnlyKeepsDDLCommands() {
+        let view = tableRef("active_users", type: .view)
+        let issued = commands(DatabaseTreeMenuSpec.sections(for: context(clicked: .table(view), isReadOnly: true)))
+
+        #expect(issued.contains(.copyDDL(view)))
+        #expect(!issued.contains(.editViewDefinition(view)))
+    }
+
+    @Test("Only a materialized view offers Refresh Materialized View")
+    func refreshIsMaterializedViewOnly() {
+        let matview = tableRef("sales_totals", type: .materializedView)
+        let view = tableRef("active_users", type: .view)
+        let table = tableRef("users")
+
+        #expect(commands(DatabaseTreeMenuSpec.sections(
+            for: context(clicked: .table(matview), objectToolSupport: postgresSupport)
+        )).contains(.refreshMaterializedView(matview)))
+
+        for ref in [view, table] {
+            #expect(!commands(DatabaseTreeMenuSpec.sections(
+                for: context(clicked: .table(ref), objectToolSupport: postgresSupport)
+            )).contains(.refreshMaterializedView(ref)))
+        }
+    }
+
+    @Test("Refresh is absent without a driver statement for it, and when read-only")
+    func refreshNeedsDriverSupportAndWriteAccess() {
+        let matview = tableRef("sales_totals", type: .materializedView)
+
+        #expect(!commands(DatabaseTreeMenuSpec.sections(for: context(clicked: .table(matview))))
+            .contains(.refreshMaterializedView(matview)))
+        #expect(!commands(DatabaseTreeMenuSpec.sections(
+            for: context(clicked: .table(matview), isReadOnly: true, objectToolSupport: postgresSupport)
+        )).contains(.refreshMaterializedView(matview)))
+    }
+
+    @Test("Edit Comment follows the kinds the driver can comment on")
+    func editCommentFollowsDriverSupport() {
+        let table = tableRef("users")
+        let matview = tableRef("sales_totals", type: .materializedView)
+        let external = tableRef("events", type: .externalTable)
+
+        for ref in [table, matview] {
+            #expect(commands(DatabaseTreeMenuSpec.sections(
+                for: context(clicked: .table(ref), objectToolSupport: postgresSupport)
+            )).contains(.editComment(ref)))
+        }
+        #expect(!commands(DatabaseTreeMenuSpec.sections(
+            for: context(clicked: .table(external), objectToolSupport: postgresSupport)
+        )).contains(.editComment(external)))
+        #expect(!commands(DatabaseTreeMenuSpec.sections(for: context(clicked: .table(table))))
+            .contains(.editComment(table)))
+        #expect(!commands(DatabaseTreeMenuSpec.sections(
+            for: context(clicked: .table(table), isReadOnly: true, objectToolSupport: postgresSupport)
+        )).contains(.editComment(table)))
     }
 
     // MARK: - Containers

--- a/docs/databases/postgresql.mdx
+++ b/docs/databases/postgresql.mdx
@@ -66,6 +66,14 @@ In the list editor, reorder rows with the arrows, add and remove elements, and s
 
 Enums, composites, domains and ranges are listed under **Types** in each schema, the `CREATE` statement rebuilt from `pg_type`. An enum's labels are edited in place with `ALTER TYPE … ADD VALUE` and, from PostgreSQL 10, `RENAME VALUE`; PostgreSQL has no statement that drops or reorders a label. The structure editor's type picker offers the schema's types under **User-Defined**. See [User-Defined Types](/features/user-defined-types).
 
+## Views and comments
+
+A view's definition is rebuilt to run anywhere. Every table it reads is schema-qualified, and `WITH (security_barrier)`, `WITH (security_invoker)` and `WITH CASCADED CHECK OPTION` are written back, so executing the statement elsewhere keeps the restrictions the original carried. Read it with **Show DDL**, copy it with **Copy DDL**, or edit it with **Edit View Definition**. A materialized view's statement carries its access method, storage parameters and tablespace, and the DDL tab adds its indexes.
+
+`REFRESH MATERIALIZED VIEW` runs from **Refresh Materialized View…**. A plain refresh holds an `ACCESS EXCLUSIVE` lock, so nothing reads the view until it finishes. **Refresh concurrently** takes `EXCLUSIVE` instead and leaves readers working, and PostgreSQL accepts it only for a populated view with a valid unique index on plain columns, no `WHERE` clause and no expressions; a partial or expression index does not qualify. The refresh runs on its own connection, outside any transaction a query editor holds open. Refreshing needs ownership of the view, or the `MAINTAIN` privilege from PostgreSQL 17.
+
+**Edit Comment…** writes `COMMENT ON`, picking `TABLE`, `VIEW`, `MATERIALIZED VIEW` or `FOREIGN TABLE` to match the object. Column comments are written from the Columns tab as `COMMENT ON COLUMN`. Clearing the field writes `IS NULL`, which removes the comment. Only the object's owner may comment on it.
+
 ## Cross-database tabs
 
 PostgreSQL has no in-place `USE`, so a tab bound to a database other than the connection's active one runs on a second connection opened for that database. It shares no temp tables, session variables, or open transaction with the query editor on the main connection: keep a multi-statement transaction or a `CREATE TEMP TABLE` on tabs bound to one database. Binding itself is on [Tabs](/features/tabs#where-a-tab-points).

--- a/docs/development/plugin-development.mdx
+++ b/docs/development/plugin-development.mdx
@@ -13,7 +13,7 @@ A plugin is a macOS loadable bundle target with `WRAPPER_EXTENSION = tableplugin
 
 | Key | Type | Required | Purpose |
 |-----|------|----------|---------|
-| `TableProPluginKitVersion` | integer | Yes | The PluginKit ABI the plugin was built against. Current value: 25 |
+| `TableProPluginKitVersion` | integer | Yes | The PluginKit ABI the plugin was built against. Current value: 26 |
 | `TableProProvidesDatabaseTypeIds` | array of strings | Recommended | Database type IDs the plugin serves, which is what makes lazy loading possible |
 | `CFBundleShortVersionString` | string | Yes | Plugin version, read by registry update checks |
 | `TableProMinAppVersion` | string | No | The loader rejects the plugin on an older app |

--- a/docs/development/plugin-registry.mdx
+++ b/docs/development/plugin-registry.mdx
@@ -68,13 +68,13 @@ Themes carry no native code, so they match on architecture alone.
   "binaries": [
     {
       "architecture": "arm64",
-      "pluginKitVersion": 25,
+      "pluginKitVersion": 26,
       "downloadURL": "https://github.com/TableProApp/TablePro/releases/download/plugin-oracle-v1.0.26/OracleDriver-arm64.zip",
       "sha256": "<sha256>"
     },
     {
       "architecture": "x86_64",
-      "pluginKitVersion": 25,
+      "pluginKitVersion": 26,
       "downloadURL": "https://github.com/TableProApp/TablePro/releases/download/plugin-oracle-v1.0.26/OracleDriver-x86_64.zip",
       "sha256": "<sha256>"
     }

--- a/docs/features/table-operations.mdx
+++ b/docs/features/table-operations.mdx
@@ -84,6 +84,12 @@ Views carry an eye icon in the sidebar; materialized views and foreign tables ge
 
 Right-click empty space and choose **New View…** to write a new one; right-click an existing view and choose **Edit View Definition** to open the current definition in a query tab. Either way, execute the statement to apply it.
 
+**Show DDL** opens the definition in a read-only tab, with **Copy**, **Export** and **Open in Editor** on it; **Copy DDL** puts the same statement straight on the clipboard. Both stay available on a read-only connection, where **Edit View Definition** is hidden.
+
+A materialized view holds stored rows, so refreshing it is a server operation. Right-click one and choose **Refresh Materialized View…**, or use **Database > Refresh Materialized View…**. The confirmation names the view and warns that other sessions cannot read it while the refresh runs. **Refresh concurrently** leaves readers alone; it is available on PostgreSQL for a view that holds rows and carries a unique index on plain columns with no `WHERE` clause, and the alert says which of the two is missing when it is dimmed. Tabs showing the view reload when the refresh finishes. A plain view stores nothing, so `Cmd+R` re-runs its query instead.
+
+Comments are edited per object. Right-click a table, view, materialized view or foreign table, choose **Edit Comment…**, and type the text; saving an empty field removes the comment. Column comments live in the [Columns tab](/features/table-structure#columns-tab). Both need an engine that writes comments, which today means PostgreSQL and PGlite.
+
 ## Databases and schemas
 
 `Cmd+K` switches database, covered in [Managing Connections](/connections#switch-connections-and-databases). The switcher takes the engine's own vocabulary: Schema on Oracle and Spanner, Keyspace on Cassandra, Dataset on BigQuery, Namespace on SurrealDB. SQLite is file-based, so it points at the welcome window to open a different file.

--- a/docs/features/table-structure.mdx
+++ b/docs/features/table-structure.mdx
@@ -171,6 +171,8 @@ Triggers are available for MySQL, MariaDB, PostgreSQL, SQLite, SQL Server, Oracl
 
 Read-only `CREATE TABLE` with syntax highlighting and font size controls. **Copy**, **Export** as a `.sql` file, and **Open in Editor** send it onward. On PostgreSQL the `CREATE SEQUENCE` and `CREATE TYPE … AS ENUM` statements the table depends on are prepended, so the script runs on an empty database.
 
+Open the tab on a view and it carries that view's own `CREATE VIEW` or `CREATE MATERIALIZED VIEW` instead, the same statement **Show DDL** opens. A materialized view's indexes follow it.
+
 ## Parts tab (ClickHouse)
 
 Lists partitions and parts from `system.parts`. **Optimize** merges parts; **Drop Partition** and **Detach Partition** act on the selected partition. Detached data stays on disk and is unreadable until it is re-attached.

--- a/project.yml
+++ b/project.yml
@@ -519,6 +519,8 @@ targets:
       - Plugins/PostgreSQLDriverPlugin/PostgreSQLCatalogTypeNames.swift
       - Plugins/PostgreSQLDriverPlugin/PostgreSQLCheckConstraintDefinition.swift
       - Plugins/PostgreSQLDriverPlugin/PostgreSQLObjectQueries.swift
+      - Plugins/PostgreSQLDriverPlugin/PostgreSQLRelationSQL.swift
+      - Plugins/PostgreSQLDriverPlugin/PostgreSQLViewDefinition.swift
       - Plugins/PostgreSQLDriverPlugin/PostgreSQLSchemaQueries.swift
       - Plugins/PostgreSQLDriverPlugin/PostgreSQLSystemDatabases.swift
       - Plugins/PostgreSQLDriverPlugin/PostgreSQLTableListingLadder.swift

--- a/scripts/check-postgres-matview-refresh.sh
+++ b/scripts/check-postgres-matview-refresh.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+#
+# Check the concurrent-refresh rule against a real PostgreSQL server.
+#
+# PostgreSQL refuses REFRESH MATERIALIZED VIEW CONCURRENTLY unless the view is populated and has a
+# unique index it can diff through, and it says so only when the statement runs. TablePro decides
+# whether to offer the option beforehand, from a catalog predicate in PostgreSQLRelationSQL. That
+# predicate is a hand-written copy of a server rule, which is the shape that drifts silently: offer
+# the option too freely and the refresh fails, too rarely and the option is missing for a view that
+# qualifies.
+#
+# This builds a materialized view for every index shape that matters, asks the predicate, runs the
+# real refresh, and compares the two answers.
+#
+# Usage:
+#   scripts/check-postgres-matview-refresh.sh [host] [port] [user]
+#
+# Needs psql and a reachable PostgreSQL 9.4 or newer the user may create a database on. Exits
+# non-zero on a disagreement.
+
+set -uo pipefail
+
+HOST="${1:-127.0.0.1}"
+PORT="${2:-5432}"
+USER_NAME="${3:-postgres}"
+SOURCE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/Plugins/PostgreSQLDriverPlugin/PostgreSQLRelationSQL.swift"
+DATABASE="tablepro_matview_refresh_check"
+
+command -v psql > /dev/null || {
+    echo "psql not found" >&2
+    exit 3
+}
+[ -f "$SOURCE" ] || {
+    echo "not found: $SOURCE" >&2
+    exit 3
+}
+
+psql_do() {
+    psql -X -q -h "$HOST" -p "$PORT" -U "$USER_NAME" -d "$1" -v ON_ERROR_STOP=1 "${@:2}"
+}
+
+if ! psql_do postgres -Atc "SELECT 1" > /dev/null 2>&1; then
+    echo "no PostgreSQL at $HOST:$PORT as $USER_NAME" >&2
+    exit 3
+fi
+
+VERSION="$(psql_do postgres -Atc "SHOW server_version")"
+echo "Checking the concurrent-refresh predicate against PostgreSQL $VERSION at $HOST:$PORT"
+
+# The predicate as the plugin builds it, read out of the source so the two cannot drift. The Swift
+# side interpolates the schema and the name; here they are bound per view instead.
+PREDICATE="c.relispopulated AND EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_index i
+    JOIN pg_catalog.pg_class ic ON ic.oid = i.indexrelid
+    JOIN pg_catalog.pg_am am ON am.oid = ic.relam
+    WHERE i.indrelid = c.oid
+      AND i.indisunique
+      AND i.indimmediate
+      AND i.indisvalid
+      AND i.indpred IS NULL
+      AND i.indexprs IS NULL
+      AND am.amname = 'btree'
+)"
+
+for fragment in "i.indisunique" "i.indimmediate" "i.indisvalid" "i.indpred IS NULL" "i.indexprs IS NULL" "c.relispopulated"; do
+    grep -qF "$fragment" "$SOURCE" || {
+        echo "FAIL: $SOURCE no longer tests $fragment; update this script with the predicate" >&2
+        exit 1
+    }
+done
+
+psql_do postgres -c "DROP DATABASE IF EXISTS $DATABASE" > /dev/null
+psql_do postgres -c "CREATE DATABASE $DATABASE" > /dev/null
+trap 'psql -X -q -h "$HOST" -p "$PORT" -U "$USER_NAME" -d postgres -c "DROP DATABASE IF EXISTS $DATABASE" > /dev/null 2>&1' EXIT
+
+psql_do "$DATABASE" > /dev/null <<'SQL'
+CREATE TABLE src (id int NOT NULL, a text, b text);
+INSERT INTO src SELECT g, 'a' || g, 'b' || (g % 3) FROM generate_series(1, 20) g;
+
+CREATE MATERIALIZED VIEW mv_none AS SELECT id, a, b FROM src;
+
+CREATE MATERIALIZED VIEW mv_unique AS SELECT id, a, b FROM src;
+CREATE UNIQUE INDEX mv_unique_id ON mv_unique (id);
+
+CREATE MATERIALIZED VIEW mv_unique_multi AS SELECT id, a, b FROM src;
+CREATE UNIQUE INDEX mv_unique_multi_id ON mv_unique_multi (b, id);
+
+CREATE MATERIALIZED VIEW mv_unique_include AS SELECT id, a, b FROM src;
+
+CREATE MATERIALIZED VIEW mv_partial AS SELECT id, a, b FROM src;
+CREATE UNIQUE INDEX mv_partial_id ON mv_partial (id) WHERE id > 5;
+
+CREATE MATERIALIZED VIEW mv_expression AS SELECT id, a, b FROM src;
+CREATE UNIQUE INDEX mv_expression_a ON mv_expression (lower(a));
+
+CREATE MATERIALIZED VIEW mv_mixed AS SELECT id, a, b FROM src;
+CREATE UNIQUE INDEX mv_mixed_id_lower ON mv_mixed (id, lower(a));
+
+CREATE MATERIALIZED VIEW mv_not_unique AS SELECT id, a, b FROM src;
+CREATE INDEX mv_not_unique_id ON mv_not_unique (id);
+
+CREATE MATERIALIZED VIEW mv_unpopulated AS SELECT id, a, b FROM src WITH NO DATA;
+CREATE UNIQUE INDEX mv_unpopulated_id ON mv_unpopulated (id);
+SQL
+
+# INCLUDE arrived in PostgreSQL 11; where it is missing the view keeps a plain unique index, which
+# still belongs in the comparison.
+psql_do "$DATABASE" -c "CREATE UNIQUE INDEX mv_unique_include_id ON mv_unique_include (id) INCLUDE (a)" > /dev/null 2>&1 \
+    || psql_do "$DATABASE" -c "CREATE UNIQUE INDEX mv_unique_include_id ON mv_unique_include (id)" > /dev/null
+
+VIEWS="$(psql_do "$DATABASE" -Atc "
+    SELECT c.relname
+    FROM pg_catalog.pg_class c
+    JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'm' AND n.nspname = 'public'
+    ORDER BY c.relname")"
+
+failures=0
+for view in $VIEWS; do
+    predicted="$(psql_do "$DATABASE" -Atc "
+        SELECT CASE WHEN $PREDICATE THEN 'yes' ELSE 'no' END
+        FROM pg_catalog.pg_class c
+        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        WHERE c.relkind = 'm' AND n.nspname = 'public' AND c.relname = '$view'")"
+
+    if psql -X -q -h "$HOST" -p "$PORT" -U "$USER_NAME" -d "$DATABASE" -v ON_ERROR_STOP=1 \
+        -c "REFRESH MATERIALIZED VIEW CONCURRENTLY public.$view" > /dev/null 2>&1; then
+        actual="yes"
+    else
+        actual="no"
+    fi
+
+    if [ "$predicted" = "$actual" ]; then
+        printf 'ok   %-22s predicate=%-3s server=%s\n' "$view" "$predicted" "$actual"
+    else
+        printf 'FAIL %-22s predicate=%-3s server=%s\n' "$view" "$predicted" "$actual"
+        failures=$((failures + 1))
+    fi
+done
+
+if [ "$failures" -gt 0 ]; then
+    echo "$failures view(s) disagree with the predicate in PostgreSQLRelationSQL.swift" >&2
+    exit 1
+fi
+
+echo "The predicate agrees with PostgreSQL $VERSION on every index shape."


### PR DESCRIPTION
Fixes #2726.

Five asks from the issue: refresh a materialized view, gate `CONCURRENTLY` on what the server will accept, reload a plain view, read and copy a view's creation SQL, and edit table and column comments. Ask 3 already worked (`Cmd+R` re-runs a view tab's query), so this builds the other four and fixes the code they sit on.

## What is new

**Refresh Materialized View…** on a materialized view row and in the Database menu. The confirmation names the view, says a plain refresh stops other sessions from reading it, and carries a **Refresh concurrently** checkbox that is enabled only for a view PostgreSQL would accept it for. When it is not, the alert says which requirement is missing. The statement runs on its own connection, is recorded in query history, and afterwards only the tabs showing that view reload.

**Show DDL** and **Copy DDL** on a view or materialized view row, both available on read-only connections. They read the same text the Structure tab's DDL shows, through one shared compose path.

**Edit Comment…** on a table, view, materialized view or foreign table. The sheet reads the current comment fresh, saves with `COMMENT ON`, and removes the comment when the field is left empty.

## Screens

Both dialogs are new, so there is no before to show. Captured against PostgreSQL 17.11.

The refresh confirmation on a view that carries a qualifying unique index, where the concurrent option is available:

![Refresh confirmation with the concurrent option enabled](https://github.com/user-attachments/assets/311f656a-f8df-408d-9a83-148b2515949c)

The same confirmation on a view without one. The option is dimmed and says what is missing:

![Refresh confirmation with the concurrent option dimmed and its reason](https://github.com/user-attachments/assets/1a2b662c-f60a-4ed3-a563-65f29f459c18)

The comment sheet, opened on a table that already has one:

![Edit Comment sheet showing an existing table comment](https://github.com/user-attachments/assets/8c44d4c3-361d-44c0-a1da-f5ed29e11b91)

## PluginKit

Three new `PluginDatabaseDriver` requirements, each defaulting to nil so every shipped plugin keeps working: `objectCommentStatement`, `refreshMaterializedViewStatement`, and `concurrentRefreshAvailability`. `currentPluginKitVersion` goes 25 to 26 with the plugin `Info.plist` files, as the rule for an additive change requires; `minimumCompatiblePluginKitVersion` stays at 19.

Menu items are derived by asking the driver for a statement rather than reading a declared capability, so a driver cannot offer a command it has no statement for. PostgreSQL and PGlite implement all three. CockroachDB and Redshift are separate driver classes and return nil, so the commands do not appear for them.

## The concurrent-refresh rule, measured

PostgreSQL accepts `REFRESH MATERIALIZED VIEW CONCURRENTLY` only for a populated view with a valid, immediate, non-partial, non-expression unique btree index. `scripts/check-postgres-matview-refresh.sh` builds a view for every index shape that matters, asks the predicate, runs the real refresh, and compares. Against PostgreSQL 17.11:

```
ok   mv_expression          predicate=no  server=no
ok   mv_mixed               predicate=no  server=no
ok   mv_none                predicate=no  server=no
ok   mv_not_unique          predicate=no  server=no
ok   mv_partial             predicate=no  server=no
ok   mv_unique              predicate=yes server=yes
ok   mv_unique_include      predicate=yes server=yes
ok   mv_unique_multi        predicate=yes server=yes
ok   mv_unpopulated         predicate=no  server=no
```

The script is committed so a future server version re-checks the rule instead of trusting the copy in the source.

## Defects fixed on the way

**A view definition was not safe to run back.** It came from `pg_views.definition`, which is the query alone. Measured on 17.11, against a view created `WITH (security_barrier=true, security_invoker=true) … WITH CASCADED CHECK OPTION`, read on a connection pinned to its own schema:

```sql
-- before
CREATE OR REPLACE VIEW sales.vw AS
 SELECT id, v FROM orders WHERE (id > 0);

-- after
CREATE OR REPLACE VIEW "sales"."vw" WITH (security_barrier='true', security_invoker='true') AS
 SELECT id, v FROM sales.orders WHERE id > 0
  WITH CASCADED CHECK OPTION;
```

Running the old text dropped every option: `pg_class.reloptions` went to NULL, and a role holding rights on the view alone could then read the base table through it. `FROM orders` is unqualified, so the same text run elsewhere bound the view to whichever `orders` that session found first. The statement is now rebuilt from the catalog with `search_path` emptied for the read. On a pooled connection the prefix and the read are one implicit transaction, so the path is restored as the read ends; where metadata shares the session connection, as PGlite does, the read is wrapped in a savepoint so it cannot leak into a transaction a query tab left open.

**Structure → DDL showed `CREATE TABLE` for a view.** `pg_attribute` covers views, so the column-based DDL built one happily. PostgreSQL's `fetchTableDDL` now returns the view's own statement for relkind `v` and `m`, which also fixes the MCP `get_table_ddl` tool and makes Show DDL and that tab agree. The enum types and sequences a table's DDL prepends are no longer written in front of a view.

**Edit View Definition from the Database menu read the wrong schema.** The menu-bar path passed only the object's name and resolved it against the browsed schema, so with two schemas holding `vw` it opened the other one's definition and running it replaced that view. The command now carries the row's database and schema. It is also dimmed on a read-only connection, which the sidebar already did.

**Comment and role-password literals were escaped by doubling quotes only.** With `standard_conforming_strings` off, a value ending in a backslash eats the closing quote. Measured: `COMMENT ON TABLE base IS 'x\'; DROP TABLE victim; --'` ran the `DROP`. Those paths now use the plugin's `quoteLiteral`, which emits an `E''` string when the value holds a backslash.

## Tests

230 cases across the 18 suites that own the changed types pass on the branch rebased onto `main`. New unit suites for the PostgreSQL statement builders and the view-definition composer, the refresh prompt, the comment draft, per-object command eligibility, the new object-source kinds, and the sidebar and menu-bar availability of each command. `scripts/check-postgres-matview-refresh.sh` covers the catalog predicate against a live server.

The wired half is proven with a `swiftc` harness that runs the real `PostgreSQLPluginDriver` against PostgreSQL 17.11: view and materialized view DDL, `fetchTableDDL` routing, the availability answers for three view shapes, the comment statement per object kind, a comment round trip through `E''` quoting including clearing it, and a qualified read inside an open transaction leaving `search_path` and the transaction intact.

No `TableProUITests` coverage: every one of these flows needs a live PostgreSQL server, and the UI suites run against the bundled SQLite sample, so the flow cannot run deterministically on CI.

`scripts/check-pluginkit-abi.sh` against the merge base reports additions only: the new enum and the three requirements, each with its default. No symbol was removed. The `AllPlugins` aggregate compiled all 21 registry-only plugins except Oracle, which fails on this toolchain in `oracle-nio`'s `@TaskLocal` macro expansion the same way on unrelated branches.

## Not in this change

Found while investigating #2726 and reported rather than built: the Maintenance submenu's object-kind and schema handling and its SQL preview, materialized view columns missing from the Structure tab, the Structure grid offering table-only edits on a view, CockroachDB's schema-ignoring DDL fetchers, comments missing from table DDL and SQL exports, and the remaining catalog-name literals that use the same quote-doubling escape.
