### PR TITLE
fix(plugin-postgresql): end COPY state so the connection stays usable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Wrong SQLSTATE code in PostgreSQL, Redshift, CockroachDB and PGlite error messages.
 - Read-only write explanation never shown on PostgreSQL servers.
 - Safe Mode minimum from a configuration profile missing from the toolbar, the Database menu and the connection form. (#2030)
+- PostgreSQL connection hanging after running `COPY FROM STDIN` or `COPY TO STDOUT` in the query editor and on iOS.
 - Stop not ending queries on MySQL and MariaDB servers without TLS.
 - Wrong results after MySQL retakes a dropped connection, on a session that had set a variable, a session setting or a database.
 - Session state set by the `/*! ... */` statements a MySQL dump writes counting as a comment.

--- a/Plugins/PostgreSQLDriverPlugin/LibPQCopyDirection+UnsupportedMessage.swift
+++ b/Plugins/PostgreSQLDriverPlugin/LibPQCopyDirection+UnsupportedMessage.swift
@@ -1,0 +1,19 @@
+//
+//  LibPQCopyDirection+UnsupportedMessage.swift
+//  PostgreSQLDriverPlugin
+//
+
+import Foundation
+
+nonisolated extension LibPQCopyDirection {
+    var unsupportedMessage: String {
+        switch self {
+        case .copyIn:
+            return String(localized: "The query editor cannot send data to COPY FROM STDIN, so no rows were sent. Use Import to load a file into a table.")
+        case .copyOut:
+            return String(localized: "The query editor cannot receive the output of COPY TO STDOUT, so it was discarded. Run a SELECT, or use Export to save the rows to a file.")
+        case .copyBoth:
+            return String(localized: "The query editor cannot run a replication COPY.")
+        }
+    }
+}

--- a/Plugins/PostgreSQLDriverPlugin/LibPQCopyState.swift
+++ b/Plugins/PostgreSQLDriverPlugin/LibPQCopyState.swift
@@ -1,0 +1,76 @@
+//
+//  LibPQCopyState.swift
+//  PostgreSQLDriverPlugin
+//
+
+import CLibPQ
+import Foundation
+
+nonisolated enum LibPQCopyState {
+    static let unsentInputReason = "no COPY data was sent"
+
+    static func copy(of result: OpaquePointer) -> LibPQCopy? {
+        guard let direction = direction(of: PQresultStatus(result)) else { return nil }
+        return LibPQCopy(direction: direction, format: PQbinaryTuples(result) == 1 ? .binary : .textual)
+    }
+
+    static func direction(of status: ExecStatusType) -> LibPQCopyDirection? {
+        switch status {
+        case PGRES_COPY_IN: return .copyIn
+        case PGRES_COPY_OUT: return .copyOut
+        case PGRES_COPY_BOTH: return .copyBoth
+        default: return nil
+        }
+    }
+
+    static func finishPendingResults(_ conn: OpaquePointer, cancellingOutput: Bool) -> LibPQDrainOutcome {
+        LibPQPendingResultDrain.drain(
+            nextResult: {
+                guard let result = PQgetResult(conn) else { return nil }
+                defer { PQclear(result) }
+                return copy(of: result).map(LibPQPendingResult.copy) ?? .completed
+            },
+            endCopy: { end($0, conn: conn, cancellingOutput: cancellingOutput) }
+        )
+    }
+
+    /// A textual or CSV `COPY FROM STDIN` ends with CopyDone, which completes the statement with
+    /// zero rows and leaves an open transaction in `INTRANS`. CopyFail aborts the transaction, so
+    /// it is kept for binary input alone, where CopyDone fails on the missing file signature.
+    /// Measured on 9.1.24 and 17.11.
+    static func end(_ copy: LibPQCopy, conn: OpaquePointer, cancellingOutput: Bool) {
+        switch copy.direction {
+        case .copyIn:
+            endInput(copy, conn: conn)
+        case .copyOut:
+            discardOutput(conn, cancelling: cancellingOutput)
+        case .copyBoth:
+            endInput(copy, conn: conn)
+            discardOutput(conn, cancelling: cancellingOutput)
+        }
+    }
+
+    private static func endInput(_ copy: LibPQCopy, conn: OpaquePointer) {
+        guard copy.format == .binary else {
+            _ = PQputCopyEnd(conn, nil)
+            return
+        }
+        _ = unsentInputReason.withCString { PQputCopyEnd(conn, $0) }
+    }
+
+    private static func discardOutput(_ conn: OpaquePointer, cancelling: Bool) {
+        if cancelling { cancelStatement(conn) }
+        var buffer: UnsafeMutablePointer<CChar>?
+        while PQgetCopyData(conn, &buffer, 0) > 0 {
+            PQfreemem(buffer)
+            buffer = nil
+        }
+    }
+
+    private static func cancelStatement(_ conn: OpaquePointer) {
+        guard let cancelObject = PQgetCancel(conn) else { return }
+        defer { PQfreeCancel(cancelObject) }
+        var errbuf = [CChar](repeating: 0, count: 256)
+        PQcancel(cancelObject, &errbuf, Int32(errbuf.count))
+    }
+}

--- a/Plugins/PostgreSQLDriverPlugin/LibPQPendingResultDrain.swift
+++ b/Plugins/PostgreSQLDriverPlugin/LibPQPendingResultDrain.swift
@@ -1,0 +1,60 @@
+//
+//  LibPQPendingResultDrain.swift
+//  PostgreSQLDriverPlugin
+//
+
+import Foundation
+
+nonisolated enum LibPQCopyDirection: Sendable, Equatable {
+    case copyIn
+    case copyOut
+    case copyBoth
+}
+
+nonisolated enum LibPQCopyFormat: Sendable, Equatable {
+    case textual
+    case binary
+}
+
+nonisolated struct LibPQCopy: Sendable, Equatable {
+    let direction: LibPQCopyDirection
+    let format: LibPQCopyFormat
+}
+
+nonisolated enum LibPQPendingResult: Sendable, Equatable {
+    case copy(LibPQCopy)
+    case completed
+}
+
+nonisolated struct LibPQDrainOutcome: Sendable, Equatable {
+    let endedCopies: [LibPQCopy]
+    let stuckInCopy: LibPQCopy?
+
+    static let idle = LibPQDrainOutcome(endedCopies: [], stuckInCopy: nil)
+
+    var abandonedCopy: LibPQCopy? { endedCopies.first ?? stuckInCopy }
+    var leavesConnectionUnusable: Bool { stuckInCopy != nil }
+}
+
+nonisolated enum LibPQPendingResultDrain {
+    static func drain(
+        nextResult: () -> LibPQPendingResult?,
+        endCopy: (LibPQCopy) -> Void
+    ) -> LibPQDrainOutcome {
+        var endedCopies: [LibPQCopy] = []
+        var copyAwaitingCompletion: LibPQCopy?
+        while let pending = nextResult() {
+            guard case .copy(let copy) = pending else {
+                copyAwaitingCompletion = nil
+                continue
+            }
+            if let unfinished = copyAwaitingCompletion {
+                return LibPQDrainOutcome(endedCopies: endedCopies, stuckInCopy: unfinished)
+            }
+            copyAwaitingCompletion = copy
+            endedCopies.append(copy)
+            endCopy(copy)
+        }
+        return LibPQDrainOutcome(endedCopies: endedCopies, stuckInCopy: nil)
+    }
+}

--- a/Plugins/PostgreSQLDriverPlugin/LibPQPluginConnection.swift
+++ b/Plugins/PostgreSQLDriverPlugin/LibPQPluginConnection.swift
@@ -532,6 +532,7 @@ final class LibPQPluginConnection: @unchecked Sendable {
         let generation = cancellationGate.beginQuery()
         defer { cancellationGate.endQuery(generation) }
 
+        let cancelsOutput = cancelsAbandonedOutput(conn)
         let localQuery = String(query)
         let result: OpaquePointer? = localQuery.withCString { queryPtr in
             PQexec(conn, queryPtr)
@@ -564,6 +565,10 @@ final class LibPQPluginConnection: @unchecked Sendable {
             return try fetchResults(from: result, conn: conn, generation: generation)
 
         default:
+            if let copy = LibPQCopyState.copy(of: result) {
+                PQclear(result)
+                throw abandonedCopyError(copy, conn: conn, cancellingOutput: cancelsOutput, generation: generation)
+            }
             let error = getResultError(from: result)
             PQclear(result)
             if cancellationGate.isCancelled(generation) { throw CancellationError() }
@@ -593,14 +598,14 @@ final class LibPQPluginConnection: @unchecked Sendable {
         /// Started before the drain, so a result the previous statement abandoned is charged to the
         /// time before the first row rather than appearing as this query's row transfer.
         let sentAt = Date()
-        while let stale = PQgetResult(conn) { PQclear(stale) }
 
         /// Cancelling a statement inside a transaction block puts the transaction into the aborted
         /// state, and every later command fails until ROLLBACK. Reading the tail of one result costs
         /// less than throwing away the transaction the user opened, so the cancel is withheld here
         /// and the connection is drained instead.
-        let insideTransaction = PQtransactionStatus(conn) == PQTRANS_INTRANS
-        let suppressCancel = suppressServerSideCancel || insideTransaction
+        let cancelsOutput = cancelsAbandonedOutput(conn)
+        let suppressCancel = !cancelsOutput
+        _ = finishPendingResults(conn, cancellingOutput: cancelsOutput)
 
         let localQuery = String(query)
         let sendOk = localQuery.withCString { queryPtr in
@@ -609,7 +614,7 @@ final class LibPQPluginConnection: @unchecked Sendable {
         guard sendOk != 0 else { throw getError(from: conn) }
 
         guard PQsetSingleRowMode(conn) != 0 else {
-            Self.cancelAndDrain(conn, suppressCancel: suppressCancel)
+            _ = cancelAndDrain(conn, suppressCancel: suppressCancel)
             throw LibPQPluginError(message: "Failed to enter single-row mode", sqlState: nil, detail: nil)
         }
 
@@ -644,7 +649,7 @@ final class LibPQPluginConnection: @unchecked Sendable {
                 rows.append(row)
 
                 if cancellationGate.isCancelled(generation) {
-                    Self.cancelAndDrain(conn, suppressCancel: suppressCancel)
+                    _ = cancelAndDrain(conn, suppressCancel: suppressCancel)
                     throw CancellationError()
                 }
                 if rows.count > rowCap {
@@ -667,22 +672,27 @@ final class LibPQPluginConnection: @unchecked Sendable {
                 continue
             }
 
+            if let copy = LibPQCopyState.copy(of: result) {
+                pendingError = Self.unsupportedCopyError(copy)
+                PQclear(result)
+                break
+            }
+
             pendingError = getResultError(from: result)
             PQclear(result)
             break
         }
 
-        if truncated {
-            Self.cancelAndDrain(conn, suppressCancel: suppressCancel)
-        } else {
-            while let trailing = PQgetResult(conn) { PQclear(trailing) }
-        }
+        let outcome = truncated
+            ? cancelAndDrain(conn, suppressCancel: suppressCancel)
+            : finishPendingResults(conn, cancellingOutput: cancelsOutput)
 
         if let pendingError {
             if cancellationGate.isCancelled(generation) { throw CancellationError() }
             throw pendingError
         }
         if cancellationGate.isCancelled(generation) { throw CancellationError() }
+        if let abandoned = abandonedCopyError(outcome, generation: generation) { throw abandoned }
 
         if truncated { rows.removeLast() }
 
@@ -713,6 +723,7 @@ final class LibPQPluginConnection: @unchecked Sendable {
         let generation = cancellationGate.beginQuery()
         defer { cancellationGate.endQuery(generation) }
 
+        let cancelsOutput = cancelsAbandonedOutput(conn)
         var paramValues: [UnsafePointer<CChar>?] = []
         var paramLengths: [Int32] = []
         var paramFormats: [Int32] = []
@@ -802,6 +813,10 @@ final class LibPQPluginConnection: @unchecked Sendable {
             return try fetchResults(from: result, conn: conn, generation: generation)
 
         default:
+            if let copy = LibPQCopyState.copy(of: result) {
+                PQclear(result)
+                throw abandonedCopyError(copy, conn: conn, cancellingOutput: cancelsOutput, generation: generation)
+            }
             let error = getResultError(from: result)
             PQclear(result)
             if cancellationGate.isCancelled(generation) { throw CancellationError() }
@@ -809,9 +824,52 @@ final class LibPQPluginConnection: @unchecked Sendable {
         }
     }
 
+    // MARK: - Pending Results
+
+    /// A statement the user did not get to see is worse than a slow one, so a COPY ended by any
+    /// drain is reported rather than swallowed: `INSERT INTO t VALUES (1); COPY t FROM STDIN` used
+    /// to come back as "INSERT 0 1" with the COPY discarded.
+    private func abandonedCopyError(_ outcome: LibPQDrainOutcome, generation: Int) -> Error? {
+        guard let copy = outcome.abandonedCopy else { return nil }
+        if cancellationGate.isCancelled(generation) { return CancellationError() }
+        return Self.unsupportedCopyError(copy)
+    }
+
+    private func abandonedCopyError(
+        _ copy: LibPQCopy,
+        conn: OpaquePointer,
+        cancellingOutput: Bool,
+        generation: Int
+    ) -> Error {
+        _ = finishPendingResults(conn, cancellingOutput: cancellingOutput)
+        if cancellationGate.isCancelled(generation) { return CancellationError() }
+        return Self.unsupportedCopyError(copy)
+    }
+
+    private static func unsupportedCopyError(_ copy: LibPQCopy) -> LibPQPluginError {
+        LibPQPluginError(message: copy.direction.unsupportedMessage, sqlState: nil, detail: nil)
+    }
+
+    /// Reading `COPY TO STDOUT` to its end defeats the row cap the bounded read exists for, so the
+    /// statement is cancelled first wherever a cancel is safe. Inside a transaction block it is not,
+    /// because a cancel aborts the transaction the user opened.
+    private func cancelsAbandonedOutput(_ conn: OpaquePointer) -> Bool {
+        !suppressServerSideCancel && PQtransactionStatus(conn) != PQTRANS_INTRANS
+    }
+
+    private func finishPendingResults(_ conn: OpaquePointer, cancellingOutput: Bool) -> LibPQDrainOutcome {
+        let outcome = LibPQCopyState.finishPendingResults(conn, cancellingOutput: cancellingOutput)
+        guard let stuck = outcome.stuckInCopy else { return outcome }
+        logger.fault(
+            "libpq stayed in \(String(describing: stuck.direction), privacy: .public); dropping the connection"
+        )
+        disconnect()
+        return outcome
+    }
+
     // MARK: - Streaming Query
 
-    private static func cancelAndDrain(_ conn: OpaquePointer, suppressCancel: Bool) {
+    private func cancelAndDrain(_ conn: OpaquePointer, suppressCancel: Bool) -> LibPQDrainOutcome {
         if !suppressCancel {
             let cancelObj = PQgetCancel(conn)
             if let cancelObj {
@@ -820,7 +878,7 @@ final class LibPQPluginConnection: @unchecked Sendable {
                 PQfreeCancel(cancelObj)
             }
         }
-        while let res = PQgetResult(conn) { PQclear(res) }
+        return finishPendingResults(conn, cancellingOutput: false)
     }
 
     /// The abort is polled by the producer rather than acted on from `onTermination`, because both
@@ -850,12 +908,11 @@ final class LibPQPluginConnection: @unchecked Sendable {
                     return
                 }
 
-                while let res = PQgetResult(conn) { PQclear(res) }
-
                 /// Read before the query goes out: once it is in flight the status is
                 /// PQTRANS_ACTIVE, and the transaction this guard exists for is invisible.
-                let suppressCancel = suppressServerSideCancel
-                    || PQtransactionStatus(conn) == PQTRANS_INTRANS
+                let cancelsOutput = cancelsAbandonedOutput(conn)
+                let suppressCancel = !cancelsOutput
+                _ = finishPendingResults(conn, cancellingOutput: cancelsOutput)
 
                 let sendOk = queryToRun.withCString { queryPtr in
                     PQsendQuery(conn, queryPtr)
@@ -867,7 +924,7 @@ final class LibPQPluginConnection: @unchecked Sendable {
                 }
 
                 if PQsetSingleRowMode(conn) == 0 {
-                    Self.cancelAndDrain(conn, suppressCancel: suppressCancel)
+                    _ = cancelAndDrain(conn, suppressCancel: suppressCancel)
                     continuation.finish(throwing: LibPQPluginError(
                         message: "Failed to enter single-row mode", sqlState: nil, detail: nil))
                     return
@@ -935,7 +992,7 @@ final class LibPQPluginConnection: @unchecked Sendable {
                             if !batch.isEmpty {
                                 continuation.yield(.rows(batch))
                             }
-                            Self.cancelAndDrain(conn, suppressCancel: suppressCancel)
+                            _ = cancelAndDrain(conn, suppressCancel: suppressCancel)
                             continuation.finish(throwing: CancellationError())
                             return
                         }
@@ -946,10 +1003,15 @@ final class LibPQPluginConnection: @unchecked Sendable {
                         lastCommandTag = getCommandTag(from: result)
                         PQclear(result)
                         break
+                    } else if let copy = LibPQCopyState.copy(of: result) {
+                        PQclear(result)
+                        continuation.finish(throwing: abandonedCopyError(
+                            copy, conn: conn, cancellingOutput: cancelsOutput, generation: generation))
+                        return
                     } else {
                         let error = getResultError(from: result)
                         PQclear(result)
-                        while let res = PQgetResult(conn) { PQclear(res) }
+                        _ = finishPendingResults(conn, cancellingOutput: cancelsOutput)
                         if cancellationGate.isCancelled(generation) {
                             continuation.finish(throwing: CancellationError())
                             return
@@ -963,7 +1025,7 @@ final class LibPQPluginConnection: @unchecked Sendable {
                     continuation.yield(.rows(batch))
                 }
 
-                while let res = PQgetResult(conn) { PQclear(res) }
+                let outcome = finishPendingResults(conn, cancellingOutput: cancelsOutput)
                 /// The header went out with the first row, so this stream keeps what it said;
                 /// the lookup is for the results that follow.
                 let missing = unresolvedOids(in: columnOids)
@@ -971,6 +1033,10 @@ final class LibPQPluginConnection: @unchecked Sendable {
                     learnTypeNames(for: missing, conn: conn)
                 }
                 noteCommandTag(lastCommandTag, conn: conn)
+                if let abandoned = abandonedCopyError(outcome, generation: generation) {
+                    continuation.finish(throwing: abandoned)
+                    return
+                }
                 continuation.finish()
             }
         }

--- a/TableProMobile/TableProMobile/Drivers/PostgreSQLCopyState.swift
+++ b/TableProMobile/TableProMobile/Drivers/PostgreSQLCopyState.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+nonisolated extension LibPQCopyDirection {
+    var unsupportedMessage: String {
+        switch self {
+        case .copyIn:
+            return String(localized: "TablePro cannot send data to COPY FROM STDIN, so no rows were sent. Insert the rows with INSERT instead.")
+        case .copyOut:
+            return String(localized: "TablePro cannot receive the output of COPY TO STDOUT, so it was discarded. Run a SELECT instead.")
+        case .copyBoth:
+            return String(localized: "TablePro cannot run a replication COPY.")
+        }
+    }
+}

--- a/TableProMobile/TableProMobile/Drivers/PostgreSQLDriver.swift
+++ b/TableProMobile/TableProMobile/Drivers/PostgreSQLDriver.swift
@@ -1,5 +1,6 @@
 import CLibPQ
 import Foundation
+import os
 import TableProDatabase
 import TableProModels
 
@@ -94,6 +95,10 @@ nonisolated final class PostgreSQLDriver: DatabaseDriver, @unchecked Sendable {
                     let beginResult = try await actor.beginStream(query: query)
                     switch beginResult {
                     case .commandOk(let affectedRows):
+                        if let abandoned = await actor.takeAbandonedCopyError() {
+                            continuation.finish(throwing: abandoned)
+                            return
+                        }
                         if affectedRows != 0 {
                             continuation.yield(.rowsAffected(affectedRows))
                         }
@@ -115,6 +120,10 @@ nonisolated final class PostgreSQLDriver: DatabaseDriver, @unchecked Sendable {
                             continuation.yield(.truncated(reason: .rowCap(options.maxRows)))
                         }
                         await actor.endStream()
+                        if let abandoned = await actor.takeAbandonedCopyError() {
+                            continuation.finish(throwing: abandoned)
+                            return
+                        }
                         continuation.finish()
                     }
                 } catch is CancellationError {
@@ -479,12 +488,18 @@ private actor PostgreSQLActor {
         guard let conn else { throw PostgreSQLError.notConnected }
 
         let start = Date()
+        let cancelsOutput = cancelsAbandonedOutput(conn)
         let result = PQexec(conn, query)
         defer {
             if result != nil { PQclear(result) }
         }
 
         let status = PQresultStatus(result)
+
+        if let copy = result.flatMap(LibPQCopyState.copy(of:)) {
+            _ = finishPendingResults(conn, cancellingOutput: cancelsOutput)
+            throw PostgreSQLError.unsupported(copy.direction.unsupportedMessage)
+        }
 
         if status == PGRES_FATAL_ERROR {
             let msg = result.flatMap { String(cString: PQresultErrorMessage($0)) } ?? "Unknown error"
@@ -546,10 +561,14 @@ private actor PostgreSQLActor {
 
     private var pendingResult: OpaquePointer?
     private var streamingFinished = true
+    private var abandonedCopy: LibPQCopy?
+    private var streamCancelsAbandonedOutput = false
 
     func beginStream(query: String) throws -> PGBeginStreamResult {
         guard let conn else { throw PostgreSQLError.notConnected }
+        streamCancelsAbandonedOutput = cancelsAbandonedOutput(conn)
         endStream()
+        abandonedCopy = nil
 
         guard PQsendQuery(conn, query) == 1 else {
             throw PostgreSQLError.queryFailed(String(cString: PQerrorMessage(conn)))
@@ -566,6 +585,12 @@ private actor PostgreSQLActor {
         }
 
         let status = PQresultStatus(firstResult)
+        if let copy = LibPQCopyState.copy(of: firstResult) {
+            PQclear(firstResult)
+            drainResults()
+            abandonedCopy = nil
+            throw PostgreSQLError.unsupported(copy.direction.unsupportedMessage)
+        }
         switch status {
         case PGRES_COMMAND_OK:
             let affectedStr = String(cString: PQcmdTuples(firstResult))
@@ -654,10 +679,36 @@ private actor PostgreSQLActor {
             pendingResult = nil
         }
         guard let conn else { return }
-        while let extra = PQgetResult(conn) {
-            PQclear(extra)
-        }
+        let outcome = finishPendingResults(conn, cancellingOutput: streamCancelsAbandonedOutput)
+        guard let copy = outcome.abandonedCopy, abandonedCopy == nil else { return }
+        abandonedCopy = copy
     }
+
+    /// A COPY the drain ended is reported, never swallowed: `INSERT INTO t VALUES (1); COPY t FROM
+    /// STDIN` used to stream as a plain "INSERT 0 1" with the COPY silently discarded.
+    func takeAbandonedCopyError() -> PostgreSQLError? {
+        guard let copy = abandonedCopy else { return nil }
+        abandonedCopy = nil
+        return PostgreSQLError.unsupported(copy.direction.unsupportedMessage)
+    }
+
+    private func finishPendingResults(_ conn: OpaquePointer, cancellingOutput: Bool) -> LibPQDrainOutcome {
+        let outcome = LibPQCopyState.finishPendingResults(conn, cancellingOutput: cancellingOutput)
+        guard let stuck = outcome.stuckInCopy else { return outcome }
+        Self.logger.fault(
+            "libpq stayed in \(String(describing: stuck.direction), privacy: .public); dropping the connection"
+        )
+        close()
+        return outcome
+    }
+
+    /// Cancelling inside a transaction block aborts it, so the cancel that keeps a `COPY TO STDOUT`
+    /// from transferring the whole table is sent only outside one.
+    private func cancelsAbandonedOutput(_ conn: OpaquePointer) -> Bool {
+        PQtransactionStatus(conn) != PQTRANS_INTRANS
+    }
+
+    private static let logger = Logger(subsystem: "com.TablePro", category: "PostgreSQLActor")
 
     private func parseColumns(_ result: OpaquePointer) -> [ColumnInfo] {
         let colCount = Int(PQnfields(result))

--- a/TableProMobile/TableProMobileTests/Drivers/PostgreSQLCopyStateTests.swift
+++ b/TableProMobile/TableProMobileTests/Drivers/PostgreSQLCopyStateTests.swift
@@ -1,0 +1,61 @@
+import CLibPQ
+import Foundation
+@testable import TableProMobile
+import Testing
+
+@Suite("PostgreSQL COPY state")
+struct PostgreSQLCopyStateTests {
+    @Test("Every libpq COPY status maps to its direction")
+    func copyStatusMapping() {
+        #expect(LibPQCopyState.direction(of: PGRES_COPY_IN) == .copyIn)
+        #expect(LibPQCopyState.direction(of: PGRES_COPY_OUT) == .copyOut)
+        #expect(LibPQCopyState.direction(of: PGRES_COPY_BOTH) == .copyBoth)
+    }
+
+    @Test("A result that is not a COPY maps to no direction")
+    func nonCopyStatusMapping() {
+        #expect(LibPQCopyState.direction(of: PGRES_COMMAND_OK) == nil)
+        #expect(LibPQCopyState.direction(of: PGRES_TUPLES_OK) == nil)
+        #expect(LibPQCopyState.direction(of: PGRES_SINGLE_TUPLE) == nil)
+        #expect(LibPQCopyState.direction(of: PGRES_FATAL_ERROR) == nil)
+        #expect(LibPQCopyState.direction(of: PGRES_EMPTY_QUERY) == nil)
+    }
+
+    @Test("Every direction explains itself and names the COPY form it rejects")
+    func unsupportedMessages() {
+        #expect(LibPQCopyDirection.copyIn.unsupportedMessage.contains("COPY FROM STDIN"))
+        #expect(LibPQCopyDirection.copyIn.unsupportedMessage.contains("no rows were sent"))
+        #expect(LibPQCopyDirection.copyOut.unsupportedMessage.contains("COPY TO STDOUT"))
+        #expect(!LibPQCopyDirection.copyBoth.unsupportedMessage.isEmpty)
+        let messages = Set([LibPQCopyDirection.copyIn, .copyOut, .copyBoth].map(\.unsupportedMessage))
+        #expect(messages.count == 3)
+    }
+
+    @Test("A COPY behind an earlier statement is ended and reported, never discarded in silence")
+    func copyAfterAnotherStatementIsReported() {
+        let copy = LibPQCopy(direction: .copyIn, format: .textual)
+        var pending: [LibPQPendingResult] = [.completed, .copy(copy)]
+        var ended: [LibPQCopy] = []
+        let outcome = LibPQPendingResultDrain.drain(
+            nextResult: { pending.isEmpty ? nil : pending.removeFirst() },
+            endCopy: { ended.append($0) }
+        )
+        #expect(ended == [copy])
+        #expect(outcome.abandonedCopy == copy)
+    }
+
+    @Test("A COPY libpq never leaves stops the drain and marks the connection unusable")
+    func stuckCopyTerminates() {
+        var reads = 0
+        let outcome = LibPQPendingResultDrain.drain(
+            nextResult: {
+                reads += 1
+                return .copy(LibPQCopy(direction: .copyOut, format: .textual))
+            },
+            endCopy: { _ in }
+        )
+        #expect(outcome.stuckInCopy == LibPQCopy(direction: .copyOut, format: .textual))
+        #expect(outcome.leavesConnectionUnusable)
+        #expect(reads == 2)
+    }
+}

--- a/TableProMobile/project.yml
+++ b/TableProMobile/project.yml
@@ -63,6 +63,9 @@ targets:
       - ../Plugins/MySQLDriverPlugin/MySQLConnectionEncoding.swift
       - ../Plugins/MySQLDriverPlugin/MySQLLatin1.swift
       - ../Plugins/MySQLDriverPlugin/MySQLServerFlavor.swift
+      # libpq COPY handling the iOS PostgreSQL driver shares with the macOS plugin.
+      - ../Plugins/PostgreSQLDriverPlugin/LibPQPendingResultDrain.swift
+      - ../Plugins/PostgreSQLDriverPlugin/LibPQCopyState.swift
     configFiles:
       Debug: ../Configs/Version-iOS.xcconfig
       Release: ../Configs/Version-iOS.xcconfig

--- a/TableProTests/Plugins/LibPQPendingResultDrainTests.swift
+++ b/TableProTests/Plugins/LibPQPendingResultDrainTests.swift
@@ -1,0 +1,124 @@
+//
+//  LibPQPendingResultDrainTests.swift
+//  TableProTests
+//
+
+import Foundation
+import Testing
+
+private final class SimulatedLibPQConnection {
+    private var queue: [LibPQPendingResult]
+    private var activeCopy: LibPQCopy?
+    private let leavesCopyOnEnd: Bool
+    private(set) var endedCopies: [LibPQCopy] = []
+    private(set) var reads = 0
+
+    init(results: [LibPQPendingResult], leavesCopyOnEnd: Bool = true) {
+        self.queue = results
+        self.leavesCopyOnEnd = leavesCopyOnEnd
+    }
+
+    func nextResult() -> LibPQPendingResult? {
+        reads += 1
+        if let activeCopy { return .copy(activeCopy) }
+        guard !queue.isEmpty else { return nil }
+        let next = queue.removeFirst()
+        if case .copy(let copy) = next { activeCopy = copy }
+        return next
+    }
+
+    func endCopy(_ copy: LibPQCopy) {
+        endedCopies.append(copy)
+        guard leavesCopyOnEnd else { return }
+        activeCopy = nil
+        queue.insert(.completed, at: 0)
+    }
+
+    func drain() -> LibPQDrainOutcome {
+        LibPQPendingResultDrain.drain(nextResult: nextResult, endCopy: endCopy)
+    }
+}
+
+private func textual(_ direction: LibPQCopyDirection) -> LibPQCopy {
+    LibPQCopy(direction: direction, format: .textual)
+}
+
+@Suite("LibPQPendingResultDrain")
+struct LibPQPendingResultDrainTests {
+    @Test("An idle connection drains without ending anything")
+    func idleConnection() {
+        let connection = SimulatedLibPQConnection(results: [])
+        let outcome = connection.drain()
+        #expect(outcome == .idle)
+        #expect(outcome.abandonedCopy == nil)
+        #expect(!outcome.leavesConnectionUnusable)
+        #expect(connection.endedCopies.isEmpty)
+    }
+
+    @Test("Ordinary results are read until libpq has none left")
+    func ordinaryResults() {
+        let connection = SimulatedLibPQConnection(results: [.completed, .completed, .completed])
+        #expect(connection.drain() == .idle)
+        #expect(connection.endedCopies.isEmpty)
+        #expect(connection.reads == 4)
+    }
+
+    @Test(
+        "A COPY that repeats its state until ended is ended once and reported",
+        arguments: [LibPQCopyDirection.copyIn, .copyOut, .copyBoth]
+    )
+    func copyStateIsEndedAndReported(direction: LibPQCopyDirection) {
+        let connection = SimulatedLibPQConnection(results: [.copy(textual(direction))])
+        let outcome = connection.drain()
+        #expect(connection.endedCopies == [textual(direction)])
+        #expect(outcome.abandonedCopy == textual(direction))
+        #expect(!outcome.leavesConnectionUnusable)
+    }
+
+    @Test("A COPY behind an earlier statement is still reported, so nothing is discarded in silence")
+    func copyAfterAnotherStatementIsReported() {
+        let connection = SimulatedLibPQConnection(results: [.completed, .copy(textual(.copyIn))])
+        let outcome = connection.drain()
+        #expect(outcome.abandonedCopy == textual(.copyIn))
+        #expect(connection.endedCopies == [textual(.copyIn)])
+    }
+
+    @Test("Each COPY in a multi-statement string is ended in turn and the first is reported")
+    func consecutiveCopyStatements() {
+        let connection = SimulatedLibPQConnection(
+            results: [.completed, .copy(textual(.copyOut)), .copy(textual(.copyIn)), .completed]
+        )
+        let outcome = connection.drain()
+        #expect(connection.endedCopies == [textual(.copyOut), textual(.copyIn)])
+        #expect(outcome.abandonedCopy == textual(.copyOut))
+    }
+
+    @Test("The COPY format travels with the direction, because binary input cannot end with CopyDone")
+    func formatIsCarried() {
+        let binary = LibPQCopy(direction: .copyIn, format: .binary)
+        let connection = SimulatedLibPQConnection(results: [.copy(binary)])
+        #expect(connection.drain().abandonedCopy == binary)
+        #expect(connection.endedCopies == [binary])
+    }
+
+    @Test("A COPY libpq refuses to leave stops the drain and marks the connection unusable")
+    func stuckCopyTerminates() {
+        let connection = SimulatedLibPQConnection(results: [.copy(textual(.copyIn))], leavesCopyOnEnd: false)
+        let outcome = connection.drain()
+        #expect(outcome.stuckInCopy == textual(.copyIn))
+        #expect(outcome.leavesConnectionUnusable)
+        #expect(outcome.abandonedCopy == textual(.copyIn))
+        #expect(connection.endedCopies == [textual(.copyIn)])
+        #expect(connection.reads == 2)
+    }
+
+    @Test("Every direction explains itself in query editor terms and names the COPY form it rejects")
+    func unsupportedMessages() {
+        #expect(LibPQCopyDirection.copyIn.unsupportedMessage.contains("COPY FROM STDIN"))
+        #expect(LibPQCopyDirection.copyIn.unsupportedMessage.contains("no rows were sent"))
+        #expect(LibPQCopyDirection.copyOut.unsupportedMessage.contains("COPY TO STDOUT"))
+        #expect(!LibPQCopyDirection.copyBoth.unsupportedMessage.isEmpty)
+        let messages = Set([LibPQCopyDirection.copyIn, .copyOut, .copyBoth].map(\.unsupportedMessage))
+        #expect(messages.count == 3)
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -511,6 +511,8 @@ targets:
       - Plugins/PostgreSQLDriverPlugin/LibPQByteaDecoder.swift
       - Plugins/PostgreSQLDriverPlugin/LibPQCellDecoding.swift
       - Plugins/PostgreSQLDriverPlugin/LibPQConnectionString.swift
+      - Plugins/PostgreSQLDriverPlugin/LibPQCopyDirection+UnsupportedMessage.swift
+      - Plugins/PostgreSQLDriverPlugin/LibPQPendingResultDrain.swift
       - Plugins/PostgreSQLDriverPlugin/LibPQPluginError.swift
       - Plugins/PostgreSQLDriverPlugin/LibPQSSLMapping.swift
       - Plugins/PostgreSQLDriverPlugin/PostGISSpatialRewrite.swift


### PR DESCRIPTION
Found while investigating #2734.

## Problem

Running `COPY t FROM STDIN` or `COPY t TO STDOUT` left the libpq connection in COPY state. libpq's `PQgetResult` keeps returning a new `PGRES_COPY_IN` / `PGRES_COPY_OUT` result for as long as the COPY is open, so every `while let r = PQgetResult(conn) { PQclear(r) }` drain spun at 100% CPU:

- macOS (`LibPQPluginConnection`, shared by the PostgreSQL, Redshift, CockroachDB and PGlite drivers): the bounded (query tab) and streaming paths hung on the COPY statement itself; the buffered path returned an error with an empty message, and the next bounded or streaming query on that connection hung in its pre-send drain. Cancel could not free it, because the loop never reached the server.
- iOS (`PostgreSQLDriver`): a streamed COPY hung in `drainResults()`, and a buffered COPY returned "PostgreSQL query failed: " with nothing after it and left the connection in COPY state, so the next streamed query failed and then hung in the same drain.

## Fix

- `LibPQPendingResultDrain` (pure, Foundation only) owns the drain loop, and `LibPQCopyState` owns the libpq calls. Both are compiled into the macOS plugin and the iOS app, the way the Redis and MSSQL helpers already are, so neither half is written twice.
- The drain reports what it ended. A COPY is never discarded in silence: `INSERT INTO t VALUES (1); COPY t FROM STDIN` used to come back as "INSERT 0 1" with the COPY dropped, and now the INSERT lands and the statement reports that the COPY did not run. Every call site checks the outcome: buffered, parameterized, bounded, the stream's trailing drain, `cancelAndDrain`, and on iOS `execute`, `beginStream`, `fetchNextRow` and `endStream` (whose result reaches the caller through `takeAbandonedCopyError`).
- A textual or CSV `COPY FROM STDIN` ends with CopyDone rather than CopyFail, so an open transaction survives. Measured on 9.1.24 and 17.11: CopyDone leaves the transaction `INTRANS` and copies zero rows, CopyFail leaves it `INERROR`. Binary input keeps CopyFail, because CopyDone fails there on the missing file signature; `PQbinaryTuples` on the COPY result is what tells the two apart.
- `COPY TO STDOUT` is cancelled before its output is discarded whenever a cancel is safe, which it is not inside a transaction block, since a cancel aborts it. That restores the row cap the bounded read exists for.
- A COPY libpq will not leave now drops the connection instead of only logging, so the session reconnects rather than answering "another command is already in progress" forever.
- The messages say what happened: "The query editor cannot send data to COPY FROM STDIN, so no rows were sent. Use Import to load a file into a table." iOS has its own wording, since it has no data Import or Export.

## Verification

Both probes drive the real driver code with a 20 s watchdog per step. The macOS probe compiles `LibPQPluginConnection` from the plugin sources. The iOS probe compiles the real `TableProMobile/Drivers/PostgreSQLDriver.swift` for macOS with the mobile target's settings (Swift 6, default MainActor isolation, approachable concurrency), linked against TableProCore and the macOS libpq; only `DriverSSLConfiguration` is stubbed, because it pulls in the Oracle core. It is the same libpq API as the iOS xcframework (checked in its `libpq-fe.h`), but it is not an iOS build.

Against origin/main, on PostgreSQL 9.1.24, 17.11 and CockroachDB: a buffered COPY gave an empty error and the bounded or streamed COPY hung. On this branch every step returns a message and the connection stays usable.

The review's four cases, measured on 9.1.24 and 17.11:

| Case | Before this revision | Now |
| --- | --- | --- |
| `INSERT INTO t VALUES (1); COPY t FROM STDIN`, streamed (macOS and iOS) | reported "INSERT 0 1", COPY discarded, row count unchanged | the INSERT lands, the call reports the COPY did not run |
| `SELECT 1; COPY t TO STDOUT`, streamed | reported success, output discarded | reports that the output was discarded |
| `COPY t FROM STDIN` inside `BEGIN` | transaction aborted, next statement "current transaction is aborted" | transaction survives, the next INSERT in it succeeds |
| `COPY big TO STDOUT`, bounded, 200,000 rows, outside a transaction | whole result transferred: 261 ms on 9.1, 39 ms on 17 | cancelled first: 4 ms on 9.1, 1 ms on 17 (iOS: 83 ms to 4 ms, 37 ms to 1 ms) |

Binary `COPY FROM STDIN` was measured separately on both servers: it reports the same way and leaves no COPY behind.

Other steps covered: buffered, bounded, parameterized and streaming COPY IN and COPY OUT; a streamed query right after a buffered COPY; `COPY t FROM STDIN; SELECT 2`. Every step is followed by a `SELECT` on the same connection.

Unit tests:
- `LibPQPendingResultDrainTests` (TableProTests, 8 tests): a COPY behind an earlier statement is reported, two COPYs in one string are both ended, the format travels with the direction, and a COPY libpq refuses to leave returns after two reads and marks the connection unusable.
- `PostgreSQLCopyStateTests` (TableProMobileTests, 5 tests): the status-to-direction mapping over the real libpq constants, including the statuses that are not COPY, plus the iOS messages and the drain as compiled into the mobile target.

Both suites were also compiled and run standalone with Swift Testing: 8/8 and 5/5 pass.

## Verification

- Rebased on `main`. Build: PASS. `LibPQPendingResultDrainTests`, `LibPQByteaDecoderHexTests`, `LibPQPluginErrorTests`: 28 of 28 passed.
- Lint clean on the changed files.
- Review: Codex was unavailable (usage limit), so this was reviewed with the `code-review` skill. Its findings are applied: a COPY behind an earlier statement is reported instead of silently dropped, text and CSV `COPY FROM STDIN` end with CopyDone so an open transaction survives, bounded `COPY TO STDOUT` cancels before transferring, a stuck COPY drops the connection, and the libpq-facing half is one file shared with iOS.
- iOS: TableProMobile cannot be built on this machine; the third-party `oracle-nio` package fails on an `@TaskLocal` macro with the installed Xcode, on `main` too. The iOS driver changes were compiled for macOS and run against 9.1 and 17 through a probe (11 steps each), but they have not been through the iOS compiler or `PostgreSQLCopyStateTests` in the simulator. CI covers that.
