### PR TITLE
fix(plugin-postgresql): write table and column comments into SQL exports (#2726)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Default PostgreSQL schema taken from the schema list rather than the search path.
 - Safe Mode minimum from a configuration profile missing from the toolbar, the Database menu and the connection form. (#2030)
 - PostgreSQL connection hanging after running `COPY FROM STDIN` or `COPY TO STDOUT` in the query editor and on iOS.
+- Table, view and column comments missing from a PostgreSQL SQL export. (#2726)
 - Stop not ending queries on MySQL and MariaDB servers without TLS.
 - Wrong results after MySQL retakes a dropped connection, on a session that had set a variable, a session setting or a database.
 - Session state set by the `/*! ... */` statements a MySQL dump writes counting as a comment.

--- a/Plugins/BeancountDriverPlugin/Info.plist
+++ b/Plugins/BeancountDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>27</integer>
+	<integer>28</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Beancount</string>

--- a/Plugins/BigQueryDriverPlugin/Info.plist
+++ b/Plugins/BigQueryDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>27</integer>
+	<integer>28</integer>
 </dict>
 </plist>

--- a/Plugins/CSVExportPlugin/Info.plist
+++ b/Plugins/CSVExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>27</integer>
+	<integer>28</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>csv</string>

--- a/Plugins/CSVImportPlugin/Info.plist
+++ b/Plugins/CSVImportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>27</integer>
+	<integer>28</integer>
 	<key>TableProProvidesImportFormatIds</key>
 	<array>
 		<string>csv</string>

--- a/Plugins/CassandraDriverPlugin/Info.plist
+++ b/Plugins/CassandraDriverPlugin/Info.plist
@@ -21,6 +21,6 @@
 	<key>NSPrincipalClass</key>
 	<string>$(PRODUCT_MODULE_NAME).CassandraPlugin</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>27</integer>
+	<integer>28</integer>
 </dict>
 </plist>

--- a/Plugins/ClickHouseDriverPlugin/Info.plist
+++ b/Plugins/ClickHouseDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>27</integer>
+	<integer>28</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>ClickHouse</string>

--- a/Plugins/CloudflareD1DriverPlugin/Info.plist
+++ b/Plugins/CloudflareD1DriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>27</integer>
+	<integer>28</integer>
 </dict>
 </plist>

--- a/Plugins/CloudflareR2SQLDriverPlugin/Info.plist
+++ b/Plugins/CloudflareR2SQLDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>27</integer>
+	<integer>28</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Cloudflare R2 SQL</string>

--- a/Plugins/DamengDriverPlugin/Info.plist
+++ b/Plugins/DamengDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>27</integer>
+	<integer>28</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Dameng</string>

--- a/Plugins/DuckDBDriverPlugin/Info.plist
+++ b/Plugins/DuckDBDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>27</integer>
+	<integer>28</integer>
 </dict>
 </plist>

--- a/Plugins/DynamoDBDriverPlugin/Info.plist
+++ b/Plugins/DynamoDBDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>27</integer>
+	<integer>28</integer>
 </dict>
 </plist>

--- a/Plugins/ElasticsearchDriverPlugin/Info.plist
+++ b/Plugins/ElasticsearchDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.53.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>27</integer>
+	<integer>28</integer>
 </dict>
 </plist>

--- a/Plugins/EtcdDriverPlugin/Info.plist
+++ b/Plugins/EtcdDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>27</integer>
+	<integer>28</integer>
 </dict>
 </plist>

--- a/Plugins/HTMLExportPlugin/Info.plist
+++ b/Plugins/HTMLExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>27</integer>
+	<integer>28</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>html</string>

--- a/Plugins/JSONExportPlugin/Info.plist
+++ b/Plugins/JSONExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>27</integer>
+	<integer>28</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>json</string>

--- a/Plugins/JSONImportPlugin/Info.plist
+++ b/Plugins/JSONImportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>27</integer>
+	<integer>28</integer>
 	<key>TableProProvidesImportFormatIds</key>
 	<array>
 		<string>json</string>

--- a/Plugins/KafkaDriverPlugin/Info.plist
+++ b/Plugins/KafkaDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>27</integer>
+	<integer>28</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Kafka</string>

--- a/Plugins/LibSQLDriverPlugin/Info.plist
+++ b/Plugins/LibSQLDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>27</integer>
+	<integer>28</integer>
 </dict>
 </plist>

--- a/Plugins/MQLExportPlugin/Info.plist
+++ b/Plugins/MQLExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>27</integer>
+	<integer>28</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>mql</string>

--- a/Plugins/MSSQLDriverPlugin/Info.plist
+++ b/Plugins/MSSQLDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>27</integer>
+	<integer>28</integer>
 </dict>
 </plist>

--- a/Plugins/MarkdownExportPlugin/Info.plist
+++ b/Plugins/MarkdownExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>27</integer>
+	<integer>28</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>md</string>

--- a/Plugins/MongoDBDriverPlugin/Info.plist
+++ b/Plugins/MongoDBDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>27</integer>
+	<integer>28</integer>
 </dict>
 </plist>

--- a/Plugins/MySQLDriverPlugin/Info.plist
+++ b/Plugins/MySQLDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>27</integer>
+	<integer>28</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>MySQL</string>

--- a/Plugins/OracleDriverPlugin/Info.plist
+++ b/Plugins/OracleDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>27</integer>
+	<integer>28</integer>
 </dict>
 </plist>

--- a/Plugins/ParquetExportPlugin/Info.plist
+++ b/Plugins/ParquetExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>27</integer>
+	<integer>28</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>parquet</string>

--- a/Plugins/PostgreSQLDriverPlugin/Info.plist
+++ b/Plugins/PostgreSQLDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>27</integer>
+	<integer>28</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>PostgreSQL</string>

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLCommentStatements.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLCommentStatements.swift
@@ -1,0 +1,79 @@
+//
+//  PostgreSQLCommentStatements.swift
+//  PostgreSQLDriverPlugin
+//
+//  The COMMENT statements that reattach one relation's comment and its column comments. Pure, so it
+//  is testable without a server.
+//
+
+import Foundation
+
+public enum PostgreSQLCommentStatements {
+    /// The relation's own comment first, then one row per commented column in `attnum` order, which
+    /// is the order `pg_dump` writes them in.
+    ///
+    /// `relkind` rides on every row, the column rows included, because it is what decides the
+    /// keyword `COMMENT ON` takes and a relation with no comment of its own still has columns to
+    /// write. A row with no description is filtered out here rather than rendered as `IS NULL`, which
+    /// would erase a comment instead of restoring one.
+    public static func catalogQuery(name: String, schema: String) -> String {
+        let nameLiteral = PostgreSQLObjectQueries.quoteLiteral(name)
+        let schemaLiteral = PostgreSQLObjectQueries.quoteLiteral(schema)
+        return """
+        SELECT relkind, attname, description
+        FROM (
+            SELECT
+                c.relkind::text AS relkind,
+                NULL::text AS attname,
+                pg_catalog.obj_description(c.oid, 'pg_class') AS description,
+                0 AS ordinal,
+                0 AS attnum
+            FROM pg_catalog.pg_class c
+            JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+            WHERE n.nspname = \(schemaLiteral)
+              AND c.relname = \(nameLiteral)
+              AND c.relkind IN ('r', 'p', 'f', 'v', 'm')
+              AND pg_catalog.obj_description(c.oid, 'pg_class') IS NOT NULL
+            UNION ALL
+            SELECT
+                c.relkind::text AS relkind,
+                a.attname AS attname,
+                pg_catalog.col_description(c.oid, a.attnum) AS description,
+                1 AS ordinal,
+                a.attnum AS attnum
+            FROM pg_catalog.pg_class c
+            JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+            JOIN pg_catalog.pg_attribute a ON a.attrelid = c.oid
+            WHERE n.nspname = \(schemaLiteral)
+              AND c.relname = \(nameLiteral)
+              AND c.relkind IN ('r', 'p', 'f', 'v', 'm')
+              AND a.attnum > 0
+              AND NOT a.attisdropped
+              AND pg_catalog.col_description(c.oid, a.attnum) IS NOT NULL
+        ) AS relation_comments
+        ORDER BY ordinal, attnum
+        """
+    }
+
+    /// Renders what `catalogQuery` answered. Rows are projected as `relkind`, `attname`,
+    /// `description`, and a nil `attname` marks the relation's own comment.
+    public static func statements(name: String, schema: String, rows: [[String?]]) -> [String] {
+        let target = PostgreSQLObjectQueries.qualifiedName(schema: schema, name: name)
+        return rows.compactMap { statement(target: target, row: $0) }
+    }
+
+    private static func statement(target: String, row: [String?]) -> String? {
+        guard row.count >= 3,
+              let relkind = row[0],
+              let keyword = PostgreSQLRelationSQL.commentKeyword(forRelkind: relkind),
+              let description = row[2],
+              !description.isEmpty
+        else { return nil }
+        let literal = PostgreSQLObjectQueries.quoteLiteral(description)
+        guard let column = row[1], !column.isEmpty else {
+            return "COMMENT ON \(keyword) \(target) IS \(literal)"
+        }
+        let columnRef = "\(target).\(PostgreSQLObjectQueries.quoteIdentifier(column))"
+        return "COMMENT ON COLUMN \(columnRef) IS \(literal)"
+    }
+}

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver+Comments.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver+Comments.swift
@@ -1,0 +1,25 @@
+//
+//  PostgreSQLPluginDriver+Comments.swift
+//  PostgreSQLDriverPlugin
+//
+
+import Foundation
+import TableProPluginKit
+
+extension PostgreSQLPluginDriver {
+    /// A plain read rather than the `search_path`-emptied one `fetchViewDefinition` takes: nothing
+    /// here is deparsed by the server, so the session's path cannot change the answer.
+    ///
+    /// Cockroach, Redshift and PGlite inherit this, which is correct: all three keep
+    /// `obj_description` and `col_description`.
+    func fetchCommentDDL(table: String, schema: String?) async throws -> [String] {
+        let resolvedSchema = schema ?? core.currentSchema
+        let query = PostgreSQLCommentStatements.catalogQuery(name: table, schema: resolvedSchema)
+        let result = try await execute(query: query)
+        return PostgreSQLCommentStatements.statements(
+            name: table,
+            schema: resolvedSchema,
+            rows: result.rows.map { $0.map(\.asText) }
+        )
+    }
+}

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLRelationSQL.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLRelationSQL.swift
@@ -28,6 +28,23 @@ public enum PostgreSQLRelationSQL {
         }
     }
 
+    /// The same keyword read from `pg_class.relkind`, which is what a catalog read has to hand. A
+    /// partitioned table takes `TABLE`, the keyword `COMMENT ON PARTITIONED TABLE` does not exist.
+    public static func commentKeyword(forRelkind relkind: String) -> String? {
+        switch relkind {
+        case "r", "p":
+            return "TABLE"
+        case "f":
+            return "FOREIGN TABLE"
+        case "v":
+            return "VIEW"
+        case "m":
+            return "MATERIALIZED VIEW"
+        default:
+            return nil
+        }
+    }
+
     /// `COMMENT` takes a literal and nothing else, so the value is quoted here rather than bound. The
     /// quoting reads the same whatever `standard_conforming_strings` is set to.
     public static func commentStatement(

--- a/Plugins/RedisDriverPlugin/Info.plist
+++ b/Plugins/RedisDriverPlugin/Info.plist
@@ -21,7 +21,7 @@
 	<key>NSPrincipalClass</key>
 	<string>$(PRODUCT_MODULE_NAME).RedisPlugin</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>27</integer>
+	<integer>28</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Redis</string>

--- a/Plugins/SQLExportPlugin/Info.plist
+++ b/Plugins/SQLExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>27</integer>
+	<integer>28</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>sql</string>

--- a/Plugins/SQLExportPlugin/SQLExportPlugin.swift
+++ b/Plugins/SQLExportPlugin/SQLExportPlugin.swift
@@ -54,6 +54,10 @@ final class SQLExportPlugin: ExportFormatPlugin, SettablePlugin, @unchecked Send
     /// a table whose `CREATE TABLE` came back fine and only lost its indexes is a different thing
     /// to tell the user about.
     var indexFailures: [String] = []
+
+    /// Kept apart for the same reason `indexFailures` is: an object whose definition came back fine
+    /// and only lost its comments is a different thing to tell the user about.
+    var commentFailures: [String] = []
     var metadataWarnings: [String] = []
 
     /// The tables a foreign key cycle left the ordering unable to place. They keep the order the
@@ -114,6 +118,7 @@ final class SQLExportPlugin: ExportFormatPlugin, SettablePlugin, @unchecked Send
     ) async throws -> ExportFormatResult {
         ddlFailures = []
         indexFailures = []
+        commentFailures = []
         metadataWarnings = []
         exportSpansContainers = false
         tablesUnorderedByCycle = []
@@ -243,6 +248,11 @@ final class SQLExportPlugin: ExportFormatPlugin, SettablePlugin, @unchecked Send
             warnings.append(String(
                 format: String(localized: "Could not fetch indexes for: %@"),
                 indexFailures.joined(separator: ", ")))
+        }
+        if !commentFailures.isEmpty {
+            warnings.append(String(
+                format: String(localized: "Could not fetch comments for: %@"),
+                commentFailures.joined(separator: ", ")))
         }
         warnings.append(contentsOf: metadataWarnings)
         return ExportFormatResult(warnings: warnings)
@@ -489,7 +499,51 @@ final class SQLExportPlugin: ExportFormatPlugin, SettablePlugin, @unchecked Send
                 let ddlWarning = "Warning: failed to fetch DDL for table \(sanitizedName): \(error)"
                 Self.logger.warning("Failed to fetch DDL for table \(sanitizedName): \(error)")
                 try writer.write("-- \(PluginExportUtilities.sanitizeForSQLComment(ddlWarning))\n\n")
+                continue
             }
+            try await writeComments(for: table, dataSource: dataSource, to: writer)
+        }
+    }
+
+    /// The kinds whose `CREATE` this dump writes as the object the driver's `COMMENT` keyword names.
+    /// A routine, trigger, sequence or type is skipped rather than asked, so a dump of one costs no
+    /// round trip.
+    ///
+    /// A foreign table is left out for a harder reason: the dump writes `CREATE TABLE` for it, so
+    /// PostgreSQL's own `COMMENT ON FOREIGN TABLE` fails the restore with `"f_orders" is not a
+    /// foreign table`. Measured on PostgreSQL 17.11. Add it back once a foreign table's `CREATE` is
+    /// its own.
+    private static let commentedKinds: Set<PluginExportObjectKind> = [
+        .table, .view, .materializedView
+    ]
+
+    /// Writes an object's comments directly after its own `CREATE`, which is where `pg_dump` puts
+    /// them, so a comment travels with the object it belongs to rather than with a later phase.
+    ///
+    /// Only ever called on the success branch: a `COMMENT` on an object whose `CREATE` was not
+    /// written fails the restore. An unreadable comment list is recorded and commented into the file
+    /// rather than failing the export, exactly as the index phase does.
+    private func writeComments(
+        for object: PluginExportTable,
+        dataSource: any PluginExportDataSource,
+        to writer: SQLExportFileWriter
+    ) async throws {
+        guard Self.commentedKinds.contains(object.kind) else { return }
+        let sanitizedName = PluginExportUtilities.sanitizeForSQLComment(object.name)
+        do {
+            let statements = try await dataSource.fetchCommentDDL(
+                table: object.name, databaseName: object.databaseName)
+            guard !statements.isEmpty else { return }
+            for statement in statements {
+                let terminated = statement.hasSuffix(";") ? statement : "\(statement);"
+                try writer.write("\(terminated)\n")
+            }
+            try writer.write("\n")
+        } catch {
+            commentFailures.append(sanitizedName)
+            Self.logger.warning("Failed to fetch comments for \(sanitizedName): \(error)")
+            let warning = "Warning: failed to fetch comments for \(sanitizedName): \(error)"
+            try writer.write("-- \(PluginExportUtilities.sanitizeForSQLComment(warning))\n\n")
         }
     }
 
