### PR TITLE
fix(plugin-clickhouse): keep binary values through export, object copy and compare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Garbled ClickHouse text whenever another value in the same result held binary data.
 - Carriage returns, quotes, NUL bytes and Enum type names shown with backslash escapes on ClickHouse.
 - Edits and deletes matching no row on ClickHouse tables with a binary value in the row.
+- Binary ClickHouse values written as replacement characters by an export, an object copy and a compare. (#2725)
+- ClickHouse export with a **Row limit** failing with a syntax error. (#2725)
 - Non-ASCII SQL Server filter values turned into `?` and matching the wrong rows on non-Unicode collations.
 - Empty structure, missing indexes and failed renames for non-ASCII SQL Server object names on non-Unicode collations.
 - Changing a defaulted SQL Server column failing when a name contains a quote or non-ASCII text.

--- a/Plugins/BeancountDriverPlugin/Info.plist
+++ b/Plugins/BeancountDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>26</integer>
+	<integer>27</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Beancount</string>

--- a/Plugins/BigQueryDriverPlugin/Info.plist
+++ b/Plugins/BigQueryDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>26</integer>
+	<integer>27</integer>
 </dict>
 </plist>

--- a/Plugins/CSVExportPlugin/Info.plist
+++ b/Plugins/CSVExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>26</integer>
+	<integer>27</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>csv</string>

--- a/Plugins/CSVImportPlugin/Info.plist
+++ b/Plugins/CSVImportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>26</integer>
+	<integer>27</integer>
 	<key>TableProProvidesImportFormatIds</key>
 	<array>
 		<string>csv</string>

--- a/Plugins/CassandraDriverPlugin/Info.plist
+++ b/Plugins/CassandraDriverPlugin/Info.plist
@@ -21,6 +21,6 @@
 	<key>NSPrincipalClass</key>
 	<string>$(PRODUCT_MODULE_NAME).CassandraPlugin</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>26</integer>
+	<integer>27</integer>
 </dict>
 </plist>

--- a/Plugins/ClickHouseDriverPlugin/ClickHouseHTTPChunks.swift
+++ b/Plugins/ClickHouseDriverPlugin/ClickHouseHTTPChunks.swift
@@ -1,0 +1,116 @@
+import Foundation
+import TableProPluginKit
+
+/// The response body of a streaming read, as the bytes the socket produced.
+///
+/// `URLSession.AsyncBytes.lines` hands back a UTF-8 decoded `String`, which replaces every byte a
+/// `String` column holds that is not valid UTF-8 before anything can look at it, and iterating the
+/// same sequence a byte at a time costs an async suspension per byte: measured on a million-row
+/// read, 7.6s for `lines` and 44s for the bytes under it. A per-task delegate hands over the `Data`
+/// untouched and about 85 KB at a time, and the same read then costs 0.18s. It is a *task* delegate
+/// rather than a session one so the driver keeps its own session, and with it the
+/// `ClickHouseTLSDelegate` that answers the server trust challenge.
+///
+/// One chunk is in flight at a time: the transfer is suspended as each chunk is handed over and
+/// resumed once the reader has finished with it, so a slow writer downstream stops the download
+/// rather than letting the rest of the result pile up in memory. That resume is why the body is
+/// read through `forEachChunk` and not by iterating a sequence: a caller cannot forget it.
+internal final class ClickHouseHTTPChunks: NSObject, URLSessionDataDelegate, @unchecked Sendable {
+    /// An error body is text the user reads, not a result, so it is held whole up to this and the
+    /// rest dropped. ClickHouse exception text runs to a few kilobytes at most.
+    private static let errorBodyByteCap = 65_536
+
+    private let stream: AsyncThrowingStream<Data, Error>
+    private let continuation: AsyncThrowingStream<Data, Error>.Continuation
+    private let lock = NSLock()
+    private var task: URLSessionDataTask?
+    private var isTransferSuspended = false
+    private var failureStatusCode: Int?
+    private var failureBody = Data()
+
+    internal init(session: URLSession, request: URLRequest) {
+        (stream, continuation) = AsyncThrowingStream<Data, Error>.makeStream()
+        super.init()
+
+        let dataTask = session.dataTask(with: request)
+        dataTask.delegate = self
+        lock.withLock { task = dataTask }
+        continuation.onTermination = { _ in dataTask.cancel() }
+        dataTask.resume()
+    }
+
+    /// The transfer is torn down on every way out, a thrown error and a cancellation included. A
+    /// reader that walks away leaves the task suspended mid-body with nothing left to resume it, so
+    /// without this the connection stays open until the driver disconnects.
+    internal func forEachChunk(_ body: (Data) async throws -> Void) async throws {
+        defer { endTransfer() }
+        for try await chunk in stream {
+            try await body(chunk)
+            resumeTransfer()
+        }
+    }
+
+    internal func urlSession(
+        _ session: URLSession,
+        dataTask: URLSessionDataTask,
+        didReceive response: URLResponse,
+        completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
+    ) {
+        if let statusCode = (response as? HTTPURLResponse)?.statusCode, statusCode >= 400 {
+            lock.withLock { failureStatusCode = statusCode }
+        }
+        completionHandler(.allow)
+    }
+
+    internal func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+        let isFailure = lock.withLock { () -> Bool in
+            guard failureStatusCode != nil else { return false }
+            let room = Self.errorBodyByteCap - failureBody.count
+            if room > 0 { failureBody.append(data.prefix(room)) }
+            return true
+        }
+        guard !isFailure else { return }
+
+        continuation.yield(data)
+        let shouldSuspend = lock.withLock { () -> Bool in
+            guard !isTransferSuspended else { return false }
+            isTransferSuspended = true
+            return true
+        }
+        guard shouldSuspend else { return }
+        dataTask.suspend()
+    }
+
+    internal func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        let failure = lock.withLock { () -> Error? in
+            guard failureStatusCode != nil else { return error }
+            let body = String(decoding: failureBody, as: UTF8.self) // swiftlint:disable:this optional_data_string_conversion
+            return ClickHouseError(message: body.trimmingCharacters(in: .whitespacesAndNewlines))
+        }
+        guard let failure else {
+            continuation.finish()
+            return
+        }
+        continuation.finish(throwing: failure)
+    }
+
+    private func resumeTransfer() {
+        let suspended = lock.withLock { () -> URLSessionDataTask? in
+            guard isTransferSuspended else { return nil }
+            isTransferSuspended = false
+            return task
+        }
+        suspended?.resume()
+    }
+
+    private func endTransfer() {
+        let outstanding = lock.withLock { () -> URLSessionDataTask? in
+            let current = task
+            task = nil
+            isTransferSuspended = false
+            return current
+        }
+        outstanding?.cancel()
+        continuation.finish()
+    }
+}

