### PR TITLE
test(storage): stop the preference key guard flagging dictionary and layer keys

### DIFF
--- a/TableProTests/Core/Storage/PreferenceKeysGuardTests.swift
+++ b/TableProTests/Core/Storage/PreferenceKeysGuardTests.swift
@@ -20,7 +20,7 @@ struct PreferenceKeysGuardTests {
 
     @Test("No off-namespace forKey: literals outside the frozen baseline")
     func noNewRawForKeyLiterals() throws {
-        let offenders = try Self.scan(pattern: #"forKey:\s*"([^"\\]+)""#)
+        let offenders = try Self.scan(pattern: #"forKey:\s*"([^"\\]+)""#, ignoringCalls: Self.nonPreferenceCalls)
             .filter { !$0.hasPrefix("com.TablePro") && Self.grandfatheredForKey[$0] == nil }
         #expect(offenders.isEmpty, "Route new UserDefaults keys through PreferenceKeys: \(offenders.sorted())")
     }
@@ -32,12 +32,19 @@ struct PreferenceKeysGuardTests {
         #expect(offenders.isEmpty, "Route new @AppStorage keys through the preferences layer: \(offenders.sorted())")
     }
 
+    /// `forKey:` is not UserDefaults' label alone: `Dictionary.removeValue(forKey:)` and
+    /// `CALayer.add(_:forKey:)` spell it the same way, and a text scan cannot tell them apart. The
+    /// baseline grew one entry per dictionary key instead, three of its five, and the fourth arrived
+    /// as `removeValue(forKey: "LC_ALL")` in the dump environment (#2747), which failed this suite on
+    /// main for a value no preference has ever read. Naming the calls that are not preferences keeps
+    /// the baseline for the keys that genuinely are.
+    private static let nonPreferenceCalls: Set<String> = [
+        "removeValue", "updateValue", "add", "animation", "removeAnimation",
+    ]
+
     private static let grandfatheredForKey: [String: String] = [
         "AppleLanguages": "Apple system default written when switching app language",
         "NSTableViewDefaultSizeMode": "Apple system default read by the workspace rail for Sidebar icon size, never written",
-        "blink": "CALayer animation key in VimCursorManager, not a preference",
-        "extensions": "MCP capabilities field stripped by BridgeProxy for legacy clients, not a preference",
-        "preConnectScript": "additionalFields dictionary key in ConnectionFormCoordinator, not a preference",
     ]
 
     private static let grandfatheredAppStorage: [String: String] = [
@@ -46,7 +53,7 @@ struct PreferenceKeysGuardTests {
         "structureCodeFontSize": "legacy structure font size, migrates to PreferenceKeys in a later phase",
     ]
 
-    private static func scan(pattern: String) throws -> Set<String> {
+    private static func scan(pattern: String, ignoringCalls ignored: Set<String> = []) throws -> Set<String> {
         let sourceRoot = try repoRoot().appendingPathComponent("TablePro")
         let regex = try NSRegularExpression(pattern: pattern)
         guard let enumerator = FileManager.default.enumerator(
@@ -59,12 +66,48 @@ struct PreferenceKeysGuardTests {
             let text = try String(contentsOf: url, encoding: .utf8)
             let range = NSRange(text.startIndex..., in: text)
             for match in regex.matches(in: text, range: range) where match.numberOfRanges > 1 {
-                if let captured = Range(match.range(at: 1), in: text) {
-                    matches.insert(String(text[captured]))
-                }
+                guard let captured = Range(match.range(at: 1), in: text),
+                      let start = Range(match.range, in: text)?.lowerBound
+                else { continue }
+                if let call = enclosingCall(in: text, at: start), ignored.contains(call) { continue }
+                matches.insert(String(text[captured]))
             }
         }
         return matches
+    }
+
+    /// The function whose argument list the match sits in, found by walking back to the innermost
+    /// unmatched `(`. Nested parentheses in an earlier argument are skipped, so
+    /// `layer.add(makeBlinkAnimation(), forKey: "blink")` reports `add` rather than
+    /// `makeBlinkAnimation`.
+    private static func enclosingCall(in text: String, at index: String.Index) -> String? {
+        var depth = 0
+        var cursor = index
+        while cursor > text.startIndex {
+            cursor = text.index(before: cursor)
+            let character = text[cursor]
+            if character == ")" {
+                depth += 1
+            } else if character == "(" {
+                if depth == 0 { return identifier(in: text, endingBefore: cursor) }
+                depth -= 1
+            } else if character == "\n", depth == 0 {
+                continue
+            }
+        }
+        return nil
+    }
+
+    private static func identifier(in text: String, endingBefore index: String.Index) -> String? {
+        var end = index
+        while end > text.startIndex {
+            let previous = text.index(before: end)
+            let character = text[previous]
+            guard character.isLetter || character.isNumber || character == "_" else { break }
+            end = previous
+        }
+        guard end < index else { return nil }
+        return String(text[end ..< index])
     }
 
     private static func repoRoot() throws -> URL {


### PR DESCRIPTION
`main` is red, and this is why.

#2747 added `result.removeValue(forKey: "LC_ALL")` to the dump environment. `PreferenceKeysGuardTests` scans every Swift source under `TablePro/` for `forKey: "..."` literals to catch raw UserDefaults keys, so it flagged that one:

```
Recorded an issue (Expectation failed: (offenders → ["LC_ALL"]).isEmpty → false)
```

The production code is right. `forKey:` is not UserDefaults' label alone: `Dictionary.removeValue(forKey:)` and `CALayer.add(_:forKey:)` spell it the same way, and a text scan cannot tell them apart.

The guard had already been paying for that. Three of its five frozen entries were not preferences at all, and each says so:

```
"blink": "CALayer animation key in VimCursorManager, not a preference",
"extensions": "MCP capabilities field stripped by BridgeProxy for legacy clients, not a preference",
"preConnectScript": "additionalFields dictionary key in ConnectionFormCoordinator, not a preference",
```

So the scan now finds the call a match sits in, by walking back to the innermost unmatched `(`, and skips the APIs that only share the label. The three entries above are gone with it; `AppleLanguages` and `NSTableViewDefaultSizeMode` stay, because those are real UserDefaults keys.

The baseline shrinks from five to two, and the next dictionary key no longer fails CI for a value no preference reads.

## Verified

`PreferenceKeysGuardTests`: 3 of 3 pass. All three cases still run, including the two that scan for off-namespace keys.

No CHANGELOG entry: nothing a user can see changes.