@@ -532,7 +586,9 @@ final class SQLExportPlugin: ExportFormatPlugin, SettablePlugin, @unchecked Send
                 Self.logger.warning("Failed to fetch DDL for \(sanitizedName): \(error)")
                 let warning = "Warning: failed to fetch definition for \(label.lowercased()) \(sanitizedName): \(error)"
                 try writer.write("-- \(PluginExportUtilities.sanitizeForSQLComment(warning))\n\n")
+                continue
             }
+            try await writeComments(for: object, dataSource: dataSource, to: writer)
         }
     }
 

--- a/Plugins/SQLImportPlugin/Info.plist
+++ b/Plugins/SQLImportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>27</integer>
+	<integer>28</integer>
 	<key>TableProProvidesImportFormatIds</key>
 	<array>
 		<string>sql</string>

--- a/Plugins/SQLiteDriverPlugin/Info.plist
+++ b/Plugins/SQLiteDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>27</integer>
+	<integer>28</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>SQLite</string>

--- a/Plugins/SnowflakeDriverPlugin/Info.plist
+++ b/Plugins/SnowflakeDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.48.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>27</integer>
+	<integer>28</integer>
 </dict>
 </plist>

--- a/Plugins/SpannerDriverPlugin/Info.plist
+++ b/Plugins/SpannerDriverPlugin/Info.plist
@@ -5,7 +5,7 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>27</integer>
+	<integer>28</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Spanner</string>

--- a/Plugins/SurrealDBDriverPlugin/Info.plist
+++ b/Plugins/SurrealDBDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>27</integer>
+	<integer>28</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>SurrealDB</string>