--- a/Plugins/ClickHouseDriverPlugin/ClickHousePlugin.swift
+++ b/Plugins/ClickHouseDriverPlugin/ClickHousePlugin.swift
@@ -495,8 +495,9 @@ final class ClickHousePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
 
     // MARK: - Streaming
 
-    /// A bounded read is one HTTP request. The unbounded `streamRows` path still pays a separate
-    /// `LIMIT 0` probe to learn its columns, so it is deliberately not reused here.
+    /// A bounded read is one HTTP request, and so is the unbounded `streamRows` path: the format
+    /// both ask for names its columns, so neither pays a `LIMIT 0` probe to learn them. That probe
+    /// appended to the statement, which a query already carrying a `LIMIT` rejects outright.
     func executeBoundedQuery(query: String, rowCap: Int) async throws -> PluginQueryResult? {
         let started = Date()
         let stream = PluginRowStream.make { continuation, abort in
@@ -526,87 +527,70 @@ final class ClickHousePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
             return (session, _currentDatabase)
         }
 
-        var trimmedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        while trimmedQuery.hasSuffix(";") {
-            trimmedQuery = String(trimmedQuery.dropLast()).trimmingCharacters(in: .whitespacesAndNewlines)
-        }
+        let request = try buildStreamRequest(
+            query: Self.withoutTrailingSemicolons(query),
+            database: database,
+            rowCap: rowCap
+        )
+        try await streamTabSeparatedRows(
+            request: request,
+            session: session,
+            batchSize: min(5_000, rowCap + 1),
+            continuation: continuation
+        )
+    }
 
