### PR TITLE
fix(datagrid): offer only the structure edits an object's kind accepts (#2726)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Editor Font and Data Grid Font moved to Settings > Editor and Settings > Data & Results, and kept per Mac.
 - Editor font size range of 10 to 24 points everywhere, including zoom.
 - Structure editor options the connected PostgreSQL server does not support left out: generated columns before 12, BRIN before 9.5, and the MySQL-only FULLTEXT and SPATIAL index types.
+- Structure tab read-only on a view, a materialized view, a foreign table or a system table outside PostgreSQL. (#2726)
 
 ### Removed
 
@@ -232,6 +233,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SQL Server parameters sent to the wrong placeholders when a column name holds a question mark.
 - `[` in a SQL Server filter value read as a wildcard.
 - Non-ASCII text turned into `?` by Copy as INSERT, Copy as IN, Preview Referenced Row, compare scripts and column defaults on SQL Server.
+- Structure tab offering column, index and constraint edits that views and materialized views refuse. (#2726)
 
 ### Security
 

--- a/TablePro/Core/Coordinators/QueryExecutionCoordinator+Helpers.swift
+++ b/TablePro/Core/Coordinators/QueryExecutionCoordinator+Helpers.swift
@@ -484,6 +484,7 @@ extension QueryExecutionCoordinator {
             primaryKeyColumns: primaryKeyColumns,
             isEditable: isEditable,
             isView: context.isView,
+            objectType: context.objectType,
             keysResolved: true
         )
     }

--- a/TablePro/Core/Coordinators/QueryExecutionCoordinator+MultiStatement.swift
+++ b/TablePro/Core/Coordinators/QueryExecutionCoordinator+MultiStatement.swift
@@ -80,6 +80,7 @@ extension QueryExecutionCoordinator {
             primaryKeyColumns: [],
             isEditable: resolved.isEditable && producesRows,
             isView: tab.tableContext.isView,
+            objectType: tab.tableContext.objectType,
             keysResolved: false
         )
     }

--- a/TablePro/Core/Plugins/PluginManager+Registration.swift
+++ b/TablePro/Core/Plugins/PluginManager+Registration.swift
@@ -555,6 +555,13 @@ extension PluginManager {
             .structureEditing.foreignKeyEdit ?? .unsupported
     }
 