--- a/Plugins/TableProPluginKit/PluginDatabaseDriver.swift
+++ b/Plugins/TableProPluginKit/PluginDatabaseDriver.swift
@@ -112,6 +112,19 @@ public protocol PluginDatabaseDriver: AnyObject, Sendable {
     /// here must not also declare the same indexes in `fetchTableDDL`, or the dump creates each
     /// one twice.
     func fetchIndexDDL(table: String, schema: String?) async throws -> [String]
+
+    /// The `COMMENT` statements that reattach this relation's own comment and its column comments,
+    /// ready to run. A dump writes them directly after the object's `CREATE`, which is where every
+    /// engine's own tool puts them.
+    ///
+    /// This is statement text rather than the comment strings, because only the driver knows the
+    /// keyword its engine demands: PostgreSQL checks `COMMENT ON TABLE` against the relation's
+    /// `relkind` and refuses it on a view with "is not a table".
+    ///
+    /// Returning nothing is the right answer for an engine whose `CREATE TABLE` carries its comments
+    /// inline. A driver that answers here must not also declare the same comments in
+    /// `fetchTableDDL`, or the dump sets each one twice.
+    func fetchCommentDDL(table: String, schema: String?) async throws -> [String]
     func fetchForeignKeys(table: String, schema: String?) async throws -> [PluginForeignKeyInfo]
     func fetchTriggers(table: String, schema: String?) async throws -> [PluginTriggerInfo]
     func fetchCheckConstraints(table: String, schema: String?) async throws -> [PluginCheckConstraintInfo]
@@ -636,6 +649,11 @@ public extension PluginDatabaseDriver {
     /// its indexes and for one that has none. A driver that overrides this must drop the same
     /// statements from `fetchTableDDL` in the same change.
     func fetchIndexDDL(table: String, schema: String?) async throws -> [String] { [] }
+
+    /// Defaults to nothing, which is correct for an engine whose `CREATE TABLE` already carries its
+    /// comments and for one that stores none. A driver that overrides this must drop the same
+    /// statements from `fetchTableDDL` in the same change.
+    func fetchCommentDDL(table: String, schema: String?) async throws -> [String] { [] }
 
     /// Answers whether `fetchAllIndexes` is a single query rather than the N+1 default below.
     var providesBulkIndexFetch: Bool { false }

--- a/Plugins/TableProPluginKit/PluginExportDataSource.swift
+++ b/Plugins/TableProPluginKit/PluginExportDataSource.swift
@@ -20,6 +20,11 @@ public protocol PluginExportDataSource: AnyObject, Sendable {
     /// statements this table needs that `fetchTableDDL` does not already declare.
     func fetchIndexDDL(table: String, databaseName: String) async throws -> [String]
 
+    /// Mirrors `PluginDatabaseDriver.fetchCommentDDL` for the export side: the `COMMENT` statements
+    /// that reattach this relation's comment and its column comments, which `fetchTableDDL` does not
+    /// declare.
+    func fetchCommentDDL(table: String, databaseName: String) async throws -> [String]
+
     /// The CREATE statement for any exportable object, routines, triggers, views and user types
     /// included. One method rather than one per kind, because the caller already knows the kind and
     /// every driver answers the same question: what would recreate this.
@@ -60,6 +65,8 @@ public extension PluginExportDataSource {
     var tableDDLIncludesForeignKeys: Bool { false }
 
     func fetchIndexDDL(table: String, databaseName: String) async throws -> [String] { [] }
+
+    func fetchCommentDDL(table: String, databaseName: String) async throws -> [String] { [] }
 
     func fetchObjectDDL(_ object: PluginExportTable) async throws -> String {
         try await fetchTableDDL(table: object.name, databaseName: object.databaseName)

--- a/Plugins/TeradataDriverPlugin/Info.plist
+++ b/Plugins/TeradataDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>27</integer>
+	<integer>28</integer>
 </dict>
 </plist>

--- a/Plugins/TrinoDriverPlugin/Info.plist
+++ b/Plugins/TrinoDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>27</integer>
+	<integer>28</integer>
 </dict>
 </plist>

--- a/Plugins/TypesenseDriverPlugin/Info.plist
+++ b/Plugins/TypesenseDriverPlugin/Info.plist
@@ -5,7 +5,7 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.73.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>27</integer>
+	<integer>28</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Typesense</string>

--- a/Plugins/XLSXExportPlugin/Info.plist
+++ b/Plugins/XLSXExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>27</integer>
+	<integer>28</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>xlsx</string>

--- a/Plugins/XLSXImportPlugin/Info.plist
+++ b/Plugins/XLSXImportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>27</integer>
+	<integer>28</integer>
 	<key>TableProProvidesImportFormatIds</key>
 	<array>
 		<string>xlsx</string>

--- a/Plugins/XMLExportPlugin/Info.plist
+++ b/Plugins/XMLExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>27</integer>
+	<integer>28</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>xml</string>

--- a/TablePro/Core/Database/DatabaseDriver.swift
+++ b/TablePro/Core/Database/DatabaseDriver.swift
@@ -164,6 +164,10 @@ protocol DatabaseDriver: AnyObject, Sendable {
     /// Empty on an engine whose CREATE TABLE carries them inline. Default returns empty.
     func fetchIndexDDL(table: String) async throws -> [String]
 
+    /// The COMMENT statements that reattach this relation's comment and its column comments. Empty
+    /// on an engine whose CREATE TABLE carries them inline. Default returns empty.
+    func fetchCommentDDL(table: String) async throws -> [String]
+
     /// Fetch dependent type definitions (e.g., PostgreSQL enum types) for a table.
     /// Returns array of (typeName, labels) pairs. Default returns empty.
     func fetchDependentTypes(forTable table: String) async throws -> [(name: String, labels: [String])]
@@ -346,6 +350,8 @@ extension DatabaseDriver {
     func executeBoundedQuery(query: String, rowCap: Int) async throws -> QueryResult? { nil }
 
     func fetchIndexDDL(table: String) async throws -> [String] { [] }
+
+    func fetchCommentDDL(table: String) async throws -> [String] { [] }
 
     func resolveQueryCompletionProfile(
         databaseTypeId: String,

--- a/TablePro/Core/Database/TableDDLComposer.swift
+++ b/TablePro/Core/Database/TableDDLComposer.swift
@@ -7,24 +7,39 @@ import Foundation
 
 /// Joins a table's `CREATE TABLE` to the statements that stand outside it.
 ///
-/// A driver answers `fetchTableDDL` with the table alone and `fetchIndexDDL` with the indexes that
-/// statement does not declare, because a dump replays them in different phases: the table before
-/// its rows, the indexes after. Anything showing one table's whole definition at once, Copy DDL and
-/// the MCP schema tools among them, puts the two back together here rather than each spelling out
-/// its own separator.
+/// A driver answers `fetchTableDDL` with the table alone, `fetchCommentDDL` with its comments and
+/// `fetchIndexDDL` with the indexes that statement does not declare, because a dump replays them in
+/// different phases: the table and its comments before its rows, the indexes after. Anything showing
+/// one table's whole definition at once, Copy DDL and the MCP schema tools among them, puts the
+/// pieces back together here rather than each spelling out its own separator.
 internal enum TableDDLComposer {
-    internal static func compose(tableDDL: String, indexDDL: [String], preamble: String = "") -> String {
-        let statements = indexDDL
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { !$0.isEmpty }
-            .map { $0.hasSuffix(";") ? $0 : "\($0);" }
+    /// The comments keep the dump's own placement, between the table and its indexes, so the text
+    /// Show DDL and Copy DDL hand over is the text a restore runs.
+    internal static func compose(
+        tableDDL: String,
+        indexDDL: [String],
+        commentDDL: [String] = [],
+        preamble: String = ""
+    ) -> String {
+        let comments = terminated(commentDDL)
+        let indexes = terminated(indexDDL)
 
         var composed = preamble.isEmpty ? tableDDL : "\(preamble)\n\(tableDDL)"
-        guard !statements.isEmpty else { return composed }
+        guard !comments.isEmpty || !indexes.isEmpty else { return composed }
         if !composed.hasSuffix(";") {
             composed += ";"
         }
-        return composed + "\n\n" + statements.joined(separator: "\n")
+        for block in [comments, indexes] where !block.isEmpty {
+            composed += "\n\n" + block.joined(separator: "\n")
+        }
+        return composed
+    }
+
+    private static func terminated(_ statements: [String]) -> [String] {
+        statements
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .map { $0.hasSuffix(";") ? $0 : "\($0);" }
     }
 
     /// One object's whole definition, read on a driver already pinned to its scope. The Structure
@@ -39,7 +54,13 @@ internal enum TableDDLComposer {
         let preamble = includesDependencies ? try await dependencyPreamble(for: table, using: driver) : ""
         let baseDDL = try await driver.fetchTableDDL(table: table)
         let indexDDL = (try? await driver.fetchIndexDDL(table: table)) ?? []
-        return compose(tableDDL: baseDDL, indexDDL: indexDDL, preamble: preamble)
+        let commentDDL = (try? await driver.fetchCommentDDL(table: table)) ?? []
+        return compose(
+            tableDDL: baseDDL,
+            indexDDL: indexDDL,
+            commentDDL: commentDDL,
+            preamble: preamble
+        )
     }
 
     private static func dependencyPreamble(for table: String, using driver: DatabaseDriver) async throws -> String {

--- a/TablePro/Core/Plugins/ExportDataSourceAdapter.swift
+++ b/TablePro/Core/Plugins/ExportDataSourceAdapter.swift
@@ -213,6 +213,11 @@ final class ExportDataSourceAdapter: PluginExportDataSource, @unchecked Sendable
         return try await pluginDriver.fetchIndexDDL(table: table, schema: exportSchema(for: databaseName))
     }
 
+    func fetchCommentDDL(table: String, databaseName: String) async throws -> [String] {
+        guard let pluginDriver else { return [] }
+        return try await pluginDriver.fetchCommentDDL(table: table, schema: exportSchema(for: databaseName))
+    }
+
     // MARK: - Object DDL
 
     /// A driver addresses a routine, trigger or type through the info object it handed out, which

--- a/TablePro/Core/Plugins/PluginDriverAdapter.swift
+++ b/TablePro/Core/Plugins/PluginDriverAdapter.swift
@@ -432,6 +432,10 @@ final class PluginDriverAdapter: DatabaseDriver, SchemaSwitchable, DatabaseRepor
         try await pluginDriver.fetchIndexDDL(table: table, schema: pluginDriver.currentSchema)
     }
 
+    func fetchCommentDDL(table: String) async throws -> [String] {
+        try await pluginDriver.fetchCommentDDL(table: table, schema: pluginDriver.currentSchema)
+    }
+
     func fetchDependentTypes(forTable table: String) async throws -> [(name: String, labels: [String])] {
         try await pluginDriver.fetchDependentTypes(table: table, schema: pluginDriver.currentSchema)
     }

--- a/TablePro/Core/Plugins/PluginManager.swift
+++ b/TablePro/Core/Plugins/PluginManager.swift
@@ -14,7 +14,15 @@ import TableProPluginKit
 @MainActor @Observable
 final class PluginManager {
     static let shared = PluginManager(userDefaults: AppStorageEnvironment.shared.defaults)
-    /// Raised to 26 for `objectCommentStatement`, `refreshMaterializedViewStatement` and
+    /// Raised to 28 for `fetchCommentDDL` on `PluginDatabaseDriver` and `PluginExportDataSource`,
+    /// which is what lets a dump reattach a relation's own comment and its column comments instead
+    /// of leaving whether they appear at all to each driver's `fetchTableDDL`.
+    ///
+    /// Raised to 27 before that for `hasLostConnection`, `unsupportedStructureColumnFields`,
+    /// `unsupportedIndexTypes` and `schemaOperationRefusal` on `PluginDatabaseDriver`, plus the
+    /// `PluginSchemaOperation` the last one answers about.
+    ///
+    /// Raised to 26 before that for `objectCommentStatement`, `refreshMaterializedViewStatement` and
     /// `concurrentRefreshAvailability` on `PluginDatabaseDriver`, plus the
     /// `PluginConcurrentRefreshAvailability` the last one answers with.
     ///
@@ -41,7 +49,7 @@ final class PluginManager {
     /// rebuilt CassandraDriver for the v20 requirements it implements none of. Left at 20, such a
     /// plugin passes `validateBundleVersions` in a shipped v20 app and then fails
     /// `Bundle.loadAndReturnError`; at 21 that app refuses it and says to update.
-    nonisolated static let currentPluginKitVersion = 27
+    nonisolated static let currentPluginKitVersion = 28
 
     /// Still 19, so every plugin already published for the previous release keeps loading.
     nonisolated static let minimumCompatiblePluginKitVersion = 19

--- a/TableProTests/Core/Database/TableDDLComposerTests.swift
+++ b/TableProTests/Core/Database/TableDDLComposerTests.swift
@@ -1,0 +1,79 @@
+//
+//  TableDDLComposerTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("Table DDL composition")
+struct TableDDLComposerTests {
+    private let tableDDL = "CREATE TABLE \"app\".\"orders\" (\n    id integer\n)"
+    private let comment = "COMMENT ON TABLE \"app\".\"orders\" IS 'Orders table'"
+    private let index = "CREATE INDEX idx_orders_day ON \"app\".\"orders\" (day)"
+
+    private func offset(of needle: String, in text: String) throws -> Int {
+        let range = try #require(text.range(of: needle), "\(needle) missing from the composition")
+        return text.distance(from: text.startIndex, to: range.lowerBound)
+    }
+
+    @Test("Comments sit after the table statement and before the indexes, as a dump writes them")
+    func commentsSitBetweenTheTableAndItsIndexes() throws {
+        let composed = TableDDLComposer.compose(
+            tableDDL: tableDDL, indexDDL: [index], commentDDL: [comment])
+
+        #expect(try offset(of: "CREATE TABLE", in: composed) < offset(of: "COMMENT ON TABLE", in: composed))
+        #expect(try offset(of: "COMMENT ON TABLE", in: composed) < offset(of: "CREATE INDEX", in: composed))
+    }
+
+    @Test("Every statement is terminated once, even one the driver already terminated")
+    func statementsAreTerminatedOnce() {
+        let composed = TableDDLComposer.compose(
+            tableDDL: tableDDL,
+            indexDDL: ["\(index);"],
+            commentDDL: [comment])
+
+        #expect(composed.contains("IS 'Orders table';"))
+        #expect(!composed.contains("IS 'Orders table';;"))
+        #expect(composed.contains("(day);"))
+        #expect(!composed.contains("(day);;"))
+    }
+
+    @Test("The preamble stays first")
+    func preambleStaysFirst() throws {
+        let composed = TableDDLComposer.compose(
+            tableDDL: tableDDL,
+            indexDDL: [],
+            commentDDL: [comment],
+            preamble: "CREATE SEQUENCE orders_id_seq;")
+
+        #expect(try offset(of: "CREATE SEQUENCE", in: composed) < offset(of: "CREATE TABLE", in: composed))
+        #expect(try offset(of: "CREATE TABLE", in: composed) < offset(of: "COMMENT ON TABLE", in: composed))
+    }
+
+    @Test("An empty comment list composes exactly as it did before comments existed")
+    func emptyCommentListChangesNothing() {
+        let withComments = TableDDLComposer.compose(
+            tableDDL: tableDDL, indexDDL: [index], commentDDL: [])
+        let withoutComments = TableDDLComposer.compose(tableDDL: tableDDL, indexDDL: [index])
+
+        #expect(withComments == withoutComments)
+    }
+
+    @Test("Comments alone still terminate the table statement and stand in their own block")
+    func commentsAloneComposeWithoutIndexes() {
+        let composed = TableDDLComposer.compose(
+            tableDDL: tableDDL, indexDDL: [], commentDDL: [comment])
+
+        #expect(composed == "\(tableDDL);\n\n\(comment);")
+    }
+
+    @Test("A blank comment statement is dropped rather than written as an empty line")
+    func blankStatementsAreDropped() {
+        let composed = TableDDLComposer.compose(
+            tableDDL: tableDDL, indexDDL: [], commentDDL: ["", "   \n"])
+
+        #expect(composed == tableDDL)
+    }
+}

--- a/TableProTests/Core/Plugins/PluginKitABIResilienceTests.swift
+++ b/TableProTests/Core/Plugins/PluginKitABIResilienceTests.swift
@@ -47,6 +47,8 @@ struct PluginKitABIResilienceTests {
         #expect(try await driver.fetchSchemas().isEmpty)
         #expect(try await driver.fetchExternalSchemaNames().isEmpty)
         #expect(try await driver.fetchApproximateRowCount(table: "users", schema: nil) == nil)
+        #expect(try await driver.fetchIndexDDL(table: "users", schema: nil).isEmpty)
+        #expect(try await driver.fetchCommentDDL(table: "users", schema: nil).isEmpty)
         let base = QueryCompletionProfile(
             resolvedDialect: nil,
             statementCompletions: [CompletionEntry(label: "SELECT", insertText: "SELECT")],

--- a/TableProTests/Plugins/PostgreSQLCommentStatementsTests.swift
+++ b/TableProTests/Plugins/PostgreSQLCommentStatementsTests.swift
@@ -1,0 +1,164 @@
+//
+//  PostgreSQLCommentStatementsTests.swift
+//  TableProTests
+//
+
+import Foundation
+import Testing
+
+@Suite("PostgreSQL comment statements")
+struct PostgreSQLCommentStatementsTests {
+    private func row(relkind: String, column: String?, description: String?) -> [String?] {
+        [relkind, column, description]
+    }
+
+    @Test("The relation's own comment is rendered first, then its columns in row order")
+    func relationCommentPrecedesColumns() {
+        let statements = PostgreSQLCommentStatements.statements(
+            name: "orders",
+            schema: "app",
+            rows: [
+                row(relkind: "r", column: nil, description: "Orders table"),
+                row(relkind: "r", column: "id", description: "Primary key"),
+                row(relkind: "r", column: "label", description: "Label")
+            ])
+
+        #expect(statements == [
+            "COMMENT ON TABLE \"app\".\"orders\" IS 'Orders table'",
+            "COMMENT ON COLUMN \"app\".\"orders\".\"id\" IS 'Primary key'",
+            "COMMENT ON COLUMN \"app\".\"orders\".\"label\" IS 'Label'"
+        ])
+    }
+
+    @Test("relkind picks the keyword, because the server refuses a mismatched one")
+    func relkindPicksTheKeyword() {
+        #expect(PostgreSQLRelationSQL.commentKeyword(forRelkind: "r") == "TABLE")
+        #expect(PostgreSQLRelationSQL.commentKeyword(forRelkind: "p") == "TABLE")
+        #expect(PostgreSQLRelationSQL.commentKeyword(forRelkind: "f") == "FOREIGN TABLE")
+        #expect(PostgreSQLRelationSQL.commentKeyword(forRelkind: "v") == "VIEW")
+        #expect(PostgreSQLRelationSQL.commentKeyword(forRelkind: "m") == "MATERIALIZED VIEW")
+        #expect(PostgreSQLRelationSQL.commentKeyword(forRelkind: "i") == nil)
+    }
+
+    @Test("A view, a materialized view and a foreign table each get their own keyword")
+    func eachRelationKindRendersItsKeyword() {
+        let view = PostgreSQLCommentStatements.statements(
+            name: "v_orders", schema: "app",
+            rows: [row(relkind: "v", column: nil, description: "View comment")])
+        let matview = PostgreSQLCommentStatements.statements(
+            name: "m_orders", schema: "app",
+            rows: [row(relkind: "m", column: nil, description: "Matview comment")])
+        let foreign = PostgreSQLCommentStatements.statements(
+            name: "f_orders", schema: "app",
+            rows: [row(relkind: "f", column: nil, description: "Foreign comment")])
+
+        #expect(view == ["COMMENT ON VIEW \"app\".\"v_orders\" IS 'View comment'"])
+        #expect(matview == ["COMMENT ON MATERIALIZED VIEW \"app\".\"m_orders\" IS 'Matview comment'"])
+        #expect(foreign == ["COMMENT ON FOREIGN TABLE \"app\".\"f_orders\" IS 'Foreign comment'"])
+    }
+
+    @Test("A relkind with no COMMENT keyword yields no statement")
+    func unknownRelkindYieldsNothing() {
+        let statements = PostgreSQLCommentStatements.statements(
+            name: "orders_pkey", schema: "app",
+            rows: [row(relkind: "i", column: nil, description: "Index comment")])
+
+        #expect(statements.isEmpty)
+    }
+
+    @Test("A value holding a backslash and a quote renders the server's own quote_literal output")
+    func backslashAndQuoteRenderAsEscapeString() {
+        let statements = PostgreSQLCommentStatements.statements(
+            name: "orders", schema: "app",
+            rows: [row(
+                relkind: "r",
+                column: "path",
+                description: #"Windows path C:\temp and a quote ' here"#)])
+
+        #expect(statements == [
+            #"COMMENT ON COLUMN "app"."orders"."path" IS E'Windows path C:\\temp and a quote '' here'"#
+        ])
+    }
+
+    @Test("A comment with a single quote and no backslash stays a plain literal")
+    func singleQuoteDoublesInPlainLiteral() {
+        let statements = PostgreSQLCommentStatements.statements(
+            name: "orders", schema: "app",
+            rows: [row(relkind: "r", column: "label", description: "It's a label")])
+
+        #expect(statements == ["COMMENT ON COLUMN \"app\".\"orders\".\"label\" IS 'It''s a label'"])
+    }
+
+    @Test("A multi-line comment stays inside one literal")
+    func multiLineCommentStaysOneLiteral() {
+        let statements = PostgreSQLCommentStatements.statements(
+            name: "orders", schema: "app",
+            rows: [row(relkind: "r", column: "notes", description: "First line\nSecond line")])
+
+        #expect(statements == [
+            "COMMENT ON COLUMN \"app\".\"orders\".\"notes\" IS 'First line\nSecond line'"
+        ])
+    }
+
+    @Test("A double quote in an identifier is doubled")
+    func doubleQuoteInIdentifierIsDoubled() {
+        let statements = PostgreSQLCommentStatements.statements(
+            name: "od\"d", schema: "sc\"h",
+            rows: [row(relkind: "r", column: "co\"l", description: "Comment")])
+
+        #expect(statements == ["COMMENT ON COLUMN \"sc\"\"h\".\"od\"\"d\".\"co\"\"l\" IS 'Comment'"])
+    }
+
+    @Test("A nil or empty description yields no statement, never IS NULL")
+    func emptyDescriptionYieldsNothing() {
+        let statements = PostgreSQLCommentStatements.statements(
+            name: "orders", schema: "app",
+            rows: [
+                row(relkind: "r", column: nil, description: nil),
+                row(relkind: "r", column: "id", description: "")
+            ])
+
+        #expect(statements.isEmpty)
+    }
+
+    @Test("A short row is skipped rather than read past its end")
+    func shortRowIsSkipped() {
+        let statements = PostgreSQLCommentStatements.statements(
+            name: "orders", schema: "app", rows: [["r", nil]])
+
+        #expect(statements.isEmpty)
+    }
+
+    @Test("catalogQuery quotes both literals so a name holding a quote cannot end them")
+    func catalogQueryQuotesItsLiterals() {
+        let query = PostgreSQLCommentStatements.catalogQuery(name: "O'Brien", schema: "sa'les")
+
+        #expect(query.contains("c.relname = 'O''Brien'"))
+        #expect(query.contains("n.nspname = 'sa''les'"))
+        #expect(!query.contains("'O'Brien'"))
+    }
+
+    @Test("catalogQuery reads only the relation kinds a COMMENT statement can name")
+    func catalogQueryFiltersRelationKinds() {
+        let query = PostgreSQLCommentStatements.catalogQuery(name: "orders", schema: "app")
+
+        #expect(query.contains("c.relkind IN ('r', 'p', 'f', 'v', 'm')"))
+    }
+
+    @Test("catalogQuery excludes dropped and system columns and orders the relation before them")
+    func catalogQueryExcludesDroppedColumns() {
+        let query = PostgreSQLCommentStatements.catalogQuery(name: "orders", schema: "app")
+
+        #expect(query.contains("NOT a.attisdropped"))
+        #expect(query.contains("a.attnum > 0"))
+        #expect(query.contains("ORDER BY ordinal, attnum"))
+    }
+
+    @Test("catalogQuery reads both description functions and drops a relation with neither")
+    func catalogQueryReadsBothDescriptionFunctions() {
+        let query = PostgreSQLCommentStatements.catalogQuery(name: "orders", schema: "app")
+
+        #expect(query.contains("pg_catalog.obj_description(c.oid, 'pg_class') IS NOT NULL"))
+        #expect(query.contains("pg_catalog.col_description(c.oid, a.attnum) IS NOT NULL"))
+    }
+}

--- a/TableProTests/Plugins/SQLExportCommentPhaseTests.swift
+++ b/TableProTests/Plugins/SQLExportCommentPhaseTests.swift
@@ -1,0 +1,229 @@
+//
+//  SQLExportCommentPhaseTests.swift
+//  TableProTests
+//
+
+import Foundation
+import TableProPluginKit
+import Testing
+
+@Suite("SQL export comments")
+struct SQLExportCommentPhaseTests {
+    private final class StubExportDataSource: PluginExportDataSource, @unchecked Sendable {
+        let databaseTypeId: String
+        let commentDDL: [String: [String]]
+        let failingTables: Set<String>
+
+        init(
+            databaseTypeId: String = "PostgreSQL",
+            commentDDL: [String: [String]] = [:],
+            failingTables: Set<String> = []
+        ) {
+            self.databaseTypeId = databaseTypeId
+            self.commentDDL = commentDDL
+            self.failingTables = failingTables
+        }
+
+        func streamRows(table: String, databaseName: String) -> AsyncThrowingStream<PluginStreamElement, Error> {
+            AsyncThrowingStream { continuation in
+                continuation.yield(.header(PluginStreamHeader(columns: ["id"], columnTypeNames: ["INTEGER"])))
+                continuation.yield(.rows([[.text("1")]]))
+                continuation.finish()
+            }
+        }
+
+        func fetchTableDDL(table: String, databaseName: String) async throws -> String {
+            "CREATE TABLE \(table) (id INTEGER)"
+        }
+
+        func fetchObjectDDL(_ object: PluginExportTable) async throws -> String {
+            switch object.kind {
+            case .view: return "CREATE OR REPLACE VIEW \(object.name) AS SELECT 1"
+            case .materializedView: return "CREATE MATERIALIZED VIEW \(object.name) AS SELECT 1"
+            case .routine: return "CREATE FUNCTION \(object.name)() RETURNS integer AS $$ SELECT 1 $$ LANGUAGE sql"
+            default: return try await fetchTableDDL(table: object.name, databaseName: object.databaseName)
+            }
+        }
+
+        func fetchCommentDDL(table: String, databaseName: String) async throws -> [String] {
+            if failingTables.contains(table) {
+                throw StubError.unreadable
+            }
+            return commentDDL[table] ?? []
+        }
+
+        func execute(query: String) async throws -> PluginQueryResult {
+            PluginQueryResult(columns: [], columnTypeNames: [], rows: [], rowsAffected: 0, executionTime: 0)
+        }
+
+        func quoteIdentifier(_ identifier: String) -> String {
+            "\"\(identifier.replacingOccurrences(of: "\"", with: "\"\""))\""
+        }
+
+        func escapeStringLiteral(_ value: String) -> String {
+            value.replacingOccurrences(of: "'", with: "''")
+        }
+
+        func fetchApproximateRowCount(table: String, databaseName: String) async throws -> Int? { nil }
+    }
+
+    private enum StubError: Error {
+        case unreadable
+    }
+
+    private func table(
+        _ name: String,
+        kind: PluginExportObjectKind = .table,
+        optionValues: [Bool] = [true, true, true]
+    ) -> PluginExportTable {
+        PluginExportTable(
+            name: name,
+            databaseName: "",
+            tableType: kind.rawValue,
+            optionValues: optionValues,
+            schema: nil,
+            kind: kind)
+    }
+
+    private func runExport(
+        tables: [PluginExportTable],
+        dataSource: StubExportDataSource
+    ) async throws -> (dump: String, result: ExportFormatResult) {
+        let output = try await SQLExportHarness.shared.dump(tables: tables, dataSource: dataSource)
+        return (output.text, output.result)
+    }
+
+    private func offset(of needle: String, in dump: String) throws -> Int {
+        let range = try #require(dump.range(of: needle), "\(needle) missing from the dump")
+        return dump.distance(from: dump.startIndex, to: range.lowerBound)
+    }
+
+    @Test("A driver that reports comment DDL gets it into the dump, terminated")
+    func commentsReachTheDump() async throws {
+        let source = StubExportDataSource(commentDDL: ["orders": [
+            "COMMENT ON TABLE orders IS 'Orders table'",
+            "COMMENT ON COLUMN orders.id IS 'Primary key'"
+        ]])
+
+        let (dump, result) = try await runExport(tables: [table("orders")], dataSource: source)
+
+        #expect(dump.contains("COMMENT ON TABLE orders IS 'Orders table';"))
+        #expect(dump.contains("COMMENT ON COLUMN orders.id IS 'Primary key';"))
+        #expect(result.warnings.isEmpty)
+    }
+
+    @Test("A comment rides with its own object: after the CREATE, before the rows and the indexes")
+    func commentsFollowTheCreate() async throws {
+        let source = StubExportDataSource(
+            commentDDL: ["orders": ["COMMENT ON TABLE orders IS 'Orders table'"]])
+
+        let (dump, _) = try await runExport(tables: [table("orders")], dataSource: source)
+
+        #expect(try offset(of: "CREATE TABLE orders", in: dump) < offset(of: "COMMENT ON TABLE", in: dump))
+        #expect(try offset(of: "COMMENT ON TABLE", in: dump) < offset(of: "INSERT INTO", in: dump))
+    }
+
+    @Test("A view's comments sit in its own block, right after its CREATE")
+    func viewCommentsFollowTheViewCreate() async throws {
+        let source = StubExportDataSource(commentDDL: ["v_orders": [
+            "COMMENT ON VIEW v_orders IS 'View comment'",
+            "COMMENT ON COLUMN v_orders.id IS 'View column comment'"
+        ]])
+
+        let (dump, _) = try await runExport(
+            tables: [table("v_orders", kind: .view)], dataSource: source)
+
+        #expect(try offset(of: "CREATE OR REPLACE VIEW", in: dump) < offset(of: "COMMENT ON VIEW", in: dump))
+        #expect(dump.contains("COMMENT ON COLUMN v_orders.id IS 'View column comment';"))
+    }
+
+    @Test("A materialized view's comment falls after its CREATE and before the next object header")
+    func matviewCommentFollowsItsCreate() async throws {
+        let source = StubExportDataSource(
+            commentDDL: ["m_orders": ["COMMENT ON MATERIALIZED VIEW m_orders IS 'Matview comment'"]])
+
+        let (dump, _) = try await runExport(
+            tables: [
+                table("m_orders", kind: .materializedView),
+                table("r_sum", kind: .routine)
+            ],
+            dataSource: source)
+
+        #expect(try offset(of: "CREATE MATERIALIZED VIEW", in: dump)
+            < offset(of: "COMMENT ON MATERIALIZED VIEW", in: dump))
+        #expect(try offset(of: "COMMENT ON MATERIALIZED VIEW", in: dump)
+            < offset(of: "-- Routine: r_sum", in: dump))
+    }
+
+    @Test("A statement the driver already terminated is not terminated twice")
+    func terminatedStatementsStaySingleTerminated() async throws {
+        let source = StubExportDataSource(
+            commentDDL: ["orders": ["COMMENT ON TABLE orders IS 'Orders table';"]])
+
+        let (dump, _) = try await runExport(tables: [table("orders")], dataSource: source)
+
+        #expect(dump.contains("IS 'Orders table';"))
+        #expect(!dump.contains("IS 'Orders table';;"))
+    }
+
+    @Test("A source answering nothing writes no COMMENT ON anywhere")
+    func noCommentsWritesNothing() async throws {
+        let source = StubExportDataSource(databaseTypeId: "MySQL")
+
+        let (dump, result) = try await runExport(tables: [table("orders")], dataSource: source)
+
+        #expect(!dump.contains("COMMENT ON"))
+        #expect(result.warnings.isEmpty)
+    }
+
+    @Test("A table with Structure unticked contributes no comment statements")
+    func structureGatesTheCommentPhase() async throws {
+        let source = StubExportDataSource(
+            commentDDL: ["orders": ["COMMENT ON TABLE orders IS 'Orders table'"]])
+
+        let (dump, _) = try await runExport(
+            tables: [table("orders", optionValues: [false, true, true])], dataSource: source)
+
+        #expect(!dump.contains("COMMENT ON"))
+    }
+
+    @Test("An unreadable comment list is named in the warnings and does not fail the export")
+    func unreadableCommentsAreReported() async throws {
+        let source = StubExportDataSource(
+            commentDDL: ["customers": ["COMMENT ON TABLE customers IS 'Customers'"]],
+            failingTables: ["orders"])
+
+        let (dump, result) = try await runExport(
+            tables: [table("orders"), table("customers")], dataSource: source)
+
+        #expect(result.warnings.contains { $0.contains("Could not fetch comments for") && $0.contains("orders") })
+        #expect(dump.contains("-- Warning: failed to fetch comments for orders"))
+        #expect(dump.contains("COMMENT ON TABLE customers IS 'Customers';"))
+        #expect(dump.contains("CREATE TABLE customers (id INTEGER);"))
+        #expect(dump.contains("INSERT INTO"))
+    }
+
+    @Test("A routine is never asked for comments, so its definition is all that is written")
+    func routinesAreNotAskedForComments() async throws {
+        let source = StubExportDataSource(
+            commentDDL: ["r_sum": ["COMMENT ON FUNCTION r_sum() IS 'never asked'"]])
+
+        let (dump, _) = try await runExport(
+            tables: [table("r_sum", kind: .routine)], dataSource: source)
+
+        #expect(!dump.contains("COMMENT ON FUNCTION"))
+    }
+
+    @Test("A foreign table is never asked, because the dump writes CREATE TABLE for it")
+    func foreignTablesAreNotAskedForComments() async throws {
+        let source = StubExportDataSource(
+            commentDDL: ["f_orders": ["COMMENT ON FOREIGN TABLE f_orders IS 'Foreign comment'"]])
+
+        let (dump, result) = try await runExport(
+            tables: [table("f_orders", kind: .foreignTable)], dataSource: source)
+
+        #expect(dump.contains("CREATE TABLE f_orders"))
+        #expect(!dump.contains("COMMENT ON FOREIGN TABLE"))
+        #expect(result.warnings.isEmpty)
+    }
+}

--- a/docs/databases/postgresql.mdx
+++ b/docs/databases/postgresql.mdx
@@ -81,6 +81,8 @@ A view's definition is rebuilt to run anywhere. Every table it reads is schema-q
 
 **Edit Comment…** writes `COMMENT ON`, picking `TABLE`, `VIEW`, `MATERIALIZED VIEW` or `FOREIGN TABLE` to match the object. Column comments are written from the Columns tab as `COMMENT ON COLUMN`. Clearing the field writes `IS NULL`, which removes the comment. Only the object's owner may comment on it.
 
+An SQL export writes those statements back for tables, views and materialized views, so a dump and a restore keep their comments. See [Import & Export](/features/import-export).
+
 ## Cross-database tabs
 
 PostgreSQL has no in-place `USE`, so a tab bound to a database other than the connection's active one runs on a second connection opened for that database. It shares no temp tables, session variables, or open transaction with the query editor on the main connection: keep a multi-statement transaction or a `CREATE TEMP TABLE` on tabs bound to one database. Binding itself is on [Tabs](/features/tabs#where-a-tab-points).

--- a/docs/development/plugin-development.mdx
+++ b/docs/development/plugin-development.mdx
@@ -13,7 +13,7 @@ A plugin is a macOS loadable bundle target with `WRAPPER_EXTENSION = tableplugin
 
 | Key | Type | Required | Purpose |
 |-----|------|----------|---------|
-| `TableProPluginKitVersion` | integer | Yes | The PluginKit ABI the plugin was built against. Current value: 27 |
+| `TableProPluginKitVersion` | integer | Yes | The PluginKit ABI the plugin was built against. Current value: 28 |
 | `TableProProvidesDatabaseTypeIds` | array of strings | Recommended | Database type IDs the plugin serves, which is what makes lazy loading possible |
 | `CFBundleShortVersionString` | string | Yes | Plugin version, read by registry update checks |
 | `TableProMinAppVersion` | string | No | The loader rejects the plugin on an older app |

--- a/docs/development/plugin-registry.mdx
+++ b/docs/development/plugin-registry.mdx
@@ -68,13 +68,13 @@ Themes carry no native code, so they match on architecture alone.
   "binaries": [
     {
       "architecture": "arm64",
-      "pluginKitVersion": 27,
+      "pluginKitVersion": 28,
       "downloadURL": "https://github.com/TableProApp/TablePro/releases/download/plugin-oracle-v1.0.26/OracleDriver-arm64.zip",
       "sha256": "<sha256>"
     },
     {
       "architecture": "x86_64",
-      "pluginKitVersion": 27,
+      "pluginKitVersion": 28,
       "downloadURL": "https://github.com/TableProApp/TablePro/releases/download/plugin-oracle-v1.0.26/OracleDriver-x86_64.zip",
       "sha256": "<sha256>"
     }

--- a/docs/features/import-export.mdx
+++ b/docs/features/import-export.mdx
@@ -121,6 +121,8 @@ As SQL, a results export writes `INSERT` statements only. A result set is the ou
 
     Structure carries the table's indexes. They are written after the rows, next to the deferred foreign keys, which is where `pg_dump` and `sqlite3 .dump` put them: a bulk load into an indexed table pays to maintain an index the restore is about to build anyway. On MySQL, MariaDB, ClickHouse, Trino and CockroachDB the server writes them inside `CREATE TABLE`, so they arrive with the table instead. A materialized view's indexes follow the view.
 
+    On PostgreSQL, Structure carries comments as well. Each table, view and materialized view gets its own `COMMENT ON` and one `COMMENT ON COLUMN` per commented column, directly after its `CREATE`. A foreign table is the exception: its comments are dropped, because the dump writes `CREATE TABLE` for it and PostgreSQL then refuses `COMMENT ON FOREIGN TABLE`. Where the server's own `CREATE TABLE` already carries the comment, MySQL and MariaDB among them, it arrives with the table instead.
+
     <Warning>
     All three are on by default, so an SQL export carries `DROP TABLE IF EXISTS` unless you untick **Drop**. Run that file against the wrong database and it drops the tables first.
     </Warning>

--- a/docs/features/table-structure.mdx
+++ b/docs/features/table-structure.mdx
@@ -169,7 +169,7 @@ Triggers are available for MySQL, MariaDB, PostgreSQL, SQLite, SQL Server, Oracl
 
 ## DDL tab
 
-Read-only `CREATE TABLE` with syntax highlighting and font size controls. **Copy**, **Export** as a `.sql` file, and **Open in Editor** send it onward. On PostgreSQL the `CREATE SEQUENCE` and `CREATE TYPE … AS ENUM` statements the table depends on are prepended, so the script runs on an empty database.
+Read-only `CREATE TABLE` with syntax highlighting and font size controls. **Copy**, **Export** as a `.sql` file, and **Open in Editor** send it onward. On PostgreSQL the `CREATE SEQUENCE` and `CREATE TYPE … AS ENUM` statements the table depends on are prepended, so the script runs on an empty database, and the table's `COMMENT ON` statements follow it.
 
 Open the tab on a view and it carries that view's own `CREATE VIEW` or `CREATE MATERIALIZED VIEW` instead, the same statement **Show DDL** opens. A materialized view's indexes follow it.
 

--- a/project.yml
+++ b/project.yml
@@ -525,6 +525,7 @@ targets:
       - Plugins/PostgreSQLDriverPlugin/PostgreSQLCatalogPresence.swift
       - Plugins/PostgreSQLDriverPlugin/PostgreSQLCatalogTypeNames.swift
       - Plugins/PostgreSQLDriverPlugin/PostgreSQLCheckConstraintDefinition.swift
+      - Plugins/PostgreSQLDriverPlugin/PostgreSQLCommentStatements.swift
       - Plugins/PostgreSQLDriverPlugin/PostgreSQLForeignKeyQueries.swift
       - Plugins/PostgreSQLDriverPlugin/PostgreSQLIndexQueries.swift
       - Plugins/PostgreSQLDriverPlugin/PostgreSQLObjectQueries.swift


### PR DESCRIPTION
Part of #2726.

## The defect

A PostgreSQL SQL export carries no `COMMENT ON` at all. Nothing in the chain asks for one:

- `PostgreSQLPluginDriver.fetchTableDDL` composes `CREATE TABLE` from the column list and the p/u/c constraints.
- `fetchViewDefinition` returns the `CREATE` statement alone.
- `SQLExportPlugin.export` has header, drop, type/sequence, create, data, finalization, object-create and grant phases, and no comment phase.
- `PluginExportDataSource` had no member that could carry one.

So a dump and restore loses every table, column, view and materialized view comment while the export reports success. `git grep "COMMENT ON" origin/main -- Plugins/SQLExportPlugin/` matches nothing.

## The fix

One additive, defaulted driver requirement, implemented on the PostgreSQL driver alone.

- `PluginDatabaseDriver.fetchCommentDDL(table:schema:)` and its `PluginExportDataSource` mirror, both defaulting to `[]`. It answers statement text, not comment strings, because only the driver knows the keyword its engine demands: PostgreSQL checks `COMMENT ON TABLE` against `relkind` and refuses it on a view with `"v_orders" is not a table`.
- `PostgreSQLCommentStatements` (new, pure) holds the catalog query and the rendering. One query per relation: `obj_description(c.oid, 'pg_class')` with a NULL `attname` at ordinal 0, `UNION ALL` one row per commented attribute at ordinal 1, ordered by ordinal then `attnum`, so the relation's own comment precedes its columns in `pg_dump` order. `relkind` rides on every row, the column rows included, because a relation with no comment of its own still has columns to write.
- `PostgreSQLRelationSQL.commentKeyword(forRelkind:)` maps `r`/`p` to `TABLE`, `f` to `FOREIGN TABLE`, `v` to `VIEW`, `m` to `MATERIALIZED VIEW`, anything else to nil. A row with no keyword or an empty description renders nothing, never `IS NULL`, which would erase a comment instead of restoring one.
- Every literal goes through `PostgreSQLObjectQueries.quoteLiteral`, which emits an `E''` string when the value holds a backslash. That is the only form that is safe when `standard_conforming_strings` is off, and it matches the server's own `quote_literal` byte for byte.
- `SQLExportPlugin.writeComments` writes the statements directly after each object's own `CREATE`, on the success branch only: a `COMMENT` on an object whose `CREATE` was not written fails the restore. It is gated to `.table`, `.view` and `.materializedView`, so a routine, trigger, sequence or type costs no round trip, and a foreign table is left out for a measured reason (below). An unreadable list is recorded in `commentFailures`, commented into the file and reported as a warning, exactly as the index phase does, and never fails the export.
- `TableDDLComposer` takes the same statements between the table and its indexes, so Structure DDL, Show DDL, Copy DDL and the MCP `get_table_ddl` tool show the text a restore runs.

Cockroach, Redshift and PGlite inherit the driver method; all three keep `obj_description` and `col_description`. Comments read through the qualified-read path are not needed here: nothing is deparsed by the server, so `search_path` cannot change the answer.

## Round-trip proof against a live server

PostgreSQL 17.11. The fixture carries a table comment, three awkward column comments (a single quote, a backslash plus a quote, three lines), a view with a comment and a column comment, and a materialized view with both.

The export ran through the real `PostgreSQLPluginDriver` and the real `SQLExportPlugin`, with the data source holding the driver as `any PluginDatabaseDriver` exactly as `ExportDataSourceAdapter` does, so every call resolves through the protocol witness table. `warnings: []`, 9 `COMMENT ON` statements. The dump:

```sql
CREATE TABLE "app"."orders" (
  id integer NOT NULL,
  label text,
  path text,
  notes text,
  PRIMARY KEY (id)
);

COMMENT ON TABLE "app"."orders" IS 'Orders table';
COMMENT ON COLUMN "app"."orders"."id" IS 'Primary key';
COMMENT ON COLUMN "app"."orders"."label" IS 'It''s a label';
COMMENT ON COLUMN "app"."orders"."path" IS E'Windows path C:\\temp and a quote '' here';
COMMENT ON COLUMN "app"."orders"."notes" IS 'First line
Second line
Third line';

INSERT INTO "orders" ("id", "label", "path", "notes") VALUES
  (1, 'one', '/tmp/one', 'note one'),
  (2, 'two', '/tmp/two', 'note two');

-- --------------------------------------------------------
-- View: v_orders
-- --------------------------------------------------------

CREATE OR REPLACE VIEW "app"."v_orders" AS
 SELECT id,
    label
   FROM app.orders;

COMMENT ON VIEW "app"."v_orders" IS 'View comment';
COMMENT ON COLUMN "app"."v_orders"."id" IS 'View column comment';

-- --------------------------------------------------------
-- Materialized view: m_orders
-- --------------------------------------------------------

CREATE MATERIALIZED VIEW "app"."m_orders" AS
 SELECT id,
    label
   FROM app.orders;

COMMENT ON MATERIALIZED VIEW "app"."m_orders" IS 'Matview comment';
COMMENT ON COLUMN "app"."m_orders"."id" IS 'Matview column comment';
```

That file restored into a fresh `probe_expcomments_restore`, then every `obj_description` and `col_description` in schema `app` was read from both databases and diffed. Source and restore, identical:

```
m app.m_orders|Matview comment
m app.m_orders.id|Matview column comment
m app.m_orders.label|<none>
r app.orders|Orders table
r app.orders.id|Primary key
r app.orders.label|It's a label
r app.orders.path|Windows path C:\temp and a quote ' here
r app.orders.notes|First line
Second line
Third line
v app.v_orders|View comment
v app.v_orders.id|View column comment
v app.v_orders.label|<none>
```

`diff` exit 0, `psql -v ON_ERROR_STOP=1` exit 0, and `SELECT count(*) FROM app.orders` answers 2 in the restore. The rows reading `<none>` are columns that never had a comment, so the absence round-trips too. The restore database needed `CREATE SCHEMA app` first, because an SQL export has never written `CREATE SCHEMA`; that is unchanged here.

### The foreign-table case, which the first draft got wrong

The plan had the comment phase cover foreign tables. Probed with a `postgres_fdw` loopback table, that aborts the restore:

```
psql:expcomments-fdw-dump.sql:21: ERROR:  "f_orders" is not a foreign table
```

`PostgreSQLPluginDriver.fetchTableDDL` reads `pg_attribute`, so for `relkind` `f` it reconstructs a plain `CREATE TABLE "app"."f_orders" (...)`. The driver's `COMMENT ON FOREIGN TABLE` is correct about the object and wrong about what the dump just created, and PostgreSQL refuses the mismatch. Before this change the dump restored (as a plain table, with the foreign table's rows copied in), so emitting the comment would have turned a silently wrong restore into a failed one.

So `commentedKinds` leaves `.foreignTable` out, with the measurement in its doc comment. The same dump now restores with exit 0 and the only diff against the source is the foreign table itself, which the export never recreated as a foreign table in the first place:

```
< f app.f_orders|Foreign comment
< f app.f_orders.id|Foreign column comment
---
> r app.f_orders|<none>
> r app.f_orders.id|<none>
```

`PostgreSQLRelationSQL.commentKeyword(forRelkind:)` keeps `f` to `FOREIGN TABLE`, because that is the truth about the relation and it is what `Edit Comment…` already needs on a live object. The gap is `fetchTableDDL`'s foreign-table reconstruction, a separate defect: an export cannot recreate a foreign table at all today, since it writes no `CREATE SERVER` either.

## PluginKit 28

`currentPluginKitVersion` 27 to 28, and `TableProPluginKitVersion` 28 in all 39 plugin `Info.plist` files that carry the key (`CSVInspectorPlugin` carries none and is untouched). `minimumCompatiblePluginKitVersion` stays 19, so every plugin already published keeps loading. The doc block above the constant gained the 27 entry #2765 did not write, so the chain reads down from 28 without a gap.

**No plugin re-release is needed.** The change is additive: a new protocol requirement with a default implementation in the protocol extension, and no new type, frozen or otherwise. Library Evolution fills the requirement in for every already-built plugin. The bump exists only so an older app refuses a plugin *rebuilt* against 28 cleanly instead of failing `Bundle.loadAndReturnError`. Do not run `release-all-plugins.sh` for this.

ABI check, run on a clean tree against `origin/main` (merge base `01ee1ba7`):

```
step: abi merge-base origin/main
Building current TableProPluginKit...
Building base (origin/main -> 01ee1ba7)...
@@ -1565,6 +1566,7 @@
   func fetchIndexDDL(table: Swift::String, schema: Swift::String?) async throws -> [Swift::String]
+  func fetchCommentDDL(table: Swift::String, schema: Swift::String?) async throws -> [Swift::String]

@@ -1777,6 +1778,7 @@
   public func fetchIndexDDL(table: Swift::String, schema: Swift::String?) async throws -> [Swift::String]
+  public func fetchCommentDDL(table: Swift::String, schema: Swift::String?) async throws -> [Swift::String]

@@ -1973,6 +1975,7 @@
   func fetchIndexDDL(table: Swift::String, databaseName: Swift::String) async throws -> [Swift::String]
+  func fetchCommentDDL(table: Swift::String, databaseName: Swift::String) async throws -> [Swift::String]

@@ -1990,6 +1993,7 @@
   public func fetchIndexDDL(table: Swift::String, databaseName: Swift::String) async throws -> [Swift::String]
+  public func fetchCommentDDL(table: Swift::String, databaseName: Swift::String) async throws -> [Swift::String]
```

Four `+` lines, zero `-` lines: two protocol requirements and the two public-extension defaults that back them. No symbol disappeared and no signature changed, so the verdict is **additive**. The script exits 1 on any interface change by design and asks the author to classify it; that is what this is, not a failure.

## Verified

| Step | Result |
|---|---|
| `verify.sh generate` | PASS |
| `verify.sh test` (15 suites) | PASS, `cases: 137 executed, 137 passed, 0 failed` |
| `verify.sh lint TablePro Plugins/PostgreSQLDriverPlugin Plugins/TableProPluginKit Plugins/SQLExportPlugin TableProTests` | PASS, violations: 0 |
| `verify.sh abi origin/main` | additive only (see the diff above) |
| `verify.sh docs` | PASS, house style and source claims both agree |

New suites:

- `PostgreSQLCommentStatementsTests` (13 tests): relation comment before columns, the keyword per `relkind` including the unknown case, the `E''` rendering byte-for-byte against `quote_literal`, a doubled quote in a plain literal, a multi-line comment inside one literal, a doubled double quote in an identifier, a nil or empty description rendering nothing, a short row skipped, and the catalog query's literal quoting, `relkind` filter, dropped-column exclusion and ordering.
- `SQLExportCommentPhaseTests` (10 tests): statements reach the dump terminated once, the `CREATE TABLE < COMMENT ON < INSERT INTO` placement, a view's and a matview's own blocks, a source answering `[]` writing no `COMMENT ON` anywhere (the MySQL case, comments inline in `SHOW CREATE TABLE`, so nothing doubles), Structure unticked writing none, a routine never asked, a foreign table never asked, and a throwing fetch leaving a sanitized `-- Warning` line plus a named warning while the other table keeps its DDL and rows.
- `TableDDLComposerTests` (6 tests): comments between the table and the indexes, single termination, preamble first, an empty comment list composing byte-identically to the two-argument call, comments alone, and a blank statement dropped.
- `PluginKitABIResilienceTests` gains the `fetchCommentDDL` default case, which keeps the suite's compile-time tripwire meaningful: it compiles only while every requirement has a default.

`SQLExportIndexPhaseTests` and `SQLExportForeignKeyOrderTests` pass unchanged, because their stubs answer the new requirement from its default and no asserted dump gains a `COMMENT` line.

## Still out of scope

Comments on indexes, constraints, sequences, routines, triggers, types and the schema itself are still dropped. The hook is relation-scoped, and covering those means giving it the object kind. `pg_dump` writes them.

A foreign table's comments, for the reason measured above. Fixing that means making `fetchTableDDL` emit `CREATE FOREIGN TABLE` with its server and options, and making the export write `CREATE SERVER`, which is its own change.

A foreign table's DDL tab still pairs `CREATE TABLE` with `COMMENT ON FOREIGN TABLE`, because `TableDDLComposer` joins whatever `fetchTableDDL` answered. That is the same pre-existing reconstruction defect showing through, and it is display and Copy DDL only.

`relkind` `p` comes from the PostgreSQL docs, not a probe: the server has no partitioned table. `r`, `v`, `m` and `f` were each probed.

One extra round trip per exported table, view and materialized view, the same cost the index phase already pays. Not measured on a large schema.
