### PR TITLE
feat(datagrid): mark a pending change on the value, not only behind it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Strikethrough on a row queued for deletion, and an underline on a new row or an edited value.
 - Google Cloud Spanner as a registry plugin over the REST API. (#1226, #2480)
 - TiDB and Databend connection types on the MySQL driver. (#1066, #2514)
 - Empty state in the inspector and the assistant for a connection that is not up.

--- a/TablePro/Views/Results/Cells/DataGridCellAccessibilityView.swift
+++ b/TablePro/Views/Results/Cells/DataGridCellAccessibilityView.swift
@@ -87,22 +87,32 @@ internal final class DataGridCellAccessibilityView: NSView {
 
     override internal func accessibilityValue() -> Any? { text }
 
+    /// Every combination is its own format string rather than pieces joined at run time, so a
+    /// translator sees a whole sentence and can order its parts. The pending change comes before the
+    /// highlight rule, because it is the one the reader is about to save.
     override internal func accessibilityLabel() -> String? {
-        guard let highlight = coordinator?.highlightDescription(row: row, columnIndex: dataColumn) else {
+        let pendingChange = coordinator?.pendingChangeDescription(row: row, columnIndex: dataColumn)
+        let highlight = coordinator?.highlightDescription(row: row, columnIndex: dataColumn)
+
+        if let pendingChange, let highlight {
             return String(
-                format: String(localized: "Row %d, column %d: %@"),
-                row + 1,
-                dataColumn + 1,
-                text
+                format: String(localized: "Row %d, column %d: %@, %@, highlighted where %@"),
+                row + 1, dataColumn + 1, text, pendingChange, highlight
             )
         }
-        return String(
-            format: String(localized: "Row %d, column %d: %@, highlighted where %@"),
-            row + 1,
-            dataColumn + 1,
-            text,
-            highlight
-        )
+        if let pendingChange {
+            return String(
+                format: String(localized: "Row %d, column %d: %@, %@"),
+                row + 1, dataColumn + 1, text, pendingChange
+            )
+        }
+        if let highlight {
+            return String(
+                format: String(localized: "Row %d, column %d: %@, highlighted where %@"),
+                row + 1, dataColumn + 1, text, highlight
+            )
+        }
+        return String(format: String(localized: "Row %d, column %d: %@"), row + 1, dataColumn + 1, text)
     }
 
     /// Read through rather than stored, so an edit, an undo or a display-format change is spoken

--- a/TablePro/Views/Results/Cells/DataGridCellAppearance.swift
+++ b/TablePro/Views/Results/Cells/DataGridCellAppearance.swift
@@ -17,6 +17,9 @@ struct DataGridCellAppearance: Equatable {
     let textColor: NSColor
     /// Painted behind the text, for a find match, a modified value or a highlight rule.
     let backgroundTint: NSColor?
+    /// The line a pending change draws through or under the text. Unlike the tint, it survives a
+    /// selection, which is what makes it the cue rather than a decoration on one.
+    let textMark: DataGridCellTextMark?
     let accessory: DataGridCellAccessory
     /// Which symbol the accessory draws, resolved here because it follows the row's state rather
     /// than anything the renderer can see.
@@ -94,6 +97,7 @@ struct DataGridCellAppearance: Equatable {
             font: font,
             textColor: textColor,
             backgroundTint: backgroundTint,
+            textMark: DataGridCellTextMark.resolve(state: state.visualState, columnIndex: state.columnIndex),
             accessory: accessory,
             accessoryRole: DataGridCellAccessoryGlyph.Role(
                 accessory: accessory,

--- a/TablePro/Views/Results/Cells/DataGridCellRenderer.swift
+++ b/TablePro/Views/Results/Cells/DataGridCellRenderer.swift
@@ -20,6 +20,7 @@ final class DataGridCellRenderer {
         let text: String
         let font: NSFont
         let color: NSColor
+        let mark: DataGridCellTextMark?
     }
 
     /// A viewport holds a few hundred cells and a scroll reuses them, so this only has to outlive a
@@ -64,9 +65,9 @@ final class DataGridCellRenderer {
         let availableWidth = appearance.accessory.availableTextWidth(in: rect)
         guard availableWidth > 0, let context = NSGraphicsContext.current?.cgContext else { return }
 
-        let fullLine = line(for: appearance.text, font: appearance.font, color: appearance.textColor)
+        let fullLine = line(for: appearance.text, appearance: appearance)
         let typographicWidth = CTLineGetTypographicBounds(fullLine, nil, nil, nil)
-        let ellipsis = line(for: "\u{2026}", font: appearance.font, color: appearance.textColor)
+        let ellipsis = line(for: "\u{2026}", appearance: appearance)
         let ellipsisWidth = CTLineGetTypographicBounds(ellipsis, nil, nil, nil)
         guard Double(availableWidth) >= ellipsisWidth else { return }
 
@@ -87,18 +88,22 @@ final class DataGridCellRenderer {
         context.restoreGState()
     }
 
-    private func line(for text: String, font: NSFont, color: NSColor) -> CTLine {
-        let key = LineKey(text: text, font: font, color: color)
+    /// Built with the mark's own attribute so `CTLineDraw` draws the line from the font's metrics,
+    /// and so `CTLineCreateTruncatedLine` carries it onto a truncated line and its ellipsis. The
+    /// mark is part of the key because two cells holding the same value in the same font and colour
+    /// are two different drawings once one of them is struck through.
+    private func line(for text: String, appearance: DataGridCellAppearance) -> CTLine {
+        let font = appearance.font
+        let key = LineKey(text: text, font: font, color: appearance.textColor, mark: appearance.textMark)
         if let cached = lineCache[key] { return cached }
 
         let source = text as NSString
         let laidOut = source.length > Self.maximumLaidOutCharacters
             ? source.substring(to: Self.maximumLaidOutCharacters) + "\u{2026}"
             : text
-        let attributed = NSAttributedString(
-            string: laidOut,
-            attributes: [.font: font, .foregroundColor: color]
-        )
+        var attributes: [NSAttributedString.Key: Any] = [.font: font, .foregroundColor: appearance.textColor]
+        appearance.textMark?.attributes.forEach { attributes[$0.key] = $0.value }
+        let attributed = NSAttributedString(string: laidOut, attributes: attributes)
         let created = CTLineCreateWithAttributedString(attributed as CFAttributedString)
 
         if lineCache.count >= Self.lineCacheLimit {

--- a/TablePro/Views/Results/Cells/DataGridCellTextMark.swift
+++ b/TablePro/Views/Results/Cells/DataGridCellTextMark.swift
@@ -1,0 +1,55 @@
+//
+//  DataGridCellTextMark.swift
+//  TablePro
+//
+
+import AppKit
+
+/// The line a pending change draws through or under a cell's own text, the way Pages marks tracked
+/// changes.
+///
+/// The tints alone could not carry this. A selected row paints over them, so a reader who selects
+/// the rows they are about to save loses every mark at once, and a tint says nothing to a reader
+/// who cannot see colour or is using a client that reads the grid rather than looking at it. The
+/// line is drawn in the text's own colour, so it survives selection, Dark Mode, grayscale and
+/// Increase Contrast, and the tints stay as the second cue.
+enum DataGridCellTextMark: Equatable {
+    /// A row staged for deletion, struck through as Pages strikes deleted text.
+    case struckThrough
+    /// A new row, or an edited cell, underlined as Pages underlines inserted text.
+    case underlined
+
+    /// What a pending change makes of a cell, or nil when nothing is staged for it.
+    ///
+    /// A staged delete outranks the rest: the row is going away whatever was typed into it first.
+    static func resolve(state: RowVisualState, columnIndex: Int) -> DataGridCellTextMark? {
+        if state.isDeleted { return .struckThrough }
+        if state.isInserted { return .underlined }
+        return state.isModified(columnIndex: columnIndex) ? .underlined : nil
+    }
+
+    /// Read by `CTLineDraw` itself, which draws both lines from the font's own metrics. Measured on
+    /// macOS 27: a `CTLine` built from an attributed string carrying `.underlineStyle` or
+    /// `.strikethroughStyle` draws that line, in the run's foreground colour, and
+    /// `CTLineCreateTruncatedLine` carries it onto the truncated line. So the renderer never
+    /// computes a line's position, thickness or width, and a cell that truncates is marked to
+    /// exactly where its text ends.
+    var attributes: [NSAttributedString.Key: Any] {
+        switch self {
+        case .struckThrough:
+            return [.strikethroughStyle: NSUnderlineStyle.single.rawValue]
+        case .underlined:
+            return [.underlineStyle: NSUnderlineStyle.single.rawValue]
+        }
+    }
+
+    /// What a client reading the grid is told, since a line it cannot see is no cue at all.
+    ///
+    /// Resolved from the state rather than from the mark, because one line covers two changes a
+    /// reader needs told apart: a whole row that is new, and one edited value in a row that is not.
+    static func accessibilityDescription(state: RowVisualState, columnIndex: Int) -> String? {
+        if state.isDeleted { return String(localized: "marked for deletion") }
+        if state.isInserted { return String(localized: "new row") }
+        return state.isModified(columnIndex: columnIndex) ? String(localized: "edited") : nil
+    }
+}

--- a/TablePro/Views/Results/Extensions/DataGridView+RowDecoration.swift
+++ b/TablePro/Views/Results/Extensions/DataGridView+RowDecoration.swift
@@ -45,6 +45,10 @@ extension TableViewCoordinator {
         return resolved
     }
 
+    func pendingChangeDescription(row: Int, columnIndex: Int) -> String? {
+        DataGridCellTextMark.accessibilityDescription(state: visualState(for: row), columnIndex: columnIndex)
+    }
+
     func highlightDescription(row: Int, columnIndex: Int) -> String? {
         guard let rule = visualState(for: row).drawnHighlightRule(forColumn: columnIndex) else { return nil }
         return HighlightRuleDescription.condition(of: rule, valueLimit: HighlightRuleDescription.menuValueLimit)

--- a/TableProTests/Views/Results/DataGridPendingChangeMarkTests.swift
+++ b/TableProTests/Views/Results/DataGridPendingChangeMarkTests.swift
@@ -1,0 +1,241 @@
+//
+//  DataGridPendingChangeMarkTests.swift
+//  TableProTests
+//
+//  A pending change used to show as a tint and nothing else, so selecting the rows about to be
+//  saved hid every mark at once and a client reading the grid was told nothing at all. These cover
+//  the line the cell draws instead, which selection cannot paint over.
+//
+
+import AppKit
+import CoreText
+import Testing
+
+@testable import TablePro
+
+@Suite("Pending change marks")
+@MainActor
+struct DataGridPendingChangeMarkTests {
+    private let palette = DataGridCellPalette(
+        regularFont: .monospacedSystemFont(ofSize: 13, weight: .regular),
+        italicFont: .monospacedSystemFont(ofSize: 13, weight: .regular),
+        mediumFont: .monospacedSystemFont(ofSize: 13, weight: .medium),
+        text: .labelColor,
+        placeholderText: .secondaryLabelColor,
+        booleanTrueText: nil,
+        booleanFalseText: nil,
+        rowNumberText: .secondaryLabelColor,
+        deletedRowText: .systemRed,
+        modifiedColumnTint: .systemYellow,
+        findMatchTint: .systemOrange
+    )
+
+    private static let deleted = RowVisualState(isDeleted: true, isInserted: false, modifiedColumns: [])
+    private static let inserted = RowVisualState(isDeleted: false, isInserted: true, modifiedColumns: [])
+    private static let modified = RowVisualState(isDeleted: false, isInserted: false, modifiedColumns: [1])
+
+    private func resolve(
+        text: String = "value",
+        visualState: RowVisualState = .empty,
+        columnIndex: Int = 0,
+        isCurrentFindMatch: Bool = false,
+        onEmphasizedSelection: Bool = false
+    ) -> DataGridCellAppearance {
+        DataGridCellAppearance.resolve(
+            kind: .text,
+            content: DataGridCellContent(displayText: text, rawValue: text, placeholder: nil),
+            state: DataGridCellState(
+                visualState: visualState,
+                isFocused: false,
+                isEditable: true,
+                isLargeDataset: false,
+                isCurrentFindMatch: isCurrentFindMatch,
+                row: 0,
+                columnIndex: columnIndex
+            ),
+            palette: palette,
+            nullDisplayString: "NULL",
+            onEmphasizedSelection: onEmphasizedSelection,
+            hasOverlay: false
+        )
+    }
+
+    // MARK: - Which mark a state carries
+
+    @Test("A row staged for deletion is struck through, a new row underlined")
+    func rowMarks() {
+        #expect(resolve(visualState: Self.deleted).textMark == .struckThrough)
+        #expect(resolve(visualState: Self.inserted).textMark == .underlined)
+        #expect(resolve().textMark == nil)
+    }
+
+    @Test("Only the edited cell of an edited row is underlined")
+    func modifiedColumnOnly() {
+        #expect(resolve(visualState: Self.modified, columnIndex: 1).textMark == .underlined)
+        #expect(resolve(visualState: Self.modified, columnIndex: 0).textMark == nil)
+    }
+
+    /// The row is going away whatever was typed into it first, so one line wins rather than two
+    /// crossing each other.
+    @Test("A deleted row that was edited first keeps the strike alone")
+    func deleteOutranksTheEdit() {
+        let state = RowVisualState(isDeleted: true, isInserted: false, modifiedColumns: [1])
+
+        #expect(resolve(visualState: state, columnIndex: 1).textMark == .struckThrough)
+    }
+
+    /// The whole point: the tint stands down under a selection and the find highlight, and the mark
+    /// does not.
+    @Test("The mark survives a selection and a find match, where the tint does not")
+    func markSurvivesWhatHidesTheTint() {
+        let selected = resolve(visualState: Self.modified, columnIndex: 1, onEmphasizedSelection: true)
+        let found = resolve(visualState: Self.modified, columnIndex: 1, isCurrentFindMatch: true)
+        let deletedAndSelected = resolve(visualState: Self.deleted, onEmphasizedSelection: true)
+
+        #expect(selected.backgroundTint == nil)
+        #expect(selected.textMark == .underlined)
+        #expect(found.backgroundTint == palette.findMatchTint)
+        #expect(found.textMark == .underlined)
+        #expect(deletedAndSelected.textMark == .struckThrough)
+    }
+
+    // MARK: - What a client is told
+
+    @Test("A pending change names itself, and distinguishes a new row from an edited value")
+    func accessibilityDescriptions() {
+        #expect(DataGridCellTextMark.accessibilityDescription(state: Self.deleted, columnIndex: 0) != nil)
+        #expect(
+            DataGridCellTextMark.accessibilityDescription(state: Self.inserted, columnIndex: 0)
+                != DataGridCellTextMark.accessibilityDescription(state: Self.modified, columnIndex: 1)
+        )
+        #expect(DataGridCellTextMark.accessibilityDescription(state: Self.modified, columnIndex: 0) == nil)
+        #expect(DataGridCellTextMark.accessibilityDescription(state: .empty, columnIndex: 0) == nil)
+    }
+
+    // MARK: - What is actually drawn
+
+    /// `CTLineDraw` draws both lines itself from the font's metrics, so these rasterise a cell and
+    /// read the pixels rather than trusting the attribute to have any effect.
+    ///
+    /// Drawn over mid grey, not white: a selected cell's text is
+    /// `alternateSelectedControlTextColor`, which is white, and a white-on-white cell rasterises
+    /// blank whatever it drew. Ink is any pixel that differs from the ground.
+    private func inkedColumns(of appearance: DataGridCellAppearance, in rect: NSRect) throws -> [[Int]] {
+        let host = CellHost(frame: rect)
+        host.cellAppearance = appearance
+        let rep = try #require(host.bitmapImageRepForCachingDisplay(in: host.bounds))
+        NSAppearance(named: .aqua)?.performAsCurrentDrawingAppearance {
+            host.cacheDisplay(in: host.bounds, to: rep)
+        }
+
+        let scale = rep.pixelsWide / Int(rect.width)
+        return (0 ..< rep.pixelsHigh).map { y in
+            (0 ..< rep.pixelsWide).filter { x in
+                guard let pixel = rep.colorAt(x: x, y: y)?.usingColorSpace(.sRGB) else { return false }
+                return abs(pixel.redComponent - 0.5) > 0.1
+                    || abs(pixel.greenComponent - 0.5) > 0.1
+                    || abs(pixel.blueComponent - 0.5) > 0.1
+            }.map { $0 / max(scale, 1) }
+        }
+    }
+
+    /// Flipped, because the grid's own cell surface is and the renderer positions its baseline from
+    /// the top edge. Rasterising into an unflipped context draws the cell upside down, which is how
+    /// a first pass at these tests came to read the underline as sitting above the strike.
+    ///
+    /// Mid grey, not white: a selected cell's text is `alternateSelectedControlTextColor`, which is
+    /// white, and a white-on-white cell rasterises blank whatever it drew.
+    private final class CellHost: NSView {
+        var cellAppearance: DataGridCellAppearance?
+
+        override var isFlipped: Bool { true }
+
+        static let ground = NSColor(calibratedWhite: 0.5, alpha: 1)
+
+        override func draw(_ dirtyRect: NSRect) {
+            Self.ground.setFill()
+            bounds.fill()
+            guard let cellAppearance else { return }
+            MainActor.assumeIsolated { DataGridCellRenderer().draw(cellAppearance, in: bounds) }
+        }
+    }
+
+    private static let cell = NSRect(x: 0, y: 0, width: 160, height: 24)
+
+    /// Where the mark landed: the row whose ink the mark adds over the same cell drawn unmarked, how
+    /// much it added, and how far right its own ink reaches. A glyph row gains nothing, so the
+    /// largest gain is the rule itself. The gain undercounts the rule's length wherever it crosses a
+    /// glyph the plain cell already inked, which is why reach is measured separately.
+    private func markedRow(
+        _ marked: DataGridCellAppearance,
+        against plain: DataGridCellAppearance,
+        in rect: NSRect = DataGridPendingChangeMarkTests.cell
+    ) throws -> (row: Int, gain: Int, reach: Int) {
+        let markedRows = try inkedColumns(of: marked, in: rect)
+        let plainRows = try inkedColumns(of: plain, in: rect)
+        let gains = zip(markedRows, plainRows).map { $0.count - $1.count }
+        let row = try #require(gains.indices.max(by: { gains[$0] < gains[$1] }))
+        return (row, gains[row], markedRows[row].max() ?? 0)
+    }
+
+    @Test("A struck-through cell draws a rule its plain twin does not, selected or not")
+    func strikeIsDrawn() throws {
+        let text = "0123456789"
+        let textWidth = Int(text.size(withAttributes: [.font: palette.regularFont]).width)
+
+        let struck = try markedRow(resolve(text: text, visualState: Self.deleted), against: resolve(text: text))
+        let selected = try markedRow(
+            resolve(text: text, visualState: Self.deleted, onEmphasizedSelection: true),
+            against: resolve(text: text, onEmphasizedSelection: true)
+        )
+
+        #expect(struck.gain > textWidth / 2)
+        #expect(selected.gain > textWidth / 2)
+    }
+
+    /// The two lines have to land in different places, or they are the same cue twice.
+    @Test("The underline sits below the strike")
+    func underlineSitsBelowTheStrike() throws {
+        let text = "0123456789"
+        let plain = resolve(text: text)
+        let struck = try markedRow(resolve(text: text, visualState: Self.deleted), against: plain)
+        let underlined = try markedRow(resolve(text: text, visualState: Self.inserted), against: plain)
+
+        #expect(underlined.row > struck.row)
+    }
+
+    /// A cell too narrow for its value truncates, and the mark has to stop where the text does
+    /// rather than run on across the rest of the cell.
+    @Test("The mark reaches as far as the text and no further, truncated or not")
+    func markStopsWithTheText() throws {
+        let short = "0123"
+        let inset = DataGridMetrics.cellHorizontalInset
+        let textEnd = inset + short.size(withAttributes: [.font: palette.regularFont]).width
+        let roomy = NSRect(x: 0, y: 0, width: 300, height: 24)
+        let shortMark = try markedRow(
+            resolve(text: short, visualState: Self.deleted),
+            against: resolve(text: short),
+            in: roomy
+        )
+
+        #expect(CGFloat(shortMark.reach) <= textEnd + 2)
+        #expect(CGFloat(shortMark.reach) > textEnd - 4)
+
+        let long = String(repeating: "0123456789", count: 8)
+        let narrow = NSRect(x: 0, y: 0, width: 120, height: 24)
+        let truncatedMark = try markedRow(
+            resolve(text: long, visualState: Self.deleted),
+            against: resolve(text: long),
+            in: narrow
+        )
+
+        #expect(CGFloat(truncatedMark.reach) <= narrow.width)
+        #expect(truncatedMark.reach > shortMark.reach)
+
+        /// Reach alone cannot see this: the glyphs of a truncated value already run to the cell's
+        /// edge, so a line that lost its mark reaches just as far. Only the gain separates them,
+        /// measured at 158 with the rule against 67 without it, beside the short cell's 50. So the
+        /// rule carried onto the truncated line is asserted where a regression would actually show.
+        #expect(truncatedMark.gain > shortMark.gain * 2)
+    }
+}

--- a/docs/features/change-tracking.mdx
+++ b/docs/features/change-tracking.mdx
@@ -9,6 +9,8 @@ import StagedUntilSave from "/snippets/staged-until-save.mdx";
 
 Modified cells stay highlighted, `Cmd+Shift+P` shows the statements the queue will produce, and `Cmd+S` runs them. The queue belongs to the tab, so switching tabs leaves it alone.
 
+A queued change also marks the value itself, so it stays legible once the row is selected and reads aloud to VoiceOver. An edited value and a new row are underlined, and a row queued for deletion is struck through.
+
 <Frame caption="Data grid with pending changes highlighted">
   <img className="block dark:hidden" src="/images/change-tracking.png" alt="Pending edits, inserts, and deletions highlighted in the data grid" />
   <img className="hidden dark:block" src="/images/change-tracking-dark.png" alt="Pending edits, inserts, and deletions highlighted in the data grid" />


### PR DESCRIPTION
## Summary

A pending change in the data grid showed as a background tint and nothing else. Select the rows you are about to save and every tint disappears behind the selection, which is the moment a reader most wants to see what is staged. A tint also says nothing to anyone who cannot see colour, and nothing at all to a client reading the grid rather than looking at it.

The value itself is now marked, the way Pages marks tracked changes:

- A row staged for deletion is **struck through**.
- A new row, and an edited cell, are **underlined**.
- Both lines are drawn in the text's own colour, so they survive selection, Dark Mode, grayscale and Increase Contrast. The tints stay as the second cue.
- A staged delete outranks an edit: a row edited and then staged for deletion carries one line, not two crossing each other.
- Each cell's accessibility label now names the change, and tells a new row apart from an edited value.

## Measured, not assumed

The plan for this said CoreText has no strikethrough, so the renderer would have to compute the line from the laid-out line's bounds and clip it to the truncation itself. That is wrong, and a probe settled it before any of this was written. Measured on macOS 27, `CTLineDraw` draws both lines from `.strikethroughStyle` and `.underlineStyle` on the attributed string it was built from, in the run's own foreground colour, and `CTLineCreateTruncatedLine` carries the attribute onto the truncated line and its ellipsis.

So the renderer computes no geometry at all. It adds one attribute, and a cell too narrow for its value is marked to exactly where its text ends. That also keeps the two lines on the font's own metrics rather than on a constant someone picked.

## What I tested

New `DataGridPendingChangeMarkTests`, 8 cases:

- Which mark each state carries, that only the edited column of an edited row is underlined, and that a staged delete outranks an edit.
- That the mark survives what hides the tint: an emphasized selection, and a find match.
- That the accessibility vocabulary separates a new row from an edited value.
- Three that rasterise a real cell and read the pixels: the rule appears where the plain cell has none, selected or not; the underline sits below the strike; and the mark reaches as far as the text and no further, truncated or not.

The rasterising helper draws into a flipped host view, because the grid's own cell surface is flipped and the renderer positions its baseline from the top edge. A first pass rasterised into an unflipped context, drew the cell upside down, and read the underline as sitting above the strike.

A review pass found the truncation assertions were vacuous, and it was right: `reach` is bounded by the cell width by construction, and a truncated value's glyphs run to the cell edge whether or not the rule is drawn. That case now asserts on the ink the mark adds, which is 158 with the rule against 67 without it.

97 cases across every suite that owns a touched type, passing. Lint clean, both docs checks pass.

No UI test: this is what a cell draws and what its accessibility label says, which the unit and raster tests assert directly. The flows that stage a change are already covered.

## Screenshots

The Chinook sample, row 7 staged for deletion and selected, row 9 new. Before, the selection hides the delete completely; after, the row is struck through and the new row's values are underlined. Cropped to the grid from the usual 1512x861 frame.

![Before: a row staged for deletion and selected looks like any other selected row](https://github.com/user-attachments/assets/fba38b73-e134-4500-9165-9694fa77fc06)

![After: the selected row staged for deletion is struck through and the new row is underlined](https://github.com/user-attachments/assets/1b2ad43d-a507-4097-8bb9-8cc8068cec1b)