### PR TITLE
fix(plugins): decode ClickHouse values per column and N-prefix SQL Server literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Edit View Definition** enabled in the Database menu on a read-only connection. (#2726)
 - Enum types and sequences written in front of a PostgreSQL view's DDL. (#2726)
 - Display As formats lost on a rename, and kept with column layouts after deleting a connection.
+- Garbled ClickHouse text whenever another value in the same result held binary data.
+- Carriage returns, quotes, NUL bytes and Enum type names shown with backslash escapes on ClickHouse.
+- Edits and deletes matching no row on ClickHouse tables with a binary value in the row.
+- Non-ASCII SQL Server filter values turned into `?` and matching the wrong rows on non-Unicode collations.
+- Empty structure, missing indexes and failed renames for non-ASCII SQL Server object names on non-Unicode collations.
+- Changing a defaulted SQL Server column failing when a name contains a quote or non-ASCII text.
 
 ### Security
 

--- a/Packages/TableProCore/Sources/TableProMSSQLCore/MSSQLSchemaQueries.swift
+++ b/Packages/TableProCore/Sources/TableProMSSQLCore/MSSQLSchemaQueries.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public enum MSSQLSchemaQueries {
     public static func escape(_ value: String) -> String {
-        value.replacingOccurrences(of: "'", with: "''")
+        MSSQLStringLiteral.escaped(value)
     }
 
     public static func escapeBracket(_ value: String) -> String {
@@ -127,19 +127,19 @@ public enum MSSQLSchemaQueries {
         """
 
     public static func tables(schema: String) -> String {
-        let s = escape(schema)
+        let s = MSSQLStringLiteral.quoted(schema)
         return """
             SELECT t.TABLE_NAME, t.TABLE_TYPE
             FROM INFORMATION_SCHEMA.TABLES t
-            WHERE t.TABLE_SCHEMA = '\(s)'
+            WHERE t.TABLE_SCHEMA = \(s)
               AND t.TABLE_TYPE IN ('BASE TABLE', 'VIEW')
             ORDER BY t.TABLE_NAME
             """
     }
 
     public static func columns(schema: String, table: String) -> String {
-        let s = escape(schema)
-        let t = escape(table)
+        let s = MSSQLStringLiteral.quoted(schema)
+        let t = MSSQLStringLiteral.quoted(table)
         return """
             SELECT
                 c.COLUMN_NAME,
@@ -160,17 +160,17 @@ public enum MSSQLSchemaQueries {
                     ON tc.CONSTRAINT_NAME = kcu.CONSTRAINT_NAME
                     AND tc.TABLE_SCHEMA = kcu.TABLE_SCHEMA
                 WHERE tc.CONSTRAINT_TYPE = 'PRIMARY KEY'
-                    AND tc.TABLE_SCHEMA = '\(s)'
-                    AND tc.TABLE_NAME = '\(t)'
+                    AND tc.TABLE_SCHEMA = \(s)
+                    AND tc.TABLE_NAME = \(t)
             ) pk ON c.COLUMN_NAME = pk.COLUMN_NAME
-            WHERE c.TABLE_NAME = '\(t)'
-              AND c.TABLE_SCHEMA = '\(s)'
+            WHERE c.TABLE_NAME = \(t)
+              AND c.TABLE_SCHEMA = \(s)
             ORDER BY c.ORDINAL_POSITION
             """
     }
 
     public static func indexes(schema: String, table: String) -> String {
-        let object = bracketed(schema: schema, table: table)
+        let object = MSSQLStringLiteral.quoted(bracketed(schema: schema, table: table))
         return """
             SELECT i.name, i.is_unique, i.is_primary_key, c.name AS column_name
             FROM sys.indexes i
@@ -178,15 +178,15 @@ public enum MSSQLSchemaQueries {
                 ON i.object_id = ic.object_id AND i.index_id = ic.index_id
             JOIN sys.columns c
                 ON ic.object_id = c.object_id AND ic.column_id = c.column_id
-            WHERE i.object_id = OBJECT_ID('\(object)')
+            WHERE i.object_id = OBJECT_ID(\(object))
               AND i.name IS NOT NULL
             ORDER BY i.index_id, ic.key_ordinal
             """
     }
 
     public static func foreignKeys(schema: String, table: String) -> String {
-        let s = escape(schema)
-        let t = escape(table)
+        let s = MSSQLStringLiteral.quoted(schema)
+        let t = MSSQLStringLiteral.quoted(table)
         return """
             SELECT
                 fk.name AS constraint_name,
@@ -204,7 +204,7 @@ public enum MSSQLSchemaQueries {
             JOIN sys.schemas sr ON tr.schema_id = sr.schema_id
             JOIN sys.columns cr
                 ON fkc.referenced_object_id = cr.object_id AND fkc.referenced_column_id = cr.column_id
-            WHERE tp.name = '\(t)' AND s.name = '\(s)'
+            WHERE tp.name = \(t) AND s.name = \(s)
             ORDER BY fk.name
             """
     }

--- a/Packages/TableProCore/Sources/TableProMSSQLCore/MSSQLStringLiteral.swift
+++ b/Packages/TableProCore/Sources/TableProMSSQLCore/MSSQLStringLiteral.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// The single owner of how SQL Server spells a string literal carrying user text.
+///
+/// A plain `'…'` is a `varchar` literal, so the server converts it to the database's collation
+/// code page while it parses the batch. On a non-Unicode collation every character outside that
+/// page becomes `?`, and it happens whatever the target column is: inserting `'日本語'` into an
+/// `NVARCHAR(50)` column stores `??????`, and `WHERE n = '日本語'` then matches the row that was
+/// damaged earlier rather than the row that holds the text. `N'…'` is an `nvarchar` literal and is
+/// converted by nothing. It costs nothing on ASCII, where `N'abc' = 'abc'`.
+///
+/// Only text the user or the catalog supplies goes through here. A number, an identifier, a `0x`
+/// binary literal and a fixed catalog constant such as `'PRIMARY KEY'` must stay as they are.
+public enum MSSQLStringLiteral {
+    public static func escaped(_ value: String) -> String {
+        value.replacingOccurrences(of: "'", with: "''")
+    }
+
+    public static func quoted(_ value: String) -> String {
+        "N'\(escaped(value))'"
+    }
+
+    /// `LIKE` takes its pattern as an ordinary string literal, so the prefix belongs here too. The
+    /// wildcards the user typed are escaped and declared with `ESCAPE '\'`, which stays a plain
+    /// literal because a backslash is ASCII.
+    public static func likePattern(_ value: String, prefixWildcard: Bool, suffixWildcard: Bool) -> String {
+        let body = escapeForLike(value)
+        let pattern = (prefixWildcard ? "%" : "") + body + (suffixWildcard ? "%" : "")
+        return "N'\(pattern)' ESCAPE '\\'"
+    }
+
+    public static func escapeForLike(_ value: String) -> String {
+        escaped(
+            value
+                .replacingOccurrences(of: "\\", with: "\\\\")
+                .replacingOccurrences(of: "%", with: "\\%")
+                .replacingOccurrences(of: "_", with: "\\_")
+        )
+    }
+
+    /// The `LIKE` arms of the shared filter builder write their own literal rather than asking the
+    /// driver for one, so SQL Server answers them here and lets everything else fall through.
+    public static func likeCondition(quotedColumn: String, op: String, value: String) -> String? {
+        switch op {
+        case "CONTAINS":
+            return "\(quotedColumn) LIKE \(likePattern(value, prefixWildcard: true, suffixWildcard: true))"
+        case "NOT CONTAINS":
+            return "\(quotedColumn) NOT LIKE \(likePattern(value, prefixWildcard: true, suffixWildcard: true))"
+        case "STARTS WITH":
+            return "\(quotedColumn) LIKE \(likePattern(value, prefixWildcard: false, suffixWildcard: true))"
+        case "ENDS WITH":
+            return "\(quotedColumn) LIKE \(likePattern(value, prefixWildcard: true, suffixWildcard: false))"
+        default:
+            return nil
+        }
+    }
+}

--- a/Packages/TableProCore/Tests/TableProMSSQLCoreTests/MSSQLSchemaQueriesTests.swift
+++ b/Packages/TableProCore/Tests/TableProMSSQLCoreTests/MSSQLSchemaQueriesTests.swift
@@ -18,7 +18,7 @@ final class MSSQLSchemaQueriesTests: XCTestCase {
 
     func testTablesQueryEscapesSchema() {
         let sql = MSSQLSchemaQueries.tables(schema: "O'Brien")
-        XCTAssertTrue(sql.contains("'O''Brien'"))
+        XCTAssertTrue(sql.contains("N'O''Brien'"))
         XCTAssertTrue(sql.contains("INFORMATION_SCHEMA.TABLES"))
         XCTAssertTrue(sql.contains("'BASE TABLE'"))
         XCTAssertTrue(sql.contains("'VIEW'"))
@@ -28,21 +28,21 @@ final class MSSQLSchemaQueriesTests: XCTestCase {
         let sql = MSSQLSchemaQueries.columns(schema: "dbo", table: "Users")
         XCTAssertTrue(sql.contains("IsIdentity"))
         XCTAssertTrue(sql.contains("PRIMARY KEY"))
-        XCTAssertTrue(sql.contains("'Users'"))
-        XCTAssertTrue(sql.contains("'dbo'"))
+        XCTAssertTrue(sql.contains("N'Users'"))
+        XCTAssertTrue(sql.contains("N'dbo'"))
     }
 
     func testIndexesQueryUsesBracketedIdentifier() {
         let sql = MSSQLSchemaQueries.indexes(schema: "dbo", table: "Users")
-        XCTAssertTrue(sql.contains("OBJECT_ID('[dbo].[Users]')"))
+        XCTAssertTrue(sql.contains("OBJECT_ID(N'[dbo].[Users]')"))
         XCTAssertTrue(sql.contains("sys.indexes"))
     }
 
     func testForeignKeysQueryFiltersByTableAndSchema() {
         let sql = MSSQLSchemaQueries.foreignKeys(schema: "dbo", table: "Orders")
         XCTAssertTrue(sql.contains("sys.foreign_keys"))
-        XCTAssertTrue(sql.contains("'Orders'"))
-        XCTAssertTrue(sql.contains("'dbo'"))
+        XCTAssertTrue(sql.contains("N'Orders'"))
+        XCTAssertTrue(sql.contains("N'dbo'"))
     }
 
     func testForeignKeysQuerySelectsReferencedSchema() {
@@ -174,5 +174,25 @@ final class MSSQLSchemaQueriesTests: XCTestCase {
             sql,
             "SELECT * FROM [sales].[routeCache] ORDER BY (SELECT NULL) OFFSET 0 ROWS FETCH NEXT 200 ROWS ONLY"
         )
+    }
+
+    func testCatalogPredicatesSurviveANonAsciiName() {
+        let columns = MSSQLSchemaQueries.columns(schema: "dbo", table: "顧客テーブル")
+        XCTAssertTrue(columns.contains("N'顧客テーブル'"))
+        XCTAssertFalse(columns.contains("= '顧客テーブル'"))
+
+        let indexes = MSSQLSchemaQueries.indexes(schema: "dbo", table: "顧客テーブル")
+        XCTAssertTrue(indexes.contains("OBJECT_ID(N'[dbo].[顧客テーブル]')"))
+
+        let foreignKeys = MSSQLSchemaQueries.foreignKeys(schema: "スキーマ", table: "顧客テーブル")
+        XCTAssertTrue(foreignKeys.contains("N'顧客テーブル'"))
+        XCTAssertTrue(foreignKeys.contains("N'スキーマ'"))
+    }
+
+    func testFixedCatalogConstantsStayUnprefixed() {
+        let tables = MSSQLSchemaQueries.tables(schema: "dbo")
+        XCTAssertTrue(tables.contains("IN ('BASE TABLE', 'VIEW')"))
+        XCTAssertTrue(MSSQLSchemaQueries.columns(schema: "dbo", table: "t").contains("= 'PRIMARY KEY'"))
+        XCTAssertTrue(MSSQLSchemaQueries.schemas.contains("'information_schema'"))
     }
 }

--- a/Packages/TableProCore/Tests/TableProMSSQLCoreTests/MSSQLStringLiteralTests.swift
+++ b/Packages/TableProCore/Tests/TableProMSSQLCoreTests/MSSQLStringLiteralTests.swift
@@ -1,0 +1,88 @@
+@testable import TableProMSSQLCore
+import XCTest
+
+final class MSSQLStringLiteralTests: XCTestCase {
+    func testQuotedPrefixesWithN() {
+        XCTAssertEqual(MSSQLStringLiteral.quoted("plain"), "N'plain'")
+    }
+
+    func testQuotedKeepsNonAsciiText() {
+        XCTAssertEqual(MSSQLStringLiteral.quoted("日本語メール"), "N'日本語メール'")
+    }
+
+    func testQuotedDoublesSingleQuotes() {
+        XCTAssertEqual(MSSQLStringLiteral.quoted("O'Brien"), "N'O''Brien'")
+        XCTAssertEqual(MSSQLStringLiteral.quoted("'; DROP TABLE t --"), "N'''; DROP TABLE t --'")
+    }
+
+    func testQuotedHandlesEmptyString() {
+        XCTAssertEqual(MSSQLStringLiteral.quoted(""), "N''")
+    }
+
+    func testEscapedReturnsBodyWithoutQuotes() {
+        XCTAssertEqual(MSSQLStringLiteral.escaped("O'Brien"), "O''Brien")
+        XCTAssertEqual(MSSQLStringLiteral.escaped("plain"), "plain")
+    }
+
+    func testLikePatternWrapsWildcardsInsideTheLiteral() {
+        XCTAssertEqual(
+            MSSQLStringLiteral.likePattern("メール", prefixWildcard: true, suffixWildcard: true),
+            "N'%メール%' ESCAPE '\\'"
+        )
+        XCTAssertEqual(
+            MSSQLStringLiteral.likePattern("abc", prefixWildcard: false, suffixWildcard: true),
+            "N'abc%' ESCAPE '\\'"
+        )
+        XCTAssertEqual(
+            MSSQLStringLiteral.likePattern("abc", prefixWildcard: true, suffixWildcard: false),
+            "N'%abc' ESCAPE '\\'"
+        )
+    }
+
+    func testLikePatternEscapesUserWildcards() {
+        XCTAssertEqual(
+            MSSQLStringLiteral.likePattern("50%_off", prefixWildcard: true, suffixWildcard: true),
+            "N'%50\\%\\_off%' ESCAPE '\\'"
+        )
+    }
+
+    func testLikePatternEscapesBackslashBeforeWildcards() {
+        XCTAssertEqual(
+            MSSQLStringLiteral.likePattern("a\\b", prefixWildcard: false, suffixWildcard: false),
+            "N'a\\\\b' ESCAPE '\\'"
+        )
+    }
+
+    func testLikePatternDoublesSingleQuotes() {
+        XCTAssertEqual(
+            MSSQLStringLiteral.likePattern("O'Brien", prefixWildcard: true, suffixWildcard: true),
+            "N'%O''Brien%' ESCAPE '\\'"
+        )
+    }
+
+    func testLikeConditionCoversTheFourPatternOperators() {
+        XCTAssertEqual(
+            MSSQLStringLiteral.likeCondition(quotedColumn: "[n]", op: "CONTAINS", value: "日本"),
+            "[n] LIKE N'%日本%' ESCAPE '\\'"
+        )
+        XCTAssertEqual(
+            MSSQLStringLiteral.likeCondition(quotedColumn: "[n]", op: "NOT CONTAINS", value: "日本"),
+            "[n] NOT LIKE N'%日本%' ESCAPE '\\'"
+        )
+        XCTAssertEqual(
+            MSSQLStringLiteral.likeCondition(quotedColumn: "[n]", op: "STARTS WITH", value: "日本"),
+            "[n] LIKE N'日本%' ESCAPE '\\'"
+        )
+        XCTAssertEqual(
+            MSSQLStringLiteral.likeCondition(quotedColumn: "[n]", op: "ENDS WITH", value: "日本"),
+            "[n] LIKE N'%日本' ESCAPE '\\'"
+        )
+    }
+
+    func testLikeConditionLeavesOtherOperatorsToTheSharedBuilder() {
+        XCTAssertNil(MSSQLStringLiteral.likeCondition(quotedColumn: "[n]", op: "=", value: "x"))
+        XCTAssertNil(MSSQLStringLiteral.likeCondition(quotedColumn: "[n]", op: "IN", value: "a,b"))
+        XCTAssertNil(MSSQLStringLiteral.likeCondition(quotedColumn: "[n]", op: "IS NULL", value: ""))
+        XCTAssertNil(MSSQLStringLiteral.likeCondition(quotedColumn: "[n]", op: "REGEX", value: "x"))
+    }
+}

--- a/Plugins/ClickHouseDriverPlugin/ClickHouseParameterBinding.swift
+++ b/Plugins/ClickHouseDriverPlugin/ClickHouseParameterBinding.swift
@@ -1,0 +1,69 @@
+//
+//  ClickHouseParameterBinding.swift
+//  ClickHouseDriverPlugin
+//
+
+import Foundation
+import TableProPluginKit
+
+nonisolated internal enum ClickHouseParameterBinding {
+    struct Bound {
+        let query: String
+        let params: [String: String?]
+    }
+
+    /// A ClickHouse HTTP parameter is text: `{p1:String}` takes the characters of `param_p1`
+    /// verbatim, so bytes handed over as `0xDEADBEEF` compare as those ten characters and every
+    /// predicate on a binary column matches nothing. Bytes are written into the statement as
+    /// `unhex('…')` instead, which the server turns back into the value the read produced. The hex
+    /// is generated here and holds nothing but `0-9A-F`, so it closes no quote.
+    static func bind(query: String, parameters: [PluginCellValue]) -> Bound {
+        var converted = ""
+        converted.reserveCapacity((query as NSString).length)
+        var paramMap: [String: String?] = [:]
+        var consumed = 0
+        var namedCount = 0
+        var inSingleQuote = false
+        var inDoubleQuote = false
+        var isEscaped = false
+
+        for char in query {
+            if isEscaped {
+                isEscaped = false
+                converted.append(char)
+                continue
+            }
+            if char == "\\" && (inSingleQuote || inDoubleQuote) {
+                isEscaped = true
+                converted.append(char)
+                continue
+            }
+            if char == "'" && !inDoubleQuote {
+                inSingleQuote.toggle()
+            } else if char == "\"" && !inSingleQuote {
+                inDoubleQuote.toggle()
+            }
+            guard char == "?", !inSingleQuote, !inDoubleQuote, consumed < parameters.count else {
+                converted.append(char)
+                continue
+            }
+            let parameter = parameters[consumed]
+            consumed += 1
+            if case .bytes(let data) = parameter {
+                converted.append(hexLiteral(data))
+                continue
+            }
+            namedCount += 1
+            let name = "p\(namedCount)"
+            converted.append("{\(name):String}")
+            paramMap[name] = parameter.asText
+        }
+
+        return Bound(query: converted, params: paramMap)
+    }
+
+    static func hexLiteral(_ data: Data) -> String {
+        let hex = data.map { String(format: "%02X", $0) }.joined()
+        return "unhex('\(hex)')"
+    }
+}

--- a/Plugins/ClickHouseDriverPlugin/ClickHousePlugin.swift
+++ b/Plugins/ClickHouseDriverPlugin/ClickHousePlugin.swift
@@ -286,8 +286,8 @@ final class ClickHousePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
 
         let startTime = Date()
         let queryId = UUID().uuidString
-        let (convertedQuery, paramMap) = Self.buildClickHouseParams(query: query, parameters: parameters)
-        let result = try await executeRawWithParams(convertedQuery, params: paramMap, queryId: queryId)
+        let bound = ClickHouseParameterBinding.bind(query: query, parameters: parameters)
+        let result = try await executeRawWithParams(bound.query, params: bound.params, queryId: queryId)
         let executionTime = Date().timeIntervalSince(startTime)
 
         return PluginQueryResult(

--- a/Plugins/ClickHouseDriverPlugin/ClickHousePluginDriver+Http.swift
+++ b/Plugins/ClickHouseDriverPlugin/ClickHousePluginDriver+Http.swift
@@ -47,7 +47,7 @@ extension ClickHousePluginDriver {
 
         let httpResponse = response as? HTTPURLResponse
         if let httpResponse, httpResponse.statusCode >= 400 {
-            let body = String(data: data, encoding: .utf8) ?? "Unknown error"
+            let body = String(decoding: data, as: UTF8.self) // swiftlint:disable:this optional_data_string_conversion
             let exceptionCode = httpResponse.value(forHTTPHeaderField: "X-ClickHouse-Exception-Code") ?? "none"
             Self.logger.error("ClickHouse HTTP \(httpResponse.statusCode) exception \(exceptionCode): \(body)")
             throw ClickHouseError(message: body.trimmingCharacters(in: .whitespacesAndNewlines))
@@ -153,55 +153,5 @@ extension ClickHousePluginDriver {
         request.httpBody = trimmedQuery.data(using: .utf8)
 
         return request
-    }
-
-    /// Convert `?` placeholders to `{p1:String}` and build parameter map for ClickHouse HTTP params.
-    static func buildClickHouseParams(
-        query: String,
-        parameters: [PluginCellValue]
-    ) -> (String, [String: String?]) {
-        var converted = ""
-        var paramIndex = 0
-        var inSingleQuote = false
-        var inDoubleQuote = false
-        var isEscaped = false
-
-        for char in query {
-            if isEscaped {
-                isEscaped = false
-                converted.append(char)
-                continue
-            }
-            if char == "\\" && (inSingleQuote || inDoubleQuote) {
-                isEscaped = true
-                converted.append(char)
-                continue
-            }
-            if char == "'" && !inDoubleQuote {
-                inSingleQuote.toggle()
-            } else if char == "\"" && !inSingleQuote {
-                inDoubleQuote.toggle()
-            }
-            if char == "?" && !inSingleQuote && !inDoubleQuote && paramIndex < parameters.count {
-                paramIndex += 1
-                converted.append("{p\(paramIndex):String}")
-            } else {
-                converted.append(char)
-            }
-        }
-
-        var paramMap: [String: String?] = [:]
-        for i in 0..<paramIndex where i < parameters.count {
-            switch parameters[i] {
-            case .null:
-                paramMap["p\(i + 1)"] = nil
-            case .text(let s):
-                paramMap["p\(i + 1)"] = s
-            case .bytes(let d):
-                paramMap["p\(i + 1)"] = "0x" + d.map { String(format: "%02X", $0) }.joined()
-            }
-        }
-
-        return (converted, paramMap)
     }
 }

--- a/Plugins/MSSQLDriverPlugin/MSSQLObjectQueries.swift
+++ b/Plugins/MSSQLDriverPlugin/MSSQLObjectQueries.swift
@@ -6,17 +6,18 @@
 //
 
 import Foundation
+import TableProMSSQLCore
 
 public enum MSSQLObjectQueries {
     public static func escapeLiteral(_ value: String) -> String {
-        value.replacingOccurrences(of: "'", with: "''")
+        MSSQLStringLiteral.escaped(value)
     }
 
     /// Reads sys.sql_modules, never INFORMATION_SCHEMA.ROUTINES.ROUTINE_DEFINITION. That column is
     /// nvarchar(4000) and silently returns the first 4000 characters of a longer body, which looks
     /// like a routine that ends mid-statement.
     public static func routineList(schema: String) -> String {
-        let schemaLiteral = escapeLiteral(schema)
+        let schemaLiteral = MSSQLStringLiteral.quoted(schema)
         return """
             SELECT
                 o.name,
@@ -41,7 +42,7 @@ public enum MSSQLObjectQueries {
             FROM sys.objects o
             JOIN sys.schemas s ON s.schema_id = o.schema_id
             LEFT JOIN sys.sql_modules m ON m.object_id = o.object_id
-            WHERE s.name = '\(schemaLiteral)'
+            WHERE s.name = \(schemaLiteral)
                 AND o.type IN ('P', 'FN', 'IF', 'TF')
                 AND o.is_ms_shipped = 0
             ORDER BY o.type, o.name
@@ -54,7 +55,7 @@ public enum MSSQLObjectQueries {
         FROM sys.sql_modules m
         JOIN sys.objects o ON o.object_id = m.object_id
         JOIN sys.schemas s ON s.schema_id = o.schema_id
-        WHERE s.name = '\(escapeLiteral(schema))' AND o.name = '\(escapeLiteral(name))'
+        WHERE s.name = \(MSSQLStringLiteral.quoted(schema)) AND o.name = \(MSSQLStringLiteral.quoted(name))
         """
     }
 
@@ -62,8 +63,8 @@ public enum MSSQLObjectQueries {
     /// one table is one more predicate on the same query, so the per-table list and the
     /// schema-wide list cannot disagree.
     public static func triggerList(schema: String, table: String?) -> String {
-        let schemaLiteral = escapeLiteral(schema)
-        let tablePredicate = table.map { "AND parent.name = '\(escapeLiteral($0))'" } ?? ""
+        let schemaLiteral = MSSQLStringLiteral.quoted(schema)
+        let tablePredicate = table.map { "AND parent.name = \(MSSQLStringLiteral.quoted($0))" } ?? ""
         return """
             SELECT
                 t.name,
@@ -78,7 +79,7 @@ public enum MSSQLObjectQueries {
             JOIN sys.schemas s ON s.schema_id = parent.schema_id
             JOIN sys.trigger_events te ON te.object_id = t.object_id
             WHERE t.parent_class = 1
-                AND s.name = '\(schemaLiteral)'
+                AND s.name = \(schemaLiteral)
                 \(tablePredicate)
             ORDER BY parent.name, t.name, te.type_desc
             """

--- a/Plugins/MSSQLDriverPlugin/MSSQLPlugin.swift
+++ b/Plugins/MSSQLDriverPlugin/MSSQLPlugin.swift
@@ -273,7 +273,8 @@ final class MSSQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         if MSSQLCapabilities.parse(serverVersion).hasCreateOrAlterView {
             return "CREATE OR ALTER VIEW \(quoted) AS\nSELECT * FROM table_name;"
         }
-        return "IF OBJECT_ID('\(viewName)', 'V') IS NOT NULL DROP VIEW \(quoted);\nCREATE VIEW \(quoted) AS\nSELECT * FROM table_name;"
+        let viewLiteral = MSSQLStringLiteral.quoted(viewName)
+        return "IF OBJECT_ID(\(viewLiteral), 'V') IS NOT NULL DROP VIEW \(quoted);\nCREATE VIEW \(quoted) AS\nSELECT * FROM table_name;"
     }
 
     func castColumnToText(_ column: String) -> String {
@@ -283,10 +284,6 @@ final class MSSQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     init(config: DriverConnectionConfig) {
         self.config = config
         self._currentSchema = config.additionalFields["mssqlSchema"].flatMap { $0.isEmpty ? nil : $0 } ?? "dbo"
-    }
-
-    private var escapedSchema: String {
-        _currentSchema.replacingOccurrences(of: "'", with: "''")
     }
 
     // MARK: - Connection
@@ -686,13 +683,12 @@ final class MSSQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     }
 
     func fetchApproximateRowCount(table: String, schema: String?) async throws -> Int? {
-        let esc = effectiveSchemaEscaped(schema)
-        let escapedTable = table.replacingOccurrences(of: "'", with: "''")
-        let objectName = "[\(esc)].[\(escapedTable)]"
+        let objectLiteral = MSSQLStringLiteral.quoted(
+            MSSQLSchemaQueries.bracketed(schema: effectiveSchema(schema), table: table))
         let sql = """
             SELECT SUM(p.rows)
             FROM sys.partitions p
-            WHERE p.object_id = OBJECT_ID(N'\(objectName)') AND p.index_id IN (0, 1)
+            WHERE p.object_id = OBJECT_ID(\(objectLiteral)) AND p.index_id IN (0, 1)
             """
         let result = try await execute(query: sql)
         if let row = result.rows.first, let cell = row.first, let str = cell.asText {
@@ -774,16 +770,7 @@ final class MSSQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         offset: Int,
         columnKinds: [String: PluginColumnKind]
     ) -> String? {
-        let whereClause = PluginSQLFilter.buildWhereClause(
-            filters: filters,
-            logicMode: logicMode,
-            columnKinds: columnKinds,
-            quoteIdentifier: mssqlQuoteIdentifier,
-            escapeTypedValue: mssqlEscapeValue,
-            regexCondition: { quoted, value in
-                "\(quoted) LIKE '%\(value.replacingOccurrences(of: "'", with: "''"))%'"
-            }
-        )
+        let whereClause = mssqlWhereClause(filters: filters, logicMode: logicMode, columnKinds: columnKinds)
         let orderBy = PluginSQLFilter.buildOrderByClause(
             sortColumns: sortColumns, columns: columns, quoteIdentifier: mssqlQuoteIdentifier
         ) ?? "ORDER BY (SELECT NULL)"
@@ -799,13 +786,43 @@ final class MSSQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         quoteIdentifier(identifier)
     }
 
+    /// The shared builder writes the `LIKE` arms' literal itself rather than asking for one, so
+    /// SQL Server answers those arms first and lets every other operator fall through to it.
+    private func mssqlWhereClause(
+        filters: [(column: String, op: String, value: String)],
+        logicMode: String,
+        columnKinds: [String: PluginColumnKind]
+    ) -> String {
+        let conditions = filters.compactMap { filter -> String? in
+            let quoted = mssqlQuoteIdentifier(filter.column)
+            if let like = MSSQLStringLiteral.likeCondition(
+                quotedColumn: quoted, op: filter.op, value: filter.value
+            ) {
+                return like
+            }
+            return PluginSQLFilter.buildFilterCondition(
+                column: filter.column,
+                op: filter.op,
+                value: filter.value,
+                kind: columnKinds[filter.column],
+                quoteIdentifier: mssqlQuoteIdentifier,
+                escapeTypedValue: mssqlEscapeValue,
+                regexCondition: { quoted, value in
+                    "\(quoted) LIKE \(MSSQLStringLiteral.quoted("%\(value)%"))"
+                }
+            )
+        }
+        guard !conditions.isEmpty else { return "" }
+        return conditions.joined(separator: logicMode == "and" ? " AND " : " OR ")
+    }
+
     private func mssqlEscapeValue(_ value: String, kind: PluginColumnKind?) -> String {
         PluginSQLLiteral.escapedLiteral(
             value,
             kind: kind,
             trueLiteral: "1",
             falseLiteral: "0",
-            quote: { "'\($0.replacingOccurrences(of: "'", with: "''"))'" }
+            quote: MSSQLStringLiteral.quoted
         )
     }
 
@@ -881,8 +898,8 @@ final class MSSQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         return schema
     }
 
-    func effectiveSchemaEscaped(_ schema: String?) -> String {
-        MSSQLSchemaQueries.escape(effectiveSchema(schema))
+    func effectiveSchemaQuoted(_ schema: String?) -> String {
+        MSSQLStringLiteral.quoted(effectiveSchema(schema))
     }
 
 }

--- a/Plugins/MSSQLDriverPlugin/MSSQLPluginDriver+DDL.swift
+++ b/Plugins/MSSQLDriverPlugin/MSSQLPluginDriver+DDL.swift
@@ -116,22 +116,25 @@ extension MSSQLPluginDriver {
 
         // Rename column first so subsequent statements reference the correct name
         if oldColumn.name != newColumn.name {
-            let escapedPath = "\(escapeStringLiteral(_currentSchema)).\(escapeStringLiteral(table)).\(escapeStringLiteral(oldColumn.name))"
-            stmts.append("EXEC sp_rename '\(escapedPath)', '\(escapeStringLiteral(newColumn.name))', 'COLUMN'")
+            let path = MSSQLStringLiteral.quoted("\(_currentSchema).\(table).\(oldColumn.name)")
+            let renamed = MSSQLStringLiteral.quoted(newColumn.name)
+            stmts.append("EXEC sp_rename \(path), \(renamed), 'COLUMN'")
         }
 
         let colName = quoteIdentifier(newColumn.name)
 
         // Drop existing default constraint before ALTER COLUMN or default change
         if (defaultChanged || needsTypeChange) && oldColumn.defaultValue != nil {
-            let objectId = escapeStringLiteral("\(_currentSchema).\(table)")
+            let objectLiteral = MSSQLStringLiteral.quoted(qt)
+            let dropPrefix = MSSQLStringLiteral.quoted("ALTER TABLE \(qt) DROP CONSTRAINT ")
             stmts.append("""
                 DECLARE @dfName NVARCHAR(256); \
                 SELECT @dfName = dc.name FROM sys.default_constraints dc \
                 JOIN sys.columns c ON dc.parent_column_id = c.column_id AND dc.parent_object_id = c.object_id \
-                WHERE c.name = '\(escapeStringLiteral(newColumn.name))' \
-                AND dc.parent_object_id = OBJECT_ID('\(objectId)'); \
-                IF @dfName IS NOT NULL EXEC('ALTER TABLE \(qt) DROP CONSTRAINT [' + @dfName + ']')
+                WHERE c.name = \(MSSQLStringLiteral.quoted(newColumn.name)) \
+                AND dc.parent_object_id = OBJECT_ID(\(objectLiteral)); \
+                IF @dfName IS NOT NULL BEGIN DECLARE @dropSql NVARCHAR(MAX) = \(dropPrefix) + QUOTENAME(@dfName); \
+                EXEC(@dropSql); END
                 """)
         }
 
@@ -185,17 +188,14 @@ extension MSSQLPluginDriver {
     /// `sys.check_constraints.parent_column_id` is 0 for a multi-column check, so the columns come
     /// from `sys.sql_expression_dependencies`, which lists them for both shapes.
     func fetchCheckConstraints(table: String, schema: String?) async throws -> [PluginCheckConstraintInfo] {
-        // Bracket-quoting makes `target` a safe identifier, but it lands inside a string literal
-        // here, so it needs literal escaping too: a legal name like O'Reilly would otherwise
-        // terminate the literal.
-        let target = escapeStringLiteral(mssqlQualifiedTable(table))
+        let targetLiteral = MSSQLStringLiteral.quoted(mssqlQualifiedTable(table))
         let query = """
             SELECT cc.name, cc.definition, cc.is_not_trusted,
                    COL_NAME(d.referenced_id, d.referenced_minor_id)
             FROM sys.check_constraints cc
             LEFT JOIN sys.sql_expression_dependencies d
                 ON d.referencing_id = cc.object_id AND d.referenced_minor_id > 0
-            WHERE cc.parent_object_id = OBJECT_ID(\'\(target)\')
+            WHERE cc.parent_object_id = OBJECT_ID(\(targetLiteral))
             ORDER BY cc.name
             """
         let result = try await execute(query: query)

--- a/Plugins/MSSQLDriverPlugin/MSSQLPluginDriver+Schema.swift
+++ b/Plugins/MSSQLDriverPlugin/MSSQLPluginDriver+Schema.swift
@@ -13,11 +13,11 @@ extension MSSQLPluginDriver {
 
     func fetchTables(schema: String?) async throws -> [PluginTableInfo] {
         let resolved = effectiveSchema(schema)
-        let esc = MSSQLSchemaQueries.escape(resolved)
+        let schemaLiteral = MSSQLStringLiteral.quoted(resolved)
         let sql = """
             SELECT t.TABLE_NAME, t.TABLE_TYPE
             FROM INFORMATION_SCHEMA.TABLES t
-            WHERE t.TABLE_SCHEMA = '\(esc)'
+            WHERE t.TABLE_SCHEMA = \(schemaLiteral)
               AND t.TABLE_TYPE IN ('BASE TABLE', 'VIEW')
             ORDER BY t.TABLE_NAME
             """
@@ -31,8 +31,8 @@ extension MSSQLPluginDriver {
     }
 
     func fetchColumns(table: String, schema: String?) async throws -> [PluginColumnInfo] {
-        let escapedTable = table.replacingOccurrences(of: "'", with: "''")
-        let esc = effectiveSchemaEscaped(schema)
+        let tableLiteral = MSSQLStringLiteral.quoted(table)
+        let schemaLiteral = effectiveSchemaQuoted(schema)
         let sql = """
             SELECT
                 c.COLUMN_NAME,
@@ -53,11 +53,11 @@ extension MSSQLPluginDriver {
                     ON tc.CONSTRAINT_NAME = kcu.CONSTRAINT_NAME
                     AND tc.TABLE_SCHEMA = kcu.TABLE_SCHEMA
                 WHERE tc.CONSTRAINT_TYPE = 'PRIMARY KEY'
-                    AND tc.TABLE_SCHEMA = '\(esc)'
-                    AND tc.TABLE_NAME = '\(escapedTable)'
+                    AND tc.TABLE_SCHEMA = \(schemaLiteral)
+                    AND tc.TABLE_NAME = \(tableLiteral)
             ) pk ON c.COLUMN_NAME = pk.COLUMN_NAME
-            WHERE c.TABLE_NAME = '\(escapedTable)'
-              AND c.TABLE_SCHEMA = '\(esc)'
+            WHERE c.TABLE_NAME = \(tableLiteral)
+              AND c.TABLE_SCHEMA = \(schemaLiteral)
             ORDER BY c.ORDINAL_POSITION
             """
         let result = try await execute(query: sql)
@@ -153,7 +153,7 @@ extension MSSQLPluginDriver {
     func fetchIndexes(table: String, schema: String?) async throws -> [PluginIndexInfo] {
         /// Bracket-escaped for the identifier and literal-escaped for the string it sits in:
         /// SQL Server allows both `]` and `'` in an identifier.
-        let bracketedFull = MSSQLSchemaQueries.escape(
+        let objectLiteral = MSSQLStringLiteral.quoted(
             MSSQLSchemaQueries.bracketed(schema: effectiveSchema(schema), table: table))
         let sql = """
             SELECT i.name, i.is_unique, i.is_primary_key, c.name AS column_name, i.type_desc
@@ -162,7 +162,7 @@ extension MSSQLPluginDriver {
                 ON i.object_id = ic.object_id AND i.index_id = ic.index_id
             JOIN sys.columns c
                 ON ic.object_id = c.object_id AND ic.column_id = c.column_id
-            WHERE i.object_id = OBJECT_ID('\(bracketedFull)')
+            WHERE i.object_id = OBJECT_ID(\(objectLiteral))
               AND i.name IS NOT NULL
             ORDER BY i.index_id, ic.key_ordinal
             """
@@ -208,7 +208,7 @@ extension MSSQLPluginDriver {
         /// The bracketed name is spliced into a string literal, so a name carrying a quote needs
         /// the literal escape as well as the bracket one. SQL Server allows both characters in an
         /// identifier.
-        let objectRef = MSSQLSchemaQueries.escape(
+        let objectLiteral = MSSQLStringLiteral.quoted(
             MSSQLSchemaQueries.bracketed(schema: effectiveSchema(schema), table: table))
         let sql = """
             SELECT i.name, i.type_desc, i.is_unique, i.filter_definition,
@@ -218,7 +218,7 @@ extension MSSQLPluginDriver {
                 ON i.object_id = ic.object_id AND i.index_id = ic.index_id
             JOIN sys.columns c
                 ON ic.object_id = c.object_id AND ic.column_id = c.column_id
-            WHERE i.object_id = OBJECT_ID('\(objectRef)')
+            WHERE i.object_id = OBJECT_ID(\(objectLiteral))
               AND i.name IS NOT NULL
               AND i.is_primary_key = 0
               AND i.type IN (1, 2)
@@ -270,7 +270,8 @@ extension MSSQLPluginDriver {
     func fetchTriggerDefinition(name: String, table: String, schema: String?) async throws -> String? {
         let esc = MSSQLSchemaQueries.escapeBracket(effectiveSchema(schema))
         let bracketedName = name.replacingOccurrences(of: "]", with: "]]")
-        let sql = "SELECT OBJECT_DEFINITION(OBJECT_ID('[\(esc)].[\(bracketedName)]'))"
+        let objectLiteral = MSSQLStringLiteral.quoted("[\(esc)].[\(bracketedName)]")
+        let sql = "SELECT OBJECT_DEFINITION(OBJECT_ID(\(objectLiteral)))"
         let result = try await execute(query: sql)
         guard let definition = result.rows.first?[safe: 0]?.asText, !definition.isEmpty else { return nil }
         guard let range = definition.range(of: "CREATE TRIGGER", options: .caseInsensitive) else {
@@ -285,7 +286,7 @@ extension MSSQLPluginDriver {
     }
 
     func fetchAllColumns(schema: String?) async throws -> [String: [PluginColumnInfo]] {
-        let esc = effectiveSchemaEscaped(schema)
+        let schemaLiteral = effectiveSchemaQuoted(schema)
         let sql = """
             SELECT
                 c.TABLE_NAME,
@@ -307,9 +308,9 @@ extension MSSQLPluginDriver {
                     ON tc.CONSTRAINT_NAME = kcu.CONSTRAINT_NAME
                     AND tc.TABLE_SCHEMA = kcu.TABLE_SCHEMA
                 WHERE tc.CONSTRAINT_TYPE = 'PRIMARY KEY'
-                    AND tc.TABLE_SCHEMA = '\(esc)'
+                    AND tc.TABLE_SCHEMA = \(schemaLiteral)
             ) pk ON c.TABLE_NAME = pk.TABLE_NAME AND c.COLUMN_NAME = pk.COLUMN_NAME
-            WHERE c.TABLE_SCHEMA = '\(esc)'
+            WHERE c.TABLE_SCHEMA = \(schemaLiteral)
             ORDER BY c.TABLE_NAME, c.ORDINAL_POSITION
             """
         let result = try await execute(query: sql)
@@ -377,7 +378,7 @@ extension MSSQLPluginDriver {
     var tableDDLIncludesForeignKeys: Bool { true }
 
     func fetchAllForeignKeys(schema: String?) async throws -> [String: [PluginForeignKeyInfo]] {
-        let esc = effectiveSchemaEscaped(schema)
+        let schemaLiteral = effectiveSchemaQuoted(schema)
         let sql = """
             SELECT
                 tp.name AS table_name,
@@ -396,7 +397,7 @@ extension MSSQLPluginDriver {
             JOIN sys.schemas sr ON tr.schema_id = sr.schema_id
             JOIN sys.columns cr
                 ON fkc.referenced_object_id = cr.object_id AND fkc.referenced_column_id = cr.column_id
-            WHERE s.name = '\(esc)'
+            WHERE s.name = \(schemaLiteral)
             ORDER BY tp.name, fk.name
             """
         let result = try await execute(query: sql)
@@ -472,13 +473,12 @@ extension MSSQLPluginDriver {
     }
 
     func fetchTableDDL(table: String, schema: String?) async throws -> String {
-        let escapedTable = table.replacingOccurrences(of: "'", with: "''")
-        let esc = effectiveSchemaEscaped(schema)
+        let qualified = MSSQLSchemaQueries.bracketed(schema: effectiveSchema(schema), table: table)
         let cols = try await fetchColumns(table: table, schema: schema)
         let indexes = try await fetchIndexes(table: table, schema: schema)
         let fks = try await fetchForeignKeys(table: table, schema: schema)
 
-        var ddl = "CREATE TABLE [\(esc)].[\(escapedTable)] (\n"
+        var ddl = "CREATE TABLE \(qualified) (\n"
         let colDefs = cols.map { col -> String in
             var def = "    [\(col.name)] \(col.dataType.uppercased())"
             if col.extra == "IDENTITY" { def += " IDENTITY(1,1)" }
@@ -506,16 +506,15 @@ extension MSSQLPluginDriver {
     }
 
     func fetchViewDefinition(view: String, schema: String?) async throws -> String {
-        let esc = effectiveSchemaEscaped(schema)
-        let escapedView = "\(esc).\(view.replacingOccurrences(of: "'", with: "''"))"
-        let sql = "SELECT definition FROM sys.sql_modules WHERE object_id = OBJECT_ID('\(escapedView)')"
+        let viewLiteral = MSSQLStringLiteral.quoted("\(effectiveSchema(schema)).\(view)")
+        let sql = "SELECT definition FROM sys.sql_modules WHERE object_id = OBJECT_ID(\(viewLiteral))"
         let result = try await execute(query: sql)
         return result.rows.first?.first?.asText ?? ""
     }
 
     func fetchTableMetadata(table: String, schema: String?) async throws -> PluginTableMetadata {
-        let escapedTable = table.replacingOccurrences(of: "'", with: "''")
-        let esc = effectiveSchemaEscaped(schema)
+        let tableLiteral = MSSQLStringLiteral.quoted(table)
+        let schemaLiteral = effectiveSchemaQuoted(schema)
         let sql = """
             SELECT
                 SUM(p.rows) AS row_count,
@@ -528,7 +527,7 @@ extension MSSQLPluginDriver {
             JOIN sys.allocation_units a ON p.partition_id = a.container_id
             LEFT JOIN sys.extended_properties ep
                 ON ep.major_id = t.object_id AND ep.minor_id = 0 AND ep.name = 'MS_Description'
-            WHERE t.name = '\(escapedTable)' AND s.name = '\(esc)'
+            WHERE t.name = \(tableLiteral) AND s.name = \(schemaLiteral)
             GROUP BY ep.value
             """
         let result = try await execute(query: sql)

--- a/Plugins/TableProPluginKit/ClickHouseResponseClassifier.swift
+++ b/Plugins/TableProPluginKit/ClickHouseResponseClassifier.swift
@@ -37,11 +37,11 @@ public enum ClickHouseResponseClassifier {
         if let format = headerValue(headers, named: formatHeaderName), format != requestedFormat {
             return rawOutcome(body: body)
         }
-        let text = decodedText(body)
-        guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        let bytes = [UInt8](body)
+        guard !ClickHouseTabSeparatedBytes.isAsciiWhitespace(bytes) else {
             return noResultSetOutcome(headers: headers)
         }
-        let lines = text.components(separatedBy: "\n")
+        let lines = ClickHouseTabSeparatedBytes.lines(bytes)
         guard lines.count >= 2 else {
             return rawOutcome(body: body)
         }
@@ -58,30 +58,8 @@ public enum ClickHouseResponseClassifier {
     }
 
     public static func unescapeTsvField(_ field: String) -> String {
-        var result = ""
-        result.reserveCapacity((field as NSString).length)
-        var iterator = field.makeIterator()
-
-        while let char = iterator.next() {
-            if char == "\\" {
-                if let next = iterator.next() {
-                    switch next {
-                    case "\\": result.append("\\")
-                    case "t": result.append("\t")
-                    case "n": result.append("\n")
-                    default:
-                        result.append("\\")
-                        result.append(next)
-                    }
-                } else {
-                    result.append("\\")
-                }
-            } else {
-                result.append(char)
-            }
-        }
-
-        return result
+        let bytes = Array(field.utf8)
+        return String(decoding: ClickHouseTabSeparatedBytes.unescape(bytes[...]), as: UTF8.self) // swiftlint:disable:this optional_data_string_conversion
     }
 
     private static func noResultSetOutcome(headers: [String: String]) -> Outcome {
@@ -94,31 +72,49 @@ public enum ClickHouseResponseClassifier {
         )
     }
 
+    /// A body the server wrote in a format the user asked for is one opaque value. It is text when
+    /// it decodes as text and bytes when it does not, because a `Native` or `Parquet` body read as
+    /// Latin-1 is mojibake that cannot be copied back out.
     private static func rawOutcome(body: Data) -> Outcome {
         let isTruncated = body.count > rawBodyByteCap
-        let text = decodedText(body.prefix(rawBodyByteCap))
+        let capped = [UInt8](body.prefix(rawBodyByteCap))
+        let decodable = isTruncated ? Array(droppingCutSequence(capped)) : capped
+        let value: PluginCellValue = utf8Text(decodable).map { .text($0) } ?? .bytes(Data(capped))
         return Outcome(
             columns: [String(localized: "Output")],
             columnTypeNames: ["String"],
-            rows: [[.text(text)]],
+            rows: [[value]],
             affectedRows: 1,
             isTruncated: isTruncated
         )
     }
 
-    private static func tabSeparatedOutcome(lines: [String], rowLimit: Int) -> Outcome {
-        let columns = lines[0].components(separatedBy: "\t")
-        let columnTypeNames = lines[1].components(separatedBy: "\t")
+    private static func tabSeparatedOutcome(lines: [ArraySlice<UInt8>], rowLimit: Int) -> Outcome {
+        let columns = ClickHouseTabSeparatedBytes.fields(lines[0]).map(ClickHouseTabSeparatedBytes.headerText)
+        let columnTypeNames = ClickHouseTabSeparatedBytes.fields(lines[1]).map(ClickHouseTabSeparatedBytes.headerText)
 
         var rows: [[PluginCellValue]] = []
+        var binaryColumns = Set<Int>()
         var isTruncated = false
         for index in 2..<lines.count {
             let line = lines[index]
             if line.isEmpty { continue }
 
-            let fields = line.components(separatedBy: "\t")
-            let row: [PluginCellValue] = fields.map { field in
-                field == "\\N" ? .null : .text(unescapeTsvField(field))
+            let fields = ClickHouseTabSeparatedBytes.fields(line)
+            var row: [PluginCellValue] = []
+            row.reserveCapacity(fields.count)
+            for (column, field) in fields.enumerated() {
+                if ClickHouseTabSeparatedBytes.isNullMarker(field) {
+                    row.append(.null)
+                    continue
+                }
+                let value = ClickHouseTabSeparatedBytes.unescape(field)
+                guard let text = utf8Text(value) else {
+                    binaryColumns.insert(column)
+                    row.append(.bytes(Data(value)))
+                    continue
+                }
+                row.append(.text(text))
             }
             rows.append(row)
             if rows.count >= rowLimit {
@@ -130,19 +126,52 @@ public enum ClickHouseResponseClassifier {
         return Outcome(
             columns: columns,
             columnTypeNames: columnTypeNames,
-            rows: rows,
+            rows: demoteBinaryColumns(binaryColumns, in: rows),
             affectedRows: rows.count,
             isTruncated: isTruncated
         )
     }
 
-    private static func decodedText(_ data: Data) -> String {
-        for suffixLength in 0...3 where data.count >= suffixLength {
-            if let text = String(bytes: data.dropLast(suffixLength), encoding: .utf8) {
-                return text
+    /// One value that is not text makes the whole column binary. A `FixedString(16)` of raw UUIDs
+    /// decodes on the rows whose bytes happen to be valid UTF-8 and not on the rest, and a column
+    /// that renders as hex on some rows and as mojibake on others is the worse answer. Re-encoding
+    /// a decoded value is exact: UTF-8 round-trips whenever the decode succeeded.
+    private static func demoteBinaryColumns(
+        _ binaryColumns: Set<Int>,
+        in rows: [[PluginCellValue]]
+    ) -> [[PluginCellValue]] {
+        guard !binaryColumns.isEmpty else { return rows }
+        return rows.map { row in
+            row.enumerated().map { column, value in
+                guard binaryColumns.contains(column), case .text(let text) = value else { return value }
+                return .bytes(Data(text.utf8))
             }
         }
-        return String(bytes: data, encoding: .isoLatin1) ?? ""
+    }
+
+    private static func utf8Text(_ bytes: [UInt8]) -> String? {
+        String(bytes: bytes, encoding: .utf8)
+    }
+
+    /// The byte cap can stop inside a multi-byte character, so a truncated body sheds that one
+    /// incomplete sequence and nothing else. Dropping trailing bytes until the rest decodes would
+    /// call a short binary body text, and a field is never cut, so it never comes through here.
+    private static func droppingCutSequence(_ bytes: [UInt8]) -> ArraySlice<UInt8> {
+        guard !bytes.isEmpty else { return bytes[...] }
+        for offset in 1...min(3, bytes.count) {
+            let index = bytes.count - offset
+            let byte = bytes[index]
+            if byte & 0xC0 == 0x80 { continue }
+            let sequenceLength: Int
+            switch byte {
+            case 0xC0...0xDF: sequenceLength = 2
+            case 0xE0...0xEF: sequenceLength = 3
+            case 0xF0...0xF7: sequenceLength = 4
+            default: return bytes[...]
+            }
+            return offset < sequenceLength ? bytes[..<index] : bytes[...]
+        }
+        return bytes[...]
     }
 
     private static func headerValue(_ headers: [String: String], named name: String) -> String? {

--- a/Plugins/TableProPluginKit/ClickHouseTabSeparatedBytes.swift
+++ b/Plugins/TableProPluginKit/ClickHouseTabSeparatedBytes.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+/// ClickHouse writes `TabSeparated` as a byte stream, not as text. A `String` column is an
+/// arbitrary byte sequence, and the only bytes the format escapes are the eight below, so a value
+/// holding a hash, a protobuf or a lone `0xC3` reaches the client verbatim. Splitting and
+/// unescaping therefore happen on bytes, and only a finished field is offered to a text decode.
+internal enum ClickHouseTabSeparatedBytes {
+    static let lineSeparator: UInt8 = 0x0A
+    static let fieldSeparator: UInt8 = 0x09
+    private static let backslash: UInt8 = 0x5C
+    private static let nullMarkerSuffix: UInt8 = 0x4E
+
+    static func lines(_ bytes: [UInt8]) -> [ArraySlice<UInt8>] {
+        split(bytes[...], on: lineSeparator)
+    }
+
+    static func fields(_ line: ArraySlice<UInt8>) -> [ArraySlice<UInt8>] {
+        split(line, on: fieldSeparator)
+    }
+
+    static func isNullMarker(_ field: ArraySlice<UInt8>) -> Bool {
+        field.count == 2 && field.first == backslash && field.last == nullMarkerSuffix
+    }
+
+    static func isAsciiWhitespace(_ bytes: [UInt8]) -> Bool {
+        bytes.allSatisfy { $0 == 0x20 || $0 == 0x09 || $0 == 0x0A || $0 == 0x0D || $0 == 0x0B || $0 == 0x0C }
+    }
+
+    /// The escape table ClickHouse's own `writeEscapedString` emits. An unrecognised escape keeps
+    /// both of its bytes: a future addition then reads oddly rather than losing the character.
+    static func unescape(_ field: ArraySlice<UInt8>) -> [UInt8] {
+        guard field.contains(backslash) else { return Array(field) }
+
+        var result: [UInt8] = []
+        result.reserveCapacity(field.count)
+        var index = field.startIndex
+
+        while index < field.endIndex {
+            let byte = field[index]
+            guard byte == backslash else {
+                result.append(byte)
+                index = field.index(after: index)
+                continue
+            }
+            let next = field.index(after: index)
+            guard next < field.endIndex else {
+                result.append(backslash)
+                break
+            }
+            if let decoded = escapedByte(field[next]) {
+                result.append(decoded)
+            } else {
+                result.append(backslash)
+                result.append(field[next])
+            }
+            index = field.index(after: next)
+        }
+
+        return result
+    }
+
+    /// Nil when the byte after the backslash is not one ClickHouse escapes.
+    static func escapedByte(_ byte: UInt8) -> UInt8? {
+        switch byte {
+        case 0x5C: return 0x5C
+        case 0x74: return 0x09
+        case 0x6E: return 0x0A
+        case 0x72: return 0x0D
+        case 0x30: return 0x00
+        case 0x62: return 0x08
+        case 0x66: return 0x0C
+        case 0x27: return 0x27
+        default: return nil
+        }
+    }
+
+    /// A header field has to become a `String`, so an undecodable byte is replaced rather than
+    /// dropping the column. A value never takes this path; it stays bytes instead.
+    static func headerText(_ field: ArraySlice<UInt8>) -> String {
+        String(decoding: unescape(field), as: UTF8.self) // swiftlint:disable:this optional_data_string_conversion
+    }
+
+    private static func split(_ bytes: ArraySlice<UInt8>, on separator: UInt8) -> [ArraySlice<UInt8>] {
+        var parts: [ArraySlice<UInt8>] = []
+        var start = bytes.startIndex
+        var index = bytes.startIndex
+
+        while index < bytes.endIndex {
+            if bytes[index] == separator {
+                parts.append(bytes[start..<index])
+                start = bytes.index(after: index)
+            }
+            index = bytes.index(after: index)
+        }
+        parts.append(bytes[start..<bytes.endIndex])
+        return parts
+    }
+}

--- a/TablePro/Core/Coordinators/FilterCoordinator.swift
+++ b/TablePro/Core/Coordinators/FilterCoordinator.swift
@@ -633,7 +633,8 @@ final class FilterCoordinator {
         let generator = FilterSQLGenerator(
             dialect: dialect,
             columns: queryColumns?.columns ?? [],
-            columnTypes: queryColumns?.columnTypes ?? []
+            columnTypes: queryColumns?.columnTypes ?? [],
+            stringLiteralPrefix: SQLStringLiteralPrefix.forDatabaseType(databaseType)
         )
         let filtersToPreview = filtersForPreview(in: state)
 

--- a/TablePro/Core/Database/FilterSQLGenerator.swift
+++ b/TablePro/Core/Database/FilterSQLGenerator.swift
@@ -27,16 +27,25 @@ struct FilterSQLGenerator {
     private let dialect: SQLDialectDescriptor
     private let quoteIdentifierFn: (String) -> String
     private let columnTypesByName: [String: ColumnType]
+    private let stringLiteralPrefix: String
 
     init(
         dialect: SQLDialectDescriptor,
         columns: [String] = [],
         columnTypes: [ColumnType] = [],
-        quoteIdentifier: ((String) -> String)? = nil
+        quoteIdentifier: ((String) -> String)? = nil,
+        stringLiteralPrefix: String = ""
     ) {
         self.dialect = dialect
         self.quoteIdentifierFn = quoteIdentifier ?? quoteIdentifierFromDialect(dialect)
         self.columnTypesByName = ColumnTypeSQLQuoting.lookupByName(columns: columns, columnTypes: columnTypes)
+        self.stringLiteralPrefix = stringLiteralPrefix
+    }
+
+    /// The one place a string literal is spelled, so the engine's prefix cannot be forgotten on
+    /// one arm and applied on another.
+    private func quotedLiteral(_ escapedBody: String) -> String {
+        "\(stringLiteralPrefix)'\(escapedBody)'"
     }
 
     // MARK: - Public API
@@ -147,7 +156,7 @@ struct FilterSQLGenerator {
         case .regex:
             let operand = patternOperand(quotedColumn, columnType: columnType)
             guard dialect.regexSyntax != .unsupported else {
-                let pattern = "'%\(escapeSQLQuote(filter.value))%'"
+                let pattern = quotedLiteral("%\(escapeSQLQuote(filter.value))%")
                 return "\(folding.foldingLikeOperand(operand)) \(folding.likeKeyword) "
                     + folding.foldingLikeOperand(pattern)
             }
@@ -292,7 +301,7 @@ struct FilterSQLGenerator {
         negated: Bool,
         folding: PluginSQLCaseFolding
     ) -> String {
-        let quotedPattern = "'\(escapeSQLQuote(pattern))'"
+        let quotedPattern = quotedLiteral(escapeSQLQuote(pattern))
         let keyword = negated ? folding.notLikeKeyword : folding.likeKeyword
         let operand = folding.foldingLikeOperand(column)
         return "\(operand) \(keyword) \(folding.foldingLikeOperand(quotedPattern))\(likeEscapeClause)"
@@ -357,7 +366,7 @@ struct FilterSQLGenerator {
             guard ignoresCase else { return "match(\(column), '\(escapedPattern)')" }
             return "match(\(column), '(?i)\(escapedPattern)')"
         case .unsupported:
-            return "\(column) LIKE '%\(escapedPattern)%'"
+            return "\(column) LIKE \(quotedLiteral("%\(escapedPattern)%"))"
         }
     }
 
@@ -379,7 +388,7 @@ struct FilterSQLGenerator {
             return .value(trimmed)
         }
 
-        return .value("'\(escapeStringValue(trimmed))'")
+        return .value(quotedLiteral(escapeStringValue(trimmed)))
     }
 
     private func booleanLiteral(for value: String, columnType: ColumnType?) -> String? {

--- a/TablePro/Core/Database/ForeignKeyLookupQuery.swift
+++ b/TablePro/Core/Database/ForeignKeyLookupQuery.swift
@@ -27,6 +27,7 @@ enum ForeignKeyLookupQuery {
         label: ForeignKeyLookupColumn?,
         searchTerm: String,
         dialect: SQLDialectDescriptor,
+        stringLiteralPrefix: String,
         quoteIdentifier: @escaping (String) -> String
     ) -> String? {
         let selected = selectedColumns(key: key, label: label)
@@ -35,7 +36,8 @@ enum ForeignKeyLookupQuery {
             dialect: dialect,
             columns: selected.map(\.name),
             columnTypes: selected.map(\.type),
-            quoteIdentifier: quoteIdentifier
+            quoteIdentifier: quoteIdentifier,
+            stringLiteralPrefix: stringLiteralPrefix
         )
 
         /// A referenced column may be a nullable `UNIQUE` one, and ascending order puts its NULLs

--- a/TablePro/Core/Services/Query/ForeignKeyLookupService.swift
+++ b/TablePro/Core/Services/Query/ForeignKeyLookupService.swift
@@ -72,6 +72,7 @@ enum ForeignKeyLookupService {
                 label: label,
                 searchTerm: term,
                 dialect: dialect,
+                stringLiteralPrefix: SQLStringLiteralPrefix.forDatabaseType(databaseType),
                 quoteIdentifier: driver.quoteIdentifier
             ) else {
                 return []

--- a/TablePro/Core/Services/Query/TableQueryBuilder.swift
+++ b/TablePro/Core/Services/Query/TableQueryBuilder.swift
@@ -128,7 +128,8 @@ struct TableQueryBuilder {
         if let dialect {
             let activeFilters = filters.filter { $0.isEnabled }
             let filterGen = FilterSQLGenerator(
-                dialect: dialect, columns: columns, columnTypes: columnTypes, quoteIdentifier: dialectQuote
+                dialect: dialect, columns: columns, columnTypes: columnTypes, quoteIdentifier: dialectQuote,
+                stringLiteralPrefix: SQLStringLiteralPrefix.forDatabaseType(databaseType)
             )
             let whereClause = filterGen.generateWhereClause(from: activeFilters, logicMode: logicMode)
             if !whereClause.isEmpty {
@@ -196,7 +197,8 @@ struct TableQueryBuilder {
         let quotedTable = qualifiedTable(tableName, schema: schemaName)
         let activeFilters = filters.filter { $0.isEnabled }
         let filterGen = FilterSQLGenerator(
-            dialect: dialect, columns: columns, columnTypes: columnTypes, quoteIdentifier: dialectQuote
+            dialect: dialect, columns: columns, columnTypes: columnTypes, quoteIdentifier: dialectQuote,
+            stringLiteralPrefix: SQLStringLiteralPrefix.forDatabaseType(databaseType)
         )
         let whereClause = filterGen.generateWhereClause(from: activeFilters, logicMode: logicMode)
 

--- a/TablePro/Core/Utilities/SQL/SQLStringLiteralPrefix.swift
+++ b/TablePro/Core/Utilities/SQL/SQLStringLiteralPrefix.swift
@@ -1,0 +1,27 @@
+//
+//  SQLStringLiteralPrefix.swift
+//  TablePro
+//
+
+import Foundation
+
+/// What an engine puts in front of a string literal that carries user text.
+///
+/// SQL Server is the one engine that needs anything: a plain `'…'` is a `varchar` literal, so the
+/// server converts it to the database collation's code page while it parses the batch, and on a
+/// non-Unicode collation every character outside that page becomes `?`. That happens whatever the
+/// column is, so `WHERE n = '日本語'` on an `NVARCHAR` column matches nothing the user meant.
+/// `N'…'` is an `nvarchar` literal and is converted by nothing; on ASCII the two are equal.
+///
+/// A number, an identifier and a `0x` binary literal never come through here.
+enum SQLStringLiteralPrefix {
+    static func forDatabaseType(_ databaseType: DatabaseType?) -> String {
+        guard let databaseType else { return "" }
+        switch databaseType {
+        case .mssql:
+            return "N"
+        default:
+            return ""
+        }
+    }
+}

--- a/TableProTests/Core/Database/FilterSQLGeneratorMSSQLTests.swift
+++ b/TableProTests/Core/Database/FilterSQLGeneratorMSSQLTests.swift
@@ -18,7 +18,10 @@ struct FilterSQLGeneratorMSSQLTests {
         likeEscapeStyle: .explicit, paginationStyle: .offsetFetch
     )
 
-    private let generator = FilterSQLGenerator(dialect: Self.mssqlDialect)
+    private let generator = FilterSQLGenerator(
+        dialect: Self.mssqlDialect,
+        stringLiteralPrefix: SQLStringLiteralPrefix.forDatabaseType(.mssql)
+    )
 
     // MARK: - Helpers
 
@@ -37,21 +40,21 @@ struct FilterSQLGeneratorMSSQLTests {
     func equalOperator() {
         let filter = makeFilter(op: .equal)
         let result = generator.generateCondition(from: filter)
-        #expect(result == "[name] = 'test'")
+        #expect(result == "[name] = N'test'")
     }
 
     @Test("Not equal operator uses bracket-quoted column")
     func notEqualOperator() {
         let filter = makeFilter(op: .notEqual)
         let result = generator.generateCondition(from: filter)
-        #expect(result == "[name] != 'test'")
+        #expect(result == "[name] != N'test'")
     }
 
     @Test("Contains operator generates LIKE with ESCAPE clause")
     func containsOperator() {
         let filter = makeFilter(op: .contains)
         let result = generator.generateCondition(from: filter)
-        #expect(result?.contains("[name] LIKE '%test%'") == true)
+        #expect(result?.contains("[name] LIKE N'%test%'") == true)
         #expect(result?.contains("ESCAPE") == true)
     }
 
@@ -59,7 +62,7 @@ struct FilterSQLGeneratorMSSQLTests {
     func notContainsOperator() {
         let filter = makeFilter(op: .notContains)
         let result = generator.generateCondition(from: filter)
-        #expect(result?.contains("[name] NOT LIKE '%test%'") == true)
+        #expect(result?.contains("[name] NOT LIKE N'%test%'") == true)
         #expect(result?.contains("ESCAPE") == true)
     }
 
@@ -67,7 +70,7 @@ struct FilterSQLGeneratorMSSQLTests {
     func startsWithOperator() {
         let filter = makeFilter(op: .startsWith)
         let result = generator.generateCondition(from: filter)
-        #expect(result?.contains("[name] LIKE 'test%'") == true)
+        #expect(result?.contains("[name] LIKE N'test%'") == true)
         #expect(result?.contains("ESCAPE") == true)
     }
 
@@ -75,7 +78,7 @@ struct FilterSQLGeneratorMSSQLTests {
     func endsWithOperator() {
         let filter = makeFilter(op: .endsWith)
         let result = generator.generateCondition(from: filter)
-        #expect(result?.contains("[name] LIKE '%test'") == true)
+        #expect(result?.contains("[name] LIKE N'%test'") == true)
         #expect(result?.contains("ESCAPE") == true)
     }
 
@@ -130,7 +133,7 @@ struct FilterSQLGeneratorMSSQLTests {
     func singleQuoteEscaping() {
         let filter = makeFilter(column: "name", op: .equal, value: "O'Brien")
         let result = generator.generateCondition(from: filter)
-        #expect(result == "[name] = 'O''Brien'")
+        #expect(result == "[name] = N'O''Brien'")
     }
 
     // MARK: - WHERE Clause Tests
@@ -144,7 +147,7 @@ struct FilterSQLGeneratorMSSQLTests {
         let result = generator.generateWhereClause(from: filters, logicMode: .and)
         #expect(result.contains("WHERE"))
         #expect(result.contains("AND"))
-        #expect(result.contains("[name] = 'Alice'"))
+        #expect(result.contains("[name] = N'Alice'"))
         #expect(result.contains("[age] > 18"))
     }
 
@@ -157,8 +160,8 @@ struct FilterSQLGeneratorMSSQLTests {
         let result = generator.generateWhereClause(from: filters, logicMode: .or)
         #expect(result.contains("WHERE"))
         #expect(result.contains("OR"))
-        #expect(result.contains("[name] = 'Alice'"))
-        #expect(result.contains("[name] = 'Bob'"))
+        #expect(result.contains("[name] = N'Alice'"))
+        #expect(result.contains("[name] = N'Bob'"))
     }
 
     // MARK: - Identifier Quoting Tests
@@ -168,5 +171,46 @@ struct FilterSQLGeneratorMSSQLTests {
         let filter = makeFilter(column: "user_name", op: .equal, value: "test")
         let result = generator.generateCondition(from: filter)
         #expect(result?.hasPrefix("[user_name]") == true)
+    }
+
+    // MARK: - Unicode Literals
+
+    @Test("A non-ASCII value is an nvarchar literal, so a non-Unicode collation cannot flatten it")
+    func nonAsciiValueIsANationalLiteral() {
+        let filter = makeFilter(op: .equal, value: "日本語メール")
+        #expect(generator.generateCondition(from: filter) == "[name] = N'日本語メール'")
+    }
+
+    @Test("Every value-carrying operator writes a national literal")
+    func everyValueOperatorWritesANationalLiteral() {
+        let operators: [FilterOperator] = [
+            .equal, .notEqual, .contains, .notContains, .startsWith, .endsWith, .regex
+        ]
+        for op in operators {
+            let result = generator.generateCondition(from: makeFilter(op: op, value: "メール")) ?? ""
+            let body = result.replacingOccurrences(of: " ESCAPE '!'", with: "")
+            #expect(body.contains("N'"), "\(op) wrote no national literal")
+            #expect(!body.contains(" '"), "\(op) wrote a plain literal: \(result)")
+        }
+    }
+
+    @Test("An IN list prefixes every element")
+    func inListPrefixesEveryElement() {
+        let filter = makeFilter(op: .inList, value: "メール,alpha")
+        let result = generator.generateCondition(from: filter)
+        #expect(result == "[name] IN (N'メール', N'alpha')")
+    }
+
+    @Test("Numbers and NULL never take the prefix")
+    func numbersAndNullAreNotPrefixed() {
+        #expect(generator.generateCondition(from: makeFilter(column: "age", op: .greaterThan, value: "30"))
+            == "[age] > 30")
+        #expect(generator.generateCondition(from: makeFilter(op: .isNull)) == "[name] IS NULL")
+    }
+
+    @Test("A driver with no prefix is untouched")
+    func otherEnginesKeepPlainLiterals() {
+        let plain = FilterSQLGenerator(dialect: Self.mssqlDialect)
+        #expect(plain.generateCondition(from: makeFilter(op: .equal)) == "[name] = 'test'")
     }
 }

--- a/TableProTests/Core/Database/ForeignKeyLookupQueryTests.swift
+++ b/TableProTests/Core/Database/ForeignKeyLookupQueryTests.swift
@@ -33,7 +33,8 @@ struct ForeignKeyLookupQueryTests {
         key: ForeignKeyLookupColumn? = nil,
         label: ForeignKeyLookupColumn?,
         term: String,
-        dialect: SQLDialectDescriptor? = nil
+        dialect: SQLDialectDescriptor? = nil,
+        stringLiteralPrefix: String = ""
     ) -> String? {
         ForeignKeyLookupQuery.rows(
             quotedTable: "\"Artist\"",
@@ -41,6 +42,7 @@ struct ForeignKeyLookupQueryTests {
             label: label,
             searchTerm: term,
             dialect: dialect ?? self.dialect(),
+            stringLiteralPrefix: stringLiteralPrefix,
             quoteIdentifier: quote
         )
     }

--- a/TableProTests/Core/Database/SQLStringLiteralPrefixTests.swift
+++ b/TableProTests/Core/Database/SQLStringLiteralPrefixTests.swift
@@ -1,0 +1,29 @@
+//
+//  SQLStringLiteralPrefixTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("SQL String Literal Prefix")
+struct SQLStringLiteralPrefixTests {
+    @Test("SQL Server asks for a national literal")
+    func sqlServerAsksForANationalLiteral() {
+        #expect(SQLStringLiteralPrefix.forDatabaseType(.mssql) == "N")
+    }
+
+    @Test("Every other engine writes a plain literal")
+    func otherEnginesWritePlainLiterals() {
+        for type in DatabaseType.allKnownTypes where type != .mssql {
+            #expect(SQLStringLiteralPrefix.forDatabaseType(type) == "", "\(type.rawValue) asked for a prefix")
+        }
+    }
+
+    @Test("An unknown type from a future plugin writes a plain literal")
+    func unknownTypesWritePlainLiterals() {
+        #expect(SQLStringLiteralPrefix.forDatabaseType(DatabaseType(rawValue: "SomeFutureEngine")) == "")
+        #expect(SQLStringLiteralPrefix.forDatabaseType(nil) == "")
+    }
+}

--- a/TableProTests/Core/Services/TableQueryBuilderMSSQLTests.swift
+++ b/TableProTests/Core/Services/TableQueryBuilderMSSQLTests.swift
@@ -112,4 +112,12 @@ struct TableQueryBuilderMSSQLTests {
         let query = fallback.buildBaseQuery(tableName: "users")
         #expect(query == "SELECT * FROM [users] ORDER BY (SELECT NULL) OFFSET 0 ROWS FETCH NEXT 200 ROWS ONLY")
     }
+
+    @Test("The filtered row count spells a non-ASCII value the way the browse query does")
+    func filteredCountUsesNationalLiterals() {
+        let filters = [TestFixtures.makeTableFilter(column: "name", op: .equal, value: "日本語メール")]
+        let count = builder.buildFilteredCountQuery(tableName: "users", filters: filters, columns: ["name"])
+        #expect(count?.contains("[name] = N'日本語メール'") == true)
+        #expect(count?.contains("= '日本語メール'") == false)
+    }
 }

--- a/TableProTests/Plugins/ClickHouseParameterBindingTests.swift
+++ b/TableProTests/Plugins/ClickHouseParameterBindingTests.swift
@@ -1,0 +1,88 @@
+//
+//  ClickHouseParameterBindingTests.swift
+//  TableProTests
+//
+
+import Foundation
+import TableProPluginKit
+import Testing
+
+@Suite("ClickHouse Parameter Binding")
+struct ClickHouseParameterBindingTests {
+    @Test("Text parameters become named HTTP substitutions")
+    func textParametersBecomeNamedSubstitutions() {
+        let bound = ClickHouseParameterBinding.bind(
+            query: "SELECT * FROM t WHERE a = ? AND b = ?",
+            parameters: [.text("one"), .text("two")]
+        )
+        #expect(bound.query == "SELECT * FROM t WHERE a = {p1:String} AND b = {p2:String}")
+        #expect(bound.params["p1"] == "one")
+        #expect(bound.params["p2"] == "two")
+    }
+
+    @Test("A null parameter keeps its slot with no value")
+    func nullParameterKeepsItsSlot() {
+        let bound = ClickHouseParameterBinding.bind(
+            query: "SELECT * FROM t WHERE a = ?",
+            parameters: [.null]
+        )
+        #expect(bound.query == "SELECT * FROM t WHERE a = {p1:String}")
+        #expect(bound.params["p1"] == .some(nil))
+    }
+
+    @Test("A binary parameter is written into the statement as unhex, never as text")
+    func binaryParameterBecomesUnhex() {
+        let bound = ClickHouseParameterBinding.bind(
+            query: "ALTER TABLE t DELETE WHERE raw = ?",
+            parameters: [.bytes(Data([0xDE, 0xAD, 0xBE, 0xEF]))]
+        )
+        #expect(bound.query == "ALTER TABLE t DELETE WHERE raw = unhex('DEADBEEF')")
+        #expect(bound.params.isEmpty)
+    }
+
+    @Test("Named numbering stays contiguous when a binary parameter is inlined")
+    func namedNumberingSkipsInlinedBinary() {
+        let bound = ClickHouseParameterBinding.bind(
+            query: "ALTER TABLE t UPDATE txt = ? WHERE raw = ? AND id = ?",
+            parameters: [.text("new"), .bytes(Data([0x01, 0x02])), .text("7")]
+        )
+        #expect(bound.query == "ALTER TABLE t UPDATE txt = {p1:String} WHERE raw = unhex('0102') AND id = {p2:String}")
+        #expect(bound.params["p1"] == "new")
+        #expect(bound.params["p2"] == "7")
+        #expect(bound.params.count == 2)
+    }
+
+    @Test("An empty binary value is still a binary literal")
+    func emptyBinaryParameterIsALiteral() {
+        let bound = ClickHouseParameterBinding.bind(
+            query: "SELECT ?",
+            parameters: [.bytes(Data())]
+        )
+        #expect(bound.query == "SELECT unhex('')")
+    }
+
+    @Test("A question mark inside a string literal is not a placeholder")
+    func questionMarkInsideALiteralIsNotAPlaceholder() {
+        let bound = ClickHouseParameterBinding.bind(
+            query: "SELECT * FROM t WHERE a = 'why?' AND b = ?",
+            parameters: [.text("x")]
+        )
+        #expect(bound.query == "SELECT * FROM t WHERE a = 'why?' AND b = {p1:String}")
+        #expect(bound.params["p1"] == "x")
+    }
+
+    @Test("Extra placeholders past the parameter list are left alone")
+    func extraPlaceholdersAreLeftAlone() {
+        let bound = ClickHouseParameterBinding.bind(
+            query: "SELECT ?, ?",
+            parameters: [.text("only")]
+        )
+        #expect(bound.query == "SELECT {p1:String}, ?")
+    }
+
+    @Test("The hex a binary parameter produces cannot close the literal it sits in")
+    func hexLiteralIsAlphanumericOnly() {
+        let literal = ClickHouseParameterBinding.hexLiteral(Data([0x27, 0x5C, 0x00, 0xFF]))
+        #expect(literal == "unhex('275C00FF')")
+    }
+}

--- a/TableProTests/Plugins/ClickHouseResponseClassifierTests.swift
+++ b/TableProTests/Plugins/ClickHouseResponseClassifierTests.swift
@@ -99,6 +99,113 @@ struct ClickHouseResponseClassifierTests {
         #expect(outcome.rows == [[.text("a\tb\nc\\d")]])
     }
 
+    // MARK: - The Full Escape Table ClickHouse Writes
+
+    @Test("Every escape the server emits is decoded, not left as two characters")
+    func serverEscapeTableIsDecoded() {
+        let outcome = classify(
+            headers: matchingFormatHeaders,
+            bodyText: "cr\tquote\tbell\tff\tnul\nString\tString\tString\tString\tString\n"
+                + "a\\rb\ta\\'b\ta\\bb\ta\\fb\ta\\0b\n"
+        )
+        #expect(outcome.rows == [[
+            .text("a\rb"),
+            .text("a'b"),
+            .text("a\u{8}b"),
+            .text("a\u{C}b"),
+            .text("a\u{0}b")
+        ]])
+    }
+
+    @Test("A column type name carrying escaped quotes is reported unescaped")
+    func columnTypeNameIsUnescaped() {
+        let outcome = classify(
+            headers: matchingFormatHeaders,
+            bodyText: "e\nEnum8(\\'q\\' = 1)\nq\n"
+        )
+        #expect(outcome.columnTypeNames == ["Enum8('q' = 1)"])
+    }
+
+    @Test("A column name carrying an escaped tab keeps the column count")
+    func columnNameWithEscapedTabIsOneColumn() {
+        let outcome = classify(headers: matchingFormatHeaders, bodyText: "a\\tb\nString\nv\n")
+        #expect(outcome.columns == ["a\tb"])
+        #expect(outcome.rows == [[.text("v")]])
+    }
+
+    // MARK: - Binary Values
+
+    @Test("A binary value stays bytes instead of being forced through a text decode")
+    func binaryValueStaysBytes() {
+        var body = Data("raw\nString\n".utf8)
+        body.append(contentsOf: [0xDE, 0xAD, 0xBE, 0xEF, 0x0A])
+        let outcome = ClickHouseResponseClassifier.classify(headers: matchingFormatHeaders, body: body)
+        #expect(outcome.rows == [[.bytes(Data([0xDE, 0xAD, 0xBE, 0xEF]))]])
+    }
+
+    @Test("A binary value in one column never mojibakes a text value in another")
+    func binaryValueLeavesOtherColumnsIntact() {
+        var body = Data("raw\ttxt\nString\tString\n".utf8)
+        body.append(contentsOf: [0xDE, 0xAD, 0xBE, 0xEF, 0x09])
+        body.append(contentsOf: Data("héllo\n".utf8))
+        let outcome = ClickHouseResponseClassifier.classify(headers: matchingFormatHeaders, body: body)
+        #expect(outcome.rows == [[.bytes(Data([0xDE, 0xAD, 0xBE, 0xEF])), .text("héllo")]])
+    }
+
+    @Test("One undecodable value makes the whole column bytes, losslessly")
+    func oneBinaryValueDemotesItsWholeColumn() {
+        var body = Data("v\nString\n".utf8)
+        body.append(contentsOf: Data("héllo\n".utf8))
+        body.append(contentsOf: [0xC3, 0x0A])
+        let outcome = ClickHouseResponseClassifier.classify(headers: matchingFormatHeaders, body: body)
+        #expect(outcome.rows == [
+            [.bytes(Data("héllo".utf8))],
+            [.bytes(Data([0xC3]))]
+        ])
+    }
+
+    @Test("A binary value does not demote a text column beside it")
+    func demotionIsPerColumn() {
+        var body = Data("a\tb\nString\tString\n".utf8)
+        body.append(contentsOf: [0xC3, 0x09])
+        body.append(contentsOf: Data("keep\n".utf8))
+        let outcome = ClickHouseResponseClassifier.classify(headers: matchingFormatHeaders, body: body)
+        #expect(outcome.rows == [[.bytes(Data([0xC3])), .text("keep")]])
+    }
+
+    @Test("A tab or newline inside binary data arrives escaped and never splits a field")
+    func escapedControlBytesInBinaryDoNotSplitFields() {
+        var body = Data("v\nString\n".utf8)
+        body.append(contentsOf: Array("\\t\\n".utf8))
+        body.append(contentsOf: [0x0B, 0x41, 0x0A])
+        let outcome = ClickHouseResponseClassifier.classify(headers: matchingFormatHeaders, body: body)
+        #expect(outcome.rows == [[.text("\t\n\u{B}A")]])
+    }
+
+    @Test("A body in another format that is not text is kept as bytes")
+    func nonTextRawBodyIsKeptAsBytes() {
+        let body = Data([0x00, 0x01, 0xFF, 0xFE])
+        let outcome = ClickHouseResponseClassifier.classify(headers: ["X-ClickHouse-Format": "Native"], body: body)
+        #expect(outcome.rows == [[.bytes(body)]])
+    }
+
+    @Test("A body cut by the byte cap mid-character still reads as text")
+    func cappedBodyCutMidCharacterIsText() {
+        let cap = 1_048_576
+        var body = Data(repeating: UInt8(ascii: "x"), count: cap - 1)
+        body.append(contentsOf: Data("é".utf8))
+        let outcome = ClickHouseResponseClassifier.classify(headers: ["X-ClickHouse-Format": "Pretty"], body: body)
+        #expect(outcome.isTruncated)
+        #expect(outcome.rows[0][0].asText?.utf8.count == cap - 1)
+    }
+
+    @Test("A body the cap did not cut is never trimmed to make it decode")
+    func uncutBodyIsNotTrimmed() {
+        let body = Data([0x61, 0x62, 0xC3])
+        let outcome = ClickHouseResponseClassifier.classify(headers: ["X-ClickHouse-Format": "Native"], body: body)
+        #expect(outcome.rows == [[.bytes(body)]])
+    }
+
     @Test("Rows beyond the limit are dropped and marked truncated")
     func rowLimitTruncates() {
         let outcome = classify(

--- a/TableProTests/Plugins/ObjectCatalogQueryTests.swift
+++ b/TableProTests/Plugins/ObjectCatalogQueryTests.swift
@@ -172,7 +172,7 @@ struct MSSQLObjectQueryTests {
         let all = MSSQLObjectQueries.triggerList(schema: "dbo", table: nil)
         let one = MSSQLObjectQueries.triggerList(schema: "dbo", table: "Orders")
         #expect(!all.contains("parent.name ="))
-        #expect(one.contains("parent.name = 'Orders'"))
+        #expect(one.contains("parent.name = N'Orders'"))
         #expect(all.contains("sys.trigger_events"))
     }
 
@@ -186,8 +186,23 @@ struct MSSQLObjectQueryTests {
 
     @Test("A quote in a schema or table is escaped")
     func literalsAreEscaped() {
-        #expect(MSSQLObjectQueries.routineList(schema: "it's").contains("'it''s'"))
-        #expect(MSSQLObjectQueries.triggerList(schema: "dbo", table: "o'brien").contains("'o''brien'"))
+        #expect(MSSQLObjectQueries.routineList(schema: "it's").contains("N'it''s'"))
+        #expect(MSSQLObjectQueries.triggerList(schema: "dbo", table: "o'brien").contains("N'o''brien'"))
+    }
+
+    @Test("A non-ASCII schema, routine or table name is an nvarchar literal")
+    func catalogNamesAreNationalLiterals() {
+        #expect(MSSQLObjectQueries.routineList(schema: "販売").contains("s.name = N'販売'"))
+        let definition = MSSQLObjectQueries.routineDefinition(schema: "販売", name: "集計")
+        #expect(definition.contains("s.name = N'販売' AND o.name = N'集計'"))
+        let triggers = MSSQLObjectQueries.triggerList(schema: "販売", table: "注文")
+        #expect(triggers.contains("s.name = N'販売'"))
+        #expect(triggers.contains("parent.name = N'注文'"))
+    }
+
+    @Test("Fixed catalog type codes stay plain literals")
+    func catalogTypeCodesStayPlain() {
+        #expect(MSSQLObjectQueries.routineList(schema: "dbo").contains("o.type IN ('P', 'FN', 'IF', 'TF')"))
     }
 }
 

--- a/docs/databases/clickhouse.mdx
+++ b/docs/databases/clickhouse.mdx
@@ -86,6 +86,7 @@ The CA file may be PEM or DER. If **Verify CA** cannot read it, the connection f
 - No auto-increment, and the primary key and sorting key are fixed at creation. Structure editing covers adding, modifying, and dropping columns and data-skipping indexes; recreate the table for anything else.
 - A `SET` does not carry to the next statement. Every statement is its own HTTP request with no session id, and the setting is gone by the next one. Put it in a `SETTINGS` clause on the query itself.
 - A query with its own `FORMAT` clause, such as `SELECT 1 FORMAT JSON`, shows the server's raw output in one column instead of a parsed table. Drop the clause to get a grid.
+- A column with even one value that is not valid UTF-8 shows every row as hex, and its cells do not open for inline editing. `String` and `FixedString` hold raw bytes, so a hash or a stray byte is enough. Select `toValidUTF8(column)` to read it as text, with the bad bytes replaced.
 
 ## Troubleshooting
 

--- a/project.yml
+++ b/project.yml
@@ -403,6 +403,7 @@ targets:
       - Plugins/ClickHouseDriverPlugin/ClickHouseCapabilities.swift
       - Plugins/ClickHouseDriverPlugin/ClickHouseCredentials.swift
       - Plugins/ClickHouseDriverPlugin/ClickHouseGeneratedColumnClassification.swift
+      - Plugins/ClickHouseDriverPlugin/ClickHouseParameterBinding.swift
       - Plugins/ClickHouseDriverPlugin/ClickHousePlugin.swift
       - Plugins/ClickHouseDriverPlugin/ClickHousePluginDriver+Http.swift
       - Plugins/ClickHouseDriverPlugin/ClickHousePluginDriver+Schema.swift


### PR DESCRIPTION
Two text-encoding defects found while investigating #2725 (MySQL comments decoded as mojibake). Neither is that issue and neither has an issue of its own. Both were treated as hypotheses and proven against a live server before anything changed.

## 1. ClickHouse decoded every value as UTF-8, all or nothing

The driver asks for `TabSeparatedWithNamesAndTypes`. That format is a byte stream: a `String` column is an arbitrary byte sequence, and ClickHouse escapes only eight bytes (`\t \n \r \\ \' \b \f \0`). Everything else, including invalid UTF-8, is written verbatim. Measured on ClickHouse 24.8.14: `SELECT unhex('deadbeef')` puts the raw bytes `de ad be ef` on the wire, and `unhex('090a0b41')` arrives as `\t\n` + raw `0b` + `A`, so a raw tab or newline never appears inside a value.

`ClickHouseResponseClassifier` threw that away. It decoded the **whole body** as UTF-8 first, and when any byte anywhere failed it fell back to Latin-1 for the whole body, then split the resulting string. Running the old code on a real response from `CREATE TABLE b (id UInt8, raw String, txt String)` with one binary row:

```
before: ["1", "Þ­¾ï", "hÃ©llo"]     ["2", "plain", "wÃ¶rld"]
after:  ["1", .bytes(0xDEADBEEF), "héllo"]   ["2", .bytes(0x706C61696E), "wörld"]
```

One binary value mojibaked every text value in every other column and row. Three more defects sat on the same path:

- The unescape table covered 3 of the 8 escapes. `'a''b'` came back as `a\'b`, a carriage return as the two characters `\r`, and `\b`, `\f`, `\0` likewise.
- Column names and type names were never unescaped, so `Enum8('q' = 1)` was reported as `Enum8(\'q\' = 1)`.
- Every value was `.text`, never `.bytes`, so binary was always forced through a text decode.

The write side had the twin defect. A binary parameter was sent as the text `0xDEADBEEF` in a `{p1:String}` substitution, which compares as those ten characters. On the live server `WHERE raw = {p1:String}` with that value matched 0 rows; `WHERE raw = unhex('DEADBEEF')` matched 1. Since `buildWhereClause` puts every column into the row predicate, an edit or delete on any row holding a binary value silently affected nothing.

### Fix

- `ClickHouseTabSeparatedBytes` (new, PluginKit, internal): splits lines and fields on bytes, unescapes the full table ClickHouse's `writeEscapedString` emits, and only then offers a finished field to a strict UTF-8 decode.
- Per-column decision: a field that is not valid UTF-8 stays `.bytes`, and one such field makes its whole column bytes. Re-encoding the column's already-decoded values is exact, because UTF-8 round-trips whenever the decode succeeded. This matches the per-column rule `MySQLColumnDecoding` and the MongoDB UUID invariant follow, and it keeps a `FixedString(16)` of raw UUIDs from rendering as hex on some rows and as garbage text on others. ClickHouse has no charset metadata to decide from, so no charset negotiation is invented; the column's own bytes decide.
- Header names and type names are unescaped.
- A body in a user-chosen `FORMAT` is text when it decodes and bytes when it does not. The 1 MB cap now sheds only the one multi-byte sequence it cut, instead of dropping up to three trailing bytes until anything decodes, which would have called a short binary body text.
- `ClickHouseParameterBinding` (new, pure, in the test target) writes a `.bytes` parameter as `unhex('…')`. The hex is generated from the bytes and holds only `0-9A-F`.
- The HTTP error body is decoded lossily instead of collapsing a non-UTF-8 message to "Unknown error".

The public `classify(headers:body:rowLimit:)` and `unescapeTsvField(_:)` signatures are unchanged and the new type is internal. `scripts/check-pluginkit-abi.sh` against the merge base reports the PluginKit ABI unchanged.

Side effect, measured: the byte-level parser is about 4x faster. 200,000 rows (14 MB) took 1,348 to 1,577 ms with the old classifier and 333 to 343 ms with the new one.

## 2. SQL Server string literals were not `N`-prefixed

A plain `'…'` is a `varchar` literal. The server converts it to the database collation's code page while it parses the batch, so on a non-Unicode collation every character outside that page becomes `?`, whatever the target column is. Measured on SQL Server 2022 (16.0.4275.2), database collation `SQL_Latin1_General_CP1_CI_AS`, column `NVARCHAR(50)`:

| Statement | Result |
|---|---|
| `INSERT … VALUES ('日本語メール')` | stored `??????` |
| `INSERT … VALUES (N'日本語メール')` | stored `日本語メール` |
| `WHERE n = '日本語メール'` | matched the **damaged row** (`??????`), not the real one |
| `WHERE n = N'日本語メール'` | matched the real row |
| `UPDATE … SET n = '再現'` | stored `??` |
| `INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = '顧客テーブル'` | 0 columns |
| same with `N'顧客テーブル'` | 2 columns |
| `OBJECT_ID('[dbo].[顧客テーブル]')` | `NULL` |
| `OBJECT_ID(N'[dbo].[顧客テーブル]')` | the object id |
| `N'abc' = 'abc'` | true, so `N` is free on ASCII |

### What was already right

The row writes were not affected. `SQLStatementGenerator` and the plugin's own `generateStatements` only emit `?` placeholders, and `executeParameterized` already sends every parameter as `@pN NVARCHAR(MAX) = N'…'` through `sp_executesql N'…'`. The row-identity `WHERE` for update and delete is parameterized the same way. The hypothesis was wrong for those paths, and they are untouched.

### What was wrong, and is fixed

Every literal the MSSQL driver writes itself:

- **Filter arms.** `=`, `!=`, `<`, `<=`, `>`, `>=`, `IN`, `NOT IN` and `BETWEEN` went through a plain `quote:` closure. `CONTAINS`, `NOT CONTAINS`, `STARTS WITH` and `ENDS WITH` bypassed the driver entirely: the shared `PluginSQLFilter.buildFilterCondition` writes their `'%…%'` itself. The REGEX fallback wrote a plain `LIKE '%…%'`.
- **Catalog queries.** Every schema, table, view, routine and trigger predicate, and every `OBJECT_ID('…')`, in `MSSQLPluginDriver+Schema`, `MSSQLObjectQueries`, `MSSQLPluginDriver+DDL` and the shared `MSSQLSchemaQueries` (which the iOS driver also uses). These compare against `sysname`, which is `nvarchar(128)`, so a non-ASCII object name produced an empty Structure tab, no indexes, foreign keys or triggers, and no size or comment in the table info.
- **DDL.** `sp_rename` for a column wrote plain literals (the table rename beside it already used `N'…'`). The default-constraint lookup that runs before a column change did too, so on a non-ASCII column it found no default and the `ALTER COLUMN` after it failed. Its dynamic `EXEC('ALTER TABLE [dbo].[t] DROP CONSTRAINT [' + @dfName + ']')` also spliced the bracketed table name into a literal without quote escaping, so a table named `O'Reilly` ended the literal early and the whole batch failed to parse, and it wrapped the constraint name in hand-written brackets. It now builds the statement in an `NVARCHAR(MAX)` variable from an escaped `N'…'` prefix plus `QUOTENAME(@dfName)`; `EXEC(…)` accepts only literals and variables, not a function call.
- **The edit-view template.** `OBJECT_ID('\(viewName)', 'V')` interpolated the view name with no quote escaping at all; it now goes through the same helper.
- **The app-side filter generator.** `FilterSQLGenerator` builds the filtered `COUNT(*)` for MSSQL (that path has no plugin arm), the foreign key value picker's search, and the filter preview. Left alone, fixing the plugin would have made the row count disagree with the rows.

### Fix

- `MSSQLStringLiteral` in `TableProMSSQLCore` is now the single owner of how SQL Server spells a literal carrying user text: `N'…'` with quotes doubled, plus the `LIKE` pattern form with `ESCAPE '\'`. The plugin, the shared schema queries and the iOS driver all go through it.
- The plugin answers the four `LIKE` operators itself through `MSSQLStringLiteral.likeCondition` and lets every other operator fall through to `PluginSQLFilter`, so no PluginKit signature changes.
- `FilterSQLGenerator` takes a `stringLiteralPrefix`, resolved from the database type by `SQLStringLiteralPrefix` (`N` for SQL Server, empty for every other engine and for unknown plugin types), and spells every value literal through one `quotedLiteral` helper.
- Left plain on purpose: numbers, booleans, `NULL`, identifiers, fixed catalog constants (`'PRIMARY KEY'`, `'BASE TABLE'`, `'MS_Description'`, `o.type IN ('P','FN','IF','TF')`, the system schema list), `'COLUMN'` in `sp_rename`, and `ESCAPE` clauses. Tests pin each of these.

Two adjacent corrections came with the edit: `fetchTableDDL` and `fetchApproximateRowCount` built `[schema].[table]` from quote-escaped rather than bracket-escaped names, so a `]` in a name broke them. Both now use `MSSQLSchemaQueries.bracketed`. (`fetchApproximateRowCount` already used `N'…'`.)

## Verification

Both servers ran in Docker on this machine: ClickHouse `clickhouse/clickhouse-server:24.8` (24.8.14.39) and SQL Server `mcr.microsoft.com/mssql/server:2022-latest` (16.0.4275.2) with a `SQL_Latin1_General_CP1_CI_AS` database.

- **ClickHouse, live.** A harness compiled the real `ClickHouseResponseClassifier.swift`, `ClickHouseTabSeparatedBytes.swift` and `ClickHouseParameterBinding.swift` and ran them against real HTTP responses. Output is the "after" line quoted above; `Enum8('q' = 1)` and `a'b` came back unescaped; `WHERE raw = unhex('DEADBEEF')` built by the binder matched the row, alone and combined with a `{p1:String}` text parameter.
- **SQL Server, live.** A harness compiled the real `TableProMSSQLCore` sources and ran the SQL they generate through `sqlcmd`. Columns of `顧客テーブル`: 2 rows (plain literal: 0). Its primary key index: found (plain: `OBJECT_ID` was `NULL`). Equality, `CONTAINS`, `STARTS WITH`, `ENDS WITH`, `NOT CONTAINS` and `IN` on `日本語メール`: each returned the correct row. A `%` typed into `CONTAINS` matched literally. `sp_rename` of a non-ASCII column succeeded and renamed it back. The default-constraint drop, on a table named `O'Reilly 顧客` with column `値` and a constraint named `DF weird]name`: the old batch failed with `Incorrect syntax near 'Reilly'` and left the default in place; the new batch dropped it (1 default before, 0 after). That batch was transcribed from `generateModifyColumnSQL` into the harness, since the function itself needs the FreeTDS-linked driver.
- **Not run live:** the MSSQL plugin binary itself, which needs FreeTDS, and the app. The plugin's filter dispatch is a thin loop over `MSSQLStringLiteral.likeCondition` and `PluginSQLFilter`, both unit tested, and the SQL it emits is the SQL the harness ran.
- **Unit tests.** `TableProTests`: 14 suites, 232 cases, all passing after rebasing onto `2751c606f`, including `ClickHouseResponseClassifierTests` (11 new cases), `ClickHouseParameterBindingTests` (new), `FilterSQLGeneratorMSSQLTests` (5 new), `SQLStringLiteralPrefixTests` (new), `MSSQLObjectQueryTests` (2 new), `TableQueryBuilderMSSQLTests` (1 new). `swift test --package-path Packages/TableProCore`: `MSSQLStringLiteralTests` (11, new) and `MSSQLSchemaQueriesTests` (28, 2 new). Every new test name was confirmed in the logs.
- **Builds.** App: `BUILD SUCCEEDED`. `ClickHouseDriver` and `MSSQLDriver` schemes compiled directly, both `BUILD SUCCEEDED`. The `AllPlugins` aggregate was not run: it fails on this machine before reaching either plugin, because OracleNIO does not compile under Xcode-beta (`unknown attribute 'usableFromInlinenonisolated'`), which is unrelated to this change.
- **Lint.** `swiftlint lint --strict` over all 24 changed Swift files reports 12 violations, and linting the `origin/main` copies of the same files with the same config reports the same 12. None is introduced here.
- **Docs.** `check-writing-style.sh` and `check-docs-against-source.py` pass. `docs/databases/clickhouse.mdx` gains one limitation, since a text column with one non-UTF-8 value now shows as hex and does not open for inline editing; `toValidUTF8()` was checked on the live server. `mssql.mdx` is unchanged, because nothing the reader does is different.

Existing specs that pinned the old, wrong output were updated in the same commit: `FilterSQLGeneratorMSSQLTests` now builds its generator with the SQL Server prefix, and `MSSQLSchemaQueriesTests` / `MSSQLObjectQueryTests` assert `N'…'`.

## Found and deliberately left out

- **ClickHouse streaming.** `streamRows` and `boundedStreamRows`, used by export, object copy and compare, request `JSONEachRow` / `JSONCompactEachRowWithNamesAndTypes` and read `URLSession.AsyncBytes.lines`. ClickHouse 24.8 writes raw non-UTF-8 bytes into that JSON too (measured), and `.lines` decodes them lossily, so binary still reaches those three features as text with replacement characters. Fixing it needs a byte-level streaming parser.
- **SQL Server literals written by shared app code**, each still plain `'…'`: Preview Referenced Row (`ForeignKeyPreviewQuery.swift:22`), SQL export (`SQLExportPlugin.swift:941`, which also writes binary as `X'…'`, not T-SQL), Copy as INSERT/UPDATE (`SQLRowToStatementConverter.swift:120`), Copy as IN clause (`InClauseConverter.swift:55`), compare and data sync scripts (`CompareSQLLiteral`, `DataSyncScriptBuilder`), MCP `export_data` in SQL format (`MCPExportWriters.swift`), and the column default value picker (`CustomValueContentView.swift:100`). They sit outside the driver and serve every engine; giving them the prefix means carrying it on `SQLDialectDescriptor`, which is a PluginKit change with its own ABI review.
- **SQL Server binary parameters become `NULL`.** `executeParameterized` maps parameters through `asText` (`MSSQLPlugin.swift:674`), which is `nil` for `.bytes`, so `buildSpExecuteSql` binds `@pN = NULL`. A row predicate over a `VARBINARY` column therefore matches nothing. Not an `N'` defect.
- **`[` in a SQL Server `LIKE` value** is still a character-class wildcard; neither escaper handles it.
