### PR TITLE
fix(plugin-mssql): write every SQL Server string literal the app builds as N'...'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Non-ASCII SQL Server filter values turned into `?` and matching the wrong rows on non-Unicode collations.
 - Empty structure, missing indexes and failed renames for non-ASCII SQL Server object names on non-Unicode collations.
 - Changing a defaulted SQL Server column failing when a name contains a quote or non-ASCII text.
+- Non-ASCII text turned into `?` by Copy as INSERT, Copy as IN, Preview Referenced Row, compare scripts and column defaults on SQL Server.
 
 ### Security
 

--- a/TablePro/Core/Compare/CompareSQLLiteral.swift
+++ b/TablePro/Core/Compare/CompareSQLLiteral.swift
@@ -22,10 +22,18 @@ internal enum CompareSQLLiteral {
         driver: any PluginDatabaseDriver
     ) -> String {
         guard case .bytes(let data) = value else {
-            return driver.sqlLiteral(for: value)
+            return prefixed(driver.sqlLiteral(for: value), databaseType: databaseType)
         }
         return binaryLiteral(for: data, databaseType: databaseType)
             ?? driver.sqlLiteral(for: value)
+    }
+
+    /// The prefix belongs to a quoted literal and to nothing else. `sqlLiteral(for:)` answers
+    /// `NULL` for a null and passes a number through unquoted, and `N` in front of either is a
+    /// syntax error, so the opening quote is what decides.
+    internal static func prefixed(_ literal: String, databaseType: DatabaseType) -> String {
+        guard literal.hasPrefix("'") else { return literal }
+        return SQLStringLiteralPrefix.forDatabaseType(databaseType) + literal
     }
 
     internal static func binaryLiteral(for data: Data, databaseType: DatabaseType) -> String? {

--- a/TablePro/Core/Database/ForeignKeyPreviewQuery.swift
+++ b/TablePro/Core/Database/ForeignKeyPreviewQuery.swift
@@ -17,9 +17,11 @@ enum ForeignKeyPreviewQuery {
         quotedTable: String,
         quotedColumn: String,
         escapedValue: String,
+        stringLiteralPrefix: String,
         dialect: SQLDialectDescriptor?
     ) -> String {
-        "SELECT * FROM \(quotedTable) WHERE \(quotedColumn) = '\(escapedValue)' \(limitClause(dialect: dialect))"
+        let literal = "\(stringLiteralPrefix)'\(escapedValue)'"
+        return "SELECT * FROM \(quotedTable) WHERE \(quotedColumn) = \(literal) \(limitClause(dialect: dialect))"
     }
 
     /// OFFSET/FETCH is part of ORDER BY in T-SQL and Oracle, so the dialect's filler clause travels

--- a/TablePro/Core/Services/Query/ForeignKeyRowFetcher.swift
+++ b/TablePro/Core/Services/Query/ForeignKeyRowFetcher.swift
@@ -52,6 +52,7 @@ enum ForeignKeyRowFetcher {
             quotedTable: quotedTable,
             quotedColumn: driver.quoteIdentifier(reference.referencedColumn),
             escapedValue: driver.escapeStringLiteral(value),
+            stringLiteralPrefix: SQLStringLiteralPrefix.forDatabaseType(databaseType),
             dialect: PluginManager.shared.sqlDialect(for: databaseType)
         )
 

--- a/TablePro/Core/Utilities/SQL/InClauseConverter.swift
+++ b/TablePro/Core/Utilities/SQL/InClauseConverter.swift
@@ -11,6 +11,11 @@ internal struct InClauseConverter {
     internal let columnTypes: [ColumnType]
     internal let escapeStringLiteral: ((String) -> String)?
 
+    /// What the engine puts in front of a string literal. SQL Server's `N` is the only one, and
+    /// without it an `IN` list pasted into a query on a non-Unicode collation matches the rows
+    /// whose text was already damaged rather than the rows the user copied.
+    internal var stringLiteralPrefix: String = ""
+
     private static let maxRows = 50_000
 
     func generateInClause(rows: [[PluginCellValue]]) -> String {
@@ -55,6 +60,6 @@ internal struct InClauseConverter {
 
     private func quoted(_ value: String) -> String {
         let escaped = escapeStringLiteral?(value) ?? value.replacingOccurrences(of: "'", with: "''")
-        return "'\(escaped)'"
+        return "\(stringLiteralPrefix)'\(escaped)'"
     }
 }

--- a/TablePro/Core/Utilities/SQL/SQLRowToStatementConverter.swift
+++ b/TablePro/Core/Utilities/SQL/SQLRowToStatementConverter.swift
@@ -117,7 +117,7 @@ internal struct SQLRowToStatementConverter {
         case .null:
             return "NULL"
         case .text(let s):
-            return "'\(escapeStringFn(s))'"
+            return "\(SQLStringLiteralPrefix.forDatabaseType(databaseType))'\(escapeStringFn(s))'"
         case .bytes(let data):
             return formatBinaryLiteral(data)
         }

--- a/TablePro/Views/Results/DataGridView+RowActions.swift
+++ b/TablePro/Views/Results/DataGridView+RowActions.swift
@@ -216,7 +216,8 @@ extension TableViewCoordinator {
         let converter = InClauseConverter(
             columnIndex: columnIndex,
             columnTypes: tableRows.columnTypes,
-            escapeStringLiteral: driver?.escapeStringLiteral
+            escapeStringLiteral: driver?.escapeStringLiteral,
+            stringLiteralPrefix: SQLStringLiteralPrefix.forDatabaseType(databaseType)
         )
         ClipboardService.shared.writeText(converter.generateInClause(rows: rows))
     }

--- a/TablePro/Views/Results/Extensions/DataGridView+Click.swift
+++ b/TablePro/Views/Results/Extensions/DataGridView+Click.swift
@@ -197,6 +197,7 @@ extension TableViewCoordinator {
 
         let currentValue = cellValue(at: row, column: columnIndex) ?? ""
         let escape = resolveDriver()?.escapeStringLiteral ?? SQLEscaping.escapeStringLiteral
+        let literalPrefix = SQLStringLiteralPrefix.forDatabaseType(databaseType)
 
         let cellRect = tableView.rect(ofRow: row).intersection(tableView.rect(ofColumn: column))
         dismissActiveCellEditorPopover()
@@ -207,6 +208,7 @@ extension TableViewCoordinator {
             CustomValueContentView(
                 initialValue: currentValue,
                 escapeStringLiteral: escape,
+                stringLiteralPrefix: literalPrefix,
                 onCommit: { newValue in
                     guard let self else { return }
                     self.commitPopoverEdit(row: row, columnIndex: columnIndex, newValue: newValue)

--- a/TablePro/Views/RowInspector/FieldEditors/ValuePickerFieldView.swift
+++ b/TablePro/Views/RowInspector/FieldEditors/ValuePickerFieldView.swift
@@ -43,6 +43,7 @@ internal struct ValuePickerFieldView: View {
                 CustomValueContentView(
                     initialValue: context.value.wrappedValue,
                     escapeStringLiteral: escapeStringLiteral,
+                    stringLiteralPrefix: stringLiteralPrefix,
                     onCommit: { context.value.wrappedValue = $0 },
                     onDismiss: { isCustomPresented = false }
                 )
@@ -83,5 +84,16 @@ internal struct ValuePickerFieldView: View {
             return SQLEscaping.escapeStringLiteral
         }
         return driver.escapeStringLiteral
+    }
+
+    /// From the same connection the escaping comes from, so a default typed here is written the
+    /// way the engine reads it back. No connection means no prefix, which is what every engine but
+    /// SQL Server wants anyway.
+    private var stringLiteralPrefix: String {
+        guard let connectionId = context.userDefinedTypeScope?.connectionId,
+              let driver = DatabaseManager.shared.driver(for: connectionId) else {
+            return ""
+        }
+        return SQLStringLiteralPrefix.forDatabaseType(driver.connection.type)
     }
 }

--- a/TablePro/Views/Structure/CustomValueContentView.swift
+++ b/TablePro/Views/Structure/CustomValueContentView.swift
@@ -22,6 +22,10 @@ internal struct CustomValueContentView: View {
     /// The connected driver's own escaping, so a value is escaped the way the engine reads it.
     /// MySQL doubles backslashes as well as quotes, which the shared helper does not.
     internal let escapeStringLiteral: (String) -> String
+    /// What the engine puts in front of a string literal, `N` on SQL Server and nothing anywhere
+    /// else. A default written without it is a `varchar` literal, so a non-Unicode collation turns
+    /// every character outside its code page into `?` as it parses the `ALTER TABLE`.
+    internal let stringLiteralPrefix: String
     internal let onCommit: (String) -> Void
     internal let onDismiss: () -> Void
 
@@ -32,15 +36,20 @@ internal struct CustomValueContentView: View {
     internal init(
         initialValue: String,
         escapeStringLiteral: @escaping (String) -> String,
+        stringLiteralPrefix: String = "",
         onCommit: @escaping (String) -> Void,
         onDismiss: @escaping () -> Void
     ) {
         self.initialValue = initialValue
         self.escapeStringLiteral = escapeStringLiteral
+        self.stringLiteralPrefix = stringLiteralPrefix
         self.onCommit = onCommit
         self.onDismiss = onDismiss
-        if let text = SQLStringLiteral.unquoted(initialValue),
-           initialValue == "'\(escapeStringLiteral(text))'" {
+        let quotedPart = stringLiteralPrefix.isEmpty || !initialValue.hasPrefix(stringLiteralPrefix)
+            ? initialValue
+            : String(initialValue.dropFirst(stringLiteralPrefix.count))
+        if let text = SQLStringLiteral.unquoted(quotedPart),
+           initialValue == "\(stringLiteralPrefix)'\(escapeStringLiteral(text))'" {
             _mode = State(initialValue: .text)
             _text = State(initialValue: text)
         } else {
@@ -97,7 +106,7 @@ internal struct CustomValueContentView: View {
 
     private var resolvedSQL: String {
         switch mode {
-        case .text: "'\(escapeStringLiteral(text))'"
+        case .text: "\(stringLiteralPrefix)'\(escapeStringLiteral(text))'"
         case .expression: text
         }
     }

--- a/TableProTests/Core/Compare/CompareSQLLiteralTests.swift
+++ b/TableProTests/Core/Compare/CompareSQLLiteralTests.swift
@@ -21,6 +21,21 @@ final class CompareSQLLiteralTests: XCTestCase {
         }
     }
 
+    /// A compare script runs its own statements, so a plain literal on a SQL Server database with
+    /// a non-Unicode collation writes `?` into the target rather than the text it compared.
+    func testTextLiteralsCarryTheSQLServerPrefix() {
+        XCTAssertEqual(CompareSQLLiteral.prefixed("'日本語'", databaseType: .mssql), "N'日本語'")
+        XCTAssertEqual(CompareSQLLiteral.prefixed("'abc'", databaseType: .mysql), "'abc'")
+    }
+
+    /// `sqlLiteral(for:)` answers `NULL` for a null and passes a number through unquoted. `N` in
+    /// front of either is a syntax error.
+    func testOnlyQuotedLiteralsTakeThePrefix() {
+        XCTAssertEqual(CompareSQLLiteral.prefixed("NULL", databaseType: .mssql), "NULL")
+        XCTAssertEqual(CompareSQLLiteral.prefixed("42", databaseType: .mssql), "42")
+        XCTAssertEqual(CompareSQLLiteral.prefixed("0x89504E47", databaseType: .mssql), "0x89504E47")
+    }
+
     func testPostgresFamilyUsesAByteaCast() throws {
         for type in [DatabaseType.postgresql, .cockroachdb, .redshift, .pglite] {
             let literal = try XCTUnwrap(CompareSQLLiteral.binaryLiteral(for: png, databaseType: type))

--- a/TableProTests/Core/Database/ForeignKeyPreviewQueryTests.swift
+++ b/TableProTests/Core/Database/ForeignKeyPreviewQueryTests.swift
@@ -52,6 +52,7 @@ struct ForeignKeyPreviewQueryTests {
             quotedTable: "[dbo].[customers]",
             quotedColumn: "[id]",
             escapedValue: "42",
+            stringLiteralPrefix: "",
             dialect: dialect(paginationStyle: .offsetFetch)
         )
         #expect(
@@ -66,8 +67,24 @@ struct ForeignKeyPreviewQueryTests {
             quotedTable: "\"users\"",
             quotedColumn: "\"name\"",
             escapedValue: "O''Brien",
+            stringLiteralPrefix: "",
             dialect: dialect(paginationStyle: .limit)
         )
         #expect(sql == "SELECT * FROM \"users\" WHERE \"name\" = 'O''Brien' LIMIT 1")
+    }
+
+    /// A plain literal is a `varchar` on SQL Server, so a key holding non-Latin text matched the
+    /// row whose own text the server had already damaged, and the popover reported the real row as
+    /// missing.
+    @Test("The key literal carries the engine's prefix")
+    func keyLiteralCarriesThePrefix() {
+        let sql = ForeignKeyPreviewQuery.singleRow(
+            quotedTable: "[dbo].[customers]",
+            quotedColumn: "[name]",
+            escapedValue: "日本語",
+            stringLiteralPrefix: SQLStringLiteralPrefix.forDatabaseType(.mssql),
+            dialect: dialect(paginationStyle: .offsetFetch)
+        )
+        #expect(sql.contains("[name] = N'日本語'"))
     }
 }

--- a/TableProTests/Core/Utilities/InClauseConverterTests.swift
+++ b/TableProTests/Core/Utilities/InClauseConverterTests.swift
@@ -14,9 +14,34 @@ struct InClauseConverterTests {
     private func makeConverter(
         columnIndex: Int,
         columnTypes: [ColumnType],
-        escape: ((String) -> String)? = nil
+        escape: ((String) -> String)? = nil,
+        stringLiteralPrefix: String = ""
     ) -> InClauseConverter {
-        InClauseConverter(columnIndex: columnIndex, columnTypes: columnTypes, escapeStringLiteral: escape)
+        InClauseConverter(
+            columnIndex: columnIndex,
+            columnTypes: columnTypes,
+            escapeStringLiteral: escape,
+            stringLiteralPrefix: stringLiteralPrefix
+        )
+    }
+
+    /// An `IN` list pasted into a query on a SQL Server database with a non-Unicode collation
+    /// matched the rows whose text the server had already damaged, never the rows copied.
+    @Test("A text value carries the engine's literal prefix, and a number does not")
+    func textValuesCarryThePrefix() {
+        let converter = makeConverter(
+            columnIndex: 0,
+            columnTypes: [.text(rawType: nil)],
+            stringLiteralPrefix: SQLStringLiteralPrefix.forDatabaseType(.mssql)
+        )
+        #expect(converter.generateInClause(rows: [[.text("日本語")], [.text("b")]]) == "(N'日本語', N'b')")
+
+        let numbers = makeConverter(
+            columnIndex: 0,
+            columnTypes: [.integer(rawType: nil)],
+            stringLiteralPrefix: SQLStringLiteralPrefix.forDatabaseType(.mssql)
+        )
+        #expect(numbers.generateInClause(rows: [[.text("1")], [.text("2")]]) == "(1, 2)")
     }
 
     @Test("Empty rows yields empty parens")

--- a/TableProTests/Core/Utilities/SQLRowToStatementConverterTests.swift
+++ b/TableProTests/Core/Utilities/SQLRowToStatementConverterTests.swift
@@ -152,11 +152,24 @@ struct SQLRowToStatementConverterTests {
         #expect(result == "UPDATE `users` SET `name` = 'Alice', `email` = 'alice@example.com' WHERE `id` = '1';")
     }
 
-    @Test("MSSQL uses bracket quoting")
+    /// The `N` is not decoration: a plain `'…'` is a `varchar` literal, so pasting these
+    /// statements into a database with a non-Unicode collation stores `?` for every character
+    /// outside its code page, whatever the column type is.
+    @Test("MSSQL uses bracket quoting and N-prefixed literals")
     func mssqlUsesBracketQuoting() throws {
         let converter = try makeConverter(databaseType: .mssql, dialect: Self.mssqlDialect)
         let result = converter.generateInserts(rows: [["1", "Alice", "alice@example.com"]])
-        #expect(result == "INSERT INTO [users] ([id], [name], [email]) VALUES ('1', 'Alice', 'alice@example.com');")
+        #expect(result == "INSERT INTO [users] ([id], [name], [email]) VALUES (N'1', N'Alice', N'alice@example.com');")
+    }
+
+    @Test("MSSQL: non-Latin text survives a copied INSERT and UPDATE")
+    func mssqlKeepsNonLatinText() throws {
+        let converter = try makeConverter(databaseType: .mssql, dialect: Self.mssqlDialect)
+        let inserts = converter.generateInserts(rows: [["1", "日本語", "a@b.c"]])
+        #expect(inserts.contains("N'日本語'"))
+        let updates = converter.generateUpdates(rows: [["1", "日本語", "a@b.c"]])
+        #expect(updates.contains("[name] = N'日本語'"))
+        #expect(updates.contains("WHERE [id] = N'1'"))
     }
 
     @Test("PostgreSQL uses double-quote quoting")


### PR DESCRIPTION
Follows #2756, which made the SQL Server driver and the filter builder write `N'…'` literals. Five more paths in the app still wrote plain ones. Found while investigating #2725.

## What was wrong

A plain `'…'` is a `varchar` literal, so SQL Server converts it to the database collation's code page while it parses the batch. On a non-Unicode collation every character outside that page becomes `?`, whatever the target column is. #2756 covered the filter, the table query and the driver's own statements. These were left:

| Path | What the user got |
| --- | --- |
| Copy as INSERT, Copy as UPDATE | A statement that stores `?` for every non-ASCII character when pasted back |
| Copy as IN | An `IN` list that matches the rows whose text was already damaged, not the rows copied |
| Preview Referenced Row | The popover looked up a damaged row, or reported "Failed to load referenced row" for a key holding non-Latin text |
| Compare and sync scripts | The generated script writes `?` into the target |
| Column default, from the row inspector menu and the structure grid chevron | `ALTER TABLE` stores a default with `?` in it |

The binary half was already right in three of these (`0x…` for SQL Server), so only the text literals moved.

## The fix

Every one of them now asks `SQLStringLiteralPrefix.forDatabaseType`, the helper #2756 added, and puts the answer in front of the quote. That is `N` for SQL Server and nothing for every other engine, so nothing else changes.

`CompareSQLLiteral` is the one that needed a rule rather than a prefix: it renders through `driver.sqlLiteral(for:)`, which answers `NULL` for a null and passes a number through unquoted, and `N` in front of either is a syntax error. The opening quote decides, and a test pins all three cases.

`CustomValueContentView` also reads a default back to decide whether to show it as text or as a SQL expression, so it now strips the prefix before that comparison. Without that, an existing `N'…'` default would open in the expression editor and be escaped a second time on save.

## Verification

- **Build:** PASS. **Lint:** PASS, 0 violations. **Docs:** PASS.
- **Tests:** PASS, 87 cases across `SQLRowToStatementConverterTests`, `InClauseConverterTests`, `CompareSQLLiteralTests`, `ForeignKeyPreviewQueryTests`, `SQLStringLiteralPrefixTests`, `FilterSQLGeneratorMSSQLTests` and `ColumnDefaultRoundTripTests`.
- Not run against a live SQL Server: these are pure string builders and the tests cover them directly. #2756 measured the underlying server behaviour on SQL Server 2022 with a Latin-1 collation.
- One existing expectation changed: `mssqlUsesBracketQuoting` asserted `VALUES ('1', 'Alice', …)`. That expectation encoded the bug, and the test now asserts the `N` prefix and says why.

## Still open

- **SQL export** writes plain literals, and writes binary as `X'…'`, which SQL Server rejects outright. The export plugin holds a `PluginExportDataSource`, which exposes the escaping but not the prefix or a binary spelling, so fixing it means widening that protocol. Not in this PR.
- The `quote_identifiers` MCP tool reports the escaped body without the prefix. A caller that builds a literal from it gets a plain one.
