### PR TITLE
fix(plugin-postgresql): quote every catalog literal so a backslash cannot escape it (#2726)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -215,7 +215,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - BigQuery Google sign-in accepting an authorization response without PKCE or a state check.
 - PostgreSQL sessions inheriting `standard_conforming_strings = off`, which let a backslash break out of any quoted literal.
-- PostgreSQL comment and password literals escaped by quote doubling alone, which a backslash can break out of. (#2726)
+- PostgreSQL catalog, comment and password literals escaped by quote doubling alone, which a backslash can break out of. (#2726)
 
 ## [0.73.0] - 2026-09-09
 

--- a/Plugins/PostgreSQLDriverPlugin/CockroachPluginDriver.swift
+++ b/Plugins/PostgreSQLDriverPlugin/CockroachPluginDriver.swift
@@ -57,11 +57,11 @@ final class CockroachPluginDriver: LibPQBackedDriver, @unchecked Sendable {
     // MARK: - Schema
 
     func fetchTables(schema: String?) async throws -> [PluginTableInfo] {
-        let schemaLiteral = escapeLiteral(schema ?? core.currentSchema)
+        let resolvedSchema = schema ?? core.currentSchema
         let query = """
             SELECT table_name, table_type
             FROM information_schema.tables
-            WHERE table_schema = '\(schemaLiteral)'
+            WHERE table_schema = \(PostgreSQLObjectQueries.quoteLiteral(resolvedSchema))
             ORDER BY table_name
             """
         let result = try await execute(query: query)
@@ -74,16 +74,18 @@ final class CockroachPluginDriver: LibPQBackedDriver, @unchecked Sendable {
     }
 
     func fetchColumns(table: String, schema: String?) async throws -> [PluginColumnInfo] {
-        let safeTable = escapeLiteral(table)
-        let schemaLiteral = escapeLiteral(schema ?? core.currentSchema)
-        let query = Self.columnsQuery(schemaLiteral: schemaLiteral, tableFilter: "AND c.table_name = '\(safeTable)'")
+        let resolvedSchema = schema ?? core.currentSchema
+        let query = Self.columnsQuery(
+            schema: resolvedSchema,
+            tableFilter: "AND c.table_name = \(PostgreSQLObjectQueries.quoteLiteral(table))"
+        )
         let result = try await execute(query: query)
         return result.rows.compactMap { Self.mapColumnRow($0, includesTableName: false) }
     }
 
     func fetchAllColumns(schema: String?) async throws -> [String: [PluginColumnInfo]] {
-        let schemaLiteral = escapeLiteral(schema ?? core.currentSchema)
-        let query = Self.columnsQuery(schemaLiteral: schemaLiteral, tableFilter: "", includesTableName: true)
+        let resolvedSchema = schema ?? core.currentSchema
+        let query = Self.columnsQuery(schema: resolvedSchema, tableFilter: "", includesTableName: true)
         let result = try await execute(query: query)
         var allColumns: [String: [PluginColumnInfo]] = [:]
         for row in result.rows {
@@ -145,8 +147,8 @@ final class CockroachPluginDriver: LibPQBackedDriver, @unchecked Sendable {
 
     func fetchForeignKeys(table: String, schema: String?) async throws -> [PluginForeignKeyInfo] {
         let query = PostgreSQLCatalogForeignKeys.query(
-            schemaLiteral: PostgreSQLObjectQueries.quoteLiteral(schema ?? core.currentSchema),
-            tableLiteral: PostgreSQLObjectQueries.quoteLiteral(table),
+            schema: schema ?? core.currentSchema,
+            table: table,
             excludesPartitionClones: PostgreSQLCatalogForeignKeys.excludesPartitionClones(
                 serverVersionNumber: core.serverVersionNumber
             )
@@ -190,11 +192,11 @@ final class CockroachPluginDriver: LibPQBackedDriver, @unchecked Sendable {
     }
 
     func fetchDatabaseMetadata(_ database: String) async throws -> PluginDatabaseMetadata {
-        let escapedDb = escapeLiteral(database)
+        let databaseLiteral = PostgreSQLObjectQueries.quoteLiteral(database)
         let query = """
             SELECT COUNT(*)
             FROM information_schema.tables
-            WHERE table_catalog = '\(escapedDb)'
+            WHERE table_catalog = \(databaseLiteral)
               AND table_schema NOT IN ('pg_catalog', 'information_schema', 'crdb_internal', 'pg_extension')
             """
         let tableCount = (try? await execute(query: query))
@@ -226,10 +228,11 @@ final class CockroachPluginDriver: LibPQBackedDriver, @unchecked Sendable {
     // MARK: - Query Helpers
 
     private static func columnsQuery(
-        schemaLiteral: String,
+        schema: String,
         tableFilter: String,
         includesTableName: Bool = false
     ) -> String {
+        let schemaLiteral = PostgreSQLObjectQueries.quoteLiteral(schema)
         let selectPrefix = includesTableName ? "c.table_name,\n" : ""
         let orderBy = includesTableName ? "c.table_name, c.ordinal_position" : "c.ordinal_position"
         return """
@@ -256,9 +259,9 @@ final class CockroachPluginDriver: LibPQBackedDriver, @unchecked Sendable {
                     ON tc.constraint_name = kcu.constraint_name
                     AND tc.table_schema = kcu.table_schema
                 WHERE tc.constraint_type = 'PRIMARY KEY'
-                    AND tc.table_schema = '\(schemaLiteral)'
+                    AND tc.table_schema = \(schemaLiteral)
             ) pk ON c.table_name = pk.table_name AND c.column_name = pk.column_name
-            WHERE c.table_schema = '\(schemaLiteral)' \(tableFilter)
+            WHERE c.table_schema = \(schemaLiteral) \(tableFilter)
             ORDER BY \(orderBy)
             """
     }

--- a/Plugins/PostgreSQLDriverPlugin/ColumnQueryShape.swift
+++ b/Plugins/PostgreSQLDriverPlugin/ColumnQueryShape.swift
@@ -20,24 +20,29 @@ enum ColumnQueryShape {
         let orderBy: String
     }
 
-    /// Fragments for a column query scoped to one schema. Passing `tableLiteral`
-    /// restricts the query to a single table; passing `nil` returns every table's
-    /// columns, prefixes each row with `table_name`, and orders by table.
-    static func fragments(tableLiteral: String?) -> Fragments {
-        let includesTableName = tableLiteral == nil
+    /// Fragments for a column query scoped to one schema. Passing `table` restricts
+    /// the query to a single table; passing `nil` returns every table's columns,
+    /// prefixes each row with `table_name`, and orders by table.
+    ///
+    /// The name arrives raw and is quoted here through
+    /// `PostgreSQLObjectQueries.quoteLiteral`, which is the only spelling that reads
+    /// the same whatever `standard_conforming_strings` is set to.
+    static func fragments(table: String?) -> Fragments {
+        let includesTableName = table == nil
+        let tableLiteral = table.map { PostgreSQLObjectQueries.quoteLiteral($0) }
         return Fragments(
             selectPrefix: includesTableName ? "c.table_name,\n" : "",
             pkSelect: includesTableName ? "kcu.table_name, kcu.column_name" : "kcu.column_name",
-            pkTableFilter: tableLiteral.map { "\n                    AND tc.table_name = '\($0)'" } ?? "",
+            pkTableFilter: tableLiteral.map { "\n                    AND tc.table_name = \($0)" } ?? "",
             pkJoin: includesTableName
                 ? "c.table_name = pk.table_name AND c.column_name = pk.column_name"
                 : "c.column_name = pk.column_name",
-            mainTableFilter: tableLiteral.map { " AND c.table_name = '\($0)'" } ?? "",
+            mainTableFilter: tableLiteral.map { " AND c.table_name = \($0)" } ?? "",
             orderBy: includesTableName ? "c.table_name, c.ordinal_position" : "c.ordinal_position"
         )
     }
 
-    static func primaryKeyJoin(schemaLiteral: String, fragments: Fragments) -> String {
+    static func primaryKeyJoin(schema: String, fragments: Fragments) -> String {
         """
         LEFT JOIN (
                 SELECT DISTINCT \(fragments.pkSelect)
@@ -47,7 +52,7 @@ enum ColumnQueryShape {
                     AND tc.table_schema = kcu.table_schema
                     AND tc.table_name = kcu.table_name
                 WHERE tc.constraint_type = 'PRIMARY KEY'
-                    AND tc.table_schema = '\(schemaLiteral)'\(fragments.pkTableFilter)
+                    AND tc.table_schema = \(PostgreSQLObjectQueries.quoteLiteral(schema))\(fragments.pkTableFilter)
             ) pk ON \(fragments.pkJoin)
         """
     }

--- a/Plugins/PostgreSQLDriverPlugin/LibPQDriverCore.swift
+++ b/Plugins/PostgreSQLDriverPlugin/LibPQDriverCore.swift
@@ -203,7 +203,7 @@ final class LibPQDriverCore: @unchecked Sendable {
 
     func applyQueryTimeout(_ seconds: Int) async throws {
         let ms = seconds * 1_000
-        _ = try await execute(query: "SET statement_timeout = '\(ms)'")
+        _ = try await execute(query: "SET statement_timeout = \(ms)")
     }
 
     private func connection() throws -> LibPQPluginConnection {
@@ -310,11 +310,12 @@ extension LibPQBackedDriver {
     var hasLostConnection: Bool { core.hasLostConnection }
     var parameterStyle: ParameterStyle { .dollar }
 
+    /// The PluginKit requirement, whose contract is inner text: the app and the export plugins wrap
+    /// the result in their own quotes. Nothing in this plugin may build catalog SQL with it, because
+    /// its correctness rests on `standard_conforming_strings` still being what the last connection
+    /// message reported. `PostgreSQLObjectQueries.quoteLiteral` needs no such agreement, so every
+    /// statement this plugin builds goes through that instead.
     func escapeStringLiteral(_ value: String) -> String {
         LibPQStringConformance.escape(value, standardConformingStrings: core.standardConformingStrings)
-    }
-
-    func escapeLiteral(_ str: String) -> String {
-        escapeStringLiteral(str)
     }
 }

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLCatalogForeignKeys.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLCatalogForeignKeys.swift
@@ -37,7 +37,9 @@ nonisolated enum PostgreSQLCatalogForeignKeys {
         }
     }
 
-    static func query(schemaLiteral: String, tableLiteral: String, excludesPartitionClones: Bool) -> String {
+    static func query(schema: String, table: String, excludesPartitionClones: Bool) -> String {
+        let schemaLiteral = PostgreSQLObjectQueries.quoteLiteral(schema)
+        let tableLiteral = PostgreSQLObjectQueries.quoteLiteral(table)
         let cloneFilter = excludesPartitionClones ? """
 
               AND NOT EXISTS (
@@ -49,7 +51,7 @@ nonisolated enum PostgreSQLCatalogForeignKeys {
         let branches = Side.allCases.map { side in
             """
             SELECT c.oid, c.conname, ref_ns.nspname, ref_cl.relname, c.confdeltype, c.confupdtype,
-                   c.conkey, c.confkey, '\(side.rawValue)', a.attnum, a.attname
+                   c.conkey, c.confkey, \(PostgreSQLObjectQueries.quoteLiteral(side.rawValue)), a.attnum, a.attname
             FROM pg_catalog.pg_constraint c
             JOIN pg_catalog.pg_class cl ON cl.oid = c.conrelid
             JOIN pg_catalog.pg_namespace ns ON ns.oid = cl.relnamespace

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLObjectQueries.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLObjectQueries.swift
@@ -10,20 +10,29 @@ import Foundation
 import TableProPluginKit
 
 public enum PostgreSQLObjectQueries {
-    public static func escapeLiteral(_ value: String) -> String {
-        value.replacingOccurrences(of: "'", with: "''")
+    /// The single owner of literal quoting for every statement this plugin builds, which is why it
+    /// returns the quotes too: the `E` prefix sits outside them, so a helper that returns inner text
+    /// for a call site to wrap can never be setting-independent. Measured on PostgreSQL 17.11 with
+    /// `standard_conforming_strings = off`: a schema named `a\b` listed as `'a\b'` returns no rows,
+    /// and one named `x\' OR true--` listed that way closes the literal after `x'` and runs
+    /// `OR true` as SQL, which turned a one-row listing into every relation in the database.
+    ///
+    /// Doubling the quote is enough while the value holds no backslash, and the output is then
+    /// byte-identical to plain quote doubling. With one, the value is written as an `E''` string,
+    /// where a backslash is always an escape whatever the setting says, and is doubled here. This is
+    /// what the server's own `quote_literal` emits for the same values.
+    ///
+    /// A NUL is dropped rather than escaped. libpq takes a NUL-terminated C string, so a NUL would
+    /// truncate the statement, and PostgreSQL rejects `\000` in a literal outright ("invalid byte
+    /// sequence for encoding UTF8"). This matches the PluginKit default's own NUL strip.
+    public static func quoteLiteral(_ value: String) -> String {
+        let stripped = value.replacingOccurrences(of: "\0", with: "")
+        guard stripped.contains("\\") else { return "'\(escapeQuotes(stripped))'" }
+        return "E'\(escapeQuotes(stripped.replacingOccurrences(of: "\\", with: "\\\\")))'"
     }
 
-    /// A literal that reads the same whatever `standard_conforming_strings` is set to. Doubling the
-    /// quote is enough while the value has no backslash; with one, a server running the legacy
-    /// setting would let `\'` swallow a doubled quote and close the literal early, so such a value
-    /// is written as an `E''` string, where a backslash is always an escape and is doubled here.
-    public static func quoteLiteral(_ value: String) -> String {
-        guard value.contains("\\") else { return "'\(escapeLiteral(value))'" }
-        let escaped = value
-            .replacingOccurrences(of: "\\", with: "\\\\")
-            .replacingOccurrences(of: "'", with: "''")
-        return "E'\(escaped)'"
+    private static func escapeQuotes(_ value: String) -> String {
+        value.replacingOccurrences(of: "'", with: "''")
     }
 
     public static func quoteIdentifier(_ name: String) -> String {

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver+BulkMetadata.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver+BulkMetadata.swift
@@ -35,7 +35,7 @@ extension PostgreSQLPluginDriver {
     var providesBulkTableMetadataFetch: Bool { true }
 
     func fetchAllTableMetadata(schema: String?) async throws -> [String: PluginTableMetadata] {
-        let schemaLiteral = escapeLiteral(schema ?? core.currentSchema)
+        let schemaLiteral = PostgreSQLObjectQueries.quoteLiteral(schema ?? core.currentSchema)
         let query = """
             SELECT
                 c.relname AS table_name,
@@ -46,7 +46,7 @@ extension PostgreSQLPluginDriver {
                 obj_description(c.oid, 'pg_class') AS comment
             FROM pg_class c
             JOIN pg_namespace n ON n.oid = c.relnamespace
-            WHERE n.nspname = '\(schemaLiteral)' AND c.relkind IN ('r', 'p', 'm', 'f')
+            WHERE n.nspname = \(schemaLiteral) AND c.relkind IN ('r', 'p', 'm', 'f')
             ORDER BY c.relname
             """
         let result = try await execute(query: query)

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver+ColumnReorder.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver+ColumnReorder.swift
@@ -118,28 +118,28 @@ extension PostgreSQLPluginDriver {
         /// A new identity column starts its sequence at one, so it is wound forward to the rows the
         /// copy just wrote. Without this the next insert collides with an existing key.
         ///
-        /// Both arguments are escaped. A schema or table name may legally contain an apostrophe,
-        /// and it lands inside a single-quoted literal here.
+        /// `qualified` is already a quoted identifier pair, and `pg_get_serial_sequence` takes the
+        /// whole pair as one literal, so it is composed first and quoted once. A schema, table or
+        /// column name may legally contain an apostrophe or a backslash, and both land inside a
+        /// literal here.
         func identityResets(qualified: String, quote: (String) -> String) -> [String] {
-            identityColumns.map { column in
-                """
+            let relationLiteral = PostgreSQLObjectQueries.quoteLiteral(qualified)
+            return identityColumns.map { column in
+                let columnLiteral = PostgreSQLObjectQueries.quoteLiteral(column)
+                return """
                 SELECT setval(
-                  pg_get_serial_sequence('\(literal(qualified))', '\(literal(column))'),
+                  pg_get_serial_sequence(\(relationLiteral), \(columnLiteral)),
                   GREATEST(COALESCE((SELECT MAX(\(quote(column))) FROM \(qualified)), 0), 1),
                   true
                 )
                 """
             }
         }
-
-        private func literal(_ value: String) -> String {
-            value.replacingOccurrences(of: "'", with: "''")
-        }
     }
 
     private func fetchRebuildParts(table: String, schema: String) async throws -> RebuildParts {
-        let safeTable = escapeLiteral(table)
-        let safeSchema = escapeLiteral(schema)
+        let tableLiteral = PostgreSQLObjectQueries.quoteLiteral(table)
+        let schemaLiteral = PostgreSQLObjectQueries.quoteLiteral(schema)
         let caps = versionedCapabilities
         var parts = RebuildParts()
 
@@ -182,7 +182,7 @@ extension PostgreSQLPluginDriver {
             JOIN pg_class c ON c.oid = a.attrelid
             JOIN pg_namespace n ON n.oid = c.relnamespace
             LEFT JOIN pg_attrdef d ON d.adrelid = c.oid AND d.adnum = a.attnum
-            WHERE c.relname = '\(safeTable)' AND n.nspname = '\(safeSchema)'
+            WHERE c.relname = \(tableLiteral) AND n.nspname = \(schemaLiteral)
               AND a.attnum > 0 AND NOT a.attisdropped
             ORDER BY a.attnum
             """).rows
@@ -203,7 +203,7 @@ extension PostgreSQLPluginDriver {
             FROM pg_constraint con
             JOIN pg_class c ON c.oid = con.conrelid
             JOIN pg_namespace n ON n.oid = c.relnamespace
-            WHERE c.relname = '\(safeTable)' AND n.nspname = '\(safeSchema)'
+            WHERE c.relname = \(tableLiteral) AND n.nspname = \(schemaLiteral)
               AND con.contype IN ('p', 'u', 'c', 'x')
             ORDER BY CASE con.contype WHEN 'p' THEN 0 WHEN 'u' THEN 1 ELSE 2 END, con.conname
             """)
@@ -213,7 +213,7 @@ extension PostgreSQLPluginDriver {
             FROM pg_constraint con
             JOIN pg_class c ON c.oid = con.conrelid
             JOIN pg_namespace n ON n.oid = c.relnamespace
-            WHERE c.relname = '\(safeTable)' AND n.nspname = '\(safeSchema)' AND con.contype = 'f'
+            WHERE c.relname = \(tableLiteral) AND n.nspname = \(schemaLiteral) AND con.contype = 'f'
             ORDER BY con.conname
             """)
 
@@ -226,7 +226,7 @@ extension PostgreSQLPluginDriver {
             JOIN pg_namespace n ON n.oid = c.relnamespace
             JOIN pg_class c2 ON c2.oid = con.conrelid
             JOIN pg_namespace n2 ON n2.oid = c2.relnamespace
-            WHERE c.relname = '\(safeTable)' AND n.nspname = '\(safeSchema)' AND con.contype = 'f'
+            WHERE c.relname = \(tableLiteral) AND n.nspname = \(schemaLiteral) AND con.contype = 'f'
               AND con.conrelid <> con.confrelid
             ORDER BY con.conname
             """
@@ -245,12 +245,12 @@ extension PostgreSQLPluginDriver {
         /// fail on a duplicate name.
         parts.indexes = try await textRows("""
             SELECT indexdef FROM pg_indexes
-            WHERE tablename = '\(safeTable)' AND schemaname = '\(safeSchema)'
+            WHERE tablename = \(tableLiteral) AND schemaname = \(schemaLiteral)
               AND indexname NOT IN (
                 SELECT con.conname FROM pg_constraint con
                 JOIN pg_class c ON c.oid = con.conrelid
                 JOIN pg_namespace n ON n.oid = c.relnamespace
-                WHERE c.relname = '\(safeTable)' AND n.nspname = '\(safeSchema)'
+                WHERE c.relname = \(tableLiteral) AND n.nspname = \(schemaLiteral)
               )
             ORDER BY indexname
             """)
@@ -260,7 +260,7 @@ extension PostgreSQLPluginDriver {
             FROM pg_trigger t
             JOIN pg_class c ON c.oid = t.tgrelid
             JOIN pg_namespace n ON n.oid = c.relnamespace
-            WHERE c.relname = '\(safeTable)' AND n.nspname = '\(safeSchema)' AND NOT t.tgisinternal
+            WHERE c.relname = \(tableLiteral) AND n.nspname = \(schemaLiteral) AND NOT t.tgisinternal
             ORDER BY t.tgname
             """)
 
@@ -279,7 +279,7 @@ extension PostgreSQLPluginDriver {
             FROM pg_trigger t
             JOIN pg_class c ON c.oid = t.tgrelid
             JOIN pg_namespace n ON n.oid = c.relnamespace
-            WHERE c.relname = '\(safeTable)' AND n.nspname = '\(safeSchema)' AND NOT t.tgisinternal
+            WHERE c.relname = \(tableLiteral) AND n.nspname = \(schemaLiteral) AND NOT t.tgisinternal
               AND t.tgenabled <> 'O'
             ORDER BY t.tgname
             """)
@@ -296,7 +296,7 @@ extension PostgreSQLPluginDriver {
             FROM pg_attribute a
             JOIN pg_class c ON c.oid = a.attrelid
             JOIN pg_namespace n ON n.oid = c.relnamespace
-            WHERE c.relname = '\(safeTable)' AND n.nspname = '\(safeSchema)'
+            WHERE c.relname = \(tableLiteral) AND n.nspname = \(schemaLiteral)
               AND a.attnum > 0 AND NOT a.attisdropped
               AND \(caps.hasIdentityColumns ? "a.attidentity = ''" : "true")
               AND pg_get_serial_sequence(
@@ -310,7 +310,7 @@ extension PostgreSQLPluginDriver {
                    || ' IS ' || quote_literal(obj_description(c.oid, 'pg_class'))
             FROM pg_class c
             JOIN pg_namespace n ON n.oid = c.relnamespace
-            WHERE c.relname = '\(safeTable)' AND n.nspname = '\(safeSchema)'
+            WHERE c.relname = \(tableLiteral) AND n.nspname = \(schemaLiteral)
               AND obj_description(c.oid, 'pg_class') IS NOT NULL
             UNION ALL
             SELECT 'COMMENT ON COLUMN ' || quote_ident(n.nspname) || '.' || quote_ident(c.relname)
@@ -319,7 +319,7 @@ extension PostgreSQLPluginDriver {
             FROM pg_attribute a
             JOIN pg_class c ON c.oid = a.attrelid
             JOIN pg_namespace n ON n.oid = c.relnamespace
-            WHERE c.relname = '\(safeTable)' AND n.nspname = '\(safeSchema)'
+            WHERE c.relname = \(tableLiteral) AND n.nspname = \(schemaLiteral)
               AND a.attnum > 0 AND NOT a.attisdropped
               AND col_description(c.oid, a.attnum) IS NOT NULL
             """)
@@ -332,7 +332,7 @@ extension PostgreSQLPluginDriver {
             JOIN pg_namespace dn ON dn.oid = dc.relnamespace
             JOIN pg_class c ON c.oid = d.refobjid
             JOIN pg_namespace n ON n.oid = c.relnamespace
-            WHERE c.relname = '\(safeTable)' AND n.nspname = '\(safeSchema)'
+            WHERE c.relname = \(tableLiteral) AND n.nspname = \(schemaLiteral)
               AND dc.relkind IN ('v', 'm')
               AND dc.oid <> c.oid
             ORDER BY 1

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver+Columns.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver+Columns.swift
@@ -8,12 +8,10 @@ import TableProPluginKit
 
 extension PostgreSQLPluginDriver {
     func fetchColumns(table: String, schema: String?) async throws -> [PluginColumnInfo] {
-        let safeSchema = escapeStringLiteral(schema ?? core.currentSchema)
-        let safeTable = escapeStringLiteral(table)
         let catalog = try await fetchTypeCatalog()
         let query = PostgreSQLSchemaQueries.columnsQuery(
-            schemaLiteral: safeSchema,
-            tableLiteral: safeTable,
+            schema: schema ?? core.currentSchema,
+            table: table,
             capabilities: versionedCapabilities,
             includeMaterializedViews: includesMaterializedViews()
         )
@@ -24,11 +22,10 @@ extension PostgreSQLPluginDriver {
     }
 
     func fetchAllColumns(schema: String?) async throws -> [String: [PluginColumnInfo]] {
-        let safeSchema = escapeStringLiteral(schema ?? core.currentSchema)
         let catalog = try await fetchTypeCatalog()
         let query = PostgreSQLSchemaQueries.columnsQuery(
-            schemaLiteral: safeSchema,
-            tableLiteral: nil,
+            schema: schema ?? core.currentSchema,
+            table: nil,
             capabilities: versionedCapabilities,
             includeMaterializedViews: includesMaterializedViews()
         )

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver+Principals.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver+Principals.swift
@@ -28,7 +28,7 @@ extension PostgreSQLPluginDriver: PluginPrincipalManagement {
     ) async throws -> [PluginPrivilegeScope] {
         let database = try await currentDatabaseName()
         let sql = PostgreSQLPrincipalQueries.searchObjects(
-            patternLiteral: escapeStringLiteral(query),
+            pattern: query,
             limit: limit
         )
         let result = try await execute(query: sql)
@@ -78,13 +78,13 @@ extension PostgreSQLPluginDriver: PluginPrincipalManagement {
     }
 
     func fetchGrants(for principal: PluginPrincipalRef) async throws -> [PluginGrantInfo] {
-        let roleLiteral = escapeStringLiteral(principal.name)
+        let role = principal.name
         let database = try await currentDatabaseName()
 
-        let databaseGrants = try await fetchDatabaseGrants(roleLiteral: roleLiteral)
-        let schemaGrants = try await fetchSchemaGrants(roleLiteral: roleLiteral, database: database)
-        let tableGrants = try await fetchTableGrants(roleLiteral: roleLiteral, database: database)
-        let columnGrants = try await fetchColumnGrants(roleLiteral: roleLiteral, database: database)
+        let databaseGrants = try await fetchDatabaseGrants(role: role)
+        let schemaGrants = try await fetchSchemaGrants(role: role, database: database)
+        let tableGrants = try await fetchTableGrants(role: role, database: database)
+        let columnGrants = try await fetchColumnGrants(role: role, database: database)
 
         return databaseGrants + schemaGrants + tableGrants + columnGrants
     }
@@ -118,7 +118,7 @@ extension PostgreSQLPluginDriver: PluginPrincipalManagement {
     }
 
     private func tables(in database: String, schema: String) async throws -> [PluginPrivilegeScope] {
-        let query = PostgreSQLPrincipalQueries.tables(schemaLiteral: escapeStringLiteral(schema))
+        let query = PostgreSQLPrincipalQueries.tables(schema: schema)
         let result = try await execute(query: query)
         return result.rows.compactMap { row in
             guard let table = row[safe: 0]?.asText else { return nil }
@@ -132,8 +132,8 @@ extension PostgreSQLPluginDriver: PluginPrincipalManagement {
         table: String
     ) async throws -> [PluginPrivilegeScope] {
         let query = PostgreSQLPrincipalQueries.columns(
-            schemaLiteral: escapeStringLiteral(schema),
-            tableLiteral: escapeStringLiteral(table)
+            schema: schema,
+            table: table
         )
         let result = try await execute(query: query)
         return result.rows.compactMap { row in
@@ -142,8 +142,8 @@ extension PostgreSQLPluginDriver: PluginPrincipalManagement {
         }
     }
 
-    private func fetchColumnGrants(roleLiteral: String, database: String) async throws -> [PluginGrantInfo] {
-        let query = PostgreSQLPrincipalQueries.columnGrants(roleLiteral: roleLiteral)
+    private func fetchColumnGrants(role: String, database: String) async throws -> [PluginGrantInfo] {
+        let query = PostgreSQLPrincipalQueries.columnGrants(role: role)
         let result = try await execute(query: query)
         return result.rows.compactMap { row -> PluginGrantInfo? in
             guard let schema = row[safe: 0]?.asText,
@@ -166,7 +166,7 @@ extension PostgreSQLPluginDriver: PluginPrincipalManagement {
 
     func principalOwnsObjects(_ principal: PluginPrincipalRef) async throws -> Bool {
         let query = PostgreSQLPrincipalQueries.ownsObjects(
-            roleLiteral: escapeStringLiteral(principal.name)
+            role: principal.name
         )
         let result = try await execute(query: query)
         return PostgreSQLCatalogBoolean.isTrue(result.rows.first?[safe: 0]?.asText)
@@ -188,8 +188,8 @@ extension PostgreSQLPluginDriver: PluginPrincipalManagement {
         return result.rows.first?[safe: 0]?.asText ?? ""
     }
 
-    private func fetchDatabaseGrants(roleLiteral: String) async throws -> [PluginGrantInfo] {
-        let query = PostgreSQLPrincipalQueries.databaseGrants(roleLiteral: roleLiteral)
+    private func fetchDatabaseGrants(role: String) async throws -> [PluginGrantInfo] {
+        let query = PostgreSQLPrincipalQueries.databaseGrants(role: role)
         let result = try await execute(query: query)
         return result.rows.compactMap { row -> PluginGrantInfo? in
             guard let database = row[safe: 0]?.asText,
@@ -202,8 +202,8 @@ extension PostgreSQLPluginDriver: PluginPrincipalManagement {
         }
     }
 
-    private func fetchSchemaGrants(roleLiteral: String, database: String) async throws -> [PluginGrantInfo] {
-        let query = PostgreSQLPrincipalQueries.schemaGrants(roleLiteral: roleLiteral)
+    private func fetchSchemaGrants(role: String, database: String) async throws -> [PluginGrantInfo] {
+        let query = PostgreSQLPrincipalQueries.schemaGrants(role: role)
         let result = try await execute(query: query)
         return result.rows.compactMap { row -> PluginGrantInfo? in
             guard let schema = row[safe: 0]?.asText,
@@ -216,8 +216,8 @@ extension PostgreSQLPluginDriver: PluginPrincipalManagement {
         }
     }
 
-    private func fetchTableGrants(roleLiteral: String, database: String) async throws -> [PluginGrantInfo] {
-        let query = PostgreSQLPrincipalQueries.tableGrants(roleLiteral: roleLiteral)
+    private func fetchTableGrants(role: String, database: String) async throws -> [PluginGrantInfo] {
+        let query = PostgreSQLPrincipalQueries.tableGrants(role: role)
         let result = try await execute(query: query)
         return result.rows.compactMap { row -> PluginGrantInfo? in
             guard let schema = row[safe: 0]?.asText,

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver+TriggerEditing.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver+TriggerEditing.swift
@@ -31,9 +31,9 @@ internal extension PostgreSQLPluginDriver {
             FROM pg_catalog.pg_trigger t
             JOIN pg_catalog.pg_class c ON c.oid = t.tgrelid
             JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
-            WHERE t.tgname = '\(escapeLiteral(name))'
-                AND c.relname = '\(escapeLiteral(table))'
-                AND n.nspname = '\(escapeLiteral(resolvedSchema))'
+            WHERE t.tgname = \(PostgreSQLObjectQueries.quoteLiteral(name))
+                AND c.relname = \(PostgreSQLObjectQueries.quoteLiteral(table))
+                AND n.nspname = \(PostgreSQLObjectQueries.quoteLiteral(resolvedSchema))
                 AND NOT t.tgisinternal
             LIMIT 1
             """

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver.swift
@@ -220,11 +220,10 @@ class PostgreSQLPluginDriver: LibPQBackedDriver, @unchecked Sendable {
 
     func fetchPartitions(table: String, schema: String?) async throws -> [PluginTableInfo] {
         guard versionedCapabilities.hasDeclarativePartitioning else { return [] }
-        let schemaLiteral = escapeLiteral(schema ?? core.currentSchema)
         let result = try await execute(
             query: PostgreSQLSchemaQueries.fetchPartitions(
-                schemaLiteral: schemaLiteral,
-                tableLiteral: escapeLiteral(table)
+                schema: schema ?? core.currentSchema,
+                table: table
             )
         )
         return result.rows.compactMap { row -> PluginTableInfo? in
@@ -304,7 +303,7 @@ class PostgreSQLPluginDriver: LibPQBackedDriver, @unchecked Sendable {
         let query = """
             SELECT reltuples::bigint
             FROM pg_class
-            WHERE relname = '\(escapeLiteral(table))'
+            WHERE relname = \(PostgreSQLObjectQueries.quoteLiteral(table))
               AND relnamespace = (
                   SELECT oid FROM pg_namespace WHERE nspname = current_schema()
               )
@@ -315,9 +314,9 @@ class PostgreSQLPluginDriver: LibPQBackedDriver, @unchecked Sendable {
     }
 
     func fetchTableDDL(table: String, schema: String?) async throws -> String {
-        let safeTable = escapeLiteral(table)
+        let tableLiteral = PostgreSQLObjectQueries.quoteLiteral(table)
         let resolvedSchema = schema ?? core.currentSchema
-        let schemaLiteral = escapeLiteral(resolvedSchema)
+        let schemaLiteral = PostgreSQLObjectQueries.quoteLiteral(resolvedSchema)
         let quotedTable = quoteIdentifier(table)
         let caps = versionedCapabilities
 
@@ -364,8 +363,8 @@ class PostgreSQLPluginDriver: LibPQBackedDriver, @unchecked Sendable {
             JOIN pg_class c ON c.oid = a.attrelid
             JOIN pg_namespace n ON n.oid = c.relnamespace
             LEFT JOIN pg_attrdef d ON d.adrelid = c.oid AND d.adnum = a.attnum
-            WHERE c.relname = '\(safeTable)'
-              AND n.nspname = '\(schemaLiteral)'
+            WHERE c.relname = \(tableLiteral)
+              AND n.nspname = \(schemaLiteral)
               AND a.attnum > 0
               AND NOT a.attisdropped
             ORDER BY a.attnum
@@ -377,8 +376,8 @@ class PostgreSQLPluginDriver: LibPQBackedDriver, @unchecked Sendable {
             FROM pg_constraint con
             JOIN pg_class c ON c.oid = con.conrelid
             JOIN pg_namespace n ON n.oid = c.relnamespace
-            WHERE c.relname = '\(safeTable)'
-              AND n.nspname = '\(schemaLiteral)'
+            WHERE c.relname = \(tableLiteral)
+              AND n.nspname = \(schemaLiteral)
               AND con.contype IN ('p', 'u', 'c')
             ORDER BY
               CASE con.contype WHEN 'p' THEN 0 WHEN 'u' THEN 1 WHEN 'c' THEN 2 END
@@ -428,8 +427,8 @@ class PostgreSQLPluginDriver: LibPQBackedDriver, @unchecked Sendable {
             JOIN pg_class c ON c.oid = ix.indrelid
             JOIN pg_class i ON i.oid = ix.indexrelid
             JOIN pg_namespace n ON n.oid = c.relnamespace
-            WHERE c.relname = '\(escapeLiteral(table))'
-              AND n.nspname = '\(escapeLiteral(schema ?? core.currentSchema))'
+            WHERE c.relname = \(PostgreSQLObjectQueries.quoteLiteral(table))
+              AND n.nspname = \(PostgreSQLObjectQueries.quoteLiteral(schema ?? core.currentSchema))
               AND NOT EXISTS (
                 SELECT 1 FROM pg_constraint con WHERE con.conindid = ix.indexrelid
               )
@@ -440,7 +439,7 @@ class PostgreSQLPluginDriver: LibPQBackedDriver, @unchecked Sendable {
     }
 
     func fetchTableMetadata(table: String, schema: String?) async throws -> PluginTableMetadata {
-        let schemaLiteral = escapeLiteral(schema ?? core.currentSchema)
+        let schemaLiteral = PostgreSQLObjectQueries.quoteLiteral(schema ?? core.currentSchema)
         let query = """
             SELECT
                 pg_total_relation_size(c.oid) AS total_size,
@@ -450,8 +449,8 @@ class PostgreSQLPluginDriver: LibPQBackedDriver, @unchecked Sendable {
                 obj_description(c.oid, 'pg_class') AS comment
             FROM pg_class c
             JOIN pg_namespace n ON n.oid = c.relnamespace
-            WHERE c.relname = '\(escapeLiteral(table))'
-              AND n.nspname = '\(schemaLiteral)'
+            WHERE c.relname = \(PostgreSQLObjectQueries.quoteLiteral(table))
+              AND n.nspname = \(schemaLiteral)
             """
         let result = try await execute(query: query)
         guard let row = result.rows.first else {
@@ -486,12 +485,12 @@ class PostgreSQLPluginDriver: LibPQBackedDriver, @unchecked Sendable {
     }
 
     func fetchDatabaseMetadata(_ database: String) async throws -> PluginDatabaseMetadata {
-        let escapedDbLiteral = escapeLiteral(database)
+        let databaseLiteral = PostgreSQLObjectQueries.quoteLiteral(database)
         let query = """
             SELECT
                 (SELECT COUNT(*)
                  FROM information_schema.tables t
-                 WHERE t.table_catalog = '\(escapedDbLiteral)'
+                 WHERE t.table_catalog = \(databaseLiteral)
                    AND t.table_schema NOT LIKE 'pg!_%' ESCAPE '!'
                    AND t.table_schema <> 'information_schema'
                    AND NOT EXISTS (
@@ -503,7 +502,7 @@ class PostgreSQLPluginDriver: LibPQBackedDriver, @unchecked Sendable {
                          WHERE cn.nspname = t.table_schema
                            AND child.relname = t.table_name
                            AND parent.relkind IN ('p', 'I'))),
-                pg_database_size('\(escapedDbLiteral)')
+                pg_database_size(\(databaseLiteral))
         """
         let result = try await execute(query: query)
         let row = result.rows.first
@@ -543,8 +542,8 @@ class PostgreSQLPluginDriver: LibPQBackedDriver, @unchecked Sendable {
     private static let relkindsCreatedByTableDDL = "('r', 'p', 'f')"
 
     func fetchDependentTypes(table: String, schema: String?) async throws -> [(name: String, labels: [String])] {
-        let safeTable = escapeLiteral(table)
-        let schemaLiteral = escapeLiteral(schema ?? core.currentSchema)
+        let tableLiteral = PostgreSQLObjectQueries.quoteLiteral(table)
+        let schemaLiteral = PostgreSQLObjectQueries.quoteLiteral(schema ?? core.currentSchema)
         let query = """
             SELECT DISTINCT t.typname,
                    array_agg(e.enumlabel ORDER BY e.enumsortorder)::text
@@ -553,8 +552,8 @@ class PostgreSQLPluginDriver: LibPQBackedDriver, @unchecked Sendable {
             JOIN pg_namespace n ON n.oid = c.relnamespace
             JOIN pg_type t ON t.oid = a.atttypid
             JOIN pg_enum e ON e.enumtypid = t.oid
-            WHERE c.relname = '\(safeTable)'
-              AND n.nspname = '\(schemaLiteral)'
+            WHERE c.relname = \(tableLiteral)
+              AND n.nspname = \(schemaLiteral)
               AND c.relkind IN \(Self.relkindsCreatedByTableDDL)
               AND a.attnum > 0
               AND NOT a.attisdropped
@@ -665,7 +664,7 @@ class PostgreSQLPluginDriver: LibPQBackedDriver, @unchecked Sendable {
             )
         }
 
-        var sql = "CREATE DATABASE \(quotedName) ENCODING '\(encoding)'"
+        var sql = "CREATE DATABASE \(quotedName) ENCODING \(PostgreSQLObjectQueries.quoteLiteral(encoding))"
 
         let supportsProvider = versionedCapabilities.hasDatabaseICULocale
         let provider = supportsProvider ? (request.values["provider"] ?? "libc") : "libc"
@@ -689,8 +688,8 @@ class PostgreSQLPluginDriver: LibPQBackedDriver, @unchecked Sendable {
                     detail: nil
                 )
             }
-            let escapedCollation = escapeLiteral(collation)
-            sql += " LC_COLLATE '\(escapedCollation)' LC_CTYPE '\(escapedCollation)'"
+            let collationLiteral = PostgreSQLObjectQueries.quoteLiteral(collation)
+            sql += " LC_COLLATE \(collationLiteral) LC_CTYPE \(collationLiteral)"
 
             guard let templateDefaults = await templateDefaultsTask else {
                 throw LibPQPluginError(
@@ -726,11 +725,11 @@ class PostgreSQLPluginDriver: LibPQBackedDriver, @unchecked Sendable {
                     detail: nil
                 )
             }
-            let escapedIcu = escapeLiteral(icuLocale)
+            let icuLiteral = PostgreSQLObjectQueries.quoteLiteral(icuLocale)
             if versionedCapabilities.hasModernICUSyntax {
-                sql += " LOCALE_PROVIDER 'icu' LOCALE '\(escapedIcu)' TEMPLATE template0"
+                sql += " LOCALE_PROVIDER 'icu' LOCALE \(icuLiteral) TEMPLATE template0"
             } else {
-                sql += " LOCALE_PROVIDER 'icu' ICU_LOCALE '\(escapedIcu)' LC_COLLATE 'C' LC_CTYPE 'C' TEMPLATE template0"
+                sql += " LOCALE_PROVIDER 'icu' ICU_LOCALE \(icuLiteral) LC_COLLATE 'C' LC_CTYPE 'C' TEMPLATE template0"
             }
 
         default:

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLPrincipalQueries.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLPrincipalQueries.swift
@@ -76,14 +76,21 @@ enum PostgreSQLPrincipalQueries {
         PluginPrivilegeDescriptor(name: "REFERENCES", label: "References", category: structure)
     ]
 
-    static func searchObjects(patternLiteral: String, limit: Int) -> String {
+    /// The wildcards are wrapped around the pattern before it is quoted, because an `E` prefix
+    /// cannot be spliced into the middle of a literal: `ILIKE '%' || E'…' || '%'` would be the only
+    /// alternative, and one literal is simpler to read.
+    ///
+    /// LIKE metacharacters in the typed pattern are deliberately left alone and remain a separate
+    /// defect: a typed `%` still matches anything, and a typed backslash still acts as LIKE's own
+    /// escape. Quoting fixes which statement runs, not what the pattern means.
+    static func searchObjects(pattern: String, limit: Int) -> String {
         """
         SELECT n.nspname, c.relname
         FROM pg_class c
         JOIN pg_namespace n ON n.oid = c.relnamespace
         WHERE c.relkind IN ('r', 'v', 'm', 'p', 'f')
           AND n.nspname NOT IN ('pg_catalog', 'information_schema')
-          AND c.relname ILIKE '%\(patternLiteral)%'
+          AND c.relname ILIKE \(PostgreSQLObjectQueries.quoteLiteral("%\(pattern)%"))
         ORDER BY n.nspname, c.relname
         LIMIT \(max(1, limit))
         """
@@ -97,32 +104,32 @@ enum PostgreSQLPrincipalQueries {
         ORDER BY n.nspname
         """
 
-    static func tables(schemaLiteral: String) -> String {
+    static func tables(schema: String) -> String {
         """
         SELECT c.relname
         FROM pg_class c
         JOIN pg_namespace n ON n.oid = c.relnamespace
-        WHERE n.nspname = '\(schemaLiteral)'
+        WHERE n.nspname = \(PostgreSQLObjectQueries.quoteLiteral(schema))
           AND c.relkind IN ('r', 'v', 'm', 'p', 'f')
         ORDER BY c.relname
         """
     }
 
-    static func columns(schemaLiteral: String, tableLiteral: String) -> String {
+    static func columns(schema: String, table: String) -> String {
         """
         SELECT a.attname
         FROM pg_attribute a
         JOIN pg_class c ON c.oid = a.attrelid
         JOIN pg_namespace n ON n.oid = c.relnamespace
-        WHERE n.nspname = '\(schemaLiteral)'
-          AND c.relname = '\(tableLiteral)'
+        WHERE n.nspname = \(PostgreSQLObjectQueries.quoteLiteral(schema))
+          AND c.relname = \(PostgreSQLObjectQueries.quoteLiteral(table))
           AND a.attnum > 0
           AND NOT a.attisdropped
         ORDER BY a.attnum
         """
     }
 
-    static func columnGrants(roleLiteral: String) -> String {
+    static func columnGrants(role: String) -> String {
         """
         SELECT s.nspname, s.relname, s.attname, (s.acl).privilege_type, (s.acl).is_grantable
         FROM (
@@ -136,7 +143,7 @@ enum PostgreSQLPrincipalQueries {
               AND n.nspname NOT IN ('pg_catalog', 'information_schema')
         ) s
         JOIN pg_roles r ON r.oid = (s.acl).grantee
-        WHERE r.rolname = '\(roleLiteral)'
+        WHERE r.rolname = \(PostgreSQLObjectQueries.quoteLiteral(role))
         ORDER BY s.nspname, s.relname, s.attname, (s.acl).privilege_type
         """
     }
@@ -168,7 +175,7 @@ enum PostgreSQLPrincipalQueries {
         ORDER BY member.rolname, grantedRole.rolname
         """
 
-    static func databaseGrants(roleLiteral: String) -> String {
+    static func databaseGrants(role: String) -> String {
         """
         SELECT s.datname, (s.acl).privilege_type, (s.acl).is_grantable
         FROM (
@@ -178,12 +185,12 @@ enum PostgreSQLPrincipalQueries {
               AND NOT d.datistemplate
         ) s
         JOIN pg_roles r ON r.oid = (s.acl).grantee
-        WHERE r.rolname = '\(roleLiteral)'
+        WHERE r.rolname = \(PostgreSQLObjectQueries.quoteLiteral(role))
         ORDER BY s.datname, (s.acl).privilege_type
         """
     }
 
-    static func schemaGrants(roleLiteral: String) -> String {
+    static func schemaGrants(role: String) -> String {
         """
         SELECT s.nspname, (s.acl).privilege_type, (s.acl).is_grantable
         FROM (
@@ -193,12 +200,12 @@ enum PostgreSQLPrincipalQueries {
               AND n.nspname NOT IN ('pg_catalog', 'information_schema')
         ) s
         JOIN pg_roles r ON r.oid = (s.acl).grantee
-        WHERE r.rolname = '\(roleLiteral)'
+        WHERE r.rolname = \(PostgreSQLObjectQueries.quoteLiteral(role))
         ORDER BY s.nspname, (s.acl).privilege_type
         """
     }
 
-    static func tableGrants(roleLiteral: String) -> String {
+    static func tableGrants(role: String) -> String {
         """
         SELECT s.nspname, s.relname, (s.acl).privilege_type, (s.acl).is_grantable
         FROM (
@@ -210,18 +217,18 @@ enum PostgreSQLPrincipalQueries {
               AND n.nspname NOT IN ('pg_catalog', 'information_schema')
         ) s
         JOIN pg_roles r ON r.oid = (s.acl).grantee
-        WHERE r.rolname = '\(roleLiteral)'
+        WHERE r.rolname = \(PostgreSQLObjectQueries.quoteLiteral(role))
         ORDER BY s.nspname, s.relname, (s.acl).privilege_type
         """
     }
 
-    static func ownsObjects(roleLiteral: String) -> String {
+    static func ownsObjects(role: String) -> String {
         """
         SELECT EXISTS (
             SELECT 1
             FROM pg_shdepend s
             JOIN pg_roles r ON r.oid = s.refobjid
-            WHERE r.rolname = '\(roleLiteral)'
+            WHERE r.rolname = \(PostgreSQLObjectQueries.quoteLiteral(role))
               AND s.deptype IN ('o', 'a')
         )
         """

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLSchemaQueries.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLSchemaQueries.swift
@@ -176,15 +176,15 @@ enum PostgreSQLSchemaQueries {
     /// `relpartbound` exists only from PostgreSQL 10, so unlike `fetchTables`
     /// this query cannot be issued against an older server. The caller gates it
     /// on `PostgreSQLCapabilities.hasDeclarativePartitioning`.
-    static func fetchPartitions(schemaLiteral: String, tableLiteral: String) -> String {
+    static func fetchPartitions(schema: String, table: String) -> String {
         """
         SELECT cc.relname, cc.relkind
         FROM pg_catalog.pg_inherits i
         JOIN pg_catalog.pg_class parent ON parent.oid = i.inhparent
         JOIN pg_catalog.pg_namespace pn ON pn.oid = parent.relnamespace
         JOIN pg_catalog.pg_class cc ON cc.oid = i.inhrelid
-        WHERE pn.nspname = '\(schemaLiteral)'
-          AND parent.relname = '\(tableLiteral)'
+        WHERE pn.nspname = \(PostgreSQLObjectQueries.quoteLiteral(schema))
+          AND parent.relname = \(PostgreSQLObjectQueries.quoteLiteral(table))
           AND parent.relkind = 'p'
         ORDER BY pg_catalog.pg_get_expr(cc.relpartbound, cc.oid) = 'DEFAULT', cc.relname
         """
@@ -271,10 +271,10 @@ enum PostgreSQLSchemaQueries {
         """
     }
 
-    /// Column introspection for one schema. Passing `tableLiteral` restricts the result to a single
-    /// table; passing `nil` returns every table's columns and prefixes each row with `table_name`.
-    /// `schemaLiteral` is the only schema source, so the caller resolves the target schema
-    /// (qualified reference, then current schema) before escaping and passing it here. The identity,
+    /// Column introspection for one schema. Passing `table` restricts the result to a single table;
+    /// passing `nil` returns every table's columns and prefixes each row with `table_name`.
+    /// `schema` is the only schema source, so the caller resolves the target schema (qualified
+    /// reference, then current schema) and passes it raw; quoting happens here. The identity,
     /// generated, and attribute-join fragments come from the connected server's versioned
     /// capabilities.
     ///
@@ -287,13 +287,14 @@ enum PostgreSQLSchemaQueries {
     /// catalog presence rather than on the server version, because a PostgreSQL-compatible engine
     /// can report a recent version and still have no materialized views (#1383).
     static func columnsQuery(
-        schemaLiteral: String,
-        tableLiteral: String?,
+        schema: String,
+        table: String?,
         capabilities: PostgreSQLCapabilities,
         includeMaterializedViews: Bool
     ) -> String {
-        let shape = ColumnQueryShape.fragments(tableLiteral: tableLiteral)
-        let includesTableName = tableLiteral == nil
+        let schemaLiteral = PostgreSQLObjectQueries.quoteLiteral(schema)
+        let shape = ColumnQueryShape.fragments(table: table)
+        let includesTableName = table == nil
         let identityProjection = capabilities.hasIdentityColumns ? "a.attidentity" : "NULL::text"
         let generatedProjection = capabilities.hasGeneratedColumns ? "a.attgenerated" : "NULL::text"
         let generationExpressionProjection = capabilities.hasGeneratedColumns
@@ -326,15 +327,15 @@ enum PostgreSQLSchemaQueries {
             LEFT JOIN pg_catalog.pg_class rel
                 ON rel.relnamespace = relns.oid
                 AND rel.relname = c.table_name\(attributeJoin)
-            \(ColumnQueryShape.primaryKeyJoin(schemaLiteral: schemaLiteral, fragments: shape))
-            WHERE c.table_schema = '\(schemaLiteral)'\(shape.mainTableFilter)
+            \(ColumnQueryShape.primaryKeyJoin(schema: schema, fragments: shape))
+            WHERE c.table_schema = \(schemaLiteral)\(shape.mainTableFilter)
             """
         var arms = [informationSchemaArm]
         if includeMaterializedViews {
             arms.append(
                 materializedViewColumnsArm(
                     schemaLiteral: schemaLiteral,
-                    tableLiteral: tableLiteral,
+                    table: table,
                     capabilities: capabilities,
                     includesTableName: includesTableName
                 )
@@ -382,12 +383,12 @@ enum PostgreSQLSchemaQueries {
     /// materialized view column neither a default nor a constraint.
     private static func materializedViewColumnsArm(
         schemaLiteral: String,
-        tableLiteral: String?,
+        table: String?,
         capabilities: PostgreSQLCapabilities,
         includesTableName: Bool
     ) -> String {
         let tableNameProjection = includesTableName ? "mvc.relname AS table_name,\n    " : ""
-        let tableFilter = tableLiteral.map { "\n  AND mvc.relname = '\($0)'" } ?? ""
+        let tableFilter = table.map { "\n  AND mvc.relname = \(PostgreSQLObjectQueries.quoteLiteral($0))" } ?? ""
         let identityProjection = capabilities.hasIdentityColumns ? "mva.attidentity" : "NULL::text"
         let generatedProjection = capabilities.hasGeneratedColumns ? "mva.attgenerated" : "NULL::text"
         return """
@@ -427,7 +428,7 @@ enum PostgreSQLSchemaQueries {
         LEFT JOIN pg_catalog.pg_collation mvco ON mvco.oid = mva.attcollation
         LEFT JOIN pg_catalog.pg_namespace mvcon ON mvcon.oid = mvco.collnamespace
         WHERE mvc.relkind = 'm'
-          AND mvn.nspname = '\(schemaLiteral)'\(tableFilter)
+          AND mvn.nspname = \(schemaLiteral)\(tableFilter)
           AND NOT pg_catalog.pg_is_other_temp_schema(mvn.oid)
           AND (pg_catalog.pg_has_role(mvc.relowner, 'USAGE')
                OR pg_catalog.has_column_privilege(mvc.oid, mva.attnum, 'SELECT, INSERT, UPDATE, REFERENCES'))

--- a/Plugins/PostgreSQLDriverPlugin/RedshiftExternalSchemaQueries.swift
+++ b/Plugins/PostgreSQLDriverPlugin/RedshiftExternalSchemaQueries.swift
@@ -21,30 +21,30 @@ enum RedshiftExternalSchemaQueries {
 
     /// Tables registered in one external schema. Both views carry rows for
     /// every database on the cluster, so the connected database is part of the
-    /// filter; two databases can each hold a schema of the same name. Literals
-    /// are escaped by the caller, matching the convention in
+    /// filter; two databases can each hold a schema of the same name. Names
+    /// arrive raw and are quoted here, matching the convention in
     /// RedshiftSchemaQueries.
-    static func listExternalTables(schemaLiteral: String, databaseLiteral: String) -> String {
+    static func listExternalTables(schema: String, database: String) -> String {
         """
         SELECT tablename, tabletype
         FROM svv_external_tables
-        WHERE schemaname = '\(schemaLiteral)'
-            AND redshift_database_name = '\(databaseLiteral)'
+        WHERE schemaname = \(PostgreSQLObjectQueries.quoteLiteral(schema))
+            AND redshift_database_name = \(PostgreSQLObjectQueries.quoteLiteral(database))
         ORDER BY tablename
         """
     }
 
-    /// Column introspection for one external schema. Passing `tableLiteral`
-    /// restricts the result to a single table; passing `nil` returns every
-    /// table's columns and prefixes each row with `tablename`.
+    /// Column introspection for one external schema. Passing `table` restricts
+    /// the result to a single table; passing `nil` returns every table's columns
+    /// and prefixes each row with `tablename`.
     static func listExternalColumns(
-        schemaLiteral: String,
-        tableLiteral: String?,
-        databaseLiteral: String
+        schema: String,
+        table: String?,
+        database: String
     ) -> String {
-        let selectPrefix = tableLiteral == nil ? "tablename,\n                " : ""
-        let tableFilter = tableLiteral.map { " AND tablename = '\($0)'" } ?? ""
-        let orderBy = tableLiteral == nil ? "tablename, columnnum" : "columnnum"
+        let selectPrefix = table == nil ? "tablename,\n                " : ""
+        let tableFilter = table.map { " AND tablename = \(PostgreSQLObjectQueries.quoteLiteral($0))" } ?? ""
+        let orderBy = table == nil ? "tablename, columnnum" : "columnnum"
         return """
             SELECT
                 \(selectPrefix)columnname,
@@ -52,8 +52,8 @@ enum RedshiftExternalSchemaQueries {
                 is_nullable,
                 part_key
             FROM svv_external_columns
-            WHERE schemaname = '\(schemaLiteral)'\(tableFilter)
-                AND redshift_database_name = '\(databaseLiteral)'
+            WHERE schemaname = \(PostgreSQLObjectQueries.quoteLiteral(schema))\(tableFilter)
+                AND redshift_database_name = \(PostgreSQLObjectQueries.quoteLiteral(database))
             ORDER BY \(orderBy)
             """
     }

--- a/Plugins/PostgreSQLDriverPlugin/RedshiftPluginDriver.swift
+++ b/Plugins/PostgreSQLDriverPlugin/RedshiftPluginDriver.swift
@@ -75,11 +75,11 @@ final class RedshiftPluginDriver: LibPQBackedDriver, @unchecked Sendable {
 
     func fetchTables(schema: String?) async throws -> [PluginTableInfo] {
         let resolvedSchema = schema ?? core.currentSchema
-        let schemaLiteral = escapeLiteral(resolvedSchema)
+        let schemaLiteral = PostgreSQLObjectQueries.quoteLiteral(resolvedSchema)
         let query = """
             SELECT table_name, table_type
             FROM information_schema.tables
-            WHERE table_schema = '\(schemaLiteral)'
+            WHERE table_schema = \(schemaLiteral)
             ORDER BY table_name
             """
         let result = try await execute(query: query)
@@ -92,7 +92,7 @@ final class RedshiftPluginDriver: LibPQBackedDriver, @unchecked Sendable {
 
         guard isExternalSchema(resolvedSchema) else { return localTables }
 
-        let externalTables = await fetchExternalTables(schemaLiteral: schemaLiteral, schema: resolvedSchema)
+        let externalTables = await fetchExternalTables(schema: resolvedSchema)
         guard !externalTables.isEmpty else { return localTables }
 
         let localNames = Set(localTables.map(\.name))
@@ -100,12 +100,12 @@ final class RedshiftPluginDriver: LibPQBackedDriver, @unchecked Sendable {
         return merged.sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
     }
 
-    private func fetchExternalTables(schemaLiteral: String, schema: String) async -> [PluginTableInfo] {
+    private func fetchExternalTables(schema: String) async -> [PluginTableInfo] {
         do {
             let result = try await execute(
                 query: RedshiftExternalSchemaQueries.listExternalTables(
-                    schemaLiteral: schemaLiteral,
-                    databaseLiteral: escapeLiteral(connectedDatabase)
+                    schema: schema,
+                    database: connectedDatabase
                 )
             )
             return result.rows.compactMap { row -> PluginTableInfo? in
@@ -128,27 +128,19 @@ final class RedshiftPluginDriver: LibPQBackedDriver, @unchecked Sendable {
     func fetchColumns(table: String, schema: String?) async throws -> [PluginColumnInfo] {
         let resolvedSchema = schema ?? core.currentSchema
         if isExternalSchema(resolvedSchema) {
-            let external = await fetchExternalColumns(
-                schemaLiteral: escapeLiteral(resolvedSchema),
-                tableLiteral: escapeLiteral(table),
-                schema: resolvedSchema
-            )
+            let external = await fetchExternalColumns(schema: resolvedSchema, table: table)
             if !external.isEmpty { return external }
         }
         return try await fetchLocalColumns(table: table, schema: resolvedSchema)
     }
 
-    private func fetchExternalColumns(
-        schemaLiteral: String,
-        tableLiteral: String,
-        schema: String
-    ) async -> [PluginColumnInfo] {
+    private func fetchExternalColumns(schema: String, table: String) async -> [PluginColumnInfo] {
         do {
             let result = try await execute(
                 query: RedshiftExternalSchemaQueries.listExternalColumns(
-                    schemaLiteral: schemaLiteral,
-                    tableLiteral: tableLiteral,
-                    databaseLiteral: escapeLiteral(connectedDatabase)
+                    schema: schema,
+                    table: table,
+                    database: connectedDatabase
                 )
             )
             return result.rows.compactMap { row -> PluginColumnInfo? in
@@ -186,11 +178,7 @@ final class RedshiftPluginDriver: LibPQBackedDriver, @unchecked Sendable {
     }
 
     private func fetchLocalColumns(table: String, schema: String) async throws -> [PluginColumnInfo] {
-        let schemaLiteral = escapeLiteral(schema)
-        let query = RedshiftSchemaQueries.columnsQuery(
-            schemaLiteral: schemaLiteral,
-            tableLiteral: escapeLiteral(table)
-        )
+        let query = RedshiftSchemaQueries.columnsQuery(schema: schema, table: table)
         let result = try await execute(query: query)
         return result.rows.compactMap { row -> PluginColumnInfo? in
             guard row.count >= 4,
@@ -236,25 +224,19 @@ final class RedshiftPluginDriver: LibPQBackedDriver, @unchecked Sendable {
     func fetchAllColumns(schema: String?) async throws -> [String: [PluginColumnInfo]] {
         let resolvedSchema = schema ?? core.currentSchema
         if isExternalSchema(resolvedSchema) {
-            let external = await fetchExternalAllColumns(
-                schemaLiteral: escapeLiteral(resolvedSchema),
-                schema: resolvedSchema
-            )
+            let external = await fetchExternalAllColumns(schema: resolvedSchema)
             if !external.isEmpty { return external }
         }
         return try await fetchLocalAllColumns(schema: resolvedSchema)
     }
 
-    private func fetchExternalAllColumns(
-        schemaLiteral: String,
-        schema: String
-    ) async -> [String: [PluginColumnInfo]] {
+    private func fetchExternalAllColumns(schema: String) async -> [String: [PluginColumnInfo]] {
         do {
             let result = try await execute(
                 query: RedshiftExternalSchemaQueries.listExternalColumns(
-                    schemaLiteral: schemaLiteral,
-                    tableLiteral: nil,
-                    databaseLiteral: escapeLiteral(connectedDatabase)
+                    schema: schema,
+                    table: nil,
+                    database: connectedDatabase
                 )
             )
             var allColumns: [String: [PluginColumnInfo]] = [:]
@@ -277,8 +259,7 @@ final class RedshiftPluginDriver: LibPQBackedDriver, @unchecked Sendable {
     }
 
     private func fetchLocalAllColumns(schema: String) async throws -> [String: [PluginColumnInfo]] {
-        let schemaLiteral = escapeLiteral(schema)
-        let query = RedshiftSchemaQueries.columnsQuery(schemaLiteral: schemaLiteral, tableLiteral: nil)
+        let query = RedshiftSchemaQueries.columnsQuery(schema: schema, table: nil)
         let result = try await execute(query: query)
         var allColumns: [String: [PluginColumnInfo]] = [:]
         for row in result.rows {
@@ -326,8 +307,8 @@ final class RedshiftPluginDriver: LibPQBackedDriver, @unchecked Sendable {
     }
 
     func fetchIndexes(table: String, schema: String?) async throws -> [PluginIndexInfo] {
-        let safeTable = escapeLiteral(table)
-        let schemaLiteral = escapeLiteral(schema ?? core.currentSchema)
+        let tableLiteral = PostgreSQLObjectQueries.quoteLiteral(table)
+        let schemaLiteral = PostgreSQLObjectQueries.quoteLiteral(schema ?? core.currentSchema)
         let query = """
             SELECT
                 "column",
@@ -335,8 +316,8 @@ final class RedshiftPluginDriver: LibPQBackedDriver, @unchecked Sendable {
                 distkey,
                 sortkey
             FROM pg_table_def
-            WHERE schemaname = '\(schemaLiteral)'
-              AND tablename = '\(safeTable)'
+            WHERE schemaname = \(schemaLiteral)
+              AND tablename = \(tableLiteral)
               AND (distkey = true OR sortkey != 0)
             ORDER BY sortkey
             """
@@ -366,8 +347,8 @@ final class RedshiftPluginDriver: LibPQBackedDriver, @unchecked Sendable {
 
     func fetchForeignKeys(table: String, schema: String?) async throws -> [PluginForeignKeyInfo] {
         let query = PostgreSQLCatalogForeignKeys.query(
-            schemaLiteral: PostgreSQLObjectQueries.quoteLiteral(schema ?? core.currentSchema),
-            tableLiteral: PostgreSQLObjectQueries.quoteLiteral(table),
+            schema: schema ?? core.currentSchema,
+            table: table,
             excludesPartitionClones: PostgreSQLCatalogForeignKeys.excludesPartitionClones(
                 serverVersionNumber: core.serverVersionNumber
             )
@@ -379,13 +360,13 @@ final class RedshiftPluginDriver: LibPQBackedDriver, @unchecked Sendable {
     func fetchApproximateRowCount(table: String, schema: String?) async throws -> Int? {
         let resolvedSchema = schema ?? core.currentSchema
         guard !isExternalSchema(resolvedSchema) else { return nil }
-        let safeTable = escapeLiteral(table)
-        let schemaLiteral = escapeLiteral(resolvedSchema)
+        let tableLiteral = PostgreSQLObjectQueries.quoteLiteral(table)
+        let schemaLiteral = PostgreSQLObjectQueries.quoteLiteral(resolvedSchema)
         let query = """
             SELECT tbl_rows
             FROM svv_table_info
-            WHERE "table" = '\(safeTable)'
-              AND schema = '\(schemaLiteral)'
+            WHERE "table" = \(tableLiteral)
+              AND schema = \(schemaLiteral)
             """
         let result = try await execute(query: query)
         guard let firstRow = result.rows.first, let value = firstRow[0].asText, let count = Int(value) else { return nil }
@@ -393,9 +374,9 @@ final class RedshiftPluginDriver: LibPQBackedDriver, @unchecked Sendable {
     }
 
     func fetchTableDDL(table: String, schema: String?) async throws -> String {
-        let safeTable = escapeLiteral(table)
+        let tableLiteral = PostgreSQLObjectQueries.quoteLiteral(table)
         let resolvedSchema = schema ?? core.currentSchema
-        let schemaLiteral = escapeLiteral(resolvedSchema)
+        let schemaLiteral = PostgreSQLObjectQueries.quoteLiteral(resolvedSchema)
         let quotedTable = quoteIdentifier(table)
         let quotedSchema = quoteIdentifier(resolvedSchema)
 
@@ -417,8 +398,8 @@ final class RedshiftPluginDriver: LibPQBackedDriver, @unchecked Sendable {
             JOIN pg_class c ON c.oid = a.attrelid
             JOIN pg_namespace n ON n.oid = c.relnamespace
             LEFT JOIN pg_attrdef d ON d.adrelid = c.oid AND d.adnum = a.attnum
-            WHERE c.relname = '\(safeTable)'
-              AND n.nspname = '\(schemaLiteral)'
+            WHERE c.relname = \(tableLiteral)
+              AND n.nspname = \(schemaLiteral)
               AND a.attnum > 0
               AND NOT a.attisdropped
             ORDER BY a.attnum
@@ -483,13 +464,13 @@ final class RedshiftPluginDriver: LibPQBackedDriver, @unchecked Sendable {
     }
 
     func fetchViewDefinition(view: String, schema: String?) async throws -> String {
-        let safeView = escapeLiteral(view)
-        let schemaLiteral = escapeLiteral(schema ?? core.currentSchema)
+        let viewLiteral = PostgreSQLObjectQueries.quoteLiteral(view)
+        let schemaLiteral = PostgreSQLObjectQueries.quoteLiteral(schema ?? core.currentSchema)
         let query = """
             SELECT 'CREATE OR REPLACE VIEW ' || quote_ident(schemaname) || '.' || quote_ident(viewname) || ' AS ' || E'\\n' || definition AS ddl
             FROM pg_views
-            WHERE viewname = '\(safeView)'
-              AND schemaname = '\(schemaLiteral)'
+            WHERE viewname = \(viewLiteral)
+              AND schemaname = \(schemaLiteral)
             """
         let result = try await execute(query: query)
         guard let firstRow = result.rows.first, let ddl = firstRow[0].asText else {
@@ -503,8 +484,8 @@ final class RedshiftPluginDriver: LibPQBackedDriver, @unchecked Sendable {
         guard !isExternalSchema(resolvedSchema) else {
             return PluginTableMetadata(tableName: table, engine: "Redshift External")
         }
-        let safeTable = escapeLiteral(table)
-        let schemaLiteral = escapeLiteral(resolvedSchema)
+        let tableLiteral = PostgreSQLObjectQueries.quoteLiteral(table)
+        let schemaLiteral = PostgreSQLObjectQueries.quoteLiteral(resolvedSchema)
         let query = """
             SELECT
                 tbl_rows,
@@ -513,8 +494,8 @@ final class RedshiftPluginDriver: LibPQBackedDriver, @unchecked Sendable {
                 unsorted,
                 stats_off
             FROM svv_table_info
-            WHERE "table" = '\(safeTable)'
-              AND schema = '\(schemaLiteral)'
+            WHERE "table" = \(tableLiteral)
+              AND schema = \(schemaLiteral)
             """
         let result = try await execute(query: query)
         guard let row = result.rows.first else {
@@ -552,12 +533,12 @@ final class RedshiftPluginDriver: LibPQBackedDriver, @unchecked Sendable {
     }
 
     func fetchDatabaseMetadata(_ database: String) async throws -> PluginDatabaseMetadata {
-        let escapedDbLiteral = escapeLiteral(database)
+        let databaseLiteral = PostgreSQLObjectQueries.quoteLiteral(database)
         let countQuery = """
             SELECT COUNT(DISTINCT "table") AS table_count
             FROM svv_table_info
             WHERE schema NOT IN ('pg_internal', 'pg_catalog', 'information_schema')
-              AND database = '\(escapedDbLiteral)'
+              AND database = \(databaseLiteral)
             """
         let sizeQuery = """
             SELECT SUM(size) FROM svv_table_info WHERE database = current_database()
@@ -651,7 +632,7 @@ final class RedshiftPluginDriver: LibPQBackedDriver, @unchecked Sendable {
     // MARK: - All Tables Metadata
 
     func allTablesMetadataSQL(schema: String?) -> String? {
-        let s = schema ?? currentSchema ?? "public"
+        let schemaLiteral = PostgreSQLObjectQueries.quoteLiteral(schema ?? currentSchema ?? "public")
         return """
         SELECT
             schema,
@@ -663,7 +644,7 @@ final class RedshiftPluginDriver: LibPQBackedDriver, @unchecked Sendable {
             unsorted,
             stats_off
         FROM svv_table_info
-        WHERE schema = '\(s)'
+        WHERE schema = \(schemaLiteral)
         ORDER BY "table"
         """
     }

--- a/Plugins/PostgreSQLDriverPlugin/RedshiftSchemaQueries.swift
+++ b/Plugins/PostgreSQLDriverPlugin/RedshiftSchemaQueries.swift
@@ -10,13 +10,13 @@
 import Foundation
 
 enum RedshiftSchemaQueries {
-    /// Column introspection for one schema. Passing `tableLiteral` restricts the
-    /// result to a single table; passing `nil` returns every table's columns and
-    /// prefixes each row with `table_name`. `schemaLiteral` is the only schema
-    /// source, so the caller resolves the target schema (qualified reference,
-    /// then current schema) before escaping and passing it here.
-    static func columnsQuery(schemaLiteral: String, tableLiteral: String?) -> String {
-        let shape = ColumnQueryShape.fragments(tableLiteral: tableLiteral)
+    /// Column introspection for one schema. Passing `table` restricts the result
+    /// to a single table; passing `nil` returns every table's columns and prefixes
+    /// each row with `table_name`. `schema` is the only schema source, so the
+    /// caller resolves the target schema (qualified reference, then current
+    /// schema) and passes it raw; quoting happens here.
+    static func columnsQuery(schema: String, table: String?) -> String {
+        let shape = ColumnQueryShape.fragments(table: table)
         return """
             SELECT
                 \(shape.selectPrefix)c.column_name,
@@ -34,8 +34,8 @@ enum RedshiftSchemaQueries {
             LEFT JOIN pg_catalog.pg_description pgd
                 ON pgd.objoid = cls.oid
                 AND pgd.objsubid = c.ordinal_position
-            \(ColumnQueryShape.primaryKeyJoin(schemaLiteral: schemaLiteral, fragments: shape))
-            WHERE c.table_schema = '\(schemaLiteral)'\(shape.mainTableFilter)
+            \(ColumnQueryShape.primaryKeyJoin(schema: schema, fragments: shape))
+            WHERE c.table_schema = \(PostgreSQLObjectQueries.quoteLiteral(schema))\(shape.mainTableFilter)
             ORDER BY \(shape.orderBy)
             """
     }

--- a/TableProTests/Plugins/PostgreSQLCatalogForeignKeysTests.swift
+++ b/TableProTests/Plugins/PostgreSQLCatalogForeignKeysTests.swift
@@ -136,8 +136,8 @@ struct PostgreSQLCatalogForeignKeysTests {
     @Test("The query filters on the table's own schema and name and reads both key arrays")
     func queryFiltersOnSchemaAndTable() {
         let query = PostgreSQLCatalogForeignKeys.query(
-            schemaLiteral: "'sales'",
-            tableLiteral: "'orders'",
+            schema: "sales",
+            table: "orders",
             excludesPartitionClones: true
         )
         #expect(query.contains("ns.nspname = 'sales'"))
@@ -150,8 +150,8 @@ struct PostgreSQLCatalogForeignKeysTests {
     @Test("Both branches project every decoded column")
     func branchesProjectEveryColumn() {
         let query = PostgreSQLCatalogForeignKeys.query(
-            schemaLiteral: "'public'",
-            tableLiteral: "'t'",
+            schema: "public",
+            table: "t",
             excludesPartitionClones: false
         )
         let branches = query.components(separatedBy: "UNION ALL")
@@ -170,13 +170,13 @@ struct PostgreSQLCatalogForeignKeysTests {
     @Test("A server without conparentid is never sent the clone filter")
     func cloneFilterOmittedWhenUnsupported() {
         let filtered = PostgreSQLCatalogForeignKeys.query(
-            schemaLiteral: "'public'",
-            tableLiteral: "'t'",
+            schema: "public",
+            table: "t",
             excludesPartitionClones: true
         )
         let plain = PostgreSQLCatalogForeignKeys.query(
-            schemaLiteral: "'public'",
-            tableLiteral: "'t'",
+            schema: "public",
+            table: "t",
             excludesPartitionClones: false
         )
         #expect(filtered.contains("parent.oid = c.conparentid"))

--- a/TableProTests/Plugins/PostgreSQLColumnQueryTests.swift
+++ b/TableProTests/Plugins/PostgreSQLColumnQueryTests.swift
@@ -20,8 +20,8 @@ struct PostgreSQLColumnsQueryTests {
 
     private func singleTable(schema: String, table: String) -> String {
         PostgreSQLSchemaQueries.columnsQuery(
-            schemaLiteral: schema,
-            tableLiteral: table,
+            schema: schema,
+            table: table,
             capabilities: modern,
             includeMaterializedViews: true
         )
@@ -29,8 +29,8 @@ struct PostgreSQLColumnsQueryTests {
 
     private func allTables(schema: String) -> String {
         PostgreSQLSchemaQueries.columnsQuery(
-            schemaLiteral: schema,
-            tableLiteral: nil,
+            schema: schema,
+            table: nil,
             capabilities: legacy,
             includeMaterializedViews: false
         )
@@ -145,8 +145,8 @@ struct PostgreSQLMaterializedViewColumnsQueryTests {
         includeMaterializedViews: Bool = true
     ) -> String {
         PostgreSQLSchemaQueries.columnsQuery(
-            schemaLiteral: schema,
-            tableLiteral: table,
+            schema: schema,
+            table: table,
             capabilities: capabilities ?? modern,
             includeMaterializedViews: includeMaterializedViews
         )
@@ -251,7 +251,7 @@ struct PostgreSQLMaterializedViewColumnsQueryTests {
 struct RedshiftColumnsQueryTests {
     @Test("single-table query filters on the requested schema and table")
     func singleTableFiltersOnRequestedSchema() {
-        let query = RedshiftSchemaQueries.columnsQuery(schemaLiteral: "s2", tableLiteral: "orders")
+        let query = RedshiftSchemaQueries.columnsQuery(schema: "s2", table: "orders")
         #expect(query.contains("WHERE c.table_schema = 's2' AND c.table_name = 'orders'"))
         #expect(query.contains("AND tc.table_schema = 's2'"))
         #expect(query.contains("AND tc.table_name = 'orders'"))
@@ -261,13 +261,13 @@ struct RedshiftColumnsQueryTests {
 
     @Test("a non-active schema is not ignored", arguments: ["s2", "analytics", "public"])
     func nonActiveSchemaThreadsThrough(schema: String) {
-        let query = RedshiftSchemaQueries.columnsQuery(schemaLiteral: schema, tableLiteral: "orders")
+        let query = RedshiftSchemaQueries.columnsQuery(schema: schema, table: "orders")
         #expect(query.contains("c.table_schema = '\(schema)'"))
     }
 
     @Test("all-tables query selects table_name, drops the table filter, and orders by table")
     func allTablesProjectsTableName() {
-        let query = RedshiftSchemaQueries.columnsQuery(schemaLiteral: "s2", tableLiteral: nil)
+        let query = RedshiftSchemaQueries.columnsQuery(schema: "s2", table: nil)
         #expect(query.contains("c.table_name,"))
         #expect(query.contains("WHERE c.table_schema = 's2'"))
         #expect(!query.contains("c.table_name = '"))
@@ -278,7 +278,7 @@ struct RedshiftColumnsQueryTests {
     @Test("primary key columns are matched to the constraint's own table")
     func primaryKeyJoinIsTableScoped() {
         for table in ["orders", nil] {
-            let query = RedshiftSchemaQueries.columnsQuery(schemaLiteral: "s2", tableLiteral: table)
+            let query = RedshiftSchemaQueries.columnsQuery(schema: "s2", table: table)
             #expect(query.contains("AND tc.table_name = kcu.table_name"))
         }
     }
@@ -286,7 +286,7 @@ struct RedshiftColumnsQueryTests {
     @Test("Redshift keeps a single-arm read and never names relkind")
     func redshiftKeepsASingleArmRead() {
         for table in ["orders", nil] {
-            let query = RedshiftSchemaQueries.columnsQuery(schemaLiteral: "s2", tableLiteral: table)
+            let query = RedshiftSchemaQueries.columnsQuery(schema: "s2", table: table)
             #expect(!query.contains("UNION ALL"))
             #expect(!query.contains("relkind"))
         }

--- a/TableProTests/Plugins/PostgreSQLLegacyCatalogQueryTests.swift
+++ b/TableProTests/Plugins/PostgreSQLLegacyCatalogQueryTests.swift
@@ -33,10 +33,10 @@ struct PostgreSQLLegacyCatalogQueryTests {
             PostgreSQLSchemaQueries.checkConstraintsQuery(schema: "public", table: "t"),
             PostgreSQLSchemaQueries.collationList(capabilities: legacy),
             PostgreSQLSchemaQueries.allTablesMetadata(schema: "public"),
-            PostgreSQLPrincipalQueries.databaseGrants(roleLiteral: "r"),
-            PostgreSQLPrincipalQueries.schemaGrants(roleLiteral: "r"),
-            PostgreSQLPrincipalQueries.tableGrants(roleLiteral: "r"),
-            PostgreSQLPrincipalQueries.columnGrants(roleLiteral: "r"),
+            PostgreSQLPrincipalQueries.databaseGrants(role: "r"),
+            PostgreSQLPrincipalQueries.schemaGrants(role: "r"),
+            PostgreSQLPrincipalQueries.tableGrants(role: "r"),
+            PostgreSQLPrincipalQueries.columnGrants(role: "r"),
             PostgreSQLSequenceQueries.sequenceList(schema: "public", dependentOnTable: "orders", source: .sequenceParameters),
             PostgreSQLSchemaQueries.fetchTables(schema: "public", includeMaterializedViews: true, includeForeignTables: true),
             PostgreSQLViewDefinition.catalogQuery(name: "v", schema: "public")
@@ -382,10 +382,10 @@ struct PostgreSQLGrantQueryTests {
     @Test("aclexplode runs in a subquery's select list, which PostgreSQL 9.1 accepts")
     func grantsAvoidLateral() {
         let queries = [
-            PostgreSQLPrincipalQueries.databaseGrants(roleLiteral: "reader"),
-            PostgreSQLPrincipalQueries.schemaGrants(roleLiteral: "reader"),
-            PostgreSQLPrincipalQueries.tableGrants(roleLiteral: "reader"),
-            PostgreSQLPrincipalQueries.columnGrants(roleLiteral: "reader")
+            PostgreSQLPrincipalQueries.databaseGrants(role: "reader"),
+            PostgreSQLPrincipalQueries.schemaGrants(role: "reader"),
+            PostgreSQLPrincipalQueries.tableGrants(role: "reader"),
+            PostgreSQLPrincipalQueries.columnGrants(role: "reader")
         ]
         for sql in queries {
             #expect(!sql.contains("LATERAL"))

--- a/TableProTests/Plugins/PostgreSQLLiteralQuotingTests.swift
+++ b/TableProTests/Plugins/PostgreSQLLiteralQuotingTests.swift
@@ -1,0 +1,215 @@
+//
+//  PostgreSQLLiteralQuotingTests.swift
+//  TableProTests
+//
+
+import Foundation
+import Testing
+
+/// Every catalog statement the PostgreSQL-family plugin builds names objects by literal, and a
+/// catalog name may legally hold a backslash. With `standard_conforming_strings = off` a backslash
+/// inside a plain literal is an escape, so `'a\b'` does not mean `a\b` and `'x\'' OR true--'` ends
+/// after `x'` and leaves `OR true` as SQL. Measured on PostgreSQL 17.11: the first returned no rows
+/// for a schema holding one table, the second turned a one-row listing into 417 rows, every relation
+/// in the database.
+///
+/// `PostgreSQLObjectQueries.quoteLiteral` is the single answer, and these cases pin both halves of
+/// it: an `E''` string whenever the value holds a backslash, and output byte-identical to plain
+/// quote doubling whenever it does not.
+@Suite("PostgreSQL literal quoting")
+struct PostgreSQLLiteralQuotingTests {
+    private static let caps = PostgreSQLCapabilities.assumingModernWhenUnknown(170_000)
+
+    /// Every pure builder in the plugin that names an object by literal, called with one schema and
+    /// one table so a single assertion covers the lot. Redshift and CockroachDB are included: no
+    /// server for either was available, and a name with no backslash is byte-identical on both,
+    /// which is what makes that safe.
+    private static func statements(schema: String, table: String) -> [String] {
+        [
+            PostgreSQLSchemaQueries.fetchTables(
+                schema: schema, includeMaterializedViews: true, includeForeignTables: true
+            ),
+            PostgreSQLSchemaQueries.fetchPartitions(schema: schema, table: table),
+            PostgreSQLSchemaQueries.columnsQuery(
+                schema: schema, table: table, capabilities: caps, includeMaterializedViews: true
+            ),
+            PostgreSQLSchemaQueries.checkConstraintsQuery(schema: schema, table: table),
+            PostgreSQLSchemaQueries.allTablesMetadata(schema: schema),
+            PostgreSQLObjectQueries.routineList(schema: schema, capabilities: caps),
+            PostgreSQLObjectQueries.triggerList(schema: schema, table: table),
+            PostgreSQLObjectQueries.routineDefinitionByName(name: table, schema: schema, arguments: nil),
+            PostgreSQLObjectQueries.userDefinedTypeList(schema: schema, identity: nil, capabilities: caps),
+            PostgreSQLIndexQueries.indexList(schema: schema, table: table),
+            PostgreSQLForeignKeyQueries.foreignKeyList(schema: schema, table: table, capabilities: caps),
+            PostgreSQLSequenceQueries.sequenceList(
+                schema: schema, dependentOnTable: table, source: .sequencesView
+            ),
+            PostgreSQLCatalogForeignKeys.query(schema: schema, table: table, excludesPartitionClones: true),
+            PostgreSQLPrincipalQueries.tables(schema: schema),
+            PostgreSQLPrincipalQueries.columns(schema: schema, table: table),
+            PostgreSQLPrincipalQueries.databaseGrants(role: schema),
+            PostgreSQLPrincipalQueries.schemaGrants(role: schema),
+            PostgreSQLPrincipalQueries.tableGrants(role: schema),
+            PostgreSQLPrincipalQueries.columnGrants(role: schema),
+            PostgreSQLPrincipalQueries.ownsObjects(role: schema),
+            PostgreSQLRelationSQL.concurrentRefreshQuery(name: table, schema: schema),
+            PostgreSQLViewDefinition.catalogQuery(name: table, schema: schema),
+            RedshiftSchemaQueries.columnsQuery(schema: schema, table: table),
+            RedshiftExternalSchemaQueries.listExternalTables(schema: schema, database: table),
+            RedshiftExternalSchemaQueries.listExternalColumns(
+                schema: schema, table: table, database: table
+            ),
+            ColumnQueryShape.primaryKeyJoin(
+                schema: schema, fragments: ColumnQueryShape.fragments(table: table)
+            )
+        ]
+    }
+
+    @Test("A backslash in a catalog name is emitted as an E'' literal")
+    func backslashNamesBecomeEscapeStrings() {
+        for statement in Self.statements(schema: #"a\b"#, table: #"c\d"#) {
+            #expect(statement.contains(#"E'a\\b'"#), "No E-string for the schema in: \(statement)")
+            #expect(!statement.contains(#"'a\b'"#), "A plain literal survived in: \(statement)")
+            #expect(!statement.contains(#"'c\d'"#), "A plain literal survived in: \(statement)")
+        }
+    }
+
+    @Test("A plain name keeps its plain literal")
+    func plainNamesStayPlain() {
+        for statement in Self.statements(schema: "s2", table: "orders") {
+            #expect(statement.contains("'s2'"), "The schema lost its plain literal in: \(statement)")
+        }
+    }
+
+    @Test("An apostrophe in a catalog name is doubled and nothing else")
+    func apostropheNamesAreDoubled() {
+        for statement in Self.statements(schema: "o'brien", table: "d'ev") {
+            #expect(statement.contains("'o''brien'"), "The schema lost its doubled quote in: \(statement)")
+            #expect(!statement.contains("E'o''brien'"), "An apostrophe took an E-string in: \(statement)")
+        }
+    }
+
+    /// The blast-radius guard, stated as the property rather than per call site: for any value
+    /// holding no backslash, `quoteLiteral` emits exactly what plain quote doubling emitted before
+    /// this change, so the only statements that move are the ones that were wrong.
+    @Test("A value without a backslash quotes byte-identically to plain quote doubling")
+    func quotingIsUnchangedWithoutABackslash() {
+        let values = ["", "public", "s2", "orders", "o'brien", "''", "%wild_card%", "Ünïcødé", "a\tb"]
+        for value in values {
+            let doubled = value.replacingOccurrences(of: "'", with: "''")
+            #expect(PostgreSQLObjectQueries.quoteLiteral(value) == "'\(doubled)'")
+        }
+    }
+
+    /// The injection the probe demonstrated. Quote doubling alone wrote
+    /// `schemaname = 'x\'' OR true--'`, whose literal ends after `x'` under the legacy setting, so
+    /// `OR true` ran as SQL and the listing returned every relation in the database.
+    @Test("A quote after a backslash cannot close the literal")
+    func quoteAfterBackslashCannotEscape() {
+        let statement = PostgreSQLSchemaQueries.allTablesMetadata(schema: #"x\' OR true--"#)
+        #expect(statement.contains(#"E'x\\'' OR true--'"#))
+        #expect(!statement.contains(#"'x\'' OR true--'"#))
+        #expect(statement.components(separatedBy: "OR true").count == 2)
+    }
+
+    /// The wildcards go on before the quoting, because an `E` prefix cannot be spliced into the
+    /// middle of a literal.
+    @Test("A search pattern is wrapped in its wildcards and then quoted once")
+    func searchPatternIsQuotedAsAWhole() {
+        #expect(PostgreSQLPrincipalQueries.searchObjects(pattern: "ord", limit: 10).contains("ILIKE '%ord%'"))
+        #expect(
+            PostgreSQLPrincipalQueries.searchObjects(pattern: #"a\b"#, limit: 10)
+                .contains(#"ILIKE E'%a\\b%'"#)
+        )
+    }
+
+    @Test("A NUL is dropped on both arms rather than reaching libpq")
+    func nulIsStripped() {
+        #expect(PostgreSQLObjectQueries.quoteLiteral("a\0b") == "'ab'")
+        #expect(PostgreSQLObjectQueries.quoteLiteral("a\0\\b") == #"E'a\\b'"#)
+        #expect(!PostgreSQLSchemaQueries.allTablesMetadata(schema: "a\0b").contains("\0"))
+    }
+}
+
+/// Nothing at runtime can see a statement that wraps its own quotes around an already-complete
+/// literal: `''E'a\\b''` is valid SQL that matches nothing, and a plain `'\(name)'` only misbehaves
+/// on a server running the legacy setting. So the guard is a source scan, the same shape
+/// `IndexDDLOwnershipTests` and `SyncMapperFieldAccessTests` use.
+@Suite("PostgreSQL literal quoting source scan")
+struct PostgreSQLLiteralQuotingSourceScanTests {
+    /// `PostgreSQLObjectQueries` owns the quoting and is the one file allowed to write the quotes
+    /// itself. `LibPQConnectionString` builds a libpq conninfo string, whose quoting rules are
+    /// libpq's rather than SQL's.
+    private static let quotingOwners: Set<String> = [
+        "PostgreSQLObjectQueries.swift",
+        "LibPQConnectionString.swift"
+    ]
+
+    /// `LibPQDriverCore` carries the `escapeStringLiteral` PluginKit requirement, whose contract is
+    /// inner text for the app and the export plugins to wrap in their own quotes, and
+    /// `LibPQStringConformance` implements it. Both read the session's reported
+    /// `standard_conforming_strings`, so neither may be reached from a statement builder.
+    private static let escapeHelperOwners: Set<String> = [
+        "LibPQDriverCore.swift",
+        "LibPQStringConformance.swift"
+    ]
+
+    private static let pluginDirectory: URL? = {
+        var directory = URL(fileURLWithPath: #filePath)
+        for _ in 0..<3 { directory.deleteLastPathComponent() }
+        let plugin = directory
+            .appendingPathComponent("Plugins")
+            .appendingPathComponent("PostgreSQLDriverPlugin")
+        return FileManager.default.fileExists(atPath: plugin.path) ? plugin : nil
+    }()
+
+    private static func sources() throws -> [(name: String, text: String)] {
+        guard let pluginDirectory else { return [] }
+        let files = try FileManager.default.contentsOfDirectory(
+            at: pluginDirectory, includingPropertiesForKeys: nil)
+        return try files
+            .filter { $0.pathExtension == "swift" }
+            .map { ($0.lastPathComponent, try String(contentsOf: $0, encoding: .utf8)) }
+    }
+
+    @Test("The scan reaches the plugin sources at all")
+    func sourcesAreReachable() throws {
+        let sources = try Self.sources()
+        #expect(!sources.isEmpty, "No PostgreSQL plugin sources found; the guards below would pass vacuously")
+        #expect(sources.contains { $0.name == "PostgreSQLObjectQueries.swift" })
+        #expect(Self.escapeHelperOwners.isSubset(of: Set(sources.map(\.name))))
+    }
+
+    /// A line carrying `message:` is a Swift diagnostic quoting a name for the reader, not SQL.
+    @Test("No file builds a SQL literal by hand")
+    func noHandWrittenLiterals() throws {
+        var offenders: [String] = []
+        for source in try Self.sources() where !Self.quotingOwners.contains(source.name) {
+            for (offset, line) in source.text.components(separatedBy: "\n").enumerated()
+            where line.contains(#"'\("#) && !line.contains("message:") {
+                offenders.append("\(source.name):\(offset + 1)")
+            }
+        }
+
+        #expect(
+            offenders.isEmpty,
+            "These lines quote a literal themselves instead of calling quoteLiteral: \(offenders)"
+        )
+    }
+
+    @Test("No file builds catalog SQL through a session-dependent escape helper")
+    func noSessionDependentEscapeHelpers() throws {
+        let helpers = ["escapeLiteral(", "escapeStringLiteral(", "LibPQStringConformance.escape("]
+        var offenders: [String] = []
+        for source in try Self.sources() where !Self.escapeHelperOwners.contains(source.name) {
+            for helper in helpers where source.text.contains(helper) {
+                offenders.append("\(source.name): \(helper)")
+            }
+        }
+
+        #expect(
+            offenders.isEmpty,
+            "These files reach for an escape helper instead of quoteLiteral: \(offenders)"
+        )
+    }
+}

--- a/TableProTests/Plugins/PostgreSQLPartitionFilterTests.swift
+++ b/TableProTests/Plugins/PostgreSQLPartitionFilterTests.swift
@@ -69,7 +69,7 @@ struct PostgreSQLPartitionFilterTests {
 
     @Test("Partition listing is scoped to one parent in one schema")
     func fetchPartitionsScopesToParent() {
-        let query = PostgreSQLSchemaQueries.fetchPartitions(schemaLiteral: "public", tableLiteral: "orders")
+        let query = PostgreSQLSchemaQueries.fetchPartitions(schema: "public", table: "orders")
         #expect(query.contains("pn.nspname = 'public'"))
         #expect(query.contains("parent.relname = 'orders'"))
         #expect(query.contains("parent.relkind = 'p'"))
@@ -77,13 +77,13 @@ struct PostgreSQLPartitionFilterTests {
 
     @Test("Partition listing sorts the DEFAULT partition last")
     func fetchPartitionsSortsDefaultLast() {
-        let query = PostgreSQLSchemaQueries.fetchPartitions(schemaLiteral: "public", tableLiteral: "orders")
+        let query = PostgreSQLSchemaQueries.fetchPartitions(schema: "public", table: "orders")
         #expect(query.contains("ORDER BY pg_catalog.pg_get_expr(cc.relpartbound, cc.oid) = 'DEFAULT', cc.relname"))
     }
 
     @Test("Partition listing projects relkind so subpartitioned children stay expandable")
     func fetchPartitionsProjectsRelkind() {
-        let query = PostgreSQLSchemaQueries.fetchPartitions(schemaLiteral: "public", tableLiteral: "orders")
+        let query = PostgreSQLSchemaQueries.fetchPartitions(schema: "public", table: "orders")
         #expect(query.contains("SELECT cc.relname, cc.relkind"))
     }
 }

--- a/TableProTests/Plugins/PostgreSQLTypeQueryTests.swift
+++ b/TableProTests/Plugins/PostgreSQLTypeQueryTests.swift
@@ -116,6 +116,8 @@ struct PostgreSQLTypeQueryTests {
         #expect(PostgreSQLObjectQueries.quoteLiteral("it's") == "'it''s'")
         #expect(PostgreSQLObjectQueries.quoteLiteral("back\\slash") == "E'back\\\\slash'")
         #expect(PostgreSQLObjectQueries.quoteLiteral("\\'; DROP TYPE x; --") == "E'\\\\''; DROP TYPE x; --'")
+        #expect(PostgreSQLObjectQueries.quoteLiteral("a\0b") == "'ab'")
+        #expect(PostgreSQLObjectQueries.quoteLiteral("a\0\\b") == "E'a\\\\b'")
 
         let sql = PostgreSQLObjectQueries.userDefinedTypeList(
             schema: "a\\'b", identity: nil, capabilities: .assumingModernWhenUnknown(170_000)

--- a/TableProTests/Plugins/RedshiftExternalObjectsTests.swift
+++ b/TableProTests/Plugins/RedshiftExternalObjectsTests.swift
@@ -16,16 +16,16 @@ struct RedshiftExternalSchemaQueriesTests {
     private var allQueries: [String] {
         [
             RedshiftExternalSchemaQueries.listExternalSchemaNames,
-            RedshiftExternalSchemaQueries.listExternalTables(schemaLiteral: "etl", databaseLiteral: "dev"),
+            RedshiftExternalSchemaQueries.listExternalTables(schema: "etl", database: "dev"),
             RedshiftExternalSchemaQueries.listExternalColumns(
-                schemaLiteral: "etl",
-                tableLiteral: "customers",
-                databaseLiteral: "dev"
+                schema: "etl",
+                table: "customers",
+                database: "dev"
             ),
             RedshiftExternalSchemaQueries.listExternalColumns(
-                schemaLiteral: "etl",
-                tableLiteral: nil,
-                databaseLiteral: "dev"
+                schema: "etl",
+                table: nil,
+                database: "dev"
             ),
         ]
     }
@@ -52,7 +52,7 @@ struct RedshiftExternalSchemaQueriesTests {
 
     @Test("table listing filters on the requested schema and orders by name")
     func tableListingFiltersOnSchema() {
-        let query = RedshiftExternalSchemaQueries.listExternalTables(schemaLiteral: "etl", databaseLiteral: "dev")
+        let query = RedshiftExternalSchemaQueries.listExternalTables(schema: "etl", database: "dev")
         #expect(query.contains("FROM svv_external_tables"))
         #expect(query.contains("WHERE schemaname = 'etl'"))
         #expect(query.contains("ORDER BY tablename"))
@@ -61,20 +61,20 @@ struct RedshiftExternalSchemaQueriesTests {
 
     @Test("every external catalog read is scoped to the connected database")
     func externalReadsAreScopedToDatabase() {
-        let tables = RedshiftExternalSchemaQueries.listExternalTables(schemaLiteral: "etl", databaseLiteral: "dev")
+        let tables = RedshiftExternalSchemaQueries.listExternalTables(schema: "etl", database: "dev")
         #expect(tables.contains("redshift_database_name = 'dev'"))
 
         let single = RedshiftExternalSchemaQueries.listExternalColumns(
-            schemaLiteral: "etl",
-            tableLiteral: "customers",
-            databaseLiteral: "dev"
+            schema: "etl",
+            table: "customers",
+            database: "dev"
         )
         #expect(single.contains("redshift_database_name = 'dev'"))
 
         let all = RedshiftExternalSchemaQueries.listExternalColumns(
-            schemaLiteral: "etl",
-            tableLiteral: nil,
-            databaseLiteral: "dev"
+            schema: "etl",
+            table: nil,
+            database: "dev"
         )
         #expect(all.contains("redshift_database_name = 'dev'"))
     }
@@ -82,9 +82,9 @@ struct RedshiftExternalSchemaQueriesTests {
     @Test("single-table column query filters on the table and orders by column number")
     func singleTableColumnQuery() {
         let query = RedshiftExternalSchemaQueries.listExternalColumns(
-            schemaLiteral: "etl",
-            tableLiteral: "customers",
-            databaseLiteral: "dev"
+            schema: "etl",
+            table: "customers",
+            database: "dev"
         )
         #expect(query.contains("FROM svv_external_columns"))
         #expect(query.contains("WHERE schemaname = 'etl'"))
@@ -97,20 +97,20 @@ struct RedshiftExternalSchemaQueriesTests {
     @Test("all-tables column query prefixes tablename and omits the table filter")
     func allTablesColumnQuery() {
         let query = RedshiftExternalSchemaQueries.listExternalColumns(
-            schemaLiteral: "etl",
-            tableLiteral: nil,
-            databaseLiteral: "dev"
+            schema: "etl",
+            table: nil,
+            database: "dev"
         )
         #expect(query.contains("tablename,"))
         #expect(!query.contains("AND tablename ="))
         #expect(query.contains("ORDER BY tablename, columnnum"))
     }
 
-    @Test("escaped schema literals reach the generated SQL intact")
-    func escapedLiteralsAreInterpolated() {
+    @Test("A raw name with an apostrophe reaches the generated SQL doubled")
+    func rawNamesAreQuoted() {
         let query = RedshiftExternalSchemaQueries.listExternalTables(
-            schemaLiteral: "o''brien",
-            databaseLiteral: "d''ev"
+            schema: "o'brien",
+            database: "d'ev"
         )
         #expect(query.contains("WHERE schemaname = 'o''brien'"))
         #expect(query.contains("redshift_database_name = 'd''ev'"))

--- a/scripts/check-postgres-literal-quoting.sh
+++ b/scripts/check-postgres-literal-quoting.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#
+# Check PostgreSQLObjectQueries.quoteLiteral against a real PostgreSQL server.
+#
+# A catalog name may legally hold a backslash, and with standard_conforming_strings = off a
+# backslash inside a plain literal is an escape. So a name listed as '...' can decode to something
+# else, or end the literal early and leave the rest as SQL. Neither shows up in a unit test, because
+# both depend on a server setting, and neither raises: the first returns no rows and the second
+# returns too many.
+#
+# This builds a schema for every name shape that matters, runs the literal the plugin now emits
+# against a session with the setting off, and compares the row count with the one the plugin
+# emitted before the fix.
+#
+# Usage:
+#   scripts/check-postgres-literal-quoting.sh [host] [port] [user]
+#
+# Needs psql and a reachable PostgreSQL the user may create a database on. Exits non-zero when a
+# quoted literal does not find exactly the one table its schema holds.
+
+set -uo pipefail
+
+HOST="${1:-127.0.0.1}"
+PORT="${2:-5432}"
+USER_NAME="${3:-postgres}"
+SOURCE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/Plugins/PostgreSQLDriverPlugin/PostgreSQLObjectQueries.swift"
+DATABASE="tablepro_literal_quoting_check"
+
+command -v psql > /dev/null || {
+    echo "psql not found" >&2
+    exit 3
+}
+[ -f "$SOURCE" ] || {
+    echo "not found: $SOURCE" >&2
+    exit 3
+}
+
+psql_do() {
+    psql -X -q -h "$HOST" -p "$PORT" -U "$USER_NAME" -d "$1" -v ON_ERROR_STOP=1 "${@:2}"
+}
+
+if ! psql_do postgres -Atc "SELECT 1" > /dev/null 2>&1; then
+    echo "no PostgreSQL at $HOST:$PORT as $USER_NAME" >&2
+    exit 3
+fi
+
+grep -qF "E'" "$SOURCE" || {
+    echo "FAIL: $SOURCE no longer emits an E-string; update this script with the quoting rule" >&2
+    exit 1
+}
+
+VERSION="$(psql_do postgres -Atc "SHOW server_version")"
+echo "Checking literal quoting against PostgreSQL $VERSION at $HOST:$PORT"
+
+psql_do postgres -c "DROP DATABASE IF EXISTS $DATABASE" > /dev/null
+psql_do postgres -c "CREATE DATABASE $DATABASE" > /dev/null
+trap 'psql -X -q -h "$HOST" -p "$PORT" -U "$USER_NAME" -d postgres -c "DROP DATABASE IF EXISTS $DATABASE" > /dev/null 2>&1' EXIT
+
+# Each schema holds exactly one table, so a correct literal always answers 1.
+#   name | plain literal (the old spelling) | E-string (the spelling the plugin now emits)
+CASES=(
+    "plain|'plain'|'plain'"
+    "o'q|'o''q'|'o''q'"
+    "a\\b|'a\\b'|E'a\\\\b'"
+    "x\\' OR true--|'x\\'' OR true--'|E'x\\\\'' OR true--'"
+    "tail\\|'tail\\'|E'tail\\\\'"
+)
+
+for entry in "${CASES[@]}"; do
+    name="${entry%%|*}"
+    psql_do "$DATABASE" -c "CREATE SCHEMA \"${name//\"/\"\"}\"" > /dev/null
+    psql_do "$DATABASE" -c "CREATE TABLE \"${name//\"/\"\"}\".t1 (id int)" > /dev/null
+done
+
+# Counting relations across the whole database is what makes an early-closed literal visible: a
+# predicate the server parsed as OR true answers with every table rather than raising.
+count_for() {
+    PGOPTIONS="-c standard_conforming_strings=off" psql -X -q -A -t \
+        -h "$HOST" -p "$PORT" -U "$USER_NAME" -d "$DATABASE" -c "
+        SELECT count(*)
+        FROM pg_catalog.pg_class c
+        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = $1 AND c.relkind IN ('r', 'p', 'm', 'f')" 2> /dev/null
+}
+
+failures=0
+for entry in "${CASES[@]}"; do
+    rest="${entry#*|}"
+    name="${entry%%|*}"
+    plain="${rest%%|*}"
+    quoted="${rest#*|}"
+
+    before="$(count_for "$plain")"
+    after="$(count_for "$quoted")"
+    [ -n "$before" ] || before="error"
+
+    if [ "$after" = "1" ]; then
+        printf 'ok   %-18s before=%-6s after=%s\n' "$name" "$before" "$after"
+    else
+        printf 'FAIL %-18s before=%-6s after=%s (expected 1)\n' "$name" "$before" "$after"
+        failures=$((failures + 1))
+    fi
+done
+
+if [ "$failures" -gt 0 ]; then
+    echo "$failures literal(s) did not find exactly their own schema; see PostgreSQLObjectQueries.quoteLiteral" >&2
+    exit 1
+fi
+
+echo "Every quoted literal found exactly its own schema on PostgreSQL $VERSION with standard_conforming_strings off."


### PR DESCRIPTION
The PostgreSQL plugin names catalog objects by literal, and it built those literals as `'\(escapeLiteral(value))'`, where `escapeLiteral` doubled quotes and nothing else. A catalog name may legally hold a backslash, and with `standard_conforming_strings = off` a backslash inside a plain literal is an escape. So the literal can decode to the wrong value, or end early and leave the rest of the name as SQL.

## The demonstration

PostgreSQL 17.11, one schema per case, each holding exactly one table, read from a session with `standard_conforming_strings = off` (`PGOPTIONS="-c standard_conforming_strings=off"`). The query is the bulk table listing `fetchAllTableMetadata` sends:

```sql
SELECT count(*) FROM pg_class c
JOIN pg_namespace n ON n.oid = c.relnamespace
WHERE n.nspname = <literal> AND c.relkind IN ('r','p','m','f')
```

| schema | old literal | rows | new literal | rows |
| --- | --- | --- | --- | --- |
| `a\b` | `'a\b'` | **0** | `E'a\\b'` | **1** |
| `x\' OR true--` | `'x\'' OR true--'` | **417** | `E'x\\'' OR true--'` | **1** |
| `tail\` | `'tail\'` | **syntax error** | `E'tail\\'` | **1** |
| `o'q` | `'o''q'` | 1 | `'o''q'` | 1 |
| `plain` | `'plain'` | 1 | `'plain'` | 1 |

The first row is a silent wrong answer: the server logs only `WARNING: nonstandard use of \\ in a string literal` and the listing comes back empty, so the object list looks like an empty schema. The second is injection: the literal ends after `x'`, `OR true` is parsed as SQL, and a one-row listing becomes every relation in the database. The last two rows are the containment: a name with no backslash is quoted byte-for-byte as before.

`scripts/check-postgres-literal-quoting.sh [host] [port] [user]` is that table, automated. It creates a scratch database, runs both spellings of every case, and fails unless each new literal finds exactly the one table its schema holds. The new-literal column is not hand-written: `PostgreSQLLiteralQuotingTests` asserts those exact strings are what the builders emit, so the unit test pins the SQL and the script runs it.

## Why the helper is deleted rather than repaired

`escapeLiteral` returned inner text for the call site to wrap in its own quotes. A setting-independent literal needs the `E` prefix, which sits **outside** those quotes, so no inner-text helper can be correct: it cannot reach the character it needs to emit. Doubling backslashes inside plain quotes is not the alternative either, because that corrupts the value whenever the setting is on.

So the helper is gone from `LibPQBackedDriver` and `PostgreSQLObjectQueries.quoteLiteral` is the single owner of quoting. It returns the whole literal, plain when the value holds no backslash and `E''` when it does, which is exactly what the server's own `quote_literal` emits for the same values. Deleting the helper is also what made the conversion safe to do by hand: every one of the remaining call sites became a compile error, so none could be missed.

`escapeStringLiteral` is untouched. It is a PluginKit requirement whose contract is inner text, and `SQLEscaping.swift`, `SQLRowToStatementConverter.swift`, the SQL export data sources and the MCP bridge all wrap its result in their own quotes. Overriding it would silently corrupt generated `INSERT` SQL.

Relation to #2760, which landed last week: that forces `SET standard_conforming_strings TO on` at connect and tracks the reported value, so `escapeStringLiteral` adapts. It narrowed this a lot, but it makes ~80 catalog literals correct only while a mutable tracked flag still agrees with the server, and it does nothing for the sites that had no escaping at all. `E''` needs no agreement with anything. Two holes it did not reach, both fixed here:

- `PostgreSQLPluginDriver+ColumnReorder.swift` carried its own private `literal()` that doubled quotes with no setting awareness at all, feeding `pg_get_serial_sequence('"schema"."table"', 'column')` in the generated column-reorder script.
- `RedshiftPluginDriver.allTablesMetadataSQL` interpolated the schema raw, with no escaping of any kind. A plain apostrophe was a syntax error there whatever the setting said.

## Shape of the change

Every pure builder now takes the raw name and quotes it itself, so its output is a function of its arguments rather than of connection state. That is what lets a unit test assert anything about it. The rename from `schemaLiteral:`/`tableLiteral:`/`roleLiteral:`/`databaseLiteral:`/`patternLiteral:` to `schema:`/`table:`/`role:`/`database:`/`pattern:` is the mechanism: it forced every caller to be visited, and it removes a real ambiguity, because `PostgreSQLCatalogForeignKeys.query(schemaLiteral:)` meant *already a complete literal* while `PostgreSQLSchemaQueries.columnsQuery(schemaLiteral:)` meant *inner text*, and its tests were passing `"'sales'"` to one and `"s2"` to the other.

Two shapes needed composing before quoting, not quoting in parts:

- `pg_get_serial_sequence('"schema"."table"', 'column')` takes the quoted identifier pair as one literal, so the pair is built first and quoted once.
- `ILIKE '%pattern%'` cannot host an `E` prefix mid-literal, so the wildcards go on and the whole thing is quoted once. LIKE metacharacters in the typed pattern are deliberately left alone and noted as a separate defect: quoting fixes which statement runs, not what the pattern means.

Numbers stay numbers: `SET statement_timeout` now takes the integer unquoted.

`quoteLiteral` also strips NUL now, matching the PluginKit default. libpq takes a NUL-terminated C string, and PostgreSQL rejects `\000` in a literal outright.

## Blast radius

The guard is stated as a property rather than per call site: for any value holding no backslash, `quoteLiteral(v)` equals `"'" + v.replacingOccurrences(of: "'", with: "''") + "'"`, which is byte-for-byte what the old code produced. So the only statements whose text moves are the ones that were wrong. 26 builders are asserted against a plain name, an apostrophe name and a backslash name.

`PostgreSQLLiteralQuotingSourceScanTests` stops the pattern coming back, because nothing at runtime can see it: `''E'a\\b''` is valid SQL that matches nothing, and a plain `'\(name)'` only misbehaves on a server running the legacy setting. It scans every file in the plugin and fails on a hand-written `'\(`, skipping `PostgreSQLObjectQueries.swift` (the owner) and `LibPQConnectionString.swift` (a libpq conninfo string, not SQL), and on any reach for `escapeLiteral(`, `escapeStringLiteral(` or `LibPQStringConformance.escape(` outside the two files that own the PluginKit conformance. It is the shape `IndexDDLOwnershipTests` and `SyncMapperFieldAccessTests` already use.

## Verified

- `verify.sh generate` PASS.
- `verify.sh test` PASS, 144 cases executed, 144 passed, 0 failed, over `PostgreSQLLiteralQuotingTests`, `PostgreSQLLiteralQuotingSourceScanTests`, `PostgreSQLColumnsQueryTests`, `PostgreSQLMaterializedViewColumnsQueryTests`, `RedshiftColumnsQueryTests`, `PostgreSQLPartitionFilterTests`, `PostgreSQLTableListingLadderTests`, `RedshiftExternalSchemaQueriesTests`, `PostgreSQLCatalogForeignKeysTests`, `PostgreSQLTypeQueryTests`, `PostgreSQLLegacyCatalogQueryTests`, `PostgreSQLForeignKeyQueryTests`, `PostgreSQLIndexQueryTests`, `PostgreSQLCheckConstraintColumnTests`, `PostgreSQLSequenceQueryTests`, `PostgreSQLCollationAndMetadataQueryTests`, `PostgreSQLGrantQueryTests`, `PostgreSQLObjectQueryTests`, `LibPQStringConformanceTests`. The run builds the `PostgreSQLDriver` target, so the driver files that are not in the test target compiled too.
- `verify.sh lint TablePro Plugins/PostgreSQLDriverPlugin TableProTests` PASS, 0 violations.
- `shellcheck --severity=warning scripts/check-postgres-literal-quoting.sh` clean.
- `scripts/check-postgres-literal-quoting.sh` green against live PostgreSQL 17.11.

No PluginKit change, so no ABI bump. No docs change: this is escaping correctness with no user-visible feature or setting.

## Not verified

Redshift and CockroachDB have no server here, so their `E''` literals are unexercised. CockroachDB documents escape-string literals; Redshift is unverified. The containment is the property above: a name with no backslash is quoted byte-for-byte as before on both, and a name with one was already broken on both.