-        let request = try buildStreamRequest(query: trimmedQuery, database: database, rowCap: rowCap)
-        let (bytes, response) = try await session.bytes(for: request)
-
-        if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode >= 400 {
-            var body = ""
-            for try await line in bytes.lines {
-                body += line
-            }
-            throw ClickHouseError(message: body.trimmingCharacters(in: .whitespacesAndNewlines))
-        }
-
-        /// JSONCompactEachRowWithNamesAndTypes puts the names on line one and the types on line
-        /// two, both as positional arrays, so the columns arrive without a second round trip and
-        /// survive a zero-row result.
-        var columns: [String] = []
-        var columnTypeNames: [String] = []
+    /// `TabSeparatedWithNamesAndTypes` carries the names on line one and the types on line two, so
+    /// the columns arrive with the rows and survive a result holding none. It is the format the
+    /// non-streaming read asks for too, which is what keeps an exported value and the same value in
+    /// the grid the same text, and unlike a JSON string it can carry a byte no encoding covers.
+    private func streamTabSeparatedRows(
+        request: URLRequest,
+        session: URLSession,
+        batchSize: Int,
+        continuation: AsyncThrowingStream<PluginStreamElement, Error>.Continuation
+    ) async throws {
+        var decoder = ClickHouseTabSeparatedRowDecoder()
         var headerSent = false
-        let batchSize = min(5_000, rowCap + 1)
         var batch: [PluginRow] = []
         batch.reserveCapacity(batchSize)
 
-        for try await line in bytes.lines {
-            try Task.checkCancellation()
-
-            let trimmedLine = line.trimmingCharacters(in: .whitespacesAndNewlines)
-            if trimmedLine.isEmpty { continue }
-            guard let lineData = trimmedLine.data(using: .utf8) else { continue }
-
-            if columns.isEmpty {
-                columns = (try? JSONSerialization.jsonObject(with: lineData) as? [String]) ?? []
-                continue
-            }
-            if columnTypeNames.isEmpty {
-                columnTypeNames = (try? JSONSerialization.jsonObject(with: lineData) as? [String]) ?? []
-                continuation.yield(.header(PluginStreamHeader(
-                    columns: columns,
-                    columnTypeNames: columnTypeNames,
-                    estimatedRowCount: nil
-                )))
-                headerSent = true
-                continue
-            }
-
-            guard let values = try? JSONSerialization.jsonObject(with: lineData) as? [Any] else { continue }
-            var row: [PluginCellValue] = []
-            row.reserveCapacity(columns.count)
-            for index in columns.indices {
-                let value: Any? = index < values.count ? values[index] : nil
-                row.append(Self.boundedCellValue(value))
-            }
-            batch.append(row)
-            if batch.count >= batchSize {
-                continuation.yield(.rows(batch))
-                batch.removeAll(keepingCapacity: true)
-            }
-        }
-
-        if !headerSent {
+        func sendHeader(_ header: ClickHouseTabSeparatedRowDecoder.Header) {
+            guard !headerSent else { return }
+            headerSent = true
             continuation.yield(.header(PluginStreamHeader(
-                columns: columns,
-                columnTypeNames: columnTypeNames,
+                columns: header.columns,
+                columnTypeNames: header.columnTypeNames,
                 estimatedRowCount: nil
             )))
         }
+
+        try await ClickHouseHTTPChunks(session: session, request: request).forEachChunk { chunk in
+            try Task.checkCancellation()
+            let rows = decoder.consume(chunk)
+            if let header = decoder.header {
+                sendHeader(header)
+            }
+            batch.append(contentsOf: rows)
+            guard batch.count >= batchSize else { return }
+            continuation.yield(.rows(batch))
+            batch.removeAll(keepingCapacity: true)
+        }
+
+        batch.append(contentsOf: decoder.finish())
+        sendHeader(decoder.header ?? ClickHouseTabSeparatedRowDecoder.Header(columns: [], columnTypeNames: []))
         if !batch.isEmpty {
             continuation.yield(.rows(batch))
         }
         continuation.finish()
     }
 
-    private static func boundedCellValue(_ value: Any?) -> PluginCellValue {
-        guard let value, !(value is NSNull) else { return .null }
-        if let str = value as? String { return .text(str) }
-        if let num = value as? NSNumber { return .text(NumberText.text(for: num)) }
-        if let jsonStr = NumberText.json(from: value, sortedKeys: false) { return .text(jsonStr) }
-        return .text(String(describing: value))
+    private static func withoutTrailingSemicolons(_ query: String) -> String {
+        var trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        while trimmed.hasSuffix(";") {
+            trimmed = String(trimmed.dropLast()).trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        return trimmed
     }
 
     func streamRows(query: String) -> AsyncThrowingStream<PluginStreamElement, Error> {
@@ -633,87 +617,13 @@ final class ClickHousePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
             return (session, _currentDatabase)
         }
 
-        var trimmedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        while trimmedQuery.hasSuffix(";") {
-            trimmedQuery = String(trimmedQuery.dropLast()).trimmingCharacters(in: .whitespacesAndNewlines)
-        }
-
-        let headerResult = try await executeRaw("\(trimmedQuery) LIMIT 0")
-        continuation.yield(.header(PluginStreamHeader(
-            columns: headerResult.columns,
-            columnTypeNames: headerResult.columnTypeNames,
-            estimatedRowCount: nil
-        )))
-
-        let columnOrder = headerResult.columns
-
-        guard !columnOrder.isEmpty else {
-            continuation.finish()
-            return
-        }
-
-        let streamRequest = try buildStreamRequest(
-            query: trimmedQuery, database: database
+        let request = try buildStreamRequest(query: Self.withoutTrailingSemicolons(query), database: database)
+        try await streamTabSeparatedRows(
+            request: request,
+            session: session,
+            batchSize: 5_000,
+            continuation: continuation
         )
-
-        let (bytes, response) = try await session.bytes(for: streamRequest)
-
-        if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode >= 400 {
-            var body = ""
-            for try await line in bytes.lines {
-                body += line
-            }
-            throw ClickHouseError(message: body.trimmingCharacters(in: .whitespacesAndNewlines))
-        }
-
-        let batchSize = 5_000
-        var batch: [PluginRow] = []
-        batch.reserveCapacity(batchSize)
-
-        for try await line in bytes.lines {
-            try Task.checkCancellation()
-
-            let trimmedLine = line.trimmingCharacters(in: .whitespacesAndNewlines)
-            if trimmedLine.isEmpty { continue }
-
-            guard let lineData = trimmedLine.data(using: .utf8),
-                  let json = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any] else {
-                continue
-            }
-
-            var row: [PluginCellValue] = []
-            for colName in columnOrder {
-                if let value = json[colName] {
-                    if value is NSNull {
-                        row.append(.null)
-                    } else if let str = value as? String {
-                        row.append(.text(str))
-                    } else if let num = value as? NSNumber {
-                        row.append(.text(NumberText.text(for: num)))
-                    } else {
-                        if let jsonStr = NumberText.json(from: value, sortedKeys: false) {
-                            row.append(.text(jsonStr))
-                        } else {
-                            row.append(.text(String(describing: value)))
-                        }
-                    }
-                } else {
-                    row.append(.null)
-                }
-            }
-
-            batch.append(row)
-            if batch.count >= batchSize {
-                continuation.yield(.rows(batch))
-                batch.removeAll(keepingCapacity: true)
-            }
-        }
-
-        if !batch.isEmpty {
-            continuation.yield(.rows(batch))
-        }
-
-        continuation.finish()
     }
 
     private func buildStreamRequest(query: String, database: String, rowCap: Int? = nil) throws -> URLRequest {
@@ -729,15 +639,16 @@ final class ClickHousePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         if !database.isEmpty {
             queryItems.append(URLQueryItem(name: "database", value: database))
         }
+        queryItems.append(URLQueryItem(
+            name: "default_format",
+            value: ClickHouseResponseClassifier.requestedFormat
+        ))
         if let rowCap {
             /// The bound rides as an HTTP setting so the SQL in the body stays exactly what the
             /// user wrote. One row past the cap, so a full page can be told from a truncated one.
-            queryItems.append(URLQueryItem(name: "default_format", value: "JSONCompactEachRowWithNamesAndTypes"))
             queryItems.append(URLQueryItem(name: "max_result_rows", value: String(rowCap + 1)))
             queryItems.append(URLQueryItem(name: "result_overflow_mode", value: "break"))
             queryItems.append(URLQueryItem(name: "cancel_http_readonly_queries_on_client_close", value: "1"))
-        } else {
-            queryItems.append(URLQueryItem(name: "default_format", value: "JSONEachRow"))
         }
         components.queryItems = queryItems
 

--- a/Plugins/ClickHouseDriverPlugin/Info.plist
+++ b/Plugins/ClickHouseDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>26</integer>
+	<integer>27</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>ClickHouse</string>

--- a/Plugins/CloudflareD1DriverPlugin/Info.plist
+++ b/Plugins/CloudflareD1DriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>26</integer>
+	<integer>27</integer>
 </dict>
 </plist>

--- a/Plugins/CloudflareR2SQLDriverPlugin/Info.plist
+++ b/Plugins/CloudflareR2SQLDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>26</integer>
+	<integer>27</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Cloudflare R2 SQL</string>

--- a/Plugins/DamengDriverPlugin/Info.plist
+++ b/Plugins/DamengDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>26</integer>
+	<integer>27</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Dameng</string>

--- a/Plugins/DuckDBDriverPlugin/Info.plist
+++ b/Plugins/DuckDBDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>26</integer>
+	<integer>27</integer>
 </dict>
 </plist>

--- a/Plugins/DynamoDBDriverPlugin/Info.plist
+++ b/Plugins/DynamoDBDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>26</integer>
+	<integer>27</integer>
 </dict>
 </plist>

--- a/Plugins/ElasticsearchDriverPlugin/Info.plist
+++ b/Plugins/ElasticsearchDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.53.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>26</integer>
+	<integer>27</integer>
 </dict>
 </plist>

--- a/Plugins/EtcdDriverPlugin/Info.plist
+++ b/Plugins/EtcdDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>26</integer>
+	<integer>27</integer>
 </dict>
 </plist>

--- a/Plugins/HTMLExportPlugin/Info.plist
+++ b/Plugins/HTMLExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>26</integer>
+	<integer>27</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>html</string>

--- a/Plugins/JSONExportPlugin/Info.plist
+++ b/Plugins/JSONExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>26</integer>
+	<integer>27</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>json</string>

--- a/Plugins/JSONImportPlugin/Info.plist
+++ b/Plugins/JSONImportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>26</integer>
+	<integer>27</integer>
 	<key>TableProProvidesImportFormatIds</key>
 	<array>
 		<string>json</string>

--- a/Plugins/KafkaDriverPlugin/Info.plist
+++ b/Plugins/KafkaDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>26</integer>
+	<integer>27</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Kafka</string>

--- a/Plugins/LibSQLDriverPlugin/Info.plist
+++ b/Plugins/LibSQLDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>26</integer>
+	<integer>27</integer>
 </dict>
 </plist>

--- a/Plugins/MQLExportPlugin/Info.plist
+++ b/Plugins/MQLExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>26</integer>
+	<integer>27</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>mql</string>

--- a/Plugins/MSSQLDriverPlugin/Info.plist
+++ b/Plugins/MSSQLDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>26</integer>
+	<integer>27</integer>
 </dict>
 </plist>

--- a/Plugins/MarkdownExportPlugin/Info.plist
+++ b/Plugins/MarkdownExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>26</integer>
+	<integer>27</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>md</string>

--- a/Plugins/MongoDBDriverPlugin/Info.plist
+++ b/Plugins/MongoDBDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>26</integer>
+	<integer>27</integer>
 </dict>
 </plist>

--- a/Plugins/MySQLDriverPlugin/Info.plist
+++ b/Plugins/MySQLDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>26</integer>
+	<integer>27</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>MySQL</string>

--- a/Plugins/OracleDriverPlugin/Info.plist
+++ b/Plugins/OracleDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>26</integer>
+	<integer>27</integer>
 </dict>
 </plist>

--- a/Plugins/ParquetExportPlugin/Info.plist
+++ b/Plugins/ParquetExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>26</integer>
+	<integer>27</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>parquet</string>

--- a/Plugins/PostgreSQLDriverPlugin/Info.plist
+++ b/Plugins/PostgreSQLDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>26</integer>
+	<integer>27</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>PostgreSQL</string>

--- a/Plugins/RedisDriverPlugin/Info.plist
+++ b/Plugins/RedisDriverPlugin/Info.plist
@@ -21,7 +21,7 @@
 	<key>NSPrincipalClass</key>
 	<string>$(PRODUCT_MODULE_NAME).RedisPlugin</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>26</integer>
+	<integer>27</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Redis</string>

--- a/Plugins/SQLExportPlugin/Info.plist
+++ b/Plugins/SQLExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>26</integer>
+	<integer>27</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>sql</string>

--- a/Plugins/SQLImportPlugin/Info.plist
+++ b/Plugins/SQLImportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>26</integer>
+	<integer>27</integer>
 	<key>TableProProvidesImportFormatIds</key>
 	<array>
 		<string>sql</string>

--- a/Plugins/SQLiteDriverPlugin/Info.plist
+++ b/Plugins/SQLiteDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>26</integer>
+	<integer>27</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>SQLite</string>

--- a/Plugins/SnowflakeDriverPlugin/Info.plist
+++ b/Plugins/SnowflakeDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.48.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>26</integer>
+	<integer>27</integer>
 </dict>
 </plist>

--- a/Plugins/SpannerDriverPlugin/Info.plist
+++ b/Plugins/SpannerDriverPlugin/Info.plist
@@ -5,7 +5,7 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>26</integer>
+	<integer>27</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Spanner</string>

--- a/Plugins/SurrealDBDriverPlugin/Info.plist
+++ b/Plugins/SurrealDBDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>26</integer>
+	<integer>27</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>SurrealDB</string>

--- a/Plugins/TableProPluginKit/ClickHouseTabSeparatedRowDecoder.swift
+++ b/Plugins/TableProPluginKit/ClickHouseTabSeparatedRowDecoder.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+/// The streaming half of `ClickHouseResponseClassifier`, for the reads that hand rows back as they
+/// arrive and so can never hold the whole response. A chunk boundary falls wherever the network
+/// put it, so the bytes it cut in half are kept until the line they belong to is whole: a field is
+/// offered to a text decode only once nothing more can be appended to it.
+///
+/// A value that is not valid UTF-8 stays `.bytes`, decided per value rather than per column the
+/// way `classify` decides it. Demoting a column means rewriting the rows already handed over, and
+/// a stream has no way back to them.
+public struct ClickHouseTabSeparatedRowDecoder: Sendable {
+    public struct Header: Equatable, Sendable {
+        public let columns: [String]
+        public let columnTypeNames: [String]
+
+        public init(columns: [String], columnTypeNames: [String]) {
+            self.columns = columns
+            self.columnTypeNames = columnTypeNames
+        }
+    }
+
+    public private(set) var header: Header?
+
+    private var pendingBytes: [UInt8] = []
+    private var columnNames: [String]?
+
+    public init() {}
+
+    public mutating func consume(_ data: Data) -> [[PluginCellValue]] {
+        guard !data.isEmpty else { return [] }
+
+        var buffer = pendingBytes
+        pendingBytes = []
+        buffer.append(contentsOf: data)
+
+        var rows: [[PluginCellValue]] = []
+        var lineStart = 0
+        for index in buffer.indices where buffer[index] == ClickHouseTabSeparatedBytes.lineSeparator {
+            if let row = ingest(buffer[lineStart..<index]) {
+                rows.append(row)
+            }
+            lineStart = index + 1
+        }
+        buffer.removeFirst(lineStart)
+        pendingBytes = buffer
+        return rows
+    }
+
+    /// A body that ended without its closing newline still holds one whole row.
+    public mutating func finish() -> [[PluginCellValue]] {
+        let buffer = pendingBytes
+        pendingBytes = []
+        guard !buffer.isEmpty, let row = ingest(buffer[...]) else { return [] }
+        return [row]
+    }
+
+    private mutating func ingest(_ line: ArraySlice<UInt8>) -> [PluginCellValue]? {
+        guard let columnNames else {
+            self.columnNames = ClickHouseTabSeparatedBytes.fields(line).map(ClickHouseTabSeparatedBytes.headerText)
+            return nil
+        }
+        guard header != nil else {
+            header = Header(
+                columns: columnNames,
+                columnTypeNames: ClickHouseTabSeparatedBytes.fields(line).map(ClickHouseTabSeparatedBytes.headerText)
+            )
+            return nil
+        }
+        guard !line.isEmpty else { return nil }
+        return ClickHouseTabSeparatedBytes.fields(line).map(Self.cellValue)
+    }
+
+    private static func cellValue(_ field: ArraySlice<UInt8>) -> PluginCellValue {
+        guard !ClickHouseTabSeparatedBytes.isNullMarker(field) else { return .null }
+        let value = ClickHouseTabSeparatedBytes.unescape(field)
+        guard let text = String(bytes: value, encoding: .utf8) else { return .bytes(Data(value)) }
+        return .text(text)
+    }
+}

--- a/Plugins/TeradataDriverPlugin/Info.plist
+++ b/Plugins/TeradataDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>26</integer>
+	<integer>27</integer>
 </dict>
 </plist>

--- a/Plugins/TrinoDriverPlugin/Info.plist
+++ b/Plugins/TrinoDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>26</integer>
+	<integer>27</integer>
 </dict>
 </plist>

--- a/Plugins/TypesenseDriverPlugin/Info.plist
+++ b/Plugins/TypesenseDriverPlugin/Info.plist
@@ -5,7 +5,7 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.73.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>26</integer>
+	<integer>27</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Typesense</string>

--- a/Plugins/XLSXExportPlugin/Info.plist
+++ b/Plugins/XLSXExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>26</integer>
+	<integer>27</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>xlsx</string>

--- a/Plugins/XLSXImportPlugin/Info.plist
+++ b/Plugins/XLSXImportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>26</integer>
+	<integer>27</integer>
 	<key>TableProProvidesImportFormatIds</key>
 	<array>
 		<string>xlsx</string>

--- a/Plugins/XMLExportPlugin/Info.plist
+++ b/Plugins/XMLExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>26</integer>
+	<integer>27</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>xml</string>

--- a/TablePro/Core/Plugins/PluginManager.swift
+++ b/TablePro/Core/Plugins/PluginManager.swift
@@ -41,7 +41,7 @@ final class PluginManager {
     /// rebuilt CassandraDriver for the v20 requirements it implements none of. Left at 20, such a
     /// plugin passes `validateBundleVersions` in a shipped v20 app and then fails
     /// `Bundle.loadAndReturnError`; at 21 that app refuses it and says to update.
-    nonisolated static let currentPluginKitVersion = 26
+    nonisolated static let currentPluginKitVersion = 27
 
     /// Still 19, so every plugin already published for the previous release keeps loading.
     nonisolated static let minimumCompatiblePluginKitVersion = 19

--- a/TableProTests/Plugins/ClickHouseTabSeparatedRowDecoderTests.swift
+++ b/TableProTests/Plugins/ClickHouseTabSeparatedRowDecoderTests.swift
@@ -1,0 +1,183 @@
+//
+//  ClickHouseTabSeparatedRowDecoderTests.swift
+//  TableProTests
+//
+
+import Foundation
+import TableProPluginKit
+import Testing
+
+@Suite("ClickHouse Tab Separated Row Decoder")
+struct ClickHouseTabSeparatedRowDecoderTests {
+    private struct Decoded {
+        let header: ClickHouseTabSeparatedRowDecoder.Header?
+        let rows: [[PluginCellValue]]
+    }
+
+    private static let header = Data("id\tlabel\tpayload\nUInt32\tString\tString\n".utf8)
+
+    private func decodeAll(_ chunks: [Data]) -> Decoded {
+        var decoder = ClickHouseTabSeparatedRowDecoder()
+        var rows: [[PluginCellValue]] = []
+        for chunk in chunks {
+            rows.append(contentsOf: decoder.consume(chunk))
+        }
+        rows.append(contentsOf: decoder.finish())
+        return Decoded(header: decoder.header, rows: rows)
+    }
+
+    private func decodeAll(_ body: Data) -> Decoded {
+        decodeAll([body])
+    }
+
+    private func bytewise(_ body: Data) -> [[PluginCellValue]] {
+        decodeAll(body.map { Data([$0]) }).rows
+    }
+
+    // MARK: - Header
+
+    @Test("The first two lines are the column names and the column types")
+    func readsNamesAndTypes() {
+        let outcome = decodeAll(Self.header)
+        #expect(outcome.header?.columns == ["id", "label", "payload"])
+        #expect(outcome.header?.columnTypeNames == ["UInt32", "String", "String"])
+        #expect(outcome.rows.isEmpty)
+    }
+
+    @Test("A body holding nothing reports no header")
+    func emptyBodyHasNoHeader() {
+        let outcome = decodeAll(Data())
+        #expect(outcome.header == nil)
+        #expect(outcome.rows.isEmpty)
+    }
+
+    @Test("A name that is not valid UTF-8 keeps the column rather than dropping it")
+    func headerReplacesUndecodableBytes() {
+        var body = Data("id\t".utf8)
+        body.append(contentsOf: [0xDE, 0xAD])
+        body.append(contentsOf: Data("\nUInt32\tString\n".utf8))
+        let outcome = decodeAll(body)
+        #expect(outcome.header?.columns.count == 2)
+        #expect(outcome.header?.columns.first == "id")
+    }
+
+    // MARK: - Values
+
+    @Test("A field that decodes as UTF-8 is text")
+    func decodesTextValues() {
+        var body = Self.header
+        body.append(contentsOf: Data("1\tünïcødé\thello\n".utf8))
+        let outcome = decodeAll(body)
+        #expect(outcome.rows == [[.text("1"), .text("ünïcødé"), .text("hello")]])
+    }
+
+    @Test("A field that is not valid UTF-8 keeps its exact bytes")
+    func keepsUndecodableBytes() {
+        var body = Self.header
+        body.append(contentsOf: Data("1\tplain\t".utf8))
+        body.append(contentsOf: [0xDE, 0xAD, 0xBE, 0xEF])
+        body.append(contentsOf: Data("\n".utf8))
+        let outcome = decodeAll(body)
+        #expect(outcome.rows.count == 1)
+        #expect(outcome.rows[0][2] == .bytes(Data([0xDE, 0xAD, 0xBE, 0xEF])))
+    }
+
+    @Test("A binary value in one row leaves a text value in the same column as text")
+    func decidesPerValueRatherThanPerColumn() {
+        var body = Self.header
+        body.append(contentsOf: Data("1\ta\t".utf8))
+        body.append(contentsOf: [0xDE, 0xAD, 0xBE, 0xEF])
+        body.append(contentsOf: Data("\n2\tb\thello world\n".utf8))
+        let outcome = decodeAll(body)
+        #expect(outcome.rows.count == 2)
+        #expect(outcome.rows[0][2] == .bytes(Data([0xDE, 0xAD, 0xBE, 0xEF])))
+        #expect(outcome.rows[1][2] == .text("hello world"))
+    }
+
+    @Test("A lone backslash-N field is null")
+    func readsNullMarker() {
+        var body = Self.header
+        body.append(contentsOf: Data("1\t\\N\tvalue\n".utf8))
+        let outcome = decodeAll(body)
+        #expect(outcome.rows == [[.text("1"), .null, .text("value")]])
+    }
+
+    @Test("An escaped backslash before N is the literal text, not null")
+    func escapedBackslashIsNotNull() {
+        var body = Self.header
+        body.append(contentsOf: Data("1\t\\\\N\tvalue\n".utf8))
+        let outcome = decodeAll(body)
+        #expect(outcome.rows == [[.text("1"), .text("\\N"), .text("value")]])
+    }
+
+    @Test("Every escape ClickHouse writes comes back as its byte")
+    func unescapesEveryEscape() {
+        var body = Self.header
+        body.append(contentsOf: Data("1\ta\\tb\\nc\\rd\\0e\\be\\fg\\'h\\\\i\tvalue\n".utf8))
+        let outcome = decodeAll(body)
+        let expected = "a\tb\nc\rd\u{0}e\u{8}e\u{C}g'h\\i"
+        #expect(outcome.rows.count == 1)
+        #expect(outcome.rows[0][1] == .text(expected))
+    }
+
+    @Test("Array, Map and Tuple arrive as the text ClickHouse writes for them")
+    func keepsCompoundValuesAsWritten() {
+        var body = Data("tags\tattrs\tpair\nArray(String)\tMap(String, String)\tTuple(UInt8, String)\n".utf8)
+        body.append(contentsOf: Data("['a','b']\t{'k':'v'}\t(7,'x')\n".utf8))
+        let outcome = decodeAll(body)
+        #expect(outcome.rows == [[.text("['a','b']"), .text("{'k':'v'}"), .text("(7,'x')")]])
+    }
+
+    // MARK: - Chunk boundaries
+
+    @Test("A row split across two chunks decodes once it is whole")
+    func joinsRowsAcrossChunks() {
+        var first = Self.header
+        first.append(contentsOf: Data("1\tlab".utf8))
+        let second = Data("el\tvalue\n".utf8)
+        let outcome = decodeAll([first, second])
+        #expect(outcome.rows == [[.text("1"), .text("label"), .text("value")]])
+    }
+
+    @Test("A chunk that cuts a multi-byte character in half does not corrupt it")
+    func joinsMultiByteCharactersAcrossChunks() {
+        var body = Self.header
+        body.append(contentsOf: Data("1\tünïcødé\tvalue\n".utf8))
+        #expect(bytewise(body) == [[.text("1"), .text("ünïcødé"), .text("value")]])
+    }
+
+    @Test("Feeding one byte at a time gives the same rows as one chunk")
+    func chunkingDoesNotChangeTheResult() {
+        var body = Self.header
+        body.append(contentsOf: Data("1\ta\t".utf8))
+        body.append(contentsOf: [0xDE, 0xAD, 0xBE, 0xEF])
+        body.append(contentsOf: Data("\n2\tb\thello\n3\t\\N\t\\t\n".utf8))
+        #expect(bytewise(body) == decodeAll(body).rows)
+    }
+
+    // MARK: - Body edges
+
+    @Test("A body that ends without its closing newline still yields its last row")
+    func yieldsUnterminatedFinalRow() {
+        var body = Self.header
+        body.append(contentsOf: Data("1\tlabel\tvalue".utf8))
+        let outcome = decodeAll(body)
+        #expect(outcome.rows == [[.text("1"), .text("label"), .text("value")]])
+    }
+
+    @Test("A blank line between rows is not a row")
+    func skipsBlankLines() {
+        var body = Self.header
+        body.append(contentsOf: Data("1\ta\tb\n\n2\tc\td\n".utf8))
+        let outcome = decodeAll(body)
+        #expect(outcome.rows.count == 2)
+    }
+
+    @Test("A field holding nothing is empty text, never null")
+    func emptyFieldIsEmptyText() {
+        var body = Self.header
+        body.append(contentsOf: Data("1\t\tvalue\n".utf8))
+        let outcome = decodeAll(body)
+        #expect(outcome.rows == [[.text("1"), .text(""), .text("value")]])
+    }
+}

--- a/docs/databases/clickhouse.mdx
+++ b/docs/databases/clickhouse.mdx
@@ -86,7 +86,7 @@ The CA file may be PEM or DER. If **Verify CA** cannot read it, the connection f
 - No auto-increment, and the primary key and sorting key are fixed at creation. Structure editing covers adding, modifying, and dropping columns and data-skipping indexes; recreate the table for anything else.
 - A `SET` does not carry to the next statement. Every statement is its own HTTP request with no session id, and the setting is gone by the next one. Put it in a `SETTINGS` clause on the query itself.
 - A query with its own `FORMAT` clause, such as `SELECT 1 FORMAT JSON`, shows the server's raw output in one column instead of a parsed table. Drop the clause to get a grid.
-- A column with even one value that is not valid UTF-8 shows every row as hex, and its cells do not open for inline editing. `String` and `FixedString` hold raw bytes, so a hash or a stray byte is enough. Select `toValidUTF8(column)` to read it as text, with the bad bytes replaced.
+- A column with even one value that is not valid UTF-8 shows every row as hex in the grid, and its cells do not open for inline editing. `String` and `FixedString` hold raw bytes, so a hash or a stray byte is enough. An export, an object copy and a data compare judge each value on its own, so a row holding text stays text there. Select `toValidUTF8(column)` to read it as text, with the bad bytes replaced.
 
 ## Troubleshooting
 

--- a/docs/development/plugin-development.mdx
+++ b/docs/development/plugin-development.mdx
@@ -13,7 +13,7 @@ A plugin is a macOS loadable bundle target with `WRAPPER_EXTENSION = tableplugin
 
 | Key | Type | Required | Purpose |
 |-----|------|----------|---------|
-| `TableProPluginKitVersion` | integer | Yes | The PluginKit ABI the plugin was built against. Current value: 26 |
+| `TableProPluginKitVersion` | integer | Yes | The PluginKit ABI the plugin was built against. Current value: 27 |
 | `TableProProvidesDatabaseTypeIds` | array of strings | Recommended | Database type IDs the plugin serves, which is what makes lazy loading possible |
 | `CFBundleShortVersionString` | string | Yes | Plugin version, read by registry update checks |
 | `TableProMinAppVersion` | string | No | The loader rejects the plugin on an older app |

--- a/docs/development/plugin-registry.mdx
+++ b/docs/development/plugin-registry.mdx
@@ -68,13 +68,13 @@ Themes carry no native code, so they match on architecture alone.
   "binaries": [
     {
       "architecture": "arm64",
-      "pluginKitVersion": 26,
+      "pluginKitVersion": 27,
       "downloadURL": "https://github.com/TableProApp/TablePro/releases/download/plugin-oracle-v1.0.26/OracleDriver-arm64.zip",
       "sha256": "<sha256>"
     },
     {
       "architecture": "x86_64",
-      "pluginKitVersion": 26,
+      "pluginKitVersion": 27,
       "downloadURL": "https://github.com/TableProApp/TablePro/releases/download/plugin-oracle-v1.0.26/OracleDriver-x86_64.zip",
       "sha256": "<sha256>"
     }

--- a/project.yml
+++ b/project.yml
@@ -403,6 +403,7 @@ targets:
       - Plugins/ClickHouseDriverPlugin/ClickHouseCapabilities.swift
       - Plugins/ClickHouseDriverPlugin/ClickHouseCredentials.swift
       - Plugins/ClickHouseDriverPlugin/ClickHouseGeneratedColumnClassification.swift
+      - Plugins/ClickHouseDriverPlugin/ClickHouseHTTPChunks.swift
       - Plugins/ClickHouseDriverPlugin/ClickHouseParameterBinding.swift
       - Plugins/ClickHouseDriverPlugin/ClickHousePlugin.swift
       - Plugins/ClickHouseDriverPlugin/ClickHousePluginDriver+Http.swift


### PR DESCRIPTION
Found while investigating #2725 and left out of #2756.

#2756 moved the ClickHouse **query result** path onto `TabSeparatedWithNamesAndTypes` and read it as bytes. Three other paths still asked for JSON lines and read them through `URLSession.AsyncBytes.lines`, which decodes each line as UTF-8 before anything can look at it: **export**, **object copy** and **data compare**, all three through `streamRows(query:)` with `JSONEachRow`. The **capped query editor read** (`executeBoundedQuery`) was a fourth, on `JSONCompactEachRowWithNamesAndTypes`; #2756 did not cover it, because the path it fixed is `executeRaw`, which serves table tabs and uncapped queries.

The server is not the problem. It writes the raw bytes straight into the JSON string (measured: `"payload":"\xde\xad\xbe\xef"` on the wire). The loss is client side, in the line decode.

## What I measured

ClickHouse 24.8.14.39 in Docker. One table with a `String` column holding `unhex('deadbeef')` next to ordinary UTF-8 text:

```sql
CREATE TABLE blobs (id UInt32, label String, payload String, fixed FixedString(4),
                    tags Array(String), attrs Map(String,String), pair Tuple(UInt8,String),
                    maybe Nullable(String), big UInt64) ENGINE = MergeTree ORDER BY id;
INSERT INTO blobs VALUES (1,'plain ascii', unhex('deadbeef'), unhex('deadbeef'), ['a','b'],
                          {'k':'v'}, (7,'x'), NULL, 18446744073709551615), (2, ...);
```

Run against the real `ClickHousePluginDriver` from a `swiftc` harness, once with the plugin sources at `origin/main` and once with this branch.

**`streamRows` (export, object copy, compare), `payload`:**

| | value handed to the app |
|---|---|
| before | `.text("ޭ\u{FFFD}\u{FFFD}")`, UTF-8 `DE AD EF BF BD EF BF BD` |
| after | `.bytes(0xDEADBEEF)` |

Four bytes became eight and the original was gone. `executeBoundedQuery` measured identically, before and after.

**CSV export**, through the real `CSVExportPlugin` over the driver:

```
before   1,plain ascii,ޭ��,ޭ��
after    1,plain ascii,0xDEADBEEF,0xDEADBEEF
```

Row 2 (`hello world`, and a `FixedString` of `00 01 02 03`) is byte-identical on both sides, so nothing else in the file moved.

**Object copy**, reading `blobs` with `streamRows` and writing it back with `executeParameterized`, then `hex(payload)` on the target:

| | stored in the target |
|---|---|
| source truth | `DEADBEEF` |
| before | `DEADEFBFBDEFBFBD` |
| after | `DEADBEEF` |

**Data compare** is the worst of the three, because the corruption is lossy in a way that collapses distinct values. `unhex('deadbeef')` and `unhex('deadffff')` both decode to the same replacement text, so the diff engine was handed two equal values for two different rows:

```
before   source: .text utf8=DEADEFBFBDEFBFBD
         target: .text utf8=DEADEFBFBDEFBFBD   -> engine sees them as EQUAL
after    source: .bytes 0xDEADBEEF
         target: .bytes 0xDEADFFFF             -> engine sees them as different
```

## Second defect in the same function

`performStreamRows` learned its columns by running `"\(query) LIMIT 0"` first, because `JSONEachRow` carries no header. Appended to a statement that already ends in a `LIMIT`, that is a syntax error:

```
before   streamRows("SELECT id, label FROM blobs ORDER BY id LIMIT 1")
         -> Code: 62. DB::Exception: Syntax error: failed at position 55 ('0')
after    -> 1 row
```

That is every export with a **Row limit** set in the row-scope editor, since ClickHouse implements no `injectRowLimit` and the export appends `LIMIT n` as text. `TabSeparatedWithNamesAndTypes` names its columns on lines one and two, so the probe is gone and both streaming reads are now a single request.

## The change

- `buildStreamRequest` asks for `ClickHouseResponseClassifier.requestedFormat` on both branches, so all four read paths share one wire format.
- `ClickHouseTabSeparatedRowDecoder` (PluginKit, next to the classifier and the byte helper #2756 added) is the streaming counterpart of `classify`: it holds the bytes a chunk boundary cut in half, unescapes per field, and keeps a field that is not valid UTF-8 as `.bytes`. It decides per value rather than per column, which is the one deliberate difference from `classify`: a stream cannot rewrite rows it has already handed over, and demoting a whole column would mean buffering the result. For an export that is also the better answer, since a valid value in a column that holds one bad one still exports as its own text.
- `ClickHouseHTTPChunks` reads the body as `Data` chunks through a **per-task** delegate, so the driver keeps its own `URLSession` and with it `ClickHouseTLSDelegate`. Measured: a session delegate still receives the server-trust challenge when a task delegate is set. One chunk is in flight at a time; the transfer is suspended as each chunk is handed over and resumed when the reader is done with it, and torn down on every way out so an abandoned read does not leave a suspended task holding the connection.
- `performStreamRows` and `performBoundedStreamRows` are now four lines each over a shared `streamTabSeparatedRows`.

Per-byte iteration of `AsyncBytes` was the obvious way to keep the bytes and it is not usable: 1M rows took 44s against 1.5s for `lines`, and a 60s request timeout cut the response off mid-stream. Chunked delegate reads are faster than the JSON path they replace. End to end through the driver, 1,000,000 rows: **6.76s before, 5.28s after**.

## What I did not change, and why

- **The path #2756 fixed.** `executeRaw` and `ClickHouseResponseClassifier.classify` are untouched.
- **Nothing stayed on JSON.** I checked what the four paths need from JSON's own typing and none of it is load-bearing. Numbers arrive as text either way, and ClickHouse already quotes 64-bit integers in JSON, so nothing gains or loses precision. `Nullable` is `\N`. `Array`, `Map` and `Tuple` change spelling, from JSON (`["a","b"]`, `{"k":"v"}`, `[7,"x"]`) to ClickHouse's own (`['a','b']`, `{'k':'v'}`, `(7,'x')`), which is what the grid has shown since #2756 and what ClickHouse itself parses back. Both consumers that re-serialize (`NumberText.json`) were doing it to a string anyway.
- **Server-side query cancellation for the unbounded stream.** `cancel_http_readonly_queries_on_client_close` is set on the bounded read only, as before: measured, abandoning a `streamRows` leaves the query running on the server on both sides. Unrelated to this defect.

## PluginKit version

The ABI diff against the merge base is purely additive, one new public struct, nothing removed or changed. Per the `#2597` rule in CLAUDE.md an additive change still needs `currentPluginKitVersion` bumped, because the rebuilt ClickHouse plugin references the new symbol and an older app would accept it at version 26 and then fail `Bundle.loadAndReturnError`. So 26 to 27, `minimumCompatiblePluginKitVersion` left at 19 so every shipped plugin keeps loading, and no bulk re-release: `check-registry-readiness.py` accepts any binary in `[19, 27]`, so the registry's 26 binaries stay installable.

## Tests

`ClickHouseTabSeparatedRowDecoderTests`, 17 cases: the header pair, a row split across chunks, a multi-byte character cut in half, one byte at a time giving the same rows as one chunk, `\N` against the literal `\N`, every escape ClickHouse writes, a binary value leaving a text value in the same column as text, an unterminated final row, a blank line, and an empty field as empty text rather than null.

## Verification

| step | result |
|---|---|
| `generate` | PASS |
| `build` | PASS |
| `test` (9 ClickHouse and plugin suites) | PASS, 81 cases |
| `lint Plugins/ClickHouseDriverPlugin Plugins/TableProPluginKit TableProTests` | PASS, 0 violations |
| `docs` | PASS |
| `abi <merge-base>` | additive diff, reviewed above |

`verify.sh plugins` (the `AllPlugins` aggregate) was not run: it fails on this machine for an unrelated reason, OracleNIO not compiling under Xcode-beta. ClickHouse is a bundled plugin, so `build` compiles it. The two PluginKit doc pages that quote the current PluginKit version were updated, which `check-docs-against-source.py` checks.