+    /// The fallback is `.tablesOnly`, never a curated engine's matrix: an engine nobody has measured
+    /// must not be offered an edit on anything but a table.
+    func structureEditMatrix(for databaseType: DatabaseType) -> StructureObjectEditMatrix {
+        PluginMetadataRegistry.shared.snapshot(for: databaseType)?
+            .structureEditing.structureEdits ?? .tablesOnly
+    }
+
     func supportsDropDatabase(for databaseType: DatabaseType) -> Bool {
         PluginMetadataRegistry.shared.snapshot(for: databaseType)?
             .capabilities.supportsDropDatabase ?? false

--- a/TablePro/Core/Plugins/PluginMetadataRegistry+CuratedDefaults.swift
+++ b/TablePro/Core/Plugins/PluginMetadataRegistry+CuratedDefaults.swift
@@ -372,7 +372,9 @@ extension PluginMetadataRegistry {
                 brandColorHex: "#336791",
                 queryLanguageName: "SQL", editorLanguage: .sql,
                 connectionMode: .network, supportsDatabaseSwitching: true,
-                structureEditing: SchemaEditingSupport(columnReorder: .rebuild, foreignKeyEdit: .alter),
+                structureEditing: SchemaEditingSupport(
+                    columnReorder: .rebuild, foreignKeyEdit: .alter, structureEdits: .postgreSQL
+                ),
                 capabilities: PluginMetadataSnapshot.CapabilityFlags(
                     supportsSchemaSwitching: true,
                     supportsImport: true,

--- a/TablePro/Core/Services/Infrastructure/EditorTabOpener.swift
+++ b/TablePro/Core/Services/Infrastructure/EditorTabOpener.swift
@@ -113,6 +113,7 @@ internal enum EditorTabOpener {
                 databaseName: payload.databaseName ?? browseDatabaseName,
                 schemaName: resolvedSchemaName,
                 isView: payload.isView,
+                objectType: payload.objectType,
                 isPreview: payload.isPreview,
                 allowsDuplicate: payload.forcesNewTab
             )
@@ -126,6 +127,7 @@ internal enum EditorTabOpener {
         /// work the user did there while leaving the grid on rows the new filter never ran.
         guard didCreateTab, let index = tabManager.selectedTabIndex else { return }
         tabManager.tabs[index].tableContext.isView = payload.isView
+        tabManager.tabs[index].tableContext.objectType = payload.objectType
         tabManager.tabs[index].tableContext.isEditable = !payload.isView
         tabManager.tabs[index].tableContext.schemaName = resolvedSchemaName
         if payload.showStructure {

--- a/TablePro/Core/Services/Infrastructure/RecentlyClosedTabReopener.swift
+++ b/TablePro/Core/Services/Infrastructure/RecentlyClosedTabReopener.swift
@@ -70,6 +70,7 @@ internal enum RecentlyClosedTabReopener {
             databaseName: tab.tableContext.databaseName,
             schemaName: tab.tableContext.schemaName,
             isView: tab.tableContext.isView,
+            objectType: tab.tableContext.objectType,
             skipAutoExecute: true,
             sourceFileURL: tab.content.sourceFileURL,
             erDiagramSchemaKey: tab.display.erDiagramSchemaKey,

--- a/TablePro/Models/Database/StructureEditEligibility.swift
+++ b/TablePro/Models/Database/StructureEditEligibility.swift
@@ -1,0 +1,268 @@
+//
+//  StructureEditEligibility.swift
+//  TablePro
+//
+
+import Foundation
+import TableProPluginKit
+
+/// One change the Structure tab can ask a server to make.
+///
+/// The vocabulary is per operation rather than per object because the server answers per operation.
+/// Measured on PostgreSQL 17.11: a view takes `RENAME COLUMN`, `SET DEFAULT`, `DROP DEFAULT` and
+/// `COMMENT ON COLUMN` and refuses `ADD COLUMN`, `SET NOT NULL`, `SET DATA TYPE`, `CREATE INDEX` and
+/// every `ADD CONSTRAINT`, while a materialized view takes `CREATE INDEX` and refuses `SET DEFAULT`.
+/// A single read-only flag for the whole object would withhold four edits that work and still offer
+/// several the server always refuses.
+enum StructureEditOperation: Sendable, Hashable, CaseIterable {
+    case addColumn
+    case dropColumn
+    case renameColumn
+    case setNotNull
+    case dropNotNull
+    case setDefault
+    case dropDefault
+    case changeColumnType
+    /// The column attributes an engine can only change by rewriting the whole column definition:
+    /// primary key, auto increment, on update, charset, collation and generated. One case rather
+    /// than six, so none of them is ever gated through a proxy that means something else.
+    case redefineColumn
+    case addIndex
+    case dropIndex
+    case addForeignKey
+    case dropForeignKey
+    case addCheckConstraint
+    case dropCheckConstraint
+    case commentOnColumn
+    case reorderColumns
+
+    /// What the edit is about, which is what a refusal has to explain. A materialized view refuses
+    /// `SET DEFAULT` and `ADD CONSTRAINT FOREIGN KEY` for two different reasons, and one sentence
+    /// covering both would be true of neither.
+    enum Subject: Sendable, Hashable {
+        case columns
+        case columnOrder
+        case indexes
+        case constraints
+    }
+
+    var subject: Subject {
+        switch self {
+        case .addColumn, .dropColumn, .renameColumn, .setNotNull, .dropNotNull, .setDefault,
+             .dropDefault, .changeColumnType, .redefineColumn, .commentOnColumn:
+            return .columns
+        case .reorderColumns:
+            return .columnOrder
+        case .addIndex, .dropIndex:
+            return .indexes
+        case .addForeignKey, .dropForeignKey, .addCheckConstraint, .dropCheckConstraint:
+            return .constraints
+        }
+    }
+}
+
+/// Which structure edits each kind of object accepts on one engine.
+///
+/// Curated per `DatabaseType` in `SchemaEditingSupport` rather than asked of a driver, because the
+/// affordance has to be offered or withheld before the user starts filling a row in, and a
+/// capability the app only learns from a failed statement is far too late for that.
+struct StructureObjectEditMatrix: Sendable, Equatable {
+    private let operationsByKind: [TableInfo.TableType: Set<StructureEditOperation>]
+
+    init(_ operationsByKind: [TableInfo.TableType: Set<StructureEditOperation>]) {
+        self.operationsByKind = operationsByKind
+    }
+
+    func operations(for kind: TableInfo.TableType) -> Set<StructureEditOperation> {
+        operationsByKind[kind] ?? []
+    }
+
+    private static let everyOperation = Set(StructureEditOperation.allCases)
+
+    /// The default for an engine nobody has curated: a real table takes every edit the engine's own
+    /// flags allow, and no other kind takes any. Conservative on purpose. Offering an edit the
+    /// server refuses costs the user a filled-in row and an error at Save; withholding one it would
+    /// have taken costs a trip to the query editor.
+    static let tablesOnly = StructureObjectEditMatrix([
+        .table: everyOperation,
+        .partitionedTable: everyOperation
+    ])
+
+    /// Measured against PostgreSQL 17.11, one statement per cell. A table and a partitioned table
+    /// take all seventeen. A view and a materialized view differ on `SET DEFAULT` and on
+    /// `CREATE INDEX`, which is why one row per kind is the only shape that works. A foreign table
+    /// takes every column change and `ADD CHECK` but refuses `CREATE INDEX`, `FOREIGN KEY` and
+    /// `UNIQUE`. A system table refuses everything with "permission denied: is a system catalog",
+    /// and an external table is a Redshift Spectrum relation whose columns live in another catalog.
+    static let postgreSQL = StructureObjectEditMatrix([
+        .table: everyOperation,
+        .partitionedTable: everyOperation,
+        .view: [.renameColumn, .setDefault, .dropDefault, .commentOnColumn],
+        .materializedView: [.renameColumn, .commentOnColumn, .addIndex, .dropIndex],
+        .foreignTable: [
+            .addColumn, .dropColumn, .renameColumn, .setNotNull, .dropNotNull, .setDefault,
+            .dropDefault, .changeColumnType, .addCheckConstraint, .dropCheckConstraint,
+            .commentOnColumn
+        ],
+        .systemTable: [],
+        .externalTable: []
+    ])
+}
+
+/// Whether the Structure tab may offer one edit right now, and what to say when it may not.
+///
+/// Mirrors `ForeignKeyEditAvailability` so every refusal in this tab carries its own sentence. A
+/// control that dims without saying why reads as a broken app, and a control that stays enabled over
+/// a statement the server always refuses is worse: the user fills the row in first.
+enum StructureEditAvailability: Sendable, Equatable {
+    case available
+
+    case unavailable(reason: String)
+
+    var isAvailable: Bool { self == .available }
+
+    var unavailableReason: String? {
+        if case .unavailable(let reason) = self { return reason }
+        return nil
+    }
+}
+
+/// The single decision about which structure edits an object's kind accepts.
+///
+/// Pure, so the rule is testable without a connection, and ordered: an engine that cannot edit
+/// structure at all says that first, then the object's kind, then the engine's own statement for the
+/// operation. Reading the kind as one `isView` Bool is the defect this replaces, because
+/// `TableInfo.TableType.allowsRowEditing` is true for a materialized view, so the Structure tab
+/// offered `ADD COLUMN`, `SET NOT NULL`, type changes and constraint edits that PostgreSQL always
+/// refuses. (#2726)
+enum StructureEditEligibility {
+    static func allows(
+        _ operation: StructureEditOperation,
+        on kind: TableInfo.TableType,
+        matrix: StructureObjectEditMatrix
+    ) -> Bool {
+        matrix.operations(for: kind).contains(operation)
+    }
+
+    /// Why this kind of object refuses the operation, and nil when it does not.
+    ///
+    /// Handed to `ForeignKeyEditPolicy` and `ColumnReorderPolicy`, which used to decide it from an
+    /// `isTable` Bool and then name a view in the sentence. Only the matrix knows which of seven
+    /// kinds is in front of the user, so only the matrix can word the refusal.
+    static func refusalReason(
+        for operation: StructureEditOperation,
+        on kind: TableInfo.TableType,
+        matrix: StructureObjectEditMatrix
+    ) -> String? {
+        guard !allows(operation, on: kind, matrix: matrix) else { return nil }
+        return reason(operation.subject, kind)
+    }
+
+    static func resolve(
+        _ operation: StructureEditOperation,
+        on kind: TableInfo.TableType,
+        matrix: StructureObjectEditMatrix,
+        engineAllows: Bool,
+        engineName: String,
+        canEditSchema: Bool
+    ) -> StructureEditAvailability {
+        guard canEditSchema else {
+            return .unavailable(
+                reason: String(format: String(localized: "%@ cannot edit a table's structure."), engineName)
+            )
+        }
+        if let refusal = refusalReason(for: operation, on: kind, matrix: matrix) {
+            return .unavailable(reason: refusal)
+        }
+        guard engineAllows else {
+            return .unavailable(reason: engineReason(operation.subject, engineName))
+        }
+        return .available
+    }
+
+    /// Every field of the Columns grid this kind of object lets the user change.
+    ///
+    /// Keyed by field rather than by row, because the refusal is per column attribute: PostgreSQL
+    /// takes a view's `RENAME COLUMN` and `SET DEFAULT` and refuses its `SET NOT NULL` and
+    /// `SET DATA TYPE`, so Name and Default stay editable while Nullable and Type lock.
+    static func editableFields(
+        on kind: TableInfo.TableType,
+        matrix: StructureObjectEditMatrix
+    ) -> Set<StructureColumnField> {
+        let allowed = matrix.operations(for: kind)
+        return Set(StructureColumnField.allCases.filter { field in
+            !operations(expressing: field).isDisjoint(with: allowed)
+        })
+    }
+
+    static func allowsAnyEdit(on kind: TableInfo.TableType, matrix: StructureObjectEditMatrix) -> Bool {
+        !matrix.operations(for: kind).isEmpty
+    }
+
+    /// The operations that can express a change to this field. A field with more than one is
+    /// editable as soon as either statement is accepted, because the grid cannot know in advance
+    /// which direction the user will toggle it.
+    private static func operations(expressing field: StructureColumnField) -> Set<StructureEditOperation> {
+        switch field {
+        case .name: return [.renameColumn]
+        case .type: return [.changeColumnType]
+        case .nullable: return [.setNotNull, .dropNotNull]
+        case .defaultValue: return [.setDefault, .dropDefault]
+        case .comment: return [.commentOnColumn]
+        case .onUpdate, .primaryKey, .autoIncrement, .charset, .collation, .generated,
+             .generationExpression:
+            return [.redefineColumn]
+        @unknown default:
+            /// A field this build does not know is gated behind a full column rewrite, which is the
+            /// narrowest answer available and therefore the safe one.
+            return [.redefineColumn]
+        }
+    }
+
+    /// Why the engine cannot make the change even on a plain table. Worded per subject rather than
+    /// once, because "cannot edit a table's structure" over a dimmed **Add Index** tells the reader
+    /// nothing they could act on.
+    private static func engineReason(_ subject: StructureEditOperation.Subject, _ engineName: String) -> String {
+        switch subject {
+        case .columns:
+            return String(format: String(localized: "%@ cannot make this change to a table's columns."), engineName)
+        case .columnOrder:
+            return String(
+                format: String(localized: "%@ cannot change the order of a table's columns."),
+                engineName
+            )
+        case .indexes:
+            return String(format: String(localized: "%@ cannot add or remove a table's indexes."), engineName)
+        case .constraints:
+            return String(format: String(localized: "%@ cannot add or remove a table's constraints."), engineName)
+        }
+    }
+
+    private static func reason(_ subject: StructureEditOperation.Subject, _ kind: TableInfo.TableType) -> String {
+        let noun = objectNoun(kind)
+        switch subject {
+        case .columns:
+            return String(format: String(localized: "%@ does not accept this column change."), noun)
+        case .columnOrder:
+            return String(format: String(localized: "%@ has no column order of its own to change."), noun)
+        case .indexes:
+            return String(format: String(localized: "%@ cannot have indexes."), noun)
+        case .constraints:
+            return String(format: String(localized: "%@ cannot have constraints."), noun)
+        }
+    }
+
+    /// The object's kind as the subject of a sentence, because every refusal above names it. The
+    /// sidebar's own label is a bare noun ("View"), which reads as a heading rather than a sentence.
+    private static func objectNoun(_ kind: TableInfo.TableType) -> String {
+        switch kind {
+        case .table: return String(localized: "A table")
+        case .partitionedTable: return String(localized: "A partitioned table")
+        case .view: return String(localized: "A view")
+        case .materializedView: return String(localized: "A materialized view")
+        case .foreignTable: return String(localized: "A foreign table")
+        case .systemTable: return String(localized: "A system table")
+        case .externalTable: return String(localized: "An external table")
+        }
+    }
+}

--- a/TablePro/Models/Query/EditorTabPayload.swift
+++ b/TablePro/Models/Query/EditorTabPayload.swift
@@ -37,6 +37,10 @@ internal struct EditorTabPayload: Codable, Hashable {
     internal let initialQuery: String?
     /// Whether this tab displays a database view (read-only)
     internal let isView: Bool
+    /// The object's own kind, which decides which structure edits the tab may offer. Carried beside
+    /// `isView` because that Bool answers a different question and cannot tell a materialized view
+    /// from a table. (#2726)
+    internal let objectType: TableInfo.TableType?
     /// Whether to show the structure view instead of data (for "Show Structure" context menu)
     internal let showStructure: Bool
     /// Whether to skip automatic query execution (used for restored tabs that should lazy-load)
@@ -61,7 +65,7 @@ internal struct EditorTabPayload: Codable, Hashable {
 
     private enum CodingKeys: String, CodingKey {
         case id, connectionId, tabType, tableName, databaseName, schemaName
-        case initialQuery, isView, showStructure, skipAutoExecute, isPreview
+        case initialQuery, isView, objectType, showStructure, skipAutoExecute, isPreview
         case forcesNewTab
         case tabTitle
         case initialFilterState, sourceFileURL, erDiagramSchemaKey, objectRef, intent
@@ -78,6 +82,7 @@ internal struct EditorTabPayload: Codable, Hashable {
         schemaName: String? = nil,
         initialQuery: String? = nil,
         isView: Bool = false,
+        objectType: TableInfo.TableType? = nil,
         showStructure: Bool = false,
         skipAutoExecute: Bool = false,
         isPreview: Bool = false,
@@ -97,6 +102,7 @@ internal struct EditorTabPayload: Codable, Hashable {
         self.schemaName = schemaName
         self.initialQuery = initialQuery
         self.isView = isView
+        self.objectType = objectType
         self.showStructure = showStructure
         self.skipAutoExecute = skipAutoExecute
         self.isPreview = isPreview
@@ -119,6 +125,10 @@ internal struct EditorTabPayload: Codable, Hashable {
         schemaName = try container.decodeIfPresent(String.self, forKey: .schemaName)
         initialQuery = try container.decodeIfPresent(String.self, forKey: .initialQuery)
         isView = try container.decodeIfPresent(Bool.self, forKey: .isView) ?? false
+        /// A raw String, so a spelling a newer build invents decodes to nil rather than throwing and
+        /// losing the whole payload.
+        objectType = try container.decodeIfPresent(String.self, forKey: .objectType)
+            .flatMap(TableInfo.TableType.init(rawValue:))
         showStructure = try container.decodeIfPresent(Bool.self, forKey: .showStructure) ?? false
         skipAutoExecute = try container.decodeIfPresent(Bool.self, forKey: .skipAutoExecute) ?? false
         isPreview = try container.decodeIfPresent(Bool.self, forKey: .isPreview) ?? false
@@ -146,6 +156,7 @@ internal struct EditorTabPayload: Codable, Hashable {
         try container.encodeIfPresent(schemaName, forKey: .schemaName)
         try container.encodeIfPresent(initialQuery, forKey: .initialQuery)
         try container.encode(isView, forKey: .isView)
+        try container.encodeIfPresent(objectType?.rawValue, forKey: .objectType)
         try container.encode(showStructure, forKey: .showStructure)
         try container.encode(skipAutoExecute, forKey: .skipAutoExecute)
         try container.encode(isPreview, forKey: .isPreview)
@@ -168,6 +179,7 @@ internal struct EditorTabPayload: Codable, Hashable {
         self.schemaName = tab.tableContext.schemaName
         self.initialQuery = tab.content.query
         self.isView = tab.tableContext.isView
+        self.objectType = tab.tableContext.objectType
         self.showStructure = tab.display.resultsViewMode == .structure
         self.skipAutoExecute = skipAutoExecute
         self.isPreview = false

--- a/TablePro/Models/Query/QueryTab.swift
+++ b/TablePro/Models/Query/QueryTab.swift
@@ -203,7 +203,8 @@ struct QueryTab: Identifiable, Equatable {
             databaseName: persisted.databaseName,
             schemaName: persisted.schemaName,
             isEditable: persisted.tabType == .table && !persisted.isView,
-            isView: persisted.isView
+            isView: persisted.isView,
+            objectType: persisted.objectTypeRawValue.flatMap(TableInfo.TableType.init(rawValue:))
         )
         self.display = TabDisplayState(
             erDiagramSchemaKey: persisted.erDiagramSchemaKey,
@@ -377,6 +378,7 @@ struct QueryTab: Identifiable, Equatable {
             tabType: tabType,
             tableName: tableContext.tableName,
             isView: tableContext.isView,
+            objectTypeRawValue: tableContext.objectType?.rawValue,
             databaseName: tableContext.databaseName,
             schemaName: tableContext.schemaName,
             sourceFileURL: content.sourceFileURL,
@@ -413,6 +415,7 @@ struct QueryTab: Identifiable, Equatable {
             && lhs.display == rhs.display
             && lhs.tableContext.isEditable == rhs.tableContext.isEditable
             && lhs.tableContext.isView == rhs.tableContext.isView
+            && lhs.tableContext.objectType == rhs.tableContext.objectType
             && lhs.tabType == rhs.tabType
             && lhs.isPreview == rhs.isPreview
             && lhs.hasUserInteraction == rhs.hasUserInteraction

--- a/TablePro/Models/Query/QueryTabManager.swift
+++ b/TablePro/Models/Query/QueryTabManager.swift
@@ -299,6 +299,7 @@ final class QueryTabManager {
         databaseName: String = "",
         schemaName: String? = nil,
         isView: Bool = false,
+        objectType: TableInfo.TableType? = nil,
         isPreview: Bool = false,
         allowsDuplicate: Bool = false,
         quoteIdentifier: ((String) -> String)? = nil
@@ -330,6 +331,7 @@ final class QueryTabManager {
         )
         newTab.pagination = PaginationState(pageSize: pageSize)
         newTab.tableContext.databaseName = databaseName
+        newTab.tableContext.objectType = objectType
         newTab.tableContext.schemaName = schemaName
         newTab.isPreview = isPreview
         tabs.append(newTab)
@@ -445,7 +447,8 @@ final class QueryTabManager {
     @discardableResult
     func replaceTabContent(
         tableName: String, databaseType: DatabaseType = .mysql,
-        isView: Bool = false, databaseName: String = "",
+        isView: Bool = false, objectType: TableInfo.TableType? = nil,
+        databaseName: String = "",
         schemaName: String? = nil, isPreview: Bool = false,
         quoteIdentifier: ((String) -> String)? = nil
     ) throws -> Bool {
@@ -486,6 +489,7 @@ final class QueryTabManager {
         tab.pendingChanges = TabChangeSnapshot()
         tab.hasUserInteraction = false
         tab.tableContext.isView = isView
+        tab.tableContext.objectType = objectType
         tab.tableContext.isEditable = !isView
         tab.filterState = TabFilterState()
         tab.columnLayout = ColumnLayoutState()

--- a/TablePro/Models/Query/QueryTabState.swift
+++ b/TablePro/Models/Query/QueryTabState.swift
@@ -31,6 +31,10 @@ struct PersistedTab: Codable {
     let tabType: TabType
     let tableName: String?
     var isView: Bool = false
+    /// The object's own kind, as its `TableInfo.TableType` raw value. Optional and a raw String so a
+    /// file written before this existed decodes to nil, and a spelling a newer build invents decodes
+    /// to nil too rather than throwing and taking the whole tab aggregate with it.
+    var objectTypeRawValue: String?
     var databaseName: String = ""
     var schemaName: String?
     var sourceFileURL: URL?
@@ -61,6 +65,7 @@ struct PersistedTab: Codable {
         tabType: TabType,
         tableName: String?,
         isView: Bool = false,
+        objectTypeRawValue: String? = nil,
         databaseName: String = "",
         schemaName: String? = nil,
         sourceFileURL: URL? = nil,
@@ -84,6 +89,7 @@ struct PersistedTab: Codable {
         self.tabType = tabType
         self.tableName = tableName
         self.isView = isView
+        self.objectTypeRawValue = objectTypeRawValue
         self.databaseName = databaseName
         self.schemaName = schemaName
         self.sourceFileURL = sourceFileURL
@@ -103,7 +109,7 @@ struct PersistedTab: Codable {
     }
 
     private enum CodingKeys: String, CodingKey {
-        case id, title, query, tabType, tableName, isView, databaseName, schemaName
+        case id, title, query, tabType, tableName, isView, objectTypeRawValue, databaseName, schemaName
         case sourceFileURL, erDiagramSchemaKey, objectRef, queryParameters
         case sortColumns, sortSource, restoredPage, restoredPageSize, cursorOffset, cursorLength
         case collapsedFoldRanges
@@ -119,6 +125,7 @@ struct PersistedTab: Codable {
         tabType = try container.decode(TabType.self, forKey: .tabType)
         tableName = try container.decodeIfPresent(String.self, forKey: .tableName)
         isView = try container.decodeIfPresent(Bool.self, forKey: .isView) ?? false
+        objectTypeRawValue = try container.decodeIfPresent(String.self, forKey: .objectTypeRawValue)
         databaseName = try container.decodeIfPresent(String.self, forKey: .databaseName) ?? ""
         schemaName = try container.decodeIfPresent(String.self, forKey: .schemaName)
         sourceFileURL = try container.decodeIfPresent(URL.self, forKey: .sourceFileURL)
@@ -563,6 +570,22 @@ struct TabTableContext: Equatable {
     var primaryKeyColumns: [String] = []
     var isEditable: Bool = false
     var isView: Bool = false
+
+    /// The object's own kind, carried beside `isView` rather than replacing it.
+    ///
+    /// The two answer different questions. `isView` decides whether the *rows* may be written, which
+    /// a dozen Bool-only carriers already speak (deeplinks, the URL parser, scripting, recents), and
+    /// it comes from `allowsRowEditing`, which is deliberately true for a materialized view because
+    /// a matview does hold rows. This says which of seven kinds the object is, which is the only
+    /// thing that can say which *structure* edits it accepts. Conflating them is the defect. (#2726)
+    ///
+    /// Nil on a tab restored from a file written before this existed, and on any path that never
+    /// learned the kind; `resolvedObjectKind()` falls back to what `isView` can still tell us.
+    var objectType: TableInfo.TableType?
+
+    func resolvedObjectKind() -> TableInfo.TableType {
+        objectType ?? (isView ? .view : .table)
+    }
 
     var primaryKeyColumn: String? { primaryKeyColumns.first }
 

--- a/TablePro/Models/Query/ResultOrigin.swift
+++ b/TablePro/Models/Query/ResultOrigin.swift
@@ -19,6 +19,9 @@ struct ResultOrigin: Equatable {
     var primaryKeyColumns: [String]
     var isEditable: Bool
     var isView: Bool
+    /// The kind of object these rows came from, so a result switched back to restores the tab's
+    /// structure gate rather than the table `isView` alone would imply. (#2726)
+    var objectType: TableInfo.TableType?
 
     /// Whether anything has actually looked up this table's key columns. An empty
     /// `primaryKeyColumns` means two different things: a table that genuinely has no key, which
@@ -33,6 +36,7 @@ struct ResultOrigin: Equatable {
         primaryKeyColumns: [String] = [],
         isEditable: Bool = false,
         isView: Bool = false,
+        objectType: TableInfo.TableType? = nil,
         keysResolved: Bool = false
     ) {
         self.tableName = tableName
@@ -41,6 +45,7 @@ struct ResultOrigin: Equatable {
         self.primaryKeyColumns = primaryKeyColumns
         self.isEditable = isEditable
         self.isView = isView
+        self.objectType = objectType
         self.keysResolved = keysResolved
     }
 }

--- a/TablePro/Models/Query/TabNavigationHistory.swift
+++ b/TablePro/Models/Query/TabNavigationHistory.swift
@@ -24,6 +24,9 @@ struct TabNavigationEntry: Equatable {
     var databaseName: String
     var schemaName: String?
     var isView: Bool
+    /// The object's own kind, so Back and Forward put the tab on a materialized view rather than
+    /// falling back to the table the `isView` Bool cannot distinguish it from. (#2726)
+    var objectType: TableInfo.TableType?
     var resultsViewMode: ResultsViewMode
     var filterState: TabFilterState
     var sortColumns: [PersistedSortColumn]

--- a/TablePro/Models/Schema/ColumnReorderSupport.swift
+++ b/TablePro/Models/Schema/ColumnReorderSupport.swift
@@ -82,23 +82,24 @@ enum ColumnMove {
 /// the drop, while the drag itself was offered unconditionally, so 30 engines lifted the row,
 /// opened the insertion gap, took the drop and did nothing.
 enum ColumnReorderPolicy {
+    /// - Parameter kindRefusal: Why the object's own kind refuses a reorder, nil when it accepts one.
+    ///   Supplied by `StructureEditEligibility`, because only the per-kind matrix knows which of
+    ///   seven object kinds is in front of the user and can therefore word the refusal. (#2726)
     static func resolve(
         support: ColumnReorderSupport,
         engineName: String,
         isColumnsTab: Bool,
-        isTable: Bool,
+        kindRefusal: String?,
         canEditSchema: Bool,
         hasStagedChanges: Bool,
         isRearranged: Bool
     ) -> ColumnReorderAvailability {
         guard isColumnsTab else { return .notApplicable }
         /// Every mechanism emits table DDL, and the SQLite one looks the table up by
-        /// `sqlite_master.type = 'table'`, so a view drag would end in an error rather than an
-        /// explanation. A view's column order comes from its own `SELECT`.
-        guard isTable else {
-            return .unavailable(
-                reason: String(localized: "A view's column order comes from its query. Edit the view to change it.")
-            )
+        /// `sqlite_master.type = 'table'`, so a drag on anything else would end in an error rather
+        /// than an explanation.
+        if let kindRefusal {
+            return .unavailable(reason: kindRefusal)
         }
         guard canEditSchema else {
             return .unavailable(

--- a/TablePro/Models/Schema/ForeignKeyEditSupport.swift
+++ b/TablePro/Models/Schema/ForeignKeyEditSupport.swift
@@ -51,13 +51,29 @@ enum ForeignKeyEditAvailability: Sendable, Equatable {
         if case .unavailable(let reason) = self { return reason }
         return nil
     }
+
+    /// The same answer in the vocabulary the rest of the Structure tab speaks, so one gate can hand
+    /// every call site a single type while this policy stays the owner of the foreign key wording.
+    var structureEditAvailability: StructureEditAvailability {
+        switch self {
+        case .available:
+            return .available
+        case .unavailable(let reason):
+            return .unavailable(reason: reason)
+        }
+    }
 }
 
 enum ForeignKeyEditPolicy {
+    /// - Parameter kindRefusal: Why the object's own kind refuses a foreign key edit, nil when it
+    ///   accepts one. Supplied by `StructureEditEligibility`, because only the per-kind matrix knows
+    ///   which of seven object kinds is in front of the user. This used to be an `isTable` Bool
+    ///   derived from `allowsRowEditing`, which is true for a materialized view, so the "+" was
+    ///   offered over an `ADD CONSTRAINT` PostgreSQL always refuses. (#2726)
     static func resolve(
         support: ForeignKeyEditSupport,
         engineName: String,
-        isTable: Bool,
+        kindRefusal: String?,
         canEditSchema: Bool
     ) -> ForeignKeyEditAvailability {
         guard canEditSchema else {
@@ -65,13 +81,11 @@ enum ForeignKeyEditPolicy {
                 reason: String(format: String(localized: "%@ cannot edit a table's structure."), engineName)
             )
         }
-        /// A view has no constraints of its own, and both mechanisms emit table DDL. The rebuild one
-        /// looks the table up by `sqlite_master.type = 'table'`, so a view would end in an error
-        /// rather than an explanation.
-        guard isTable else {
-            return .unavailable(
-                reason: String(localized: "A view has no foreign keys. Edit the tables its query reads.")
-            )
+        /// Both mechanisms emit table DDL. The rebuild one looks the table up by
+        /// `sqlite_master.type = 'table'`, so anything else would end in an error rather than an
+        /// explanation.
+        if let kindRefusal {
+            return .unavailable(reason: kindRefusal)
         }
         switch support {
         case .unsupported:
@@ -97,4 +111,9 @@ enum ForeignKeyEditPolicy {
 struct SchemaEditingSupport: Sendable, Equatable {
     var columnReorder: ColumnReorderSupport = .unsupported
     var foreignKeyEdit: ForeignKeyEditSupport = .unsupported
+
+    /// Which structure edits each kind of object accepts. Defaults to tables only, so an engine
+    /// nobody has curated never offers a view, materialized view or foreign table an edit its server
+    /// would refuse.
+    var structureEdits: StructureObjectEditMatrix = .tablesOnly
 }

--- a/TablePro/Models/UI/DataGridConfiguration.swift
+++ b/TablePro/Models/UI/DataGridConfiguration.swift
@@ -21,6 +21,13 @@ struct DataGridConfiguration: Equatable {
     var showRowNumbers: Bool = true
     var hiddenColumns: Set<String> = []
 
+    /// Headings whose cells this grid must not let the user change, even though the rest of the grid
+    /// is editable. The Structure tab sets it per object kind: PostgreSQL takes a view's
+    /// `RENAME COLUMN` and `SET DEFAULT` and refuses its `SET NOT NULL` and `SET DATA TYPE`, so Name
+    /// and Default stay open while Nullable and Type lock. Name-keyed because that is the handle
+    /// `isColumnWritable` already works in. (#2726)
+    var lockedColumns: Set<String> = []
+
     /// This grid shows rows of a result, so the Data Grid sort preferences apply to it.
     ///
     /// `tabType` cannot answer this: the Structure grid runs inside a `.table` tab and lists columns,

--- a/TablePro/Views/Main/Child/MainEditorContentView.swift
+++ b/TablePro/Views/Main/Child/MainEditorContentView.swift
@@ -665,7 +665,6 @@ struct MainEditorContentView: View {
                     connection: connection,
                     databaseName: scope?.database ?? "",
                     schemaName: scope?.schema,
-                    isViewObject: tab.tableContext.isView,
                     toolbarState: coordinator.toolbarState,
                     coordinator: coordinator,
                     selectionState: selectionState,
@@ -679,7 +678,8 @@ struct MainEditorContentView: View {
                             connection: connection,
                             databaseName: scope?.database ?? "",
                             schemaName: scope?.schema,
-                            tableName: tableName
+                            tableName: tableName,
+                            objectKind: tab.tableContext.resolvedObjectKind()
                         )
                     }
             }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Navigation.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Navigation.swift
@@ -34,6 +34,7 @@ extension MainContentCoordinator {
             schema: schema ?? table.schema,
             showStructure: showStructure,
             isView: !table.type.allowsRowEditing,
+            objectType: table.type,
             forceNonPreview: forceNonPreview,
             activateGridFocus: activateGridFocus,
             forceNewTab: forceNewTab
@@ -46,6 +47,7 @@ extension MainContentCoordinator {
         schema: String? = nil,
         showStructure: Bool = false,
         isView: Bool = false,
+        objectType: TableInfo.TableType? = nil,
         forceNonPreview: Bool = false,
         activateGridFocus: Bool = false,
         forceNewTab: Bool = false
@@ -97,6 +99,7 @@ extension MainContentCoordinator {
                 currentDatabase: currentDatabase,
                 resolvedSchema: resolvedSchema,
                 isView: isView,
+                objectType: objectType,
                 createAsPreview: createAsPreview,
                 isInPlace: navigationModel == .inPlace
             )
@@ -150,6 +153,7 @@ extension MainContentCoordinator {
                 currentDatabase: currentDatabase,
                 resolvedSchema: resolvedSchema,
                 isView: isView,
+                objectType: objectType,
                 showStructure: showStructure,
                 createAsPreview: createAsPreview
             )
@@ -168,6 +172,7 @@ extension MainContentCoordinator {
             databaseName: currentDatabase,
             schemaName: resolvedSchema,
             isView: isView,
+            objectType: objectType,
             showStructure: showStructure,
             isPreview: createAsPreview,
             forcesNewTab: forceNewTab
@@ -233,6 +238,7 @@ extension MainContentCoordinator {
         currentDatabase: String,
         resolvedSchema: String?,
         isView: Bool,
+        objectType: TableInfo.TableType?,
         createAsPreview: Bool,
         isInPlace: Bool
     ) -> Bool {
@@ -243,6 +249,7 @@ extension MainContentCoordinator {
                 databaseName: currentDatabase,
                 schemaName: resolvedSchema,
                 isView: isView,
+                objectType: objectType,
                 isPreview: createAsPreview
             )
         } catch {
@@ -260,6 +267,7 @@ extension MainContentCoordinator {
             TableLoadTracer.shared.stage(.addFirstTab, token: token)
             tabManager.mutate(at: tabIndex) { tab in
                 tab.tableContext.isView = isView
+                tab.tableContext.objectType = objectType
                 tab.tableContext.isEditable = !isView
                 tab.tableContext.schemaName = resolvedSchema
                 tab.pagination.reset()
@@ -281,6 +289,7 @@ extension MainContentCoordinator {
         currentDatabase: String,
         resolvedSchema: String?,
         isView: Bool,
+        objectType: TableInfo.TableType?,
         showStructure: Bool,
         createAsPreview: Bool
     ) -> Bool {
@@ -316,6 +325,7 @@ extension MainContentCoordinator {
                 tableName: tableName,
                 databaseType: connection.type,
                 isView: isView,
+                objectType: objectType,
                 databaseName: currentDatabase,
                 schemaName: resolvedSchema,
                 isPreview: createAsPreview

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+NavigationHistory.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+NavigationHistory.swift
@@ -66,6 +66,7 @@ extension MainContentCoordinator {
             databaseName: tab.tableContext.databaseName,
             schemaName: tab.tableContext.schemaName,
             isView: tab.tableContext.isView,
+            objectType: tab.tableContext.objectType,
             resultsViewMode: tab.display.resultsViewMode,
             filterState: tab.filterState,
             sortColumns: tab.sortState.persistedColumns,
@@ -170,6 +171,7 @@ extension MainContentCoordinator {
                 tableName: entry.tableName,
                 databaseType: connection.type,
                 isView: entry.isView,
+                objectType: entry.objectType,
                 databaseName: entry.databaseName,
                 schemaName: entry.schemaName
             )

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+TableRowsMutation.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+TableRowsMutation.swift
@@ -113,6 +113,7 @@ extension MainContentCoordinator {
             tab.tableContext.primaryKeyColumns = origin?.primaryKeyColumns ?? []
             tab.tableContext.isEditable = origin?.isEditable ?? false
             tab.tableContext.isView = origin?.isView ?? false
+            tab.tableContext.objectType = origin?.objectType
             tab.schemaVersion += 1
         }
         let tab = tabManager.tabs[tabIdx]

--- a/TablePro/Views/Results/DataGridCoordinator.swift
+++ b/TablePro/Views/Results/DataGridCoordinator.swift
@@ -38,6 +38,9 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
     var changeManager: AnyChangeManager
     var isEditable: Bool
     var editRefusalMessage: String?
+    /// Headings this grid must refuse an edit for while the rest of it stays editable. See
+    /// `DataGridConfiguration.lockedColumns`.
+    var lockedColumns: Set<String> = []
     var valueFilteredIDs: [RowID]? { didSet { bumpDisplayRevision() } }
     /// Ticks whenever the displayed row order or the value filter changes.
     ///
@@ -245,6 +248,7 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
         }
         self.isEditable = isEditable
         editRefusalMessage = configuration.editRefusalMessage
+        lockedColumns = configuration.lockedColumns
         tableView?.toolTip = isEditable ? nil : configuration.editRefusalMessage
         dropdownColumns = configuration.dropdownColumns
         typePickerColumns = configuration.typePickerColumns

--- a/TablePro/Views/Results/Extensions/DataGridView+Editing.swift
+++ b/TablePro/Views/Results/Extensions/DataGridView+Editing.swift
@@ -47,6 +47,7 @@ extension TableViewCoordinator {
     /// statement can carry, so Set NULL on a MongoDB `_id`, a generated column or a
     /// `GENERATED ALWAYS AS IDENTITY` column marked the row edited and then wrote nothing.
     func isColumnWritable(_ columnName: String) -> Bool {
+        guard !lockedColumns.contains(columnName) else { return false }
         guard !changeManager.generatedColumns.contains(columnName) else { return false }
         let immutable = databaseType.map { PluginManager.shared.immutableColumns(for: $0) } ?? []
         return !immutable.contains(columnName)
@@ -66,9 +67,24 @@ extension TableViewCoordinator {
     /// A grid that will not take a keystroke and says nothing reads as broken. When the refusal has
     /// a reason the pointer already carries it as the grid's tooltip, and the beep is AppKit's own
     /// way of saying the attempt was heard and declined.
-    func refuseEditIfExplained() {
+    ///
+    /// A locked column beeps too. The rest of its grid is editable, so there is no grid-wide tooltip
+    /// to carry the reason, and a cell that swallowed the keystroke in silence would read as a dead
+    /// grid rather than a refusal. The explanation is on the dimmed pair under the list. (#2726)
+    func refuseEditIfExplained(columnIndex: Int? = nil) {
+        if let columnIndex, isLockedColumn(at: columnIndex) {
+            NSSound.beep()
+            return
+        }
         guard !isEditable, editRefusalMessage != nil else { return }
         NSSound.beep()
+    }
+
+    private func isLockedColumn(at columnIndex: Int) -> Bool {
+        guard !lockedColumns.isEmpty else { return false }
+        let columns = tableRowsProvider().columns
+        guard columnIndex >= 0, columnIndex < columns.count else { return false }
+        return lockedColumns.contains(columns[columnIndex])
     }
 
     func beginCellEdit(row: Int, tableColumnIndex: Int) {
@@ -78,7 +94,7 @@ extension TableViewCoordinator {
         guard column.identifier != ColumnIdentitySchema.rowNumberIdentifier else { return }
         guard let columnIndex = dataColumnIndex(from: column.identifier) else { return }
         guard case .editable(let value) = editEligibility(row: row, columnIndex: columnIndex) else {
-            refuseEditIfExplained()
+            refuseEditIfExplained(columnIndex: columnIndex)
             return
         }
         showOverlayEditor(

--- a/TablePro/Views/Structure/StructureEditGate.swift
+++ b/TablePro/Views/Structure/StructureEditGate.swift
@@ -1,0 +1,112 @@
+//
+//  StructureEditGate.swift
+//  TablePro
+//
+//  What the Structure tab may offer for one connection and one object.
+//
+
+import Foundation
+import TableProPluginKit
+
+/// The Structure tab's single answer to "may this edit be offered on this object".
+///
+/// One value rather than a flag per call site, because the footer pair, the grid's own keyboard and
+/// context-menu paths, the reorder drag and the per-column lock all have to agree. They did not: the
+/// footer read the engine's capability flags, the grid delegate read them again in its own guards,
+/// and only the foreign key and reorder policies asked about the object at all, as
+/// `isTable: !isViewObject`, which cannot say that a materialized view takes `CREATE INDEX` and
+/// refuses `SET DEFAULT`. (#2726)
+@MainActor
+struct StructureEditGate {
+    let databaseType: DatabaseType
+    let objectKind: TableInfo.TableType
+
+    private var matrix: StructureObjectEditMatrix {
+        PluginManager.shared.structureEditMatrix(for: databaseType)
+    }
+
+    private var canEditSchema: Bool { databaseType.supportsSchemaEditing }
+
+    func allows(_ operation: StructureEditOperation) -> Bool {
+        resolve(operation).isAvailable
+    }
+
+    func resolve(_ operation: StructureEditOperation) -> StructureEditAvailability {
+        /// The foreign key arm is answered by `ForeignKeyEditPolicy`, which also owns the `.alter`
+        /// versus `.rebuild` distinction the save itself reads, and which words an engine's refusal
+        /// as "cannot add or remove a table's foreign keys" rather than the sentence every other
+        /// constraint shares. Routing it through here rather than beside here is what keeps every
+        /// call site asking one object.
+        if operation == .addForeignKey || operation == .dropForeignKey {
+            return foreignKeyAvailability.structureEditAvailability
+        }
+        return StructureEditEligibility.resolve(
+            operation,
+            on: objectKind,
+            matrix: matrix,
+            engineAllows: engineSupports(operation),
+            engineName: databaseType.displayName,
+            canEditSchema: canEditSchema
+        )
+    }
+
+    var foreignKeyAvailability: ForeignKeyEditAvailability {
+        ForeignKeyEditPolicy.resolve(
+            support: PluginManager.shared.foreignKeyEditSupport(for: databaseType),
+            engineName: databaseType.displayName,
+            kindRefusal: kindRefusal(.addForeignKey),
+            canEditSchema: canEditSchema
+        )
+    }
+
+    /// Why the object's kind refuses the operation, ignoring the engine. Handed to
+    /// `ForeignKeyEditPolicy` and `ColumnReorderPolicy`, which own the engine half of the same
+    /// decision and would otherwise have to word a refusal about a kind they cannot see.
+    func kindRefusal(_ operation: StructureEditOperation) -> String? {
+        StructureEditEligibility.refusalReason(for: operation, on: objectKind, matrix: matrix)
+    }
+
+    /// Every field of the Columns grid this object lets the user change. A view keeps Name, Default
+    /// and Comment editable while Nullable, Type and the rest lock, because that is what PostgreSQL
+    /// accepts on one.
+    var editableColumnFields: Set<StructureColumnField> {
+        guard canEditSchema else { return [] }
+        return StructureEditEligibility.editableFields(on: objectKind, matrix: matrix)
+    }
+
+    var allowsAnyEdit: Bool {
+        canEditSchema && StructureEditEligibility.allowsAnyEdit(on: objectKind, matrix: matrix)
+    }
+
+    /// Whether the engine has a statement for this operation at all, which is a different question
+    /// from whether the object's kind accepts it. An engine with no `ADD CONSTRAINT … FOREIGN KEY`
+    /// refuses it on a plain table too.
+    ///
+    /// Exhaustive on purpose. The column attribute changes carry no capability flag of their own and
+    /// are covered by `supportsSchemaEditing`, so a `default:` arm here would silently swallow a new
+    /// operation that does need one.
+    private func engineSupports(_ operation: StructureEditOperation) -> Bool {
+        switch operation {
+        case .addColumn:
+            return databaseType.supportsAddColumn
+        case .dropColumn:
+            return databaseType.supportsDropColumn
+        case .addIndex:
+            return databaseType.supportsAddIndex
+        case .dropIndex:
+            return databaseType.supportsDropIndex
+        case .addForeignKey, .dropForeignKey:
+            /// `resolve` answers these through `ForeignKeyEditPolicy` before reaching here. Stated
+            /// anyway so this switch stays total over the operations, which is what makes a new one
+            /// fail to compile until somebody decides its engine half.
+            return PluginManager.shared.foreignKeyEditSupport(for: databaseType).isEditable
+        case .addCheckConstraint, .dropCheckConstraint:
+            return databaseType.supportsCheckConstraintEditing
+        case .reorderColumns:
+            return PluginManager.shared.columnReorderSupport(for: databaseType) != .unsupported
+        case .renameColumn, .setNotNull, .dropNotNull, .setDefault, .dropDefault,
+             .changeColumnType, .redefineColumn, .commentOnColumn:
+            return true
+        }
+    }
+}

--- a/TablePro/Views/Structure/StructureEditingSession.swift
+++ b/TablePro/Views/Structure/StructureEditingSession.swift
@@ -43,6 +43,10 @@ internal final class StructureEditingSession {
     internal let schemaName: String?
     internal let tableName: String
 
+    /// What kind of object this session edits, which decides which edits it may offer at all. A tab
+    /// retargeted to another object gets a new session, so this never has to change under a session.
+    internal let objectKind: TableInfo.TableType
+
     internal let changeManager = StructureChangeManager()
 
     /// Built here, not seeded into the view's `@State`. `State(wrappedValue:)` runs only the first
@@ -105,18 +109,21 @@ internal final class StructureEditingSession {
         connection: DatabaseConnection,
         databaseName: String,
         schemaName: String?,
-        tableName: String
+        tableName: String,
+        objectKind: TableInfo.TableType = .table
     ) {
         self.identity = identity
         self.connection = connection
         self.databaseName = databaseName
         self.schemaName = schemaName
         self.tableName = tableName
+        self.objectKind = objectKind
         gridDelegate = StructureGridDelegate(
             structureChangeManager: changeManager,
             selectedTab: .columns,
             connection: connection,
             tableName: tableName,
+            objectKind: objectKind,
             coordinator: nil
         )
         gridDelegate.referenceMenus.schemaName = schemaName

--- a/TablePro/Views/Structure/StructureFooterPolicy.swift
+++ b/TablePro/Views/Structure/StructureFooterPolicy.swift
@@ -1,0 +1,90 @@
+//
+//  StructureFooterPolicy.swift
+//  TablePro
+//
+//  What the add/remove pair under a structure list offers, and why it is dimmed when it is.
+//
+
+import Foundation
+import TableProPluginKit
+
+/// The single decision behind the "+" and "-" under the Structure tab's list.
+///
+/// Pure and SwiftUI-free so the rule is testable, and one function so the label, the enabled state
+/// and the tooltip can never disagree. They did: the labels came from one switch, the enabled state
+/// from a second that read engine capability flags alone, and the tooltip from a third that returned
+/// nil for every tab but Foreign Keys. So a view offered an enabled "Add Column" over an
+/// `ALTER TABLE … ADD COLUMN` PostgreSQL always refuses, with nothing to explain it. (#2726)
+enum StructureFooterPolicy {
+    /// Nil for a tab with nothing to add: DDL is text, Parts is read-only, and a trigger is created
+    /// through its own editor rather than by typing a row.
+    static func operation(forAdding tab: StructureTab) -> StructureEditOperation? {
+        switch tab {
+        case .columns: return .addColumn
+        case .indexes: return .addIndex
+        case .foreignKeys: return .addForeignKey
+        case .checkConstraints: return .addCheckConstraint
+        case .ddl, .parts, .triggers: return nil
+        }
+    }
+
+    static func operation(forRemoving tab: StructureTab) -> StructureEditOperation? {
+        switch tab {
+        case .columns: return .dropColumn
+        case .indexes: return .dropIndex
+        case .foreignKeys: return .dropForeignKey
+        case .checkConstraints: return .dropCheckConstraint
+        case .ddl, .parts, .triggers: return nil
+        }
+    }
+
+    static func labels(for tab: StructureTab) -> (add: String, remove: String)? {
+        switch tab {
+        case .columns:
+            return (String(localized: "Add Column"), String(localized: "Remove Column"))
+        case .indexes:
+            return (String(localized: "Add Index"), String(localized: "Remove Index"))
+        case .foreignKeys:
+            return (String(localized: "Add Foreign Key"), String(localized: "Remove Foreign Key"))
+        case .checkConstraints:
+            return (String(localized: "Add Check Constraint"), String(localized: "Remove Check Constraint"))
+        case .ddl, .parts, .triggers:
+            return nil
+        }
+    }
+
+    /// - Parameter resolve: The full availability of one operation, which the caller supplies because
+    ///   it owns the connection the engine half of the answer comes from.
+    ///
+    /// A refusing object kind keeps the pair on screen and dims it with the reason, the way the
+    /// Foreign Keys tab already did. An engine that cannot edit structure at all hides it instead:
+    /// there is nothing to explain per object when the whole tab is read-only.
+    static func resolve(
+        tab: StructureTab,
+        canEditSchema: Bool,
+        hasSelection: Bool,
+        resolve: (StructureEditOperation) -> StructureEditAvailability
+    ) -> StructureFooterCapability {
+        guard canEditSchema,
+              let labels = labels(for: tab),
+              let adding = operation(forAdding: tab),
+              let removing = operation(forRemoving: tab)
+        else {
+            return StructureFooterCapability()
+        }
+
+        let addAvailability = resolve(adding)
+        let removeAvailability = resolve(removing)
+
+        return StructureFooterCapability(
+            canAdd: addAvailability.isAvailable,
+            canRemove: hasSelection && removeAvailability.isAvailable,
+            addLabel: labels.add,
+            removeLabel: labels.remove,
+            /// Never the absence of a selection. The pair dims while nothing is selected on every
+            /// tab and on every engine, which needs no sentence; only a refusal the user could not
+            /// have predicted does.
+            unavailableReason: addAvailability.unavailableReason ?? removeAvailability.unavailableReason
+        )
+    }
+}

--- a/TablePro/Views/Structure/StructureGridDelegate.swift
+++ b/TablePro/Views/Structure/StructureGridDelegate.swift
@@ -14,13 +14,31 @@ final class StructureGridDelegate: DataGridViewDelegate {
     var selectedTab: StructureTab
     let connection: DatabaseConnection
 
-    /// Whether this engine can add and remove foreign keys, which is not the same question as
-    /// whether it has them. Every path that stages a foreign key change reads this, not just the
-    /// button under the list: a context-menu Delete that stages one on an engine with no way to
-    /// apply it only fails later, at Save.
+    /// What kind of object this grid is editing. The footer pair is not the only way in: the Edit
+    /// menu's Add Row, the grid's own shortcut, the row context menu and the empty-space menu all
+    /// reach the methods below directly, so each of them asks the same gate rather than trusting a
+    /// button to have been dimmed. (#2726)
+    let objectKind: TableInfo.TableType
+
+    /// The single answer to "may this edit be offered", shared with the view that presents this grid.
+    var editGate: StructureEditGate {
+        StructureEditGate(databaseType: connection.type, objectKind: objectKind)
+    }
+
+    /// Whether this engine can add and remove foreign keys on this object, which is not the same
+    /// question as whether the engine has them. `supportsForeignKeys` answers the second, and reading
+    /// it as the first is what offered an enabled "+" on SQLite over a driver with no statement
+    /// behind it. Every path that stages a foreign key change reads this, not just the button under
+    /// the list: a context-menu Delete that stages one with no way to apply it only fails at Save.
     var canEditForeignKeys: Bool {
-        PluginManager.shared.foreignKeyEditSupport(for: connection.type).isEditable
-            && connection.type.supportsSchemaEditing
+        editGate.allows(.addForeignKey)
+    }
+
+    /// Whether a new row may be staged on the list the user is looking at. Paste and Duplicate stage
+    /// the same add the "+" does, so they answer to the same gate rather than to the pasteboard alone.
+    var canStageAddForSelectedTab: Bool {
+        guard let adding = StructureFooterPolicy.operation(forAdding: selectedTab) else { return false }
+        return editGate.allows(adding)
     }
     let tableName: String
     /// The lists behind the Foreign Keys grid's reference cells, shared with the Create Table tab.
@@ -58,12 +76,14 @@ final class StructureGridDelegate: DataGridViewDelegate {
         selectedTab: StructureTab,
         connection: DatabaseConnection,
         tableName: String,
+        objectKind: TableInfo.TableType = .table,
         coordinator: MainContentCoordinator?
     ) {
         self.structureChangeManager = structureChangeManager
         self.selectedTab = selectedTab
         self.connection = connection
         self.tableName = tableName
+        self.objectKind = objectKind
         self.coordinator = coordinator
         self.referenceMenus = ForeignKeyReferenceMenus(connectionId: connection.id)
     }
@@ -137,7 +157,7 @@ final class StructureGridDelegate: DataGridViewDelegate {
             }
 
         case .checkConstraints:
-            guard connection.type.supportsCheckConstraintEditing,
+            guard editGate.allows(.addCheckConstraint),
                   sourceRowIndex < structureChangeManager.workingCheckConstraints.count else { return }
             var constraint = structureChangeManager.workingCheckConstraints[sourceRowIndex]
             StructureEditingSupport.updateCheckConstraint(&constraint, at: column, with: newValue ?? "")
@@ -177,7 +197,7 @@ final class StructureGridDelegate: DataGridViewDelegate {
 
         switch selectedTab {
         case .columns:
-            guard connection.type.supportsDropColumn else { return }
+            guard editGate.allows(.dropColumn) else { return }
             structureChangeManager.performAsOneUndoStep {
                 for row in translated.sorted(by: >) {
                     guard row < structureChangeManager.workingColumns.count else { continue }
@@ -186,7 +206,7 @@ final class StructureGridDelegate: DataGridViewDelegate {
                 }
             }
         case .indexes:
-            guard connection.type.supportsDropIndex else { return }
+            guard editGate.allows(.dropIndex) else { return }
             structureChangeManager.performAsOneUndoStep {
                 for row in translated.sorted(by: >) {
                     guard row < structureChangeManager.workingIndexes.count else { continue }
@@ -204,7 +224,7 @@ final class StructureGridDelegate: DataGridViewDelegate {
                 }
             }
         case .checkConstraints:
-            guard connection.type.supportsCheckConstraintEditing else { return }
+            guard editGate.allows(.addCheckConstraint) else { return }
             structureChangeManager.performAsOneUndoStep {
                 for row in translated.sorted(by: >) {
                     guard row < structureChangeManager.workingCheckConstraints.count else { continue }
@@ -315,6 +335,7 @@ final class StructureGridDelegate: DataGridViewDelegate {
     }
 
     func dataGridPasteRows() {
+        guard canStageAddForSelectedTab else { return }
         guard let data = NSPasteboard.general.data(forType: TableStructureView.structurePasteboardType),
               let jsonString = String(data: data, encoding: .utf8) else {
             return
@@ -348,10 +369,9 @@ final class StructureGridDelegate: DataGridViewDelegate {
             }
 
         case .checkConstraints:
-            guard connection.type.supportsCheckConstraintEditing,
-                  let constraints = try? decoder.decode(
-                      [EditableCheckConstraintDefinition].self, from: Data(jsonString.utf8)
-                  ) else {
+            guard let constraints = try? decoder.decode(
+                [EditableCheckConstraintDefinition].self, from: Data(jsonString.utf8)
+            ) else {
                 return
             }
             for item in constraints {
@@ -380,18 +400,15 @@ final class StructureGridDelegate: DataGridViewDelegate {
     }
 
     func dataGridAddRow() {
+        guard canStageAddForSelectedTab else { return }
         switch selectedTab {
         case .columns:
-            guard connection.type.supportsAddColumn else { return }
             structureChangeManager.addNewColumn()
         case .indexes:
-            guard connection.type.supportsAddIndex else { return }
             structureChangeManager.addNewIndex()
         case .foreignKeys:
-            guard canEditForeignKeys else { return }
             structureChangeManager.addNewForeignKey()
         case .checkConstraints:
-            guard connection.type.supportsCheckConstraintEditing else { return }
             structureChangeManager.addNewCheckConstraint()
         case .ddl, .parts, .triggers:
             break
@@ -578,16 +595,16 @@ final class StructureGridDelegate: DataGridViewDelegate {
         let label: String
         switch selectedTab {
         case .columns:
-            guard connection.type.supportsAddColumn else { return nil }
+            guard editGate.allows(.addColumn) else { return nil }
             label = String(localized: "Add Column")
         case .indexes:
-            guard connection.type.supportsAddIndex else { return nil }
+            guard editGate.allows(.addIndex) else { return nil }
             label = String(localized: "Add Index")
         case .foreignKeys:
             guard canEditForeignKeys else { return nil }
             label = String(localized: "Add Foreign Key")
         case .checkConstraints:
-            guard connection.type.supportsCheckConstraintEditing else { return nil }
+            guard editGate.allows(.addCheckConstraint) else { return nil }
             label = String(localized: "Add Check Constraint")
         case .ddl, .parts, .triggers:
             return nil
@@ -711,6 +728,7 @@ final class StructureGridDelegate: DataGridViewDelegate {
     }
 
     private func handleDuplicateItems(_ indices: Set<Int>) {
+        guard canStageAddForSelectedTab else { return }
         for row in indices.sorted() {
             switch selectedTab {
             case .columns:
@@ -730,8 +748,7 @@ final class StructureGridDelegate: DataGridViewDelegate {
                 let copy = structureChangeManager.workingForeignKeys[row]
                 structureChangeManager.addForeignKey(copy.withNewIdentity())
             case .checkConstraints:
-                guard connection.type.supportsCheckConstraintEditing,
-                      row < structureChangeManager.workingCheckConstraints.count else { continue }
+                guard row < structureChangeManager.workingCheckConstraints.count else { continue }
                 let copy = structureChangeManager.workingCheckConstraints[row]
                 structureChangeManager.addCheckConstraint(copy.withNewIdentity())
             case .ddl, .parts, .triggers:

--- a/TablePro/Views/Structure/TableStructureView+ColumnReorder.swift
+++ b/TablePro/Views/Structure/TableStructureView+ColumnReorder.swift
@@ -20,7 +20,7 @@ extension TableStructureView {
             support: PluginManager.shared.columnReorderSupport(for: connection.type),
             engineName: connection.type.displayName,
             isColumnsTab: selectedTab == .columns,
-            isTable: !isViewObject,
+            kindRefusal: editGate.kindRefusal(.reorderColumns),
             canEditSchema: connection.type.supportsSchemaEditing,
             hasStagedChanges: structureChangeManager.hasChanges,
             isRearranged: !searchText.isEmpty || structureSortDescriptor != nil

--- a/TablePro/Views/Structure/TableStructureView+EditGate.swift
+++ b/TablePro/Views/Structure/TableStructureView+EditGate.swift
@@ -1,0 +1,67 @@
+//
+//  TableStructureView+EditGate.swift
+//  TablePro
+//
+//  Which structure edits this tab offers, for the object it is open on.
+//
+
+import Foundation
+import TableProPluginKit
+
+extension TableStructureView {
+    /// Every "may this edit be offered" question the tab asks, answered from one place. The footer
+    /// pair, the grid's per-column lock, the reorder drag and the grid delegate's own keyboard and
+    /// context-menu paths all read this, so none of them can offer an edit another withholds.
+    var editGate: StructureEditGate {
+        StructureEditGate(databaseType: connection.type, objectKind: objectKind)
+    }
+
+    /// Whether this engine can add and remove foreign keys, which is not the same question as
+    /// whether it has them. `supportsForeignKeys` answers the second, and reading it as the first
+    /// is what offered an enabled "+" on SQLite over a driver with no statement behind it.
+    var foreignKeyEditAvailability: ForeignKeyEditAvailability {
+        ForeignKeyEditPolicy.resolve(
+            support: PluginManager.shared.foreignKeyEditSupport(for: connection.type),
+            engineName: connection.type.displayName,
+            kindRefusal: editGate.kindRefusal(.addForeignKey),
+            canEditSchema: connection.type.supportsSchemaEditing
+        )
+    }
+
+    /// Published to the tab's own session, which the bottom bar reads. Nothing is cleared on
+    /// disappear: the session outlives the view by design, and the bar only reads this while the
+    /// tab is showing its structure.
+    func publishFooterCapability() {
+        let gate = editGate
+        session.footer = StructureFooterPolicy.resolve(
+            tab: selectedTab,
+            canEditSchema: connection.type.supportsSchemaEditing,
+            hasSelection: !selectedRows.isEmpty,
+            resolve: { gate.resolve($0) }
+        )
+    }
+
+    /// The Columns grid's headings for the fields this object's kind will not let the user change.
+    ///
+    /// Name-keyed because that is the only handle the grid has: `isColumnWritable` is asked about a
+    /// column's heading, and the Columns grid's headings are exactly
+    /// `orderedColumnFields.map(\.displayName)`. Empty on every tab but Columns, whose rows are the
+    /// only ones that describe a column.
+    var lockedStructureColumns: Set<String> {
+        guard selectedTab == .columns else { return [] }
+        let editable = editGate.editableColumnFields
+        let locked = StructureColumnField.allCases.filter { !editable.contains($0) }
+        /// `displayName` is a `String(localized:)` lookup per field, and this is read on every body
+        /// evaluation. A table locks nothing, which is the overwhelmingly common case, so it never
+        /// pays for twelve of them.
+        guard !locked.isEmpty else { return [] }
+        return Set(locked.map(\.displayName))
+    }
+
+    /// Why the Columns grid refuses every keystroke, when it does. A grid that will not take an edit
+    /// and says nothing reads as broken, so the pointer carries this as the grid's tooltip.
+    var structureEditRefusal: String? {
+        guard !editGate.allowsAnyEdit else { return nil }
+        return editGate.resolve(.renameColumn).unavailableReason
+    }
+}

--- a/TablePro/Views/Structure/TableStructureView.swift
+++ b/TablePro/Views/Structure/TableStructureView.swift
@@ -30,10 +30,6 @@ struct TableStructureView: View {
     let databaseName: String
     let schemaName: String?
 
-    /// Whether the Structure tab is open on a view rather than a table. Every reorder mechanism
-    /// emits table DDL, so a view is withheld rather than allowed to fail at the statement.
-    var isViewObject: Bool = false
-
     let toolbarState: ConnectionToolbarState
     let coordinator: MainContentCoordinator?
     let selectionState: GridSelectionState
@@ -52,6 +48,16 @@ struct TableStructureView: View {
     /// Everything the user has staged, plus the baseline it is staged against. Held outside this
     /// view because the view is destroyed whenever the tab is deselected or switched to Data.
     let session: StructureEditingSession
+
+    /// What kind of object the tab is open on, which decides every edit it may offer.
+    ///
+    /// The real `TableInfo.TableType`, read from the session rather than passed in beside it, so the
+    /// grid delegate the session owns and the footer this view publishes can never disagree about
+    /// what they are looking at. It used to be an `isView` Bool derived from `allowsRowEditing`,
+    /// which is true for a materialized view, so a matview reached here as a table and was offered
+    /// `ADD COLUMN`, `SET NOT NULL`, type changes and constraint edits the server always refuses.
+    /// (#2726)
+    var objectKind: TableInfo.TableType { session.objectKind }
 
     /// Where the user was. Two tabs on one table are two editors, and a trip through the Data view
     /// must not lose the sub-tab, filter or sort either, so all of it lives on the session.
@@ -153,7 +159,6 @@ struct TableStructureView: View {
         connection: DatabaseConnection,
         databaseName: String,
         schemaName: String?,
-        isViewObject: Bool = false,
         toolbarState: ConnectionToolbarState,
         coordinator: MainContentCoordinator?,
         selectionState: GridSelectionState,
@@ -163,7 +168,6 @@ struct TableStructureView: View {
         self.connection = connection
         self.databaseName = databaseName
         self.schemaName = schemaName
-        self.isViewObject = isViewObject
         self.toolbarState = toolbarState
         self.coordinator = coordinator
         self.selectionState = selectionState
@@ -326,80 +330,6 @@ struct TableStructureView: View {
         .padding()
     }
 
-    // MARK: - Footer capability
-
-    /// Published to the tab's own session, which the bottom bar reads. Nothing is cleared on
-    /// disappear: the session outlives the view by design, and the bar only reads this while the
-    /// tab is showing its structure.
-    private func publishFooterCapability() {
-        guard connection.type.supportsSchemaEditing, let labels = footerLabels(for: selectedTab) else {
-            session.footer = StructureFooterCapability()
-            return
-        }
-        session.footer = StructureFooterCapability(
-            canAdd: canAdd(for: selectedTab),
-            canRemove: canRemove(for: selectedTab),
-            addLabel: labels.add,
-            removeLabel: labels.remove,
-            unavailableReason: unavailableReason(for: selectedTab)
-        )
-    }
-
-    /// Whether this engine can add and remove foreign keys, which is not the same question as
-    /// whether it has them. `supportsForeignKeys` answers the second, and reading it as the first
-    /// is what offered an enabled "+" on SQLite over a driver with no statement behind it.
-    var foreignKeyEditAvailability: ForeignKeyEditAvailability {
-        ForeignKeyEditPolicy.resolve(
-            support: PluginManager.shared.foreignKeyEditSupport(for: connection.type),
-            engineName: connection.type.displayName,
-            isTable: !isViewObject,
-            canEditSchema: connection.type.supportsSchemaEditing
-        )
-    }
-
-    private func canAdd(for tab: StructureTab) -> Bool {
-        switch tab {
-        case .columns: return connection.type.supportsAddColumn
-        case .indexes: return connection.type.supportsAddIndex
-        case .foreignKeys: return foreignKeyEditAvailability.isAvailable
-        case .checkConstraints: return connection.type.supportsCheckConstraintEditing
-        case .ddl, .parts, .triggers: return false
-        }
-    }
-
-    /// Why the pair under the list is dimmed, for its tooltip. Nil when it is not, and nil for a
-    /// tab whose absence needs no explaining: DDL and Parts have nothing to add.
-    private func unavailableReason(for tab: StructureTab) -> String? {
-        guard tab == .foreignKeys else { return nil }
-        return foreignKeyEditAvailability.unavailableReason
-    }
-
-    private func canRemove(for tab: StructureTab) -> Bool {
-        guard !selectedRows.isEmpty else { return false }
-        switch tab {
-        case .columns: return connection.type.supportsDropColumn
-        case .indexes: return connection.type.supportsDropIndex
-        case .foreignKeys: return foreignKeyEditAvailability.isAvailable
-        case .checkConstraints: return connection.type.supportsCheckConstraintEditing
-        case .ddl, .parts, .triggers: return false
-        }
-    }
-
-    private func footerLabels(for tab: StructureTab) -> (add: String, remove: String)? {
-        switch tab {
-        case .columns:
-            return (String(localized: "Add Column"), String(localized: "Remove Column"))
-        case .indexes:
-            return (String(localized: "Add Index"), String(localized: "Remove Index"))
-        case .foreignKeys:
-            return (String(localized: "Add Foreign Key"), String(localized: "Remove Foreign Key"))
-        case .checkConstraints:
-            return (String(localized: "Add Check Constraint"), String(localized: "Remove Check Constraint"))
-        case .ddl, .parts, .triggers:
-            return nil
-        }
-    }
-
     // MARK: - Tab Label with Count Badge
 
     private func tabLabel(for tab: StructureTab) -> String {
@@ -472,25 +402,27 @@ struct TableStructureView: View {
         }
     }
 
+    /// Only offered where the add behind it can actually run. An engine that lists an object but
+    /// cannot edit it shows the grid, so its real rows stay visible instead of being replaced by an
+    /// empty state whose only affordance is disabled, and a view whose kind refuses the add never
+    /// gets the empty state's button at all.
     private var shouldShowIndexesEmptyState: Bool {
         tabData.hasData(.indexes)
             && structureChangeManager.workingIndexes.isEmpty
-            && connection.type.supportsAddIndex
+            && editGate.allows(.addIndex)
     }
 
     private var shouldShowForeignKeysEmptyState: Bool {
         tabData.hasData(.foreignKeys)
             && structureChangeManager.workingForeignKeys.isEmpty
             && connection.type.supportsForeignKeys
+            && editGate.allows(.addForeignKey)
     }
 
-    /// Only offered where the engine can actually add one. An engine that lists constraints but
-    /// cannot edit them shows the grid, so a table's real constraints stay visible instead of being
-    /// replaced by an empty state whose only affordance is disabled.
     private var shouldShowCheckConstraintsEmptyState: Bool {
         tabData.hasData(.checkConstraints)
             && structureChangeManager.workingCheckConstraints.isEmpty
-            && connection.type.supportsCheckConstraintEditing
+            && editGate.allows(.addCheckConstraint)
     }
 
     // MARK: - Structure Grid (DataGridView)
@@ -536,9 +468,12 @@ struct TableStructureView: View {
     private var structureGrid: some View {
         @Bindable var session = session
         let provider = makeCurrentProvider()
-        let canEdit = connection.type.supportsSchemaEditing
+        let canEdit = editGate.allowsAnyEdit
         let customOptions = provider.customDropdownOptions
         let allDropdownColumns = provider.dropdownColumns
+        /// Resolved once. It reads the engine's curated capabilities and the object's own kind, and
+        /// this is a body property, so asking twice for the pair of values below doubled that work.
+        let reorder = columnReorderAvailability
 
         // Build the row snapshot fresh on every call rather than capturing it
         // once at body-evaluation time. After a cell edit / undo / redo the
@@ -562,12 +497,14 @@ struct TableStructureView: View {
                 tableName: tableName,
                 databaseName: databaseName,
                 schemaName: schemaName,
-                tabType: .table
+                tabType: .table,
+                lockedColumns: lockedStructureColumns,
+                editRefusalMessage: structureEditRefusal
             ),
             delegate: gridDelegate,
             rowReorder: DataGridRowReorder(
-                isEnabled: columnReorderAvailability.isAvailable,
-                unavailableReason: columnReorderAvailability.unavailableReason
+                isEnabled: reorder.isAvailable,
+                unavailableReason: reorder.unavailableReason
             ),
             selectedRowIndices: $selectedRows,
             sortState: $session.sortState,

--- a/TableProTests/Core/Plugins/StructureEditMatrixCurationTests.swift
+++ b/TableProTests/Core/Plugins/StructureEditMatrixCurationTests.swift
@@ -1,0 +1,66 @@
+//
+//  StructureEditMatrixCurationTests.swift
+//  TableProTests
+//
+
+import Foundation
+import Testing
+@testable import TablePro
+
+/// The matrix is a curated per-engine capability with no `DriverPlugin` static behind it, so it has to
+/// survive `buildMetadataSnapshot` the way every other curated capability does. A capability reset to
+/// its struct default the moment a plugin loaded is what silently disabled MongoDB's database-scoped
+/// authentication (#1970), and the same shape here would put the Structure tab's whole per-kind gate
+/// back to tables only for every build with the PostgreSQL plugin installed. (#2726)
+@Suite("Structure Edit Matrix Curation")
+@MainActor
+struct StructureEditMatrixCurationTests {
+    @Test("PostgreSQL is curated with the measured per-kind matrix")
+    func postgresIsCurated() {
+        let matrix = PluginManager.shared.structureEditMatrix(for: .postgresql)
+        #expect(StructureEditEligibility.allows(.addIndex, on: .materializedView, matrix: matrix))
+        #expect(!StructureEditEligibility.allows(.setDefault, on: .materializedView, matrix: matrix))
+        #expect(StructureEditEligibility.allows(.setDefault, on: .view, matrix: matrix))
+        #expect(!StructureEditEligibility.allows(.addColumn, on: .view, matrix: matrix))
+    }
+
+    /// Conservative on purpose. An engine nobody has measured must never be offered an edit on
+    /// anything but a table, so the fallback is `.tablesOnly` rather than another engine's matrix.
+    @Test("An engine with no curated entry falls back to tables only")
+    func uncuratedEngineFallsBackToTablesOnly() {
+        let unknown = DatabaseType(rawValue: "NotARealEngine")
+        let matrix = PluginManager.shared.structureEditMatrix(for: unknown)
+        #expect(!StructureEditEligibility.allowsAnyEdit(on: .view, matrix: matrix))
+        #expect(!StructureEditEligibility.allowsAnyEdit(on: .materializedView, matrix: matrix))
+        #expect(StructureEditEligibility.allows(.addColumn, on: .table, matrix: matrix))
+    }
+
+    @Test("Every curated engine still offers a table its edits")
+    func curatedEnginesKeepTheirTables() {
+        for type in DatabaseType.allKnownTypes {
+            let matrix = PluginManager.shared.structureEditMatrix(for: type)
+            #expect(
+                StructureEditEligibility.allowsAnyEdit(on: .table, matrix: matrix),
+                "\(type.rawValue) withholds every edit on a plain table"
+            )
+        }
+    }
+
+    @Test("The snapshot's copying helpers carry the matrix across")
+    func copyingHelpersPreserveTheMatrix() throws {
+        let original = try #require(PluginMetadataRegistry.shared.snapshot(for: .postgresql))
+        let expected = original.structureEditing.structureEdits
+
+        let copies: [(String, PluginMetadataSnapshot)] = [
+            ("withIconName", original.withIconName("other-icon")),
+            ("withExplainVariants", original.withExplainVariants([])),
+            ("withBranding", original.withBranding(from: original)),
+            ("withIsDownloadable", original.withIsDownloadable(!original.isDownloadable)),
+            ("withSwitchRouting", original.withSwitchRouting(from: original))
+        ]
+
+        for (name, copy) in copies {
+            #expect(copy.structureEditing.structureEdits == expected, "\(name) reset the per-kind matrix")
+        }
+    }
+}

--- a/TableProTests/Models/Database/StructureEditEligibilityTests.swift
+++ b/TableProTests/Models/Database/StructureEditEligibilityTests.swift
@@ -1,0 +1,262 @@
+//
+//  StructureEditEligibilityTests.swift
+//  TableProTests
+//
+
+import Foundation
+import TableProPluginKit
+import Testing
+@testable import TablePro
+
+/// Every cell of the PostgreSQL matrix below was measured against a live PostgreSQL 17.11 server,
+/// one statement per cell, rather than read out of the documentation. The pair that matters most is
+/// `SET DEFAULT` and `CREATE INDEX`: a view takes the first and refuses the second, a materialized
+/// view does the opposite, and that alone rules out sharing one row between them or collapsing the
+/// object's kind to a single read-only Bool. (#2726)
+@Suite("Structure Edit Eligibility")
+struct StructureEditEligibilityTests {
+    private func allows(
+        _ operation: StructureEditOperation,
+        _ kind: TableInfo.TableType,
+        _ matrix: StructureObjectEditMatrix
+    ) -> Bool {
+        StructureEditEligibility.allows(operation, on: kind, matrix: matrix)
+    }
+
+    // MARK: - The uncurated default
+
+    @Test("An uncurated engine offers every edit on a table and a partitioned table")
+    func tablesOnlyAllowsEverythingOnTables() {
+        for kind in [TableInfo.TableType.table, .partitionedTable] {
+            for operation in StructureEditOperation.allCases {
+                #expect(allows(operation, kind, .tablesOnly), "\(kind.rawValue) refused \(operation)")
+            }
+        }
+    }
+
+    @Test("An uncurated engine offers nothing on anything that is not a table")
+    func tablesOnlyRefusesEveryOtherKind() {
+        let kinds: [TableInfo.TableType] = [.view, .materializedView, .foreignTable, .systemTable, .externalTable]
+        for kind in kinds {
+            #expect(!StructureEditEligibility.allowsAnyEdit(on: kind, matrix: .tablesOnly), "\(kind.rawValue)")
+            for operation in StructureEditOperation.allCases {
+                #expect(!allows(operation, kind, .tablesOnly), "\(kind.rawValue) offered \(operation)")
+            }
+        }
+    }
+
+    // MARK: - PostgreSQL, as measured
+
+    @Test("A PostgreSQL view takes exactly the four edits the server accepts")
+    func postgresViewMatchesTheServer() {
+        let accepted: Set<StructureEditOperation> = [.renameColumn, .setDefault, .dropDefault, .commentOnColumn]
+        for operation in StructureEditOperation.allCases {
+            #expect(
+                allows(operation, .view, .postgreSQL) == accepted.contains(operation),
+                "view disagreed about \(operation)"
+            )
+        }
+    }
+
+    @Test("A PostgreSQL materialized view takes an index and refuses a default")
+    func postgresMaterializedViewMatchesTheServer() {
+        let accepted: Set<StructureEditOperation> = [.renameColumn, .commentOnColumn, .addIndex, .dropIndex]
+        for operation in StructureEditOperation.allCases {
+            #expect(
+                allows(operation, .materializedView, .postgreSQL) == accepted.contains(operation),
+                "materialized view disagreed about \(operation)"
+            )
+        }
+    }
+
+    /// The one cell that proves a view and a materialized view cannot share a matrix row. Measured:
+    /// `ALTER MATERIALIZED VIEW … SET DEFAULT` answers "ALTER action ALTER COLUMN ... SET DEFAULT
+    /// cannot be performed on relation mv", while the same statement on a view succeeds.
+    @Test("A view and a materialized view disagree about SET DEFAULT and CREATE INDEX")
+    func viewAndMaterializedViewDiffer() {
+        #expect(allows(.setDefault, .view, .postgreSQL))
+        #expect(!allows(.setDefault, .materializedView, .postgreSQL))
+        #expect(!allows(.addIndex, .view, .postgreSQL))
+        #expect(allows(.addIndex, .materializedView, .postgreSQL))
+    }
+
+    @Test("A PostgreSQL foreign table takes every column change but no index and no key")
+    func postgresForeignTableMatchesTheServer() {
+        let accepted: Set<StructureEditOperation> = [
+            .addColumn, .dropColumn, .renameColumn, .setNotNull, .dropNotNull, .setDefault,
+            .dropDefault, .changeColumnType, .addCheckConstraint, .dropCheckConstraint, .commentOnColumn
+        ]
+        for operation in StructureEditOperation.allCases {
+            #expect(
+                allows(operation, .foreignTable, .postgreSQL) == accepted.contains(operation),
+                "foreign table disagreed about \(operation)"
+            )
+        }
+    }
+
+    @Test("A PostgreSQL system table and external table take nothing")
+    func postgresReadOnlyKindsTakeNothing() {
+        for kind in [TableInfo.TableType.systemTable, .externalTable] {
+            #expect(!StructureEditEligibility.allowsAnyEdit(on: kind, matrix: .postgreSQL), "\(kind.rawValue)")
+        }
+    }
+
+    @Test("A PostgreSQL table and partitioned table still take every edit")
+    func postgresTablesTakeEverything() {
+        for kind in [TableInfo.TableType.table, .partitionedTable] {
+            for operation in StructureEditOperation.allCases {
+                #expect(allows(operation, kind, .postgreSQL), "\(kind.rawValue) refused \(operation)")
+            }
+        }
+    }
+
+    // MARK: - Per-field locking
+
+    @Test("A view keeps Name, Default and Comment editable and locks the rest")
+    func viewEditableFields() {
+        let fields = StructureEditEligibility.editableFields(on: .view, matrix: .postgreSQL)
+        #expect(fields == [.name, .defaultValue, .comment])
+    }
+
+    @Test("A materialized view keeps only Name and Comment editable")
+    func materializedViewEditableFields() {
+        let fields = StructureEditEligibility.editableFields(on: .materializedView, matrix: .postgreSQL)
+        #expect(fields == [.name, .comment])
+    }
+
+    /// Primary Key, Auto Inc, On Update, Charset, Collation and Generated are all expressed by
+    /// rewriting the column definition, so they travel together behind `redefineColumn` rather than
+    /// each being gated through a proxy that means something else.
+    @Test("A foreign table locks the fields that need a column rewrite and opens the rest")
+    func foreignTableEditableFields() {
+        let fields = StructureEditEligibility.editableFields(on: .foreignTable, matrix: .postgreSQL)
+        #expect(fields == [.name, .type, .nullable, .defaultValue, .comment])
+        #expect(!fields.contains(.primaryKey))
+        #expect(!fields.contains(.autoIncrement))
+    }
+
+    @Test("A system table locks every field")
+    func systemTableLocksEverything() {
+        #expect(StructureEditEligibility.editableFields(on: .systemTable, matrix: .postgreSQL).isEmpty)
+        #expect(!StructureEditEligibility.allowsAnyEdit(on: .systemTable, matrix: .postgreSQL))
+    }
+
+    @Test("A table opens every field of the Columns grid")
+    func tableOpensEveryField() {
+        let fields = StructureEditEligibility.editableFields(on: .table, matrix: .postgreSQL)
+        #expect(fields == Set(StructureColumnField.allCases))
+    }
+
+    // MARK: - Reasons
+
+    @Test("Every refusal carries a sentence, for every kind and every operation")
+    func everyRefusalExplainsItself() {
+        for kind in TableInfo.TableType.allCases {
+            for operation in StructureEditOperation.allCases {
+                let availability = StructureEditEligibility.resolve(
+                    operation,
+                    on: kind,
+                    matrix: .postgreSQL,
+                    engineAllows: true,
+                    engineName: "PostgreSQL",
+                    canEditSchema: true
+                )
+                guard !availability.isAvailable else { continue }
+                #expect(
+                    availability.unavailableReason?.isEmpty == false,
+                    "\(kind.rawValue) refused \(operation) with no reason"
+                )
+            }
+        }
+    }
+
+    /// Each refusal names the kind the user is looking at, which is the half the old `isTable` Bool
+    /// could not supply: it made every non-table say "A view ...".
+    @Test("A refusal names the object's own kind")
+    func refusalNamesTheKind() {
+        let matview = StructureEditEligibility.refusalReason(
+            for: .setDefault, on: .materializedView, matrix: .postgreSQL
+        )
+        #expect(matview?.contains("materialized view") == true)
+
+        let foreign = StructureEditEligibility.refusalReason(
+            for: .addIndex, on: .foreignTable, matrix: .postgreSQL
+        )
+        #expect(foreign?.contains("foreign table") == true)
+    }
+
+    @Test("An accepted operation has no reason to give")
+    func acceptedOperationHasNoReason() {
+        #expect(StructureEditEligibility.refusalReason(for: .addIndex, on: .materializedView, matrix: .postgreSQL) == nil)
+        #expect(StructureEditEligibility.refusalReason(for: .addColumn, on: .table, matrix: .tablesOnly) == nil)
+    }
+
+    // MARK: - Ordering
+
+    @Test("An engine that cannot edit structure at all says that first, even on a table")
+    func readOnlyEngineOutranksTheKind() {
+        let availability = StructureEditEligibility.resolve(
+            .addColumn,
+            on: .table,
+            matrix: .postgreSQL,
+            engineAllows: true,
+            engineName: "Engine",
+            canEditSchema: false
+        )
+        #expect(!availability.isAvailable)
+        #expect(availability.unavailableReason?.contains("Engine") == true)
+    }
+
+    /// The kind allowing an edit is necessary, not sufficient. An engine with no `CREATE INDEX`
+    /// refuses it on a plain table too, and that refusal has to survive the new gate.
+    @Test("An engine flag still vetoes an operation the kind allows")
+    func engineFlagStillVetoes() {
+        let availability = StructureEditEligibility.resolve(
+            .addIndex,
+            on: .table,
+            matrix: .postgreSQL,
+            engineAllows: false,
+            engineName: "Engine",
+            canEditSchema: true
+        )
+        #expect(!availability.isAvailable)
+        #expect(availability.unavailableReason?.contains("Engine") == true)
+        #expect(availability.unavailableReason?.contains("indexes") == true)
+    }
+
+    /// An engine refusal worded once would put "cannot edit a table's structure" under a dimmed
+    /// **Add Index**, which tells the reader nothing they could act on.
+    @Test("An engine refusal names what it cannot do, not just that it cannot")
+    func engineRefusalNamesTheSubject() {
+        let subjects: [(StructureEditOperation, String)] = [
+            (.addColumn, "columns"),
+            (.reorderColumns, "order"),
+            (.addIndex, "indexes"),
+            (.addCheckConstraint, "constraints")
+        ]
+        for (operation, expected) in subjects {
+            let availability = StructureEditEligibility.resolve(
+                operation,
+                on: .table,
+                matrix: .postgreSQL,
+                engineAllows: false,
+                engineName: "Engine",
+                canEditSchema: true
+            )
+            #expect(availability.unavailableReason?.contains(expected) == true, "\(operation)")
+        }
+    }
+
+    @Test("The kind outranks the engine flag, so the reason names the object rather than the engine")
+    func kindOutranksTheEngineFlag() {
+        let availability = StructureEditEligibility.resolve(
+            .addColumn,
+            on: .view,
+            matrix: .postgreSQL,
+            engineAllows: true,
+            engineName: "PostgreSQL",
+            canEditSchema: true
+        )
+        #expect(availability.unavailableReason?.contains("view") == true)
+    }
+}

--- a/TableProTests/Models/Query/TabObjectKindTests.swift
+++ b/TableProTests/Models/Query/TabObjectKindTests.swift
@@ -1,0 +1,159 @@
+//
+//  TabObjectKindTests.swift
+//  TableProTests
+//
+
+import Foundation
+import TableProPluginKit
+import Testing
+@testable import TablePro
+
+/// A tab used to carry one `isView` Bool, derived from `allowsRowEditing`, which is deliberately true
+/// for a materialized view because a matview does hold rows. So a matview reached the Structure tab as
+/// a table and was offered column, index and constraint edits PostgreSQL always refuses. The kind now
+/// travels beside the Bool rather than replacing it: they answer different questions. (#2726)
+@Suite("Tab Object Kind")
+@MainActor
+struct TabObjectKindTests {
+    private func tableTab() -> QueryTab {
+        QueryTab(id: UUID(), title: "mv_sales", query: "SELECT 1", tabType: .table, tableName: "mv_sales")
+    }
+
+    @Test("A materialized view keeps its kind and leaves row editing alone")
+    func materializedViewKeepsItsKind() throws {
+        let manager = QueryTabManager()
+        try manager.addTableTab(
+            tableName: "mv_sales",
+            databaseType: .postgresql,
+            databaseName: "shop",
+            isView: false,
+            objectType: .materializedView
+        )
+
+        let tab = try #require(manager.selectedTab)
+        #expect(tab.tableContext.objectType == .materializedView)
+        #expect(tab.tableContext.isView == false)
+        #expect(tab.tableContext.resolvedObjectKind() == .materializedView)
+    }
+
+    @Test("Retargeting a tab writes the new object's kind over the old one")
+    func retargetReplacesTheKind() throws {
+        let manager = QueryTabManager()
+        try manager.addTableTab(
+            tableName: "orders", databaseType: .postgresql, databaseName: "shop", objectType: .table
+        )
+        try manager.replaceTabContent(
+            tableName: "v_orders",
+            databaseType: .postgresql,
+            isView: true,
+            objectType: .view,
+            databaseName: "shop"
+        )
+
+        let tab = try #require(manager.selectedTab)
+        #expect(tab.tableContext.objectType == .view)
+        #expect(tab.tableContext.resolvedObjectKind() == .view)
+    }
+
+    // MARK: - Persistence
+
+    @Test("The kind round-trips through the persisted tab")
+    func kindRoundTrips() {
+        var tab = tableTab()
+        tab.tableContext.objectType = .materializedView
+
+        let persisted = tab.toPersistedTab()
+        #expect(persisted.objectTypeRawValue == "MATERIALIZED VIEW")
+        #expect(QueryTab(from: persisted, defaultPageSize: 1_000).tableContext.objectType == .materializedView)
+    }
+
+    /// A tab saved before this shipped has no key at all. It must still decode, and it must fall back
+    /// to what the Bool beside it can still say, because the alternative is a thrown error that takes
+    /// every tab in the aggregate with it.
+    ///
+    /// The JSON is built by dropping the key from a real encode rather than typed out by hand, so the
+    /// test cannot pass or fail on a spelling the encoder does not use: `TabType` has no raw value, so
+    /// it encodes as `{"table": {}}` rather than `"table"`.
+    @Test("A file written before the kind existed decodes, and falls back to the Bool")
+    func missingKeyDecodesToTheFallback() throws {
+        let persisted = try decodePersisted(droppingKindFrom: tableTab())
+        #expect(persisted.objectTypeRawValue == nil)
+
+        let restored = QueryTab(from: persisted, defaultPageSize: 1_000)
+        #expect(restored.tableContext.objectType == nil)
+        #expect(restored.tableContext.resolvedObjectKind() == .table)
+    }
+
+    @Test("A view saved before the kind existed falls back to a view, not a table")
+    func missingKeyOnAViewFallsBackToView() throws {
+        var tab = tableTab()
+        tab.tableContext.isView = true
+        tab.tableContext.objectType = .view
+
+        let persisted = try decodePersisted(droppingKindFrom: tab)
+        #expect(persisted.objectTypeRawValue == nil)
+        #expect(QueryTab(from: persisted, defaultPageSize: 1_000).tableContext.resolvedObjectKind() == .view)
+    }
+
+    /// A raw String rather than the enum, so a spelling a newer build invents is dropped instead of
+    /// throwing. A tab that comes back gated as a table is a smaller failure than a session that does
+    /// not come back.
+    @Test("A kind this build does not know decodes to nil rather than throwing")
+    func unknownKindDecodesToNil() throws {
+        var tab = tableTab()
+        tab.tableContext.objectType = .materializedView
+
+        var object = try jsonObject(of: tab.toPersistedTab())
+        object["objectTypeRawValue"] = "GRAPH"
+        let persisted = try JSONDecoder().decode(
+            PersistedTab.self, from: try JSONSerialization.data(withJSONObject: object)
+        )
+
+        #expect(persisted.objectTypeRawValue == "GRAPH")
+        #expect(QueryTab(from: persisted, defaultPageSize: 1_000).tableContext.objectType == nil)
+    }
+
+    private func jsonObject(of persisted: PersistedTab) throws -> [String: Any] {
+        let data = try JSONEncoder().encode(persisted)
+        return try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    private func decodePersisted(droppingKindFrom tab: QueryTab) throws -> PersistedTab {
+        var object = try jsonObject(of: tab.toPersistedTab())
+        object.removeValue(forKey: "objectTypeRawValue")
+        return try JSONDecoder().decode(
+            PersistedTab.self, from: try JSONSerialization.data(withJSONObject: object)
+        )
+    }
+
+    // MARK: - Window payload
+
+    @Test("The kind survives a trip through a window-tab payload")
+    func payloadCarriesTheKind() throws {
+        var tab = tableTab()
+        tab.tableContext.objectType = .foreignTable
+
+        let payload = EditorTabPayload(from: tab, connectionId: UUID())
+        #expect(payload.objectType == .foreignTable)
+
+        let decoded = try JSONDecoder().decode(
+            EditorTabPayload.self, from: try JSONEncoder().encode(payload)
+        )
+        #expect(decoded.objectType == .foreignTable)
+    }
+
+    @Test("A payload with no kind key decodes to nil")
+    func payloadWithoutTheKindDecodes() throws {
+        var tab = tableTab()
+        tab.tableContext.objectType = .materializedView
+
+        let data = try JSONEncoder().encode(EditorTabPayload(from: tab, connectionId: UUID()))
+        var object = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        object.removeValue(forKey: "objectType")
+
+        let payload = try JSONDecoder().decode(
+            EditorTabPayload.self, from: try JSONSerialization.data(withJSONObject: object)
+        )
+        #expect(payload.objectType == nil)
+    }
+}

--- a/TableProTests/Models/Schema/ColumnReorderPolicyTests.swift
+++ b/TableProTests/Models/Schema/ColumnReorderPolicyTests.swift
@@ -12,7 +12,7 @@ struct ColumnReorderPolicyTests {
     private func resolve(
         support: ColumnReorderSupport = .alter,
         isColumnsTab: Bool = true,
-        isTable: Bool = true,
+        kindRefusal: String? = nil,
         canEditSchema: Bool = true,
         hasStagedChanges: Bool = false,
         isRearranged: Bool = false
@@ -21,7 +21,7 @@ struct ColumnReorderPolicyTests {
             support: support,
             engineName: "PostgreSQL",
             isColumnsTab: isColumnsTab,
-            isTable: isTable,
+            kindRefusal: kindRefusal,
             canEditSchema: canEditSchema,
             hasStagedChanges: hasStagedChanges,
             isRearranged: isRearranged
@@ -76,11 +76,11 @@ struct ColumnReorderPolicyTests {
     /// withheld rather than acted on against the wrong column.
     /// Every mechanism emits table DDL, and the SQLite one looks its target up as a table, so a
     /// view drag would end in a statement error instead of an explanation.
-    @Test("A view is withheld, whatever the engine can do to a table")
-    func viewWithholdsTheDrag() {
-        let availability = resolve(isTable: false)
+    @Test("A refusing object kind is withheld, whatever the engine can do to a table")
+    func refusingKindWithholdsTheDrag() {
+        let availability = resolve(kindRefusal: "A view has no column order of its own to change.")
         #expect(!availability.isAvailable)
-        #expect(availability.unavailableReason != nil)
+        #expect(availability.unavailableReason == "A view has no column order of its own to change.")
     }
 
     @Test("A filtered or sorted column list withholds the drag")

--- a/TableProTests/Models/Schema/ForeignKeyEditPolicyTests.swift
+++ b/TableProTests/Models/Schema/ForeignKeyEditPolicyTests.swift
@@ -11,13 +11,13 @@ import Testing
 struct ForeignKeyEditPolicyTests {
     private func resolve(
         _ support: ForeignKeyEditSupport,
-        isTable: Bool = true,
+        kindRefusal: String? = nil,
         canEditSchema: Bool = true
     ) -> ForeignKeyEditAvailability {
         ForeignKeyEditPolicy.resolve(
             support: support,
             engineName: "Engine",
-            isTable: isTable,
+            kindRefusal: kindRefusal,
             canEditSchema: canEditSchema
         )
     }
@@ -43,11 +43,14 @@ struct ForeignKeyEditPolicyTests {
         #expect(availability.unavailableReason?.contains("Engine") == true)
     }
 
-    @Test("A view has no foreign keys of its own")
-    func withholdsOnViews() {
-        let availability = resolve(.rebuild, isTable: false)
+    /// The reason comes from the caller's per-kind matrix, because only that knows whether the user
+    /// is looking at a view, a materialized view or a foreign table. PostgreSQL refuses
+    /// `ADD CONSTRAINT … FOREIGN KEY` on all three.
+    @Test("An object kind that refuses the edit is withheld with its own reason")
+    func withholdsOnRefusingKinds() {
+        let availability = resolve(.rebuild, kindRefusal: "A materialized view cannot have constraints.")
         #expect(!availability.isAvailable)
-        #expect(availability.unavailableReason != nil)
+        #expect(availability.unavailableReason == "A materialized view cannot have constraints.")
     }
 
     /// Checked before the engine's own capability so a read-only engine explains that rather than
@@ -62,7 +65,9 @@ struct ForeignKeyEditPolicyTests {
     @Test("Every reason is a sentence, never an empty string")
     func alwaysExplainsItself() {
         let withheld = [
-            resolve(.unsupported), resolve(.rebuild, isTable: false), resolve(.alter, canEditSchema: false)
+            resolve(.unsupported),
+            resolve(.rebuild, kindRefusal: "A view cannot have constraints."),
+            resolve(.alter, canEditSchema: false)
         ]
         for availability in withheld {
             #expect(availability.unavailableReason?.isEmpty == false)

--- a/TableProTests/Views/Structure/StructureEditGateTests.swift
+++ b/TableProTests/Views/Structure/StructureEditGateTests.swift
@@ -1,0 +1,128 @@
+//
+//  StructureEditGateTests.swift
+//  TableProTests
+//
+
+import Foundation
+import TableProPluginKit
+import Testing
+@testable import TablePro
+
+/// The gate is the one impure half of the decision: it reads the engine's curated matrix and its
+/// capability flags, and every call site in the Structure tab asks it rather than reading a flag of
+/// its own. They used to read them separately, which is how the footer, the Edit menu's Add Row, the
+/// row context menu and the grid's own paste path each got to a different answer. (#2726)
+@Suite("Structure Edit Gate")
+@MainActor
+struct StructureEditGateTests {
+    private func gate(_ kind: TableInfo.TableType, _ type: DatabaseType = .postgresql) -> StructureEditGate {
+        StructureEditGate(databaseType: type, objectKind: kind)
+    }
+
+    @Test("A PostgreSQL table takes every edit end to end")
+    func tableTakesEverything() {
+        let table = gate(.table)
+        #expect(table.allowsAnyEdit)
+        for operation in StructureEditOperation.allCases {
+            #expect(table.allows(operation), "table refused \(operation)")
+        }
+    }
+
+    @Test("A PostgreSQL view refuses a column and an index but keeps a rename and a default")
+    func viewSplitsByOperation() {
+        let view = gate(.view)
+        #expect(view.allowsAnyEdit)
+        #expect(view.allows(.renameColumn))
+        #expect(view.allows(.setDefault))
+        #expect(view.allows(.commentOnColumn))
+        #expect(!view.allows(.addColumn))
+        #expect(!view.allows(.setNotNull))
+        #expect(!view.allows(.addIndex))
+        #expect(!view.allows(.addForeignKey))
+        #expect(!view.allows(.reorderColumns))
+    }
+
+    @Test("A PostgreSQL materialized view takes an index and refuses a default")
+    func materializedViewTakesAnIndex() {
+        let matview = gate(.materializedView)
+        #expect(matview.allows(.addIndex))
+        #expect(matview.allows(.dropIndex))
+        #expect(!matview.allows(.setDefault))
+        #expect(!matview.allows(.addForeignKey))
+    }
+
+    @Test("A system table allows nothing at all, so the grid has nothing to offer")
+    func systemTableAllowsNothing() {
+        let system = gate(.systemTable)
+        #expect(!system.allowsAnyEdit)
+        #expect(system.editableColumnFields.isEmpty)
+    }
+
+    @Test("A view keeps exactly Name, Default and Comment unlocked")
+    func viewEditableFields() {
+        #expect(gate(.view).editableColumnFields == [.name, .defaultValue, .comment])
+    }
+
+    /// An engine nobody has curated gets tables only, so a MySQL view's grid is read-only rather than
+    /// accepting edits MySQL refuses on a view.
+    @Test("An uncurated engine withholds every edit on a view")
+    func uncuratedEngineWithholdsOnViews() {
+        let view = gate(.view, .mysql)
+        #expect(!view.allowsAnyEdit)
+        #expect(view.editableColumnFields.isEmpty)
+        #expect(!view.allows(.renameColumn))
+        #expect(gate(.table, .mysql).allowsAnyEdit)
+    }
+
+    /// The gate answers the foreign key arm through `ForeignKeyEditPolicy`, so the engine that has to
+    /// recreate the table still offers the edit and the refusal keeps that policy's own wording
+    /// rather than the sentence every other constraint shares.
+    @Test("An engine that recreates the table to change a key still offers the edit")
+    func rebuildEngineOffersForeignKeys() {
+        #expect(gate(.table, .sqlite).allows(.addForeignKey))
+        #expect(gate(.table, .sqlite).allows(.dropForeignKey))
+        #expect(gate(.table).allows(.addForeignKey))
+    }
+
+    @Test("A refusing kind reaches the foreign key arm with the kind's own reason")
+    func foreignKeyRefusalNamesTheKind() {
+        let matview = gate(.materializedView)
+        #expect(!matview.allows(.addForeignKey))
+        #expect(matview.resolve(.addForeignKey).unavailableReason?.contains("materialized view") == true)
+        #expect(matview.foreignKeyAvailability.unavailableReason?.contains("materialized view") == true)
+    }
+
+    @Test("A refused operation carries a reason and an accepted one does not")
+    func reasonsTravelWithTheRefusal() {
+        #expect(gate(.view).kindRefusal(.addIndex)?.isEmpty == false)
+        #expect(gate(.view).kindRefusal(.renameColumn) == nil)
+        #expect(gate(.materializedView).kindRefusal(.addIndex) == nil)
+        #expect(gate(.materializedView).resolve(.setDefault).unavailableReason?.isEmpty == false)
+    }
+
+    /// The per-column lock is name-keyed, and the only names it can use are the Columns grid's own
+    /// headings. If a provider ever respelled one, the field behind it would silently unlock, so the
+    /// two lists are pinned to each other here.
+    @Test("The Columns grid's headings are exactly the field display names the lock uses")
+    func headingsMatchTheFieldNames() {
+        let provider = StructureRowProvider(
+            changeManager: StructureChangeManager(),
+            tab: .columns,
+            databaseType: .postgresql,
+            additionalFields: [.primaryKey],
+            serverSupport: .unrestricted
+        )
+        #expect(provider.columns == provider.orderedColumnFields.map(\.displayName))
+
+        let locked = Set(
+            StructureColumnField.allCases
+                .filter { !gate(.view).editableColumnFields.contains($0) }
+                .map(\.displayName)
+        )
+        let unlocked = provider.columns.filter { !locked.contains($0) }
+        #expect(unlocked.contains(StructureColumnField.name.displayName))
+        #expect(unlocked.contains(StructureColumnField.defaultValue.displayName))
+        #expect(!unlocked.contains(StructureColumnField.type.displayName))
+        #expect(!unlocked.contains(StructureColumnField.nullable.displayName))
+    }
+}

--- a/TableProTests/Views/Structure/StructureFooterPolicyTests.swift
+++ b/TableProTests/Views/Structure/StructureFooterPolicyTests.swift
@@ -1,0 +1,140 @@
+//
+//  StructureFooterPolicyTests.swift
+//  TableProTests
+//
+
+import Foundation
+import Testing
+@testable import TablePro
+
+/// The "+" and "-" under a structure list used to take their label, their enabled state and their
+/// tooltip from three different switches, and only the Foreign Keys one asked about the object at
+/// all. So a view offered an enabled "Add Column" over a statement PostgreSQL always refuses, with
+/// nothing to explain it. (#2726)
+@Suite("Structure Footer Policy")
+struct StructureFooterPolicyTests {
+    private func resolve(
+        tab: StructureTab,
+        kind: TableInfo.TableType,
+        matrix: StructureObjectEditMatrix = .postgreSQL,
+        canEditSchema: Bool = true,
+        hasSelection: Bool = true
+    ) -> StructureFooterCapability {
+        StructureFooterPolicy.resolve(
+            tab: tab,
+            canEditSchema: canEditSchema,
+            hasSelection: hasSelection,
+            resolve: { operation in
+                StructureEditEligibility.resolve(
+                    operation,
+                    on: kind,
+                    matrix: matrix,
+                    engineAllows: true,
+                    engineName: "PostgreSQL",
+                    canEditSchema: canEditSchema
+                )
+            }
+        )
+    }
+
+    @Test("A table offers both buttons on all four editable tabs")
+    func tableOffersEverything() {
+        for tab in [StructureTab.columns, .indexes, .foreignKeys, .checkConstraints] {
+            let capability = resolve(tab: tab, kind: .table)
+            #expect(capability.canAdd, "\(tab.rawValue)")
+            #expect(capability.canRemove, "\(tab.rawValue)")
+            #expect(capability.unavailableReason == nil, "\(tab.rawValue)")
+        }
+    }
+
+    /// Shown and dimmed, not hidden. The pair disappearing would read as "this tab has no columns",
+    /// and the tooltip is the only place the refusal can be stated.
+    @Test("A view keeps the Columns pair on screen, dimmed, with a reason")
+    func viewDimsTheColumnsPair() {
+        let capability = resolve(tab: .columns, kind: .view)
+        #expect(!capability.canAdd)
+        #expect(!capability.canRemove)
+        #expect(capability.isActive)
+        #expect(capability.addLabel.isEmpty == false)
+        #expect(capability.unavailableReason?.isEmpty == false)
+    }
+
+    @Test("A materialized view offers an index and refuses a column")
+    func materializedViewSplitsByTab() {
+        let indexes = resolve(tab: .indexes, kind: .materializedView)
+        #expect(indexes.canAdd)
+        #expect(indexes.canRemove)
+        #expect(indexes.unavailableReason == nil)
+
+        let columns = resolve(tab: .columns, kind: .materializedView)
+        #expect(!columns.canAdd)
+        #expect(columns.unavailableReason?.isEmpty == false)
+    }
+
+    @Test("A foreign table offers a check constraint and refuses an index")
+    func foreignTableSplitsByTab() {
+        let checks = resolve(tab: .checkConstraints, kind: .foreignTable)
+        #expect(checks.canAdd)
+
+        let indexes = resolve(tab: .indexes, kind: .foreignTable)
+        #expect(!indexes.canAdd)
+        #expect(indexes.unavailableReason?.isEmpty == false)
+    }
+
+    @Test("A foreign table refuses a foreign key, which is the constraint PostgreSQL rejects on one")
+    func foreignTableRefusesForeignKeys() {
+        let keys = resolve(tab: .foreignKeys, kind: .foreignTable)
+        #expect(!keys.canAdd)
+        #expect(keys.unavailableReason?.isEmpty == false)
+    }
+
+    /// Today's behaviour, preserved on purpose: an engine that cannot edit structure at all hides the
+    /// pair rather than showing two dead buttons on every tab.
+    @Test("An engine that cannot edit structure hides the pair entirely")
+    func readOnlyEngineHidesThePair() {
+        let capability = resolve(tab: .columns, kind: .table, canEditSchema: false)
+        #expect(!capability.isActive)
+        #expect(capability.addLabel.isEmpty)
+        #expect(!capability.canAdd)
+        #expect(!capability.canRemove)
+    }
+
+    @Test("Nothing selected dims Remove without dimming Add and without inventing a reason")
+    func emptySelectionOnlyDimsRemove() {
+        let capability = resolve(tab: .columns, kind: .table, hasSelection: false)
+        #expect(capability.canAdd)
+        #expect(!capability.canRemove)
+        #expect(capability.unavailableReason == nil)
+    }
+
+    @Test("The tabs with nothing to add have no operation and no pair")
+    func nonEditableTabsHaveNoPair() {
+        for tab in [StructureTab.ddl, .parts, .triggers] {
+            #expect(StructureFooterPolicy.operation(forAdding: tab) == nil, "\(tab.rawValue)")
+            #expect(StructureFooterPolicy.operation(forRemoving: tab) == nil, "\(tab.rawValue)")
+            #expect(!resolve(tab: tab, kind: .table).isActive, "\(tab.rawValue)")
+        }
+    }
+
+    @Test("Each editable tab names the add and the drop of its own object")
+    func operationsMatchTheirTabs() {
+        #expect(StructureFooterPolicy.operation(forAdding: .columns) == .addColumn)
+        #expect(StructureFooterPolicy.operation(forRemoving: .columns) == .dropColumn)
+        #expect(StructureFooterPolicy.operation(forAdding: .indexes) == .addIndex)
+        #expect(StructureFooterPolicy.operation(forRemoving: .indexes) == .dropIndex)
+        #expect(StructureFooterPolicy.operation(forAdding: .foreignKeys) == .addForeignKey)
+        #expect(StructureFooterPolicy.operation(forRemoving: .foreignKeys) == .dropForeignKey)
+        #expect(StructureFooterPolicy.operation(forAdding: .checkConstraints) == .addCheckConstraint)
+        #expect(StructureFooterPolicy.operation(forRemoving: .checkConstraints) == .dropCheckConstraint)
+    }
+
+    /// An engine nobody has measured falls back to tables only, so every non-table dims rather than
+    /// offering an edit its server may refuse.
+    @Test("An uncurated engine dims the pair on a view")
+    func uncuratedEngineDimsNonTables() {
+        let capability = resolve(tab: .columns, kind: .view, matrix: .tablesOnly)
+        #expect(!capability.canAdd)
+        #expect(capability.isActive)
+        #expect(capability.unavailableReason?.isEmpty == false)
+    }
+}

--- a/TableProTests/Views/Structure/StructureGridDelegateAddRowTests.swift
+++ b/TableProTests/Views/Structure/StructureGridDelegateAddRowTests.swift
@@ -16,7 +16,8 @@ import Testing
 struct StructureGridDelegateAddRowTests {
     private func makeDelegate(
         selectedTab: StructureTab = .columns,
-        type: DatabaseType = .mysql
+        type: DatabaseType = .mysql,
+        objectKind: TableInfo.TableType = .table
     ) -> (StructureGridDelegate, StructureChangeManager) {
         let manager = StructureChangeManager()
         let connection = TestFixtures.makeConnection(type: type)
@@ -25,6 +26,7 @@ struct StructureGridDelegateAddRowTests {
             selectedTab: selectedTab,
             connection: connection,
             tableName: "t",
+            objectKind: objectKind,
             coordinator: nil
         )
         return (delegate, manager)
@@ -178,5 +180,71 @@ struct StructureGridDelegateAddRowTests {
         delegate.dataGridDeleteRows([before - 1])
 
         #expect(manager.workingIndexes.count == before - 1)
+    }
+
+    // MARK: - Per object kind
+
+    /// The footer pair is not the only way in. Cmd+Shift+N reaches `dataGridAddRow` through
+    /// `structureActions`, the row and empty-space menus reach it directly, and none of them consults
+    /// the dimmed button, so the delegate has to refuse for itself. (#2726)
+    @Test("A PostgreSQL view refuses an added column, whatever reaches the delegate")
+    func viewRefusesAnAddedColumn() {
+        let (delegate, manager) = makeDelegate(selectedTab: .columns, type: .postgresql, objectKind: .view)
+        delegate.dataGridAddRow()
+        #expect(manager.workingColumns.isEmpty)
+    }
+
+    @Test("A PostgreSQL view refuses an added index and a materialized view accepts one")
+    func indexesFollowTheObjectKind() {
+        let (view, viewManager) = makeDelegate(selectedTab: .indexes, type: .postgresql, objectKind: .view)
+        view.dataGridAddRow()
+        #expect(viewManager.workingIndexes.isEmpty)
+
+        let (matview, matviewManager) = makeDelegate(
+            selectedTab: .indexes, type: .postgresql, objectKind: .materializedView
+        )
+        matview.dataGridAddRow()
+        #expect(matviewManager.workingIndexes.count == 1)
+    }
+
+    @Test("A PostgreSQL materialized view refuses a foreign key")
+    func materializedViewRefusesAForeignKey() {
+        let (delegate, manager) = makeDelegate(
+            selectedTab: .foreignKeys, type: .postgresql, objectKind: .materializedView
+        )
+        delegate.dataGridAddRow()
+        #expect(manager.workingForeignKeys.isEmpty)
+    }
+
+    @Test("A view refuses to drop a column its own grid is showing")
+    func viewRefusesADroppedColumn() {
+        let manager = StructureChangeManager()
+        manager.addColumn(.placeholder())
+        let before = manager.workingColumns.count
+        #expect(before == 1)
+
+        let view = StructureGridDelegate(
+            structureChangeManager: manager,
+            selectedTab: .columns,
+            connection: TestFixtures.makeConnection(type: .postgresql),
+            tableName: "v_sales",
+            objectKind: .view,
+            coordinator: nil
+        )
+        view.dataGridDeleteRows([0])
+
+        #expect(manager.workingColumns.count == before)
+    }
+
+    @Test("A system table refuses every add")
+    func systemTableRefusesEveryAdd() {
+        for tab in [StructureTab.columns, .indexes, .foreignKeys, .checkConstraints] {
+            let (delegate, manager) = makeDelegate(selectedTab: tab, type: .postgresql, objectKind: .systemTable)
+            delegate.dataGridAddRow()
+            #expect(manager.workingColumns.isEmpty, "\(tab.rawValue)")
+            #expect(manager.workingIndexes.isEmpty, "\(tab.rawValue)")
+            #expect(manager.workingForeignKeys.isEmpty, "\(tab.rawValue)")
+            #expect(manager.workingCheckConstraints.isEmpty, "\(tab.rawValue)")
+        }
     }
 }

--- a/docs/databases/postgresql.mdx
+++ b/docs/databases/postgresql.mdx
@@ -83,6 +83,8 @@ A view's definition is rebuilt to run anywhere. Every table it reads is schema-q
 
 An SQL export writes those statements back for tables, views and materialized views, so a dump and a restore keep their comments. See [Import & Export](/features/import-export).
 
+The Structure tab of a view, a materialized view or a foreign table offers only the edits PostgreSQL takes on that kind of object, which is fewer than a table's and different for each. See [Table Structure](/features/table-structure#what-each-object-accepts).
+
 ## Cross-database tabs
 
 PostgreSQL has no in-place `USE`, so a tab bound to a database other than the connection's active one runs on a second connection opened for that database. It shares no temp tables, session variables, or open transaction with the query editor on the main connection: keep a multi-statement transaction or a `CREATE TEMP TABLE` on tabs bound to one database. Binding itself is on [Tabs](/features/tabs#where-a-tab-points).

--- a/docs/features/table-structure.mdx
+++ b/docs/features/table-structure.mdx
@@ -16,6 +16,24 @@ Open a table and switch the result view to **Structure**, or right-click it in t
 
 The tabs are **Columns**, **Indexes**, **Foreign Keys**, **Constraints**, **Triggers**, **DDL**, and **Parts** (ClickHouse only); the first five carry item counts. A tab the engine has no concept of is hidden: ClickHouse has no Foreign Keys, Redshift no Triggers, Redis no Constraints. Every grid has a filter field, and clicking a header sorts.
 
+## What each object accepts
+
+A view is not a table, and the grid offers only the edits the server will take on the object open in front of it. A refused **+** or **-** stays on screen, dimmed, with the reason in its tooltip; a cell the object will not let you change beeps instead of opening an editor.
+
+PostgreSQL answers this per operation, so the tab does too:
+
+| Object | What it accepts |
+|--------|-----------------|
+| Table, partitioned table | Everything on this page |
+| View | Rename a column, set or clear its default, edit its comment |
+| Materialized view | Rename a column, edit its comment, add and drop indexes |
+| Foreign table | Every column change and check constraints. No indexes, no keys |
+| System table, external table | Nothing |
+
+A view and a materialized view differ in both directions: `ALTER TABLE … SET DEFAULT` runs on a view and is refused on a materialized view, and `CREATE INDEX` is the other way round.
+
+Every other engine edits a table and a partitioned table only. A view, a materialized view, a foreign table and a system table are read-only there.
+
 ## Columns tab
 
 Columns are edited in place. **Nullable**, **Primary Key**, and **Auto Inc** are YES/NO dropdowns; **Primary Key** set to YES forces **Nullable** to NO and holds it there until the key comes back off. **Type** opens a picker of the engine's types by category: search to filter, or type a parametric value such as `VARCHAR(255)` and press Return to use it as written. On PostgreSQL and PGlite the picker opens with a **User-Defined** group of the database's enums, composites, domains and ranges, each listed schema-qualified as `sales.status`. See [User-Defined Types](/features/user-defined-types).
@@ -67,7 +85,7 @@ Add a column with **+** at the right of the status bar or `Cmd+Shift+N`. Select 
 
 Flag **Primary Key** on one column, or several for a composite key in one `PRIMARY KEY (col1, col2)` clause. On an existing table that becomes a drop of the old constraint followed by an add.
 
-Drag a column row to reorder it, or right-click one and choose **Move Column Up** or **Move Column Down**. Both are dimmed with the reason spelled out under them while unsaved changes exist, while the list is filtered or sorted, on a view, and on an engine that cannot change column order.
+Drag a column row to reorder it, or right-click one and choose **Move Column Up** or **Move Column Down**. Both are dimmed with the reason spelled out under them while unsaved changes exist, while the list is filtered or sorted, on anything but a table, and on an engine that cannot change column order.
 
 What the drag does depends on the engine:
 
@@ -100,7 +118,7 @@ Everything that runs goes to query history rather than the change queue.
 
 Right-click a foreign key and choose **Open [table]** to jump to the referenced table. Right-click any row in these three grids for **Copy** (the cell under the pointer), **Copy Name**, **Copy Definition**, **Copy As** (CSV, JSON, SQL), **Duplicate**, and **Delete** (`Delete`). A row already marked for deletion offers **Undo Delete**. The same menu appears whether or not the row was already selected, and its row commands act on the whole selection.
 
-**Add Foreign Key** and **Remove Foreign Key** sit under the list. Both are dimmed on a view and on an engine that cannot edit foreign keys, with the reason in the tooltip.
+**Add Foreign Key** and **Remove Foreign Key** sit under the list. Both are dimmed on an object that cannot carry a key and on an engine that cannot edit foreign keys, with the reason in the tooltip.
 
 What the save does depends on the engine:
 


### PR DESCRIPTION
Part of #2726, found while building the view tools there.

The Structure tab decided what it could edit from engine capability flags plus one `isView` Bool. That Bool is false for a materialized view, because `TableInfo.TableType.allowsRowEditing` is true for one, so the tab offered `ADD COLUMN`, `SET NOT NULL`, type changes and constraint edits that PostgreSQL always refuses.

A single flag cannot answer this, because the server answers per operation, not per object. Measured on PostgreSQL 17.11:

| Operation | Table | Partitioned | View | Materialized view | Foreign table |
|---|---|---|---|---|---|
| Add, drop, rename column | yes | yes | rename only | no | yes |
| Set / drop NOT NULL | yes | yes | no | no | yes |
| Set / drop DEFAULT | yes | yes | yes | no | yes |
| Change column type | yes | yes | no | no | yes |
| Add / drop index | yes | yes | no | yes | no |
| Add / drop foreign key | yes | yes | no | no | no |
| Comment on column | yes | yes | yes | yes | yes |

A view takes `RENAME COLUMN`, `SET DEFAULT` and `COMMENT ON COLUMN`, so gating the whole object read-only would withhold three edits that work. A materialized view takes `CREATE INDEX` but refuses `SET DEFAULT`, which is the opposite pairing.

## What changed

`StructureEditOperation` names the seventeen edits the tab can ask for, and `StructureEditEligibility` answers per kind and per operation from a matrix curated per `DatabaseType`. The footer, the foreign key policy, the reorder policy and a new per-column grid lock all read that one answer instead of their own flags. The tab now carries the object's real `TableInfo.TableType`, so a materialized view stops arriving as a table.

A refused affordance dims and says why, and the reason is per subject: a materialized view refuses `SET DEFAULT` and a foreign key for different reasons, and one sentence covering both would be true of neither.

## Beyond PostgreSQL

Only PostgreSQL has a curated matrix. Every other engine falls back to tables-only, so a MySQL or SQLite view's grid goes read-only where it previously offered edits the server refuses anyway. That is the second CHANGELOG line, under Changed.

## Verified

`StructureEditEligibilityTests`, `StructureEditGateTests`, `StructureFooterPolicyTests`, `StructureEditMatrixCurationTests`, `TabObjectKindTests`, `ColumnReorderPolicyTests`, `ForeignKeyEditPolicyTests`, `StructureGridDelegateAddRowTests`: `cases: 87 executed, 87 passed, 0 failed`. Lint clean. Docs checks pass.

No `TableProUITests` coverage: the flow needs a live PostgreSQL server with a view and a materialized view, and the UI suites run against the bundled SQLite sample, so it cannot run deterministically on CI.

## Known limit

A tab persisted before this change decodes with no object kind and falls back to `isView ? .view : .table`, so a materialized view or foreign table restored from an older session is gated as a table until the tab is reopened.

https://claude.ai/code/session_013prPDi2xCGd2JqrfEnTELn
