### PR TITLE
fix(sidebar): offer maintenance only where it applies and preview the statement that runs (#2726)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -230,6 +230,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cross-engine copy and JSON import creating `jsonb` columns on PostgreSQL 9.3 and earlier.
 - SQL Server edits and deletes matching no row when the row is identified by a binary column.
 - SQL Server parameters sent to the wrong placeholders when a column name holds a question mark.
+- Maintenance offered on views and sequences, where the server skips or refuses it. (#2726)
+- Maintenance running against a same-named object in another schema. (#2726)
+- Maintenance SQL preview showing a statement the app never runs. (#2726)
 - `[` in a SQL Server filter value read as a wildcard.
 - Non-ASCII text turned into `?` by Copy as INSERT, Copy as IN, Preview Referenced Row, compare scripts and column defaults on SQL Server.
 

--- a/Plugins/BeancountDriverPlugin/Info.plist
+++ b/Plugins/BeancountDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>28</integer>
+	<integer>29</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Beancount</string>

--- a/Plugins/BigQueryDriverPlugin/Info.plist
+++ b/Plugins/BigQueryDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>28</integer>
+	<integer>29</integer>
 </dict>
 </plist>

--- a/Plugins/CSVExportPlugin/Info.plist
+++ b/Plugins/CSVExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>28</integer>
+	<integer>29</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>csv</string>

--- a/Plugins/CSVImportPlugin/Info.plist
+++ b/Plugins/CSVImportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>28</integer>
+	<integer>29</integer>
 	<key>TableProProvidesImportFormatIds</key>
 	<array>
 		<string>csv</string>

--- a/Plugins/CassandraDriverPlugin/Info.plist
+++ b/Plugins/CassandraDriverPlugin/Info.plist
@@ -21,6 +21,6 @@
 	<key>NSPrincipalClass</key>
 	<string>$(PRODUCT_MODULE_NAME).CassandraPlugin</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>28</integer>
+	<integer>29</integer>
 </dict>
 </plist>

--- a/Plugins/ClickHouseDriverPlugin/Info.plist
+++ b/Plugins/ClickHouseDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>28</integer>
+	<integer>29</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>ClickHouse</string>

--- a/Plugins/CloudflareD1DriverPlugin/Info.plist
+++ b/Plugins/CloudflareD1DriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>28</integer>
+	<integer>29</integer>
 </dict>
 </plist>

--- a/Plugins/CloudflareR2SQLDriverPlugin/Info.plist
+++ b/Plugins/CloudflareR2SQLDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>28</integer>
+	<integer>29</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Cloudflare R2 SQL</string>

--- a/Plugins/DamengDriverPlugin/Info.plist
+++ b/Plugins/DamengDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>28</integer>
+	<integer>29</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Dameng</string>

--- a/Plugins/DuckDBDriverPlugin/Info.plist
+++ b/Plugins/DuckDBDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>28</integer>
+	<integer>29</integer>
 </dict>
 </plist>

--- a/Plugins/DynamoDBDriverPlugin/Info.plist
+++ b/Plugins/DynamoDBDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>28</integer>
+	<integer>29</integer>
 </dict>
 </plist>

--- a/Plugins/ElasticsearchDriverPlugin/Info.plist
+++ b/Plugins/ElasticsearchDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.53.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>28</integer>
+	<integer>29</integer>
 </dict>
 </plist>

--- a/Plugins/EtcdDriverPlugin/Info.plist
+++ b/Plugins/EtcdDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>28</integer>
+	<integer>29</integer>
 </dict>
 </plist>

--- a/Plugins/HTMLExportPlugin/Info.plist
+++ b/Plugins/HTMLExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>28</integer>
+	<integer>29</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>html</string>

--- a/Plugins/JSONExportPlugin/Info.plist
+++ b/Plugins/JSONExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>28</integer>
+	<integer>29</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>json</string>

--- a/Plugins/JSONImportPlugin/Info.plist
+++ b/Plugins/JSONImportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>28</integer>
+	<integer>29</integer>
 	<key>TableProProvidesImportFormatIds</key>
 	<array>
 		<string>json</string>

--- a/Plugins/KafkaDriverPlugin/Info.plist
+++ b/Plugins/KafkaDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>28</integer>
+	<integer>29</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Kafka</string>

--- a/Plugins/LibSQLDriverPlugin/Info.plist
+++ b/Plugins/LibSQLDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>28</integer>
+	<integer>29</integer>
 </dict>
 </plist>

--- a/Plugins/MQLExportPlugin/Info.plist
+++ b/Plugins/MQLExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>28</integer>
+	<integer>29</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>mql</string>

--- a/Plugins/MSSQLDriverPlugin/Info.plist
+++ b/Plugins/MSSQLDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>28</integer>
+	<integer>29</integer>
 </dict>
 </plist>

--- a/Plugins/MarkdownExportPlugin/Info.plist
+++ b/Plugins/MarkdownExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>28</integer>
+	<integer>29</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>md</string>

--- a/Plugins/MongoDBDriverPlugin/Info.plist
+++ b/Plugins/MongoDBDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>28</integer>
+	<integer>29</integer>
 </dict>
 </plist>

--- a/Plugins/MySQLDriverPlugin/Info.plist
+++ b/Plugins/MySQLDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>28</integer>
+	<integer>29</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>MySQL</string>

--- a/Plugins/MySQLDriverPlugin/MySQLMaintenance.swift
+++ b/Plugins/MySQLDriverPlugin/MySQLMaintenance.swift
@@ -1,0 +1,95 @@
+//
+//  MySQLMaintenance.swift
+//  MySQLDriverPlugin
+//
+
+import Foundation
+import TableProPluginKit
+
+/// MySQL's maintenance operations and the statements they produce.
+///
+/// Pure, so the confirmation sheet's preview and the statement that runs are one function rather
+/// than two implementations that drifted: the sheet printed `CHECK TABLE orders MEDIUM` with the
+/// name unquoted where `CHECK TABLE \`orders\` MEDIUM` ran.
+///
+/// The kind sets come from the MySQL reference rather than from a probe, because no MySQL server was
+/// available: `OPTIMIZE TABLE`, `ANALYZE TABLE` and `REPAIR TABLE` are documented on base tables and
+/// partitioned tables, while `CHECK TABLE` is documented to check views as well, for references in
+/// the view body to tables that no longer exist.
+nonisolated internal enum MySQLMaintenance {
+    internal static let optimize = "OPTIMIZE TABLE"
+    internal static let analyze = "ANALYZE TABLE"
+    internal static let check = "CHECK TABLE"
+    internal static let repair = "REPAIR TABLE"
+
+    internal static let modeKey = "mode"
+    internal static let checkModes = ["QUICK", "FAST", "MEDIUM", "EXTENDED", "CHANGED"]
+    internal static let defaultCheckMode = "MEDIUM"
+
+    internal static let analyzeOperation = PluginMaintenanceOperation(
+        name: analyze,
+        appliesTo: [.table, .partitionedTable],
+        scope: .object
+    )
+
+    internal static let operations: [PluginMaintenanceOperation] = [
+        PluginMaintenanceOperation(
+            name: optimize,
+            appliesTo: [.table, .partitionedTable],
+            scope: .object
+        ),
+        analyzeOperation,
+        PluginMaintenanceOperation(
+            name: check,
+            appliesTo: [.table, .partitionedTable, .view],
+            scope: .object,
+            options: [
+                PluginMaintenanceOption(
+                    key: modeKey,
+                    label: String(localized: "Check mode:"),
+                    defaultValue: defaultCheckMode,
+                    choices: checkModes
+                )
+            ]
+        ),
+        PluginMaintenanceOperation(
+            name: repair,
+            appliesTo: [.table, .partitionedTable],
+            scope: .object
+        )
+    ]
+
+    /// Every MySQL maintenance statement names one table, so a nil one produces nothing rather than a
+    /// database-wide form the engine does not have.
+    ///
+    /// The mode is matched against the declared choices instead of being interpolated as it arrives.
+    /// It reaches here from an MCP client as well as from the sheet's picker, and it lands in the
+    /// statement text unquoted.
+    internal static func statements(
+        operation: String,
+        table: String?,
+        schema: String?,
+        options: [String: String],
+        flavor: MySQLServerFlavor
+    ) -> [String]? {
+        guard let table, flavor.maintenanceOperations.contains(where: { $0.name == operation }) else { return nil }
+        let target = qualified(table: table, schema: schema, flavor: flavor)
+        switch operation {
+        case optimize, analyze, repair:
+            return ["\(operation) \(target)"]
+        case check:
+            let mode = checkModes.first { $0 == options[modeKey] } ?? defaultCheckMode
+            return ["\(check) \(target) \(mode)"]
+        default:
+            return nil
+        }
+    }
+
+    private static func qualified(table: String, schema: String?, flavor: MySQLServerFlavor) -> String {
+        func quote(_ name: String) -> String {
+            flavor.isDatabend ? DatabendCatalog.quoteIdentifier(name) : mysqlQuoteIdentifier(name)
+        }
+        guard let schema, !schema.isEmpty else { return quote(table) }
+        return "\(quote(schema)).\(quote(table))"
+    }
+}

--- a/Plugins/MySQLDriverPlugin/MySQLPluginDriver.swift
+++ b/Plugins/MySQLDriverPlugin/MySQLPluginDriver.swift
@@ -1078,21 +1078,21 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     // MARK: - Maintenance
 
     func supportedMaintenanceOperations() -> [String]? {
+        flavor.maintenanceOperations.map(\.name)
+    }
+
+    func maintenanceOperations() -> [PluginMaintenanceOperation]? {
         flavor.maintenanceOperations
     }
 
     func maintenanceStatements(operation: String, table: String?, schema: String?, options: [String: String]) -> [String]? {
-        guard let table, flavor.maintenanceOperations.contains(operation) else { return nil }
-        let quoted = quoteIdentifier(table)
-        switch operation {
-        case "OPTIMIZE TABLE": return ["OPTIMIZE TABLE \(quoted)"]
-        case "ANALYZE TABLE": return ["ANALYZE TABLE \(quoted)"]
-        case "CHECK TABLE":
-            let mode = options["mode"] ?? "MEDIUM"
-            return ["CHECK TABLE \(quoted) \(mode)"]
-        case "REPAIR TABLE": return ["REPAIR TABLE \(quoted)"]
-        default: return nil
-        }
+        MySQLMaintenance.statements(
+            operation: operation,
+            table: table,
+            schema: schema,
+            options: options,
+            flavor: flavor
+        )
     }
 
     // MARK: - Create Table DDL

--- a/Plugins/MySQLDriverPlugin/MySQLServerFlavor.swift
+++ b/Plugins/MySQLDriverPlugin/MySQLServerFlavor.swift
@@ -88,12 +88,12 @@ nonisolated internal enum MySQLServerFlavor: Equatable, Sendable {
         }
     }
 
-    var maintenanceOperations: [String] {
+    var maintenanceOperations: [PluginMaintenanceOperation] {
         switch self {
         case .mysql, .mariadb:
-            return ["OPTIMIZE TABLE", "ANALYZE TABLE", "CHECK TABLE", "REPAIR TABLE"]
+            return MySQLMaintenance.operations
         case .tidb, .databend:
-            return ["ANALYZE TABLE"]
+            return [MySQLMaintenance.analyzeOperation]
         }
     }
 

--- a/Plugins/OracleDriverPlugin/Info.plist
+++ b/Plugins/OracleDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>28</integer>
+	<integer>29</integer>
 </dict>
 </plist>

--- a/Plugins/ParquetExportPlugin/Info.plist
+++ b/Plugins/ParquetExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>28</integer>
+	<integer>29</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>parquet</string>

--- a/Plugins/PostgreSQLDriverPlugin/Info.plist
+++ b/Plugins/PostgreSQLDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>28</integer>
+	<integer>29</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>PostgreSQL</string>

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLMaintenance.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLMaintenance.swift
@@ -1,0 +1,123 @@
+//
+//  PostgreSQLMaintenance.swift
+//  PostgreSQLDriverPlugin
+//
+
+import Foundation
+import TableProPluginKit
+
+/// PostgreSQL's maintenance operations and the statements they produce.
+///
+/// Pure, so the confirmation sheet's preview and the statement that runs are one function rather
+/// than two implementations that drifted: the sheet used to print `REINDEX orders`, which is not
+/// valid SQL, where `REINDEX TABLE "orders"` ran.
+///
+/// Every kind set below is what PostgreSQL 17.11 answered to the statement on that kind. The two
+/// that are not obvious: `CLUSTER` is accepted on a partitioned table and can never succeed there,
+/// because `ALTER TABLE … CLUSTER ON` refuses with "cannot mark index clustered in partitioned
+/// table"; and `ANALYZE` on a foreign table succeeds with no warning and writes `pg_statistic` rows,
+/// because the wrapper samples it, while `VACUUM` on the same table warns and skips.
+internal enum PostgreSQLMaintenance {
+    internal static let vacuum = "VACUUM"
+    internal static let analyze = "ANALYZE"
+    internal static let reindex = "REINDEX"
+    internal static let cluster = "CLUSTER"
+
+    internal static let verboseKey = "verbose"
+    internal static let fullKey = "full"
+    internal static let analyzeKey = "analyze"
+
+    internal static let operations: [PluginMaintenanceOperation] = [
+        PluginMaintenanceOperation(
+            name: vacuum,
+            appliesTo: [.table, .partitionedTable, .materializedView],
+            scope: .objectOrDatabase,
+            options: [
+                PluginMaintenanceOption(
+                    key: fullKey,
+                    label: String(localized: "FULL (rewrites the whole object, blocks access)"),
+                    defaultValue: "false"
+                ),
+                PluginMaintenanceOption(
+                    key: analyzeKey,
+                    label: String(localized: "ANALYZE (update statistics afterwards)"),
+                    defaultValue: "false"
+                ),
+                PluginMaintenanceOption(
+                    key: verboseKey,
+                    label: String(localized: "VERBOSE (report progress)"),
+                    defaultValue: "false"
+                )
+            ]
+        ),
+        PluginMaintenanceOperation(
+            name: analyze,
+            appliesTo: [.table, .partitionedTable, .materializedView, .foreignTable],
+            scope: .objectOrDatabase
+        ),
+        PluginMaintenanceOperation(
+            name: reindex,
+            appliesTo: [.table, .partitionedTable, .materializedView],
+            scope: .objectOrDatabase,
+            options: [
+                PluginMaintenanceOption(
+                    key: verboseKey,
+                    label: String(localized: "VERBOSE (report progress)"),
+                    defaultValue: "false"
+                )
+            ]
+        ),
+        PluginMaintenanceOperation(
+            name: cluster,
+            appliesTo: [.table, .materializedView],
+            scope: .object
+        )
+    ]
+
+    /// A nil `schema` leaves the name unqualified, which is what a caller with no schema to offer
+    /// means. Everything in the app does have one, and has to pass it: `search_path` resolves a bare
+    /// name against `pg_temp` first, so a temp table of the same name is what got maintained.
+    internal static func statements(
+        operation: String,
+        table: String?,
+        schema: String?,
+        options: [String: String],
+        connectedDatabase: String?,
+        capabilities: PostgreSQLCapabilities
+    ) -> [String]? {
+        let target = table.map { qualified(table: $0, schema: schema) }
+        switch operation {
+        case vacuum:
+            var flags: [String] = []
+            if isOn(options[fullKey]) { flags.append("FULL") }
+            if isOn(options[analyzeKey]) { flags.append("ANALYZE") }
+            if isOn(options[verboseKey]) { flags.append("VERBOSE") }
+            let clause = flags.isEmpty ? "" : " (\(flags.joined(separator: ", ")))"
+            return [target.map { "VACUUM\(clause) \($0)" } ?? "VACUUM\(clause)"]
+        case analyze:
+            return [target.map { "ANALYZE \($0)" } ?? "ANALYZE"]
+        case reindex:
+            guard let target else {
+                return PostgreSQLVersionedStatements.reindexDatabase(
+                    currentDatabase: connectedDatabase,
+                    capabilities: capabilities
+                ).map { [$0] }
+            }
+            let clause = isOn(options[verboseKey]) ? " (VERBOSE)" : ""
+            return ["REINDEX\(clause) TABLE \(target)"]
+        case cluster:
+            return target.map { ["CLUSTER \($0)"] }
+        default:
+            return nil
+        }
+    }
+
+    private static func qualified(table: String, schema: String?) -> String {
+        guard let schema, !schema.isEmpty else { return PostgreSQLObjectQueries.quoteIdentifier(table) }
+        return PostgreSQLObjectQueries.qualifiedName(schema: schema, name: table)
+    }
+
+    private static func isOn(_ value: String?) -> Bool {
+        value == "true"
+    }
+}

--- a/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver.swift
+++ b/Plugins/PostgreSQLDriverPlugin/PostgreSQLPluginDriver.swift
@@ -132,32 +132,22 @@ class PostgreSQLPluginDriver: LibPQBackedDriver, @unchecked Sendable {
     // MARK: - Maintenance
 
     func supportedMaintenanceOperations() -> [String]? {
-        ["VACUUM", "ANALYZE", "REINDEX", "CLUSTER"]
+        PostgreSQLMaintenance.operations.map(\.name)
+    }
+
+    func maintenanceOperations() -> [PluginMaintenanceOperation]? {
+        PostgreSQLMaintenance.operations
     }
 
     func maintenanceStatements(operation: String, table: String?, schema: String?, options: [String: String]) -> [String]? {
-        let target = table.map { quoteIdentifier($0) }
-        switch operation {
-        case "VACUUM":
-            var opts: [String] = []
-            if options["full"] == "true" { opts.append("FULL") }
-            if options["analyze"] == "true" { opts.append("ANALYZE") }
-            if options["verbose"] == "true" { opts.append("VERBOSE") }
-            let optClause = opts.isEmpty ? "" : "(\(opts.joined(separator: ", "))) "
-            return [target.map { "VACUUM \(optClause)\($0)" } ?? "VACUUM"]
-        case "ANALYZE":
-            return [target.map { "ANALYZE \($0)" } ?? "ANALYZE"]
-        case "REINDEX":
-            if let target { return ["REINDEX TABLE \(target)"] }
-            return PostgreSQLVersionedStatements.reindexDatabase(
-                currentDatabase: connectedDatabase,
-                capabilities: versionedCapabilities
-            ).map { [$0] }
-        case "CLUSTER":
-            return target.map { ["CLUSTER \($0)"] }
-        default:
-            return nil
-        }
+        PostgreSQLMaintenance.statements(
+            operation: operation,
+            table: table,
+            schema: schema,
+            options: options,
+            connectedDatabase: connectedDatabase,
+            capabilities: versionedCapabilities
+        )
     }
 
     // MARK: - View Templates

--- a/Plugins/RedisDriverPlugin/Info.plist
+++ b/Plugins/RedisDriverPlugin/Info.plist
@@ -21,7 +21,7 @@
 	<key>NSPrincipalClass</key>
 	<string>$(PRODUCT_MODULE_NAME).RedisPlugin</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>28</integer>
+	<integer>29</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Redis</string>

--- a/Plugins/SQLExportPlugin/Info.plist
+++ b/Plugins/SQLExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>28</integer>
+	<integer>29</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>sql</string>

--- a/Plugins/SQLImportPlugin/Info.plist
+++ b/Plugins/SQLImportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>28</integer>
+	<integer>29</integer>
 	<key>TableProProvidesImportFormatIds</key>
 	<array>
 		<string>sql</string>

--- a/Plugins/SQLiteDriverPlugin/Info.plist
+++ b/Plugins/SQLiteDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>28</integer>
+	<integer>29</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>SQLite</string>

--- a/Plugins/SQLiteDriverPlugin/SQLiteMaintenance.swift
+++ b/Plugins/SQLiteDriverPlugin/SQLiteMaintenance.swift
@@ -1,0 +1,50 @@
+//
+//  SQLiteMaintenance.swift
+//  SQLiteDriverPlugin
+//
+
+import Foundation
+import TableProPluginKit
+
+/// SQLite's maintenance operations and the statements they produce.
+///
+/// Pure, so the confirmation sheet's preview and the statement that runs are one function rather than
+/// two implementations that drifted: the sheet printed `VACUUM orders` where `VACUUM` ran, and
+/// `Integrity Check orders` where `PRAGMA integrity_check` ran.
+///
+/// Probed against SQLite 3.54.0. `VACUUM` and `PRAGMA integrity_check` act on the whole database and
+/// name no object, which is why they are `.database`: the table the sheet printed beside them was
+/// never in the statement. `ANALYZE` and `REINDEX` accept an object, and on a view both succeed and
+/// do nothing, `ANALYZE "vw"` writing no `sqlite_stat1` row at all, so a view is not in their kind
+/// sets. There is no kind error to go on here: a name SQLite does not recognise as a table is a
+/// silent no-op reported as success.
+nonisolated internal enum SQLiteMaintenance {
+    internal static let vacuum = "VACUUM"
+    internal static let analyze = "ANALYZE"
+    internal static let reindex = "REINDEX"
+    /// Not localized: it is the operation's identity, switched on here and sent to MCP clients as the
+    /// name they pass back.
+    internal static let integrityCheck = "Integrity Check"
+
+    internal static let operations: [PluginMaintenanceOperation] = [
+        PluginMaintenanceOperation(name: vacuum, appliesTo: [], scope: .database),
+        PluginMaintenanceOperation(name: analyze, appliesTo: [.table], scope: .objectOrDatabase),
+        PluginMaintenanceOperation(name: reindex, appliesTo: [.table], scope: .objectOrDatabase),
+        PluginMaintenanceOperation(name: integrityCheck, appliesTo: [], scope: .database)
+    ]
+
+    internal static func statements(operation: String, table: String?) -> [String]? {
+        switch operation {
+        case vacuum:
+            return [vacuum]
+        case analyze:
+            return [table.map { "ANALYZE \(sqliteQuoteIdentifier($0))" } ?? "ANALYZE"]
+        case reindex:
+            return [table.map { "REINDEX \(sqliteQuoteIdentifier($0))" } ?? "REINDEX"]
+        case integrityCheck:
+            return ["PRAGMA integrity_check"]
+        default:
+            return nil
+        }
+    }
+}

--- a/Plugins/SQLiteDriverPlugin/SQLitePlugin.swift
+++ b/Plugins/SQLiteDriverPlugin/SQLitePlugin.swift
@@ -571,8 +571,7 @@ final class SQLitePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     }
 
     func quoteIdentifier(_ name: String) -> String {
-        let escaped = name.replacingOccurrences(of: "`", with: "``")
-        return "`\(escaped)`"
+        sqliteQuoteIdentifier(name)
     }
 
     init(config: DriverConnectionConfig) {
@@ -656,17 +655,15 @@ final class SQLitePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     // MARK: - Maintenance
 
     func supportedMaintenanceOperations() -> [String]? {
-        ["VACUUM", "ANALYZE", "REINDEX", "Integrity Check"]
+        SQLiteMaintenance.operations.map(\.name)
+    }
+
+    func maintenanceOperations() -> [PluginMaintenanceOperation]? {
+        SQLiteMaintenance.operations
     }
 
     func maintenanceStatements(operation: String, table: String?, schema: String?, options: [String: String]) -> [String]? {
-        switch operation {
-        case "VACUUM": return ["VACUUM"]
-        case "ANALYZE": return table.map { ["ANALYZE \(quoteIdentifier($0))"] } ?? ["ANALYZE"]
-        case "REINDEX": return table.map { ["REINDEX \(quoteIdentifier($0))"] } ?? ["REINDEX"]
-        case "Integrity Check": return ["PRAGMA integrity_check"]
-        default: return nil
-        }
+        SQLiteMaintenance.statements(operation: operation, table: table)
     }
 
     // MARK: - View Templates

--- a/Plugins/SnowflakeDriverPlugin/Info.plist
+++ b/Plugins/SnowflakeDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.48.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>28</integer>
+	<integer>29</integer>
 </dict>
 </plist>

--- a/Plugins/SpannerDriverPlugin/Info.plist
+++ b/Plugins/SpannerDriverPlugin/Info.plist
@@ -5,7 +5,7 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>28</integer>
+	<integer>29</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Spanner</string>

--- a/Plugins/SurrealDBDriverPlugin/Info.plist
+++ b/Plugins/SurrealDBDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>28</integer>
+	<integer>29</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>SurrealDB</string>

--- a/Plugins/TableProPluginKit/PluginDatabaseDriver.swift
+++ b/Plugins/TableProPluginKit/PluginDatabaseDriver.swift
@@ -376,6 +376,15 @@ public protocol PluginDatabaseDriver: AnyObject, Sendable {
     func supportedMaintenanceOperations() -> [String]?
     func maintenanceStatements(operation: String, table: String?, schema: String?, options: [String: String]) -> [String]?
 
+    /// The maintenance operations this driver offers, each carrying the object kinds it may name, the
+    /// scope its statement has and the options it reads. Return nil where the engine has no
+    /// maintenance at all.
+    ///
+    /// `supportedMaintenanceOperations()` answers bare names, which cannot say any of that, so the
+    /// app offered every operation on every object and hand-wrote its own preview of the SQL. A
+    /// driver that answers this one is the single source of both.
+    func maintenanceOperations() -> [PluginMaintenanceOperation]?
+
     // EXPLAIN query building (optional)
     func buildExplainQuery(_ sql: String) -> String?
 
@@ -838,6 +847,13 @@ public extension PluginDatabaseDriver {
 
     func supportedMaintenanceOperations() -> [String]? { nil }
     func maintenanceStatements(operation: String, table: String?, schema: String?, options: [String: String]) -> [String]? { nil }
+
+    /// Lifts a driver that answers only the older name list into descriptors, so an already-built
+    /// plugin keeps exactly the behaviour it had. `PluginMaintenanceOperation.lifting` says what that
+    /// is, and is where the rule is asserted.
+    func maintenanceOperations() -> [PluginMaintenanceOperation]? {
+        supportedMaintenanceOperations().map(PluginMaintenanceOperation.lifting)
+    }
 
     func buildExplainQuery(_ sql: String) -> String? { nil }
 

--- a/Plugins/TableProPluginKit/PluginMaintenanceOperation.swift
+++ b/Plugins/TableProPluginKit/PluginMaintenanceOperation.swift
@@ -1,0 +1,159 @@
+//
+//  PluginMaintenanceOperation.swift
+//  TableProPluginKit
+//
+
+import Foundation
+
+/// The kind of object a maintenance operation may name, spelled as `PluginTableInfo.type` is.
+///
+/// A struct rather than an enum, for the reason `DatabaseType` is one: a driver may report a kind
+/// this framework never heard of, and `PluginDriverAdapter` already logs and falls back for exactly
+/// that. An unknown spelling has to compare unequal to every known kind rather than fail to exist.
+///
+/// The raw value is uppercased on the way in so a driver that answers `"view"` and one that answers
+/// `"VIEW"` land on the same kind.
+public struct PluginObjectKind: RawRepresentable, Hashable, Sendable, Codable {
+    public let rawValue: String
+
+    public init(rawValue: String) {
+        self.rawValue = rawValue.uppercased()
+    }
+
+    public init(_ name: String) {
+        self.init(rawValue: name)
+    }
+
+    public static let table = PluginObjectKind(rawValue: "TABLE")
+    public static let partitionedTable = PluginObjectKind(rawValue: "PARTITIONED TABLE")
+    public static let view = PluginObjectKind(rawValue: "VIEW")
+    public static let materializedView = PluginObjectKind(rawValue: "MATERIALIZED VIEW")
+    public static let foreignTable = PluginObjectKind(rawValue: "FOREIGN TABLE")
+    public static let systemTable = PluginObjectKind(rawValue: "SYSTEM TABLE")
+    public static let externalTable = PluginObjectKind(rawValue: "EXTERNAL TABLE")
+
+    /// Every kind the object browser lists as a table row.
+    ///
+    /// What a driver that answers only the older `supportedMaintenanceOperations()` inherits, so its
+    /// menu keeps exactly the shape it had before kinds existed.
+    public static let allTableLike: Set<PluginObjectKind> = [
+        .table,
+        .partitionedTable,
+        .view,
+        .materializedView,
+        .foreignTable,
+        .systemTable,
+        .externalTable
+    ]
+}
+
+/// What an operation's statement may name.
+///
+/// SQLite's `VACUUM` and `PRAGMA integrity_check` take no object at all, so an operation list of
+/// bare names cannot say that the table the sheet printed beside them was never in the statement.
+public enum PluginMaintenanceScope: String, Sendable, Codable {
+    case object
+    case database
+    case objectOrDatabase
+
+    /// Whether a statement for this operation may name one object.
+    public var admitsObject: Bool {
+        switch self {
+        case .object, .objectOrDatabase: return true
+        case .database: return false
+        }
+    }
+
+    /// Whether a statement for this operation may name no object and act on the whole database.
+    public var admitsDatabase: Bool {
+        switch self {
+        case .database, .objectOrDatabase: return true
+        case .object: return false
+        }
+    }
+}
+
+/// One option an operation accepts, as the driver that builds the statement declares it.
+///
+/// Declared rather than assumed because the confirmation sheet used to decide this itself, gated on
+/// two engine names: an engine that grew the same flags would not have been offered them, and the
+/// keys the sheet produced had to agree by hand with the keys the driver read.
+public struct PluginMaintenanceOption: Hashable, Sendable, Codable {
+    /// The key this option's value travels under in the `options` dictionary.
+    public let key: String
+    public let label: String
+    public let defaultValue: String
+    /// The fixed set of values, or nil for a boolean the caller sends as `"true"` or `"false"`.
+    public let choices: [String]?
+
+    public init(key: String, label: String, defaultValue: String, choices: [String]? = nil) {
+        self.key = key
+        self.label = label
+        self.defaultValue = defaultValue
+        self.choices = choices
+    }
+
+    public var isToggle: Bool { choices == nil }
+}
+
+/// One maintenance operation, with everything the caller needs to decide whether to offer it.
+///
+/// The older `supportedMaintenanceOperations()` answers a list of bare names, which cannot say which
+/// objects an operation works on. PostgreSQL answers `VACUUM` on a view with a WARNING and the
+/// success command tag `VACUUM`, so the app reported success over work the server skipped, while
+/// `REINDEX` on the same view failed outright.
+public struct PluginMaintenanceOperation: Hashable, Sendable, Codable {
+    public let name: String
+    public let appliesTo: Set<PluginObjectKind>
+    public let scope: PluginMaintenanceScope
+    public let options: [PluginMaintenanceOption]
+
+    public init(
+        name: String,
+        appliesTo: Set<PluginObjectKind>,
+        scope: PluginMaintenanceScope,
+        options: [PluginMaintenanceOption] = []
+    ) {
+        self.name = name
+        self.appliesTo = appliesTo
+        self.scope = scope
+        self.options = options
+    }
+
+    /// Whether a statement for this operation may name an object of `kind`.
+    public func applies(to kind: PluginObjectKind) -> Bool {
+        scope.admitsObject && appliesTo.contains(kind)
+    }
+
+    /// The object a statement for this operation should name, given the object it was reached from.
+    ///
+    /// Nil for an operation that acts on the whole database, so the object is dropped rather than
+    /// printed beside a statement that never mentions it: the sheet showed `VACUUM orders` on SQLite
+    /// where `VACUUM` ran.
+    public func target(_ objectName: String?) -> String? {
+        scope.admitsObject ? objectName : nil
+    }
+
+    /// Every option's default, which is what a caller sends when the user changes nothing.
+    public var defaultOptionValues: [String: String] {
+        var values: [String: String] = [:]
+        for option in options {
+            values[option.key] = option.defaultValue
+        }
+        return values
+    }
+
+    /// Lifts a driver's older list of bare names into descriptors.
+    ///
+    /// What `PluginDatabaseDriver.maintenanceOperations()` defaults to, so a plugin built before kinds
+    /// existed keeps exactly the behaviour it had: every table-like kind, either scope, no options.
+    public static func lifting(_ names: [String]) -> [PluginMaintenanceOperation] {
+        names.map {
+            PluginMaintenanceOperation(
+                name: $0,
+                appliesTo: PluginObjectKind.allTableLike,
+                scope: .objectOrDatabase
+            )
+        }
+    }
+}

--- a/Plugins/TeradataDriverPlugin/Info.plist
+++ b/Plugins/TeradataDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>28</integer>
+	<integer>29</integer>
 </dict>
 </plist>

--- a/Plugins/TrinoDriverPlugin/Info.plist
+++ b/Plugins/TrinoDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>28</integer>
+	<integer>29</integer>
 </dict>
 </plist>

--- a/Plugins/TypesenseDriverPlugin/Info.plist
+++ b/Plugins/TypesenseDriverPlugin/Info.plist
@@ -5,7 +5,7 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.73.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>28</integer>
+	<integer>29</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Typesense</string>

--- a/Plugins/WeaviateDriverPlugin/Info.plist
+++ b/Plugins/WeaviateDriverPlugin/Info.plist
@@ -5,7 +5,7 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.73.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>25</integer>
+	<integer>29</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Weaviate</string>

--- a/Plugins/XLSXExportPlugin/Info.plist
+++ b/Plugins/XLSXExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>28</integer>
+	<integer>29</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>xlsx</string>

--- a/Plugins/XLSXImportPlugin/Info.plist
+++ b/Plugins/XLSXImportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>28</integer>
+	<integer>29</integer>
 	<key>TableProProvidesImportFormatIds</key>
 	<array>
 		<string>xlsx</string>

--- a/Plugins/XMLExportPlugin/Info.plist
+++ b/Plugins/XMLExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>28</integer>
+	<integer>29</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>xml</string>

--- a/TablePro/Core/Database/DatabaseDriver.swift
+++ b/TablePro/Core/Database/DatabaseDriver.swift
@@ -245,12 +245,26 @@ protocol DatabaseDriver: AnyObject, Sendable {
 
     // MARK: - Maintenance
 
-    /// Returns the list of supported maintenance operations (e.g. "VACUUM", "ANALYZE").
-    /// Returns nil if maintenance is not supported.
-    func supportedMaintenanceOperations() -> [String]?
+    /// The maintenance operations this connection offers, each with the object kinds it may name, its
+    /// scope and its options. Returns nil if maintenance is not supported.
+    ///
+    /// Descriptors rather than names, because the menu has to decide whether an operation applies to
+    /// the object the user clicked: PostgreSQL skips a `VACUUM` on a view with a WARNING and the
+    /// success command tag `VACUUM`, and refuses a `REINDEX` on one outright.
+    func maintenanceOperations() -> [PluginMaintenanceOperation]?
 
-    /// Generates SQL statements for a maintenance operation.
-    func maintenanceStatements(operation: String, table: String?, options: [String: String]) -> [String]?
+    /// Generates SQL statements for a maintenance operation. The single source of the statement, so
+    /// the confirmation sheet previews this rather than writing its own copy of the SQL.
+    ///
+    /// A nil `schema` means the caller genuinely has none to offer. Everything in the app does, and
+    /// passes it: PostgreSQL resolves a bare name against `pg_temp` first, so a temp table of the
+    /// same name is what got maintained.
+    func maintenanceStatements(
+        operation: String,
+        table: String?,
+        schema: String?,
+        options: [String: String]
+    ) -> [String]?
 
     // MARK: - Object Comments and Materialized Views
 
@@ -576,8 +590,13 @@ extension DatabaseDriver {
         try await fetchFilteredRowCount(table: table, filters: filters, logicMode: logicMode)
     }
 
-    func supportedMaintenanceOperations() -> [String]? { nil }
-    func maintenanceStatements(operation: String, table: String?, options: [String: String]) -> [String]? { nil }
+    func maintenanceOperations() -> [PluginMaintenanceOperation]? { nil }
+    func maintenanceStatements(
+        operation: String,
+        table: String?,
+        schema: String?,
+        options: [String: String]
+    ) -> [String]? { nil }
 
     func objectCommentStatement(name: String, objectType: String, schema: String?, comment: String?) -> String? {
         nil

--- a/TablePro/Core/MCP/MCPConnectionBridge+Server.swift
+++ b/TablePro/Core/MCP/MCPConnectionBridge+Server.swift
@@ -213,27 +213,86 @@ extension MCPConnectionBridge {
         return sql
     }
 
+    /// Each operation carries the object kinds it applies to, its scope and its options, because a
+    /// client that only knows the name cannot tell that `VACUUM` on a view is skipped by the server or
+    /// that `VACUUM` reads a `full` option at all.
     func maintenanceOperations(connectionId: UUID) async throws -> JsonValue {
         try await ensureConnected(connectionId)
         let operations = await MainActor.run {
-            DatabaseManager.shared.driver(for: connectionId)?.supportedMaintenanceOperations()
+            DatabaseManager.shared.driver(for: connectionId)?.maintenanceOperations()
         }
+        let sorted = (operations ?? []).sorted { $0.name < $1.name }
         return .object([
-            "operations": .array((operations ?? []).sorted().map { .string($0) }),
+            "operations": .array(sorted.map(Self.encode(maintenance:))),
             "is_supported": .bool(operations != nil)
         ])
     }
 
+    static func encode(maintenance operation: PluginMaintenanceOperation) -> JsonValue {
+        .object([
+            "name": .string(operation.name),
+            "applies_to": .array(operation.appliesTo.map(\.rawValue).sorted().map { .string($0) }),
+            "scope": .string(operation.scope.rawValue),
+            "options": .array(operation.options.map(Self.encode(maintenanceOption:)))
+        ])
+    }
+
+    /// `choices` is left out rather than sent as null for a true/false flag, so the payload stays valid
+    /// against the declared output schema.
+    static func encode(maintenanceOption option: PluginMaintenanceOption) -> JsonValue {
+        var payload: [String: JsonValue] = [
+            "key": .string(option.key),
+            "label": .string(option.label),
+            "default": .string(option.defaultValue)
+        ]
+        if let choices = option.choices {
+            payload["choices"] = .array(choices.map { .string($0) })
+        }
+        return .object(payload)
+    }
+
+    /// Refuses an operation the object's kind rules out, rather than handing back a statement the
+    /// server will skip with a warning and a success tag. The kind comes from the same table listing
+    /// `list_tables` reads.
     func maintenanceStatements(
-        connectionId: UUID,
+        scope: DatabaseScope,
         operation: String,
         table: String?,
         options: [String: String]
     ) async throws -> [String] {
-        try await ensureConnected(connectionId)
+        try await ensureConnected(scope.connectionId)
+        let descriptor = try await resolveMaintenanceOperation(
+            connectionId: scope.connectionId,
+            operation: operation
+        )
+        if let table {
+            guard descriptor.scope.admitsObject else {
+                throw DatabaseAccessError.invalidArgument(
+                    String(
+                        format: String(localized: "%@ acts on the whole database. Omit 'table'."),
+                        descriptor.name
+                    )
+                )
+            }
+            try await requireMaintenanceKind(descriptor: descriptor, scope: scope, table: table)
+        } else {
+            guard descriptor.scope.admitsDatabase else {
+                throw DatabaseAccessError.invalidArgument(
+                    String(
+                        format: String(localized: "%@ needs a table. Pass 'table'."),
+                        descriptor.name
+                    )
+                )
+            }
+        }
+
         let statements = await MainActor.run {
-            DatabaseManager.shared.driver(for: connectionId)?
-                .maintenanceStatements(operation: operation, table: table, options: options)
+            DatabaseManager.shared.driver(for: scope.connectionId)?.maintenanceStatements(
+                operation: operation,
+                table: table,
+                schema: scope.schema,
+                options: options
+            )
         }
         guard let statements, !statements.isEmpty else {
             throw DatabaseAccessError.invalidArgument(
@@ -241,6 +300,46 @@ extension MCPConnectionBridge {
             )
         }
         return statements
+    }
+
+    private func resolveMaintenanceOperation(
+        connectionId: UUID,
+        operation: String
+    ) async throws -> PluginMaintenanceOperation {
+        let operations = await MainActor.run {
+            DatabaseManager.shared.driver(for: connectionId)?.maintenanceOperations()
+        }
+        guard let match = operations?.first(where: { $0.name == operation }) else {
+            throw DatabaseAccessError.invalidArgument(
+                String(localized: "That maintenance operation is not available on this connection.")
+            )
+        }
+        return match
+    }
+
+    private func requireMaintenanceKind(
+        descriptor: PluginMaintenanceOperation,
+        scope: DatabaseScope,
+        table: String
+    ) async throws {
+        let tables = try await DatabaseManager.shared.withMetadataDriver(scope: scope) { driver in
+            try await driver.fetchTables(schema: scope.schema)
+        }
+        guard let found = tables.first(where: { $0.name == table }) else {
+            throw DatabaseAccessError.invalidArgument(
+                String(format: String(localized: "No object named %@ in this schema."), table)
+            )
+        }
+        let kind = TableOperationEligibility.pluginKind(found.type)
+        guard descriptor.applies(to: kind) else {
+            throw DatabaseAccessError.invalidArgument(
+                String(
+                    format: String(localized: "%1$@ does not apply to a %2$@."),
+                    descriptor.name,
+                    found.type.rawValue
+                )
+            )
+        }
     }
 
     func sessionContexts(connectionId: UUID) async throws -> JsonValue {

--- a/TablePro/Core/MCP/Protocol/Tools/MaintenanceTools.swift
+++ b/TablePro/Core/MCP/Protocol/Tools/MaintenanceTools.swift
@@ -23,8 +23,41 @@ public struct ListMaintenanceOperationsTool: MCPToolImplementation {
     public static let outputSchema: JsonValue? = MCPToolSchema.object(
         properties: [
             "operations": MCPToolSchema.array(
-                String(localized: "Operation names, sorted"),
-                of: MCPToolSchema.stringItem
+                String(localized: "Operations, sorted by name"),
+                of: MCPToolSchema.object(
+                    properties: [
+                        "name": MCPToolSchema.string(String(localized: "Operation name to pass to run_maintenance")),
+                        "applies_to": MCPToolSchema.array(
+                            String(
+                                localized: """
+                                Object kinds this operation may name, as list_tables reports them. \
+                                Empty when it acts on the whole database only.
+                                """
+                            ),
+                            of: MCPToolSchema.stringItem
+                        ),
+                        "scope": MCPToolSchema.string(
+                            String(localized: "Whether the statement names an object, the database, or either"),
+                            enumValues: ["object", "database", "objectOrDatabase"]
+                        ),
+                        "options": MCPToolSchema.array(
+                            String(localized: "Options this operation reads, by key"),
+                            of: MCPToolSchema.object(
+                                properties: [
+                                    "key": MCPToolSchema.string(String(localized: "Key to send in 'options'")),
+                                    "label": MCPToolSchema.string(String(localized: "What the option does")),
+                                    "default": MCPToolSchema.string(String(localized: "Value used when omitted")),
+                                    "choices": MCPToolSchema.array(
+                                        String(localized: "Accepted values, or null for a true/false flag"),
+                                        of: MCPToolSchema.stringItem
+                                    )
+                                ],
+                                required: ["key", "label", "default"]
+                            )
+                        )
+                    ],
+                    required: ["name", "applies_to", "scope", "options"]
+                )
             ),
             "is_supported": MCPToolSchema.boolean(String(localized: "Whether this engine has maintenance at all"))
         ],
@@ -121,10 +154,17 @@ public struct RunMaintenanceTool: MCPToolImplementation {
         }
 
         let meta = try await ToolConnectionMetadata.resolve(connectionId: connectionId)
+        /// Resolved before the statements, because the schema it carries is what qualifies the target
+        /// and its kind is what says whether the operation applies at all.
+        let scope = try await MCPScopeArguments.resolve(
+            arguments,
+            connectionId: connectionId,
+            services: services
+        )
         let statements: [String]
         do {
             statements = try await services.connectionBridge.maintenanceStatements(
-                connectionId: connectionId,
+                scope: scope,
                 operation: operation,
                 table: table,
                 options: options
@@ -135,11 +175,6 @@ public struct RunMaintenanceTool: MCPToolImplementation {
 
         let settings = await services.settingsProvider()
         let timeoutSeconds = try MCPLimitResolver.resolveTimeoutSeconds(arguments, settings: settings)
-        let scope = try await MCPScopeArguments.resolve(
-            arguments,
-            connectionId: connectionId,
-            services: services
-        )
 
         var results: [JsonValue] = []
         for statement in statements {

--- a/TablePro/Core/Menu/MaintenanceMenuDelegate.swift
+++ b/TablePro/Core/Menu/MaintenanceMenuDelegate.swift
@@ -4,8 +4,9 @@
 //
 
 import AppKit
+import TableProPluginKit
 
-/// Which maintenance operations exist depends on the driver and on what is selected,
+/// Which maintenance operations exist depends on the driver and on the kind of the selected object,
 /// so the submenu is filled when it opens rather than at build time. `menuNeedsUpdate`
 /// is AppKit's hook for exactly that, and the responder chain resolves the window the
 /// same way it will resolve the item the user picks.
@@ -24,7 +25,7 @@ final class MaintenanceMenuDelegate: NSObject, NSMenuDelegate {
             return
         }
         for operation in operations {
-            let item = NSMenuItem(title: operation, action: Self.action, keyEquivalent: "")
+            let item = NSMenuItem(title: operation.name, action: Self.action, keyEquivalent: "")
             item.target = nil
             item.representedObject = operation
             menu.addItem(item)

--- a/TablePro/Core/Plugins/PluginDriverAdapter.swift
+++ b/TablePro/Core/Plugins/PluginDriverAdapter.swift
@@ -770,12 +770,24 @@ final class PluginDriverAdapter: DatabaseDriver, SchemaSwitchable, DatabaseRepor
 
     // MARK: - Maintenance Operations
 
-    func supportedMaintenanceOperations() -> [String]? {
-        pluginDriver.supportedMaintenanceOperations()
+    func maintenanceOperations() -> [PluginMaintenanceOperation]? {
+        pluginDriver.maintenanceOperations()
     }
 
-    func maintenanceStatements(operation: String, table: String?, options: [String: String]) -> [String]? {
-        pluginDriver.maintenanceStatements(operation: operation, table: table, schema: pluginDriver.currentSchema, options: options)
+    /// The session's own schema stands in only when the caller has none, so a command that does carry
+    /// the object's schema qualifies with that one rather than with wherever the session points.
+    func maintenanceStatements(
+        operation: String,
+        table: String?,
+        schema: String?,
+        options: [String: String]
+    ) -> [String]? {
+        pluginDriver.maintenanceStatements(
+            operation: operation,
+            table: table,
+            schema: schema ?? pluginDriver.currentSchema,
+            options: options
+        )
     }
 
     // MARK: - Object Comments and Materialized Views

--- a/TablePro/Core/Plugins/PluginManager.swift
+++ b/TablePro/Core/Plugins/PluginManager.swift
@@ -14,7 +14,13 @@ import TableProPluginKit
 @MainActor @Observable
 final class PluginManager {
     static let shared = PluginManager(userDefaults: AppStorageEnvironment.shared.defaults)
-    /// Raised to 28 for `fetchCommentDDL` on `PluginDatabaseDriver` and `PluginExportDataSource`,
+    /// Raised to 29 for `maintenanceOperations` on `PluginDatabaseDriver`, plus the
+    /// `PluginMaintenanceOperation`, `PluginMaintenanceOption`, `PluginMaintenanceScope` and
+    /// `PluginObjectKind` it answers with. Together they say which object kinds a maintenance
+    /// operation may name, whether its statement names an object at all, and which options it reads,
+    /// none of which the older list of bare names could.
+    ///
+    /// Raised to 28 before that for `fetchCommentDDL` on `PluginDatabaseDriver` and `PluginExportDataSource`,
     /// which is what lets a dump reattach a relation's own comment and its column comments instead
     /// of leaving whether they appear at all to each driver's `fetchTableDDL`.
     ///
@@ -49,7 +55,7 @@ final class PluginManager {
     /// rebuilt CassandraDriver for the v20 requirements it implements none of. Left at 20, such a
     /// plugin passes `validateBundleVersions` in a shipped v20 app and then fails
     /// `Bundle.loadAndReturnError`; at 21 that app refuses it and says to update.
-    nonisolated static let currentPluginKitVersion = 28
+    nonisolated static let currentPluginKitVersion = 29
 
     /// Still 19, so every plugin already published for the previous release keeps loading.
     nonisolated static let minimumCompatiblePluginKitVersion = 19

--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController+DatabaseMenuActions.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController+DatabaseMenuActions.swift
@@ -5,6 +5,7 @@
 
 import AppKit
 import SwiftUI
+import TableProPluginKit
 
 extension MainSplitViewController {
     @objc func switchConnection(_ sender: Any?) {
@@ -105,7 +106,8 @@ extension MainSplitViewController {
     }
 
     @objc func runMaintenanceOperation(_ sender: Any?) {
-        guard let operation = (sender as? NSMenuItem)?.representedObject as? String else { return }
+        guard let operation = (sender as? NSMenuItem)?.representedObject as? PluginMaintenanceOperation
+        else { return }
         commandActions?.runMaintenanceOperation(operation)
     }
 

--- a/TablePro/Models/Database/TableOperationEligibility.swift
+++ b/TablePro/Models/Database/TableOperationEligibility.swift
@@ -36,4 +36,36 @@ enum TableOperationEligibility {
         guard !targets.isEmpty else { return false }
         return targets.allSatisfy { canTruncate($0.table.type) }
     }
+
+    /// The driver's vocabulary for the same kind. Spelled out rather than taken from `rawValue` so
+    /// adding a case to `TableInfo.TableType` stops compiling here instead of silently producing a
+    /// kind no driver declares, which would read as "no maintenance applies".
+    static func pluginKind(_ type: TableInfo.TableType?) -> PluginObjectKind {
+        switch type {
+        case .table, .none:     return .table
+        case .partitionedTable: return .partitionedTable
+        case .view:             return .view
+        case .materializedView: return .materializedView
+        case .foreignTable:     return .foreignTable
+        case .systemTable:      return .systemTable
+        case .externalTable:    return .externalTable
+        }
+    }
+
+    /// The maintenance the driver offers on an object of this kind.
+    ///
+    /// The one answer for the sidebar's contextual menu, the menu bar's Table Maintenance submenu and
+    /// the MCP tool. Offering every operation on every row is how `VACUUM` came to be offered on a
+    /// view, where PostgreSQL skips it with a WARNING and still reports success, and `REINDEX` on one,
+    /// where it fails outright.
+    ///
+    /// An operation whose statement names no object is kept whatever the row is: the row is only
+    /// where it is reached from, which is how SQLite's `VACUUM` is reachable at all.
+    static func maintenanceOperations(
+        _ all: [PluginMaintenanceOperation],
+        for type: TableInfo.TableType?
+    ) -> [PluginMaintenanceOperation] {
+        let kind = pluginKind(type)
+        return all.filter { $0.scope.admitsObject ? $0.applies(to: kind) : true }
+    }
 }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+SidebarActions.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+SidebarActions.swift
@@ -247,13 +247,13 @@ extension MainContentCoordinator {
 
     // MARK: - Maintenance
 
-    func supportedMaintenanceOperations() -> [String] {
+    func maintenanceOperations() -> [PluginMaintenanceOperation] {
         guard let driver = DatabaseManager.shared.driver(for: connectionId) else { return [] }
-        return driver.supportedMaintenanceOperations() ?? []
+        return driver.maintenanceOperations() ?? []
     }
 
     func showMaintenanceSheet(
-        operation: String,
+        operation: PluginMaintenanceOperation,
         tableName: String,
         database: String? = nil,
         schema: String? = nil
@@ -261,6 +261,26 @@ extension MainContentCoordinator {
         activeSheet = .maintenance(
             operation: operation, tableName: tableName, database: database, schema: schema
         )
+    }
+
+    /// The statements the confirmation sheet shows, built by the driver that will run them.
+    ///
+    /// Synchronous and pure, so the sheet can call it from `body` on every toggle. It used to write
+    /// its own SQL instead, which disagreed with what ran: `REINDEX orders`, not valid SQL, where
+    /// `REINDEX TABLE "orders"` runs.
+    func maintenancePreview(
+        operation: PluginMaintenanceOperation,
+        tableName: String?,
+        schema: String?,
+        options: [String: String]
+    ) -> [String] {
+        guard let driver = DatabaseManager.shared.driver(for: connectionId) else { return [] }
+        return driver.maintenanceStatements(
+            operation: operation.name,
+            table: operation.target(tableName),
+            schema: schema,
+            options: options
+        ) ?? []
     }
 
     /// Runs against the database the object it names lives in, on a scoped lease.
@@ -273,16 +293,16 @@ extension MainContentCoordinator {
     /// Every other statement the user owns takes a scoped lease; this one now does too, which also
     /// puts it behind the same gate rather than interleaving with a tab's work on one handle.
     func executeMaintenance(
-        operation: String,
+        operation: PluginMaintenanceOperation,
         tableName: String,
         options: [String: String],
         database: String? = nil,
         schema: String? = nil
     ) {
-        guard let driver = DatabaseManager.shared.driver(for: connectionId) else { return }
-        guard let statements = driver.maintenanceStatements(
-            operation: operation, table: tableName, options: options
-        ) else { return }
+        let statements = maintenancePreview(
+            operation: operation, tableName: tableName, schema: schema, options: options
+        )
+        guard !statements.isEmpty else { return }
         /// The object the user picked names its own database, and only a command that names none
         /// falls back to where the browser is pointing. `resolvedScope` is what decides that, so a
         /// schema is never carried across a database boundary.
@@ -290,6 +310,9 @@ extension MainContentCoordinator {
             database: database, schema: schema, for: connectionId
         ) ?? browseScope else { return }
 
+        /// What the statement acts on, which is the database itself for an operation that names no
+        /// object. Reporting the table there claimed work the statement never asked for.
+        let subject = operation.target(tableName) ?? scope.database
         Task { [weak self] in
             guard let self else { return }
             let decision = await ExecutionGateProvider.shared.authorize(
@@ -300,13 +323,13 @@ extension MainContentCoordinator {
                     kind: .maintenance,
                     caller: .userInterface,
                     capabilities: .interactiveUser,
-                    operationDescription: operation
+                    operationDescription: operation.name
                 )
             )
             guard case .authorized = decision else {
                 if let reason = decision.deniedReason {
                     await AlertHelper.showErrorSheet(
-                        title: String(format: String(localized: "%@ failed"), operation),
+                        title: String(format: String(localized: "%@ failed"), operation.name),
                         message: reason,
                         window: self.contentWindow
                     )
@@ -329,14 +352,18 @@ extension MainContentCoordinator {
                     }
                 }
                 await AlertHelper.showInfoSheet(
-                    title: String(format: String(localized: "%@ completed"), operation),
+                    title: String(format: String(localized: "%@ completed"), operation.name),
                     message: lastResult?.statusMessage
-                        ?? String(format: String(localized: "%@ on %@ completed successfully."), operation, tableName),
+                        ?? String(
+                            format: String(localized: "%@ on %@ completed successfully."),
+                            operation.name,
+                            subject
+                        ),
                     window: self.contentWindow
                 )
             } catch {
                 await AlertHelper.showErrorSheet(
-                    title: String(format: String(localized: "%@ failed"), operation),
+                    title: String(format: String(localized: "%@ failed"), operation.name),
                     message: error.localizedDescription,
                     window: self.contentWindow
                 )

--- a/TablePro/Views/Main/MainContentCommandActions+DatabaseObjects.swift
+++ b/TablePro/Views/Main/MainContentCommandActions+DatabaseObjects.swift
@@ -4,6 +4,7 @@
 //
 
 import Foundation
+import TableProPluginKit
 
 /// Commands that act on the object selected in the sidebar. The sidebar's own
 /// context menu reaches the same coordinator methods, so the menu bar is a second
@@ -80,15 +81,20 @@ extension MainContentCommandActions {
         return .of(DatabaseManager.shared.driver(for: connectionId))
     }
 
-    var maintenanceOperations: [String] {
-        guard selectedObject != nil else { return [] }
-        return coordinator?.supportedMaintenanceOperations() ?? []
+    /// Narrowed to the selected object's kind, the same rule the sidebar's submenu follows. Asking
+    /// only whether something was selected is how the menu bar offered `REINDEX` on a view.
+    var maintenanceOperations: [PluginMaintenanceOperation] {
+        guard let object = selectedObject else { return [] }
+        return TableOperationEligibility.maintenanceOperations(
+            coordinator?.maintenanceOperations() ?? [],
+            for: object.type
+        )
     }
 
     /// The menu acts on the object browser's selection, and `TableInfo` carries a schema but no
     /// database, so this names only the schema and the command falls back to the database being
     /// browsed. The sidebar's own contextual menu carries the clicked row's database and does not.
-    func runMaintenanceOperation(_ operation: String) {
+    func runMaintenanceOperation(_ operation: PluginMaintenanceOperation) {
         guard let object = selectedObject else { return }
         coordinator?.showMaintenanceSheet(
             operation: operation, tableName: object.name, schema: object.schema

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -68,7 +68,12 @@ enum ActiveSheet: Identifiable {
     /// its table and nothing else, so acting on wherever the object browser happens to point
     /// maintains the same-named table in another database whenever the two have drifted apart.
     /// This is the rule the sidebar's other destructive commands already keep by carrying their ref.
-    case maintenance(operation: String, tableName: String, database: String?, schema: String?)
+    case maintenance(
+        operation: PluginMaintenanceOperation,
+        tableName: String,
+        database: String?,
+        schema: String?
+    )
     case createDatabase
     /// The object's own database and schema travel in the target, for the reason `.maintenance`
     /// carries them: the comment is written to the object the user right-clicked, not to a
@@ -94,7 +99,7 @@ enum ActiveSheet: Identifiable {
         case .restoreDatabase(let fileURL): "restoreDatabase-\(fileURL.path)"
         case .serverSideExport(let table): "serverSideExport-\(table ?? "")"
         case .maintenance(let operation, let tableName, let database, let schema):
-            "maintenance-\(operation)-\(database ?? "")-\(schema ?? "")-\(tableName)"
+            "maintenance-\(operation.name)-\(database ?? "")-\(schema ?? "")-\(tableName)"
         case .createDatabase: "createDatabase"
         case .editObjectComment(let target):
             "editObjectComment-\(target.scope.database)-\(target.scope.schema ?? "")-\(target.name)"

--- a/TablePro/Views/Main/MainContentView.swift
+++ b/TablePro/Views/Main/MainContentView.swift
@@ -214,8 +214,16 @@ struct MainContentView: View {
             MaintenanceSheet(
                 operation: operation,
                 tableName: tableName,
-                databaseType: connection.type,
-                onExecute: { operation, tableName, options in
+                databaseName: database ?? coordinator.browseDatabaseName,
+                preview: { options in
+                    coordinator.maintenancePreview(
+                        operation: operation,
+                        tableName: tableName,
+                        schema: schema,
+                        options: options
+                    )
+                },
+                onExecute: { options in
                     coordinator.executeMaintenance(
                         operation: operation,
                         tableName: tableName,

--- a/TablePro/Views/Sidebar/DatabaseTreeOutlineCoordinator+Commands.swift
+++ b/TablePro/Views/Sidebar/DatabaseTreeOutlineCoordinator+Commands.swift
@@ -76,7 +76,7 @@ extension DatabaseTreeOutlineCoordinator {
                     operation: operation,
                     tableName: tableName,
                     database: ref.database,
-                    schema: ref.schema
+                    schema: ref.qualifyingSchema
                 )
             }
         case .truncateTables(let targets, let ref):

--- a/TablePro/Views/Sidebar/DatabaseTreeOutlineCoordinator+Menu.swift
+++ b/TablePro/Views/Sidebar/DatabaseTreeOutlineCoordinator+Menu.swift
@@ -45,7 +45,7 @@ extension DatabaseTreeOutlineCoordinator: NSMenuDelegate {
             isReadOnly: mainCoordinator?.safeModeLevel.blocksAllWrites ?? false,
             supportsImport: PluginManager.shared.supportsImport(for: databaseType),
             importFormats: PluginManager.shared.importFormatOptions(for: databaseType),
-            maintenanceOperations: mainCoordinator?.supportedMaintenanceOperations() ?? [],
+            maintenanceOperations: mainCoordinator?.maintenanceOperations() ?? [],
             dropEligibility: ContainerDropEligibility.Context(
                 activeDatabase: activeDatabase,
                 activeSchema: activeSchema,

--- a/TablePro/Views/Sidebar/MaintenanceSheet.swift
+++ b/TablePro/Views/Sidebar/MaintenanceSheet.swift
@@ -2,44 +2,58 @@
 //  MaintenanceSheet.swift
 //  TablePro
 //
-//  Confirmation sheet for database maintenance operations
-//  (VACUUM, ANALYZE, OPTIMIZE, REINDEX, etc.)
-//
 
 import SwiftUI
+import TableProPluginKit
 
+/// Confirms a maintenance operation and shows the statements that will run.
+///
+/// The preview is the driver's own SQL, handed in as a closure, and the Execute button sends the same
+/// option values back through the same builder. It used to write its own copy of the statement and
+/// disagree with it: `REINDEX orders`, which is not valid SQL, where `REINDEX TABLE "orders"` ran.
+/// The option controls come from the operation for the same reason, rather than from a switch gated
+/// on two engine names.
 struct MaintenanceSheet: View {
     @Environment(\.dismiss) private var dismiss
 
-    let operation: String
-    let tableName: String
-    let databaseType: DatabaseType
-    let onExecute: (String, String, [String: String]) -> Void
+    let operation: PluginMaintenanceOperation
+    let tableName: String?
+    let databaseName: String?
+    /// Statements for the given option values. Synchronous and pure, so calling it for every toggle
+    /// while `body` runs costs an array of strings.
+    let preview: ([String: String]) -> [String]
+    let onExecute: ([String: String]) -> Void
 
-    @State private var fullVacuum = false
-    @State private var analyzeAfterVacuum = false
-    @State private var verbose = false
-    @State private var checkMode = "MEDIUM"
+    @State private var values: [String: String]
+
+    init(
+        operation: PluginMaintenanceOperation,
+        tableName: String?,
+        databaseName: String?,
+        preview: @escaping ([String: String]) -> [String],
+        onExecute: @escaping ([String: String]) -> Void
+    ) {
+        self.operation = operation
+        self.tableName = tableName
+        self.databaseName = databaseName
+        self.preview = preview
+        self.onExecute = onExecute
+        _values = State(initialValue: operation.defaultOptionValues)
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
-            HStack {
-                Image(systemName: "wrench.and.screwdriver")
-                    .font(.title2)
-                    .foregroundStyle(.secondary)
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(operation)
-                        .font(.headline)
-                    Text(tableName)
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                }
-                Spacer()
-            }
+            header
 
             Divider()
 
-            operationOptions
+            if !operation.options.isEmpty {
+                VStack(alignment: .leading, spacing: 8) {
+                    ForEach(operation.options, id: \.key) { option in
+                        optionControl(option)
+                    }
+                }
+            }
 
             VStack(alignment: .leading, spacing: 4) {
                 Text(String(localized: "SQL Preview"))
@@ -47,6 +61,7 @@ struct MaintenanceSheet: View {
                     .foregroundStyle(.secondary)
                 Text(sqlPreview)
                     .font(.system(.body, design: .monospaced))
+                    .textSelection(.enabled)
                     .padding(8)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .background(Color(nsColor: .textBackgroundColor))
@@ -60,66 +75,72 @@ struct MaintenanceSheet: View {
                 Button(String(localized: "Cancel")) { dismiss() }
                     .keyboardShortcut(.cancelAction)
                 Button(String(localized: "Execute")) {
-                    onExecute(operation, tableName, buildOptions())
+                    onExecute(values)
                     dismiss()
                 }
                 .keyboardShortcut(.defaultAction)
                 .buttonStyle(.borderedProminent)
+                .disabled(sqlPreview.isEmpty)
             }
         }
         .padding(20)
         .frame(width: 420)
     }
 
-    // MARK: - Options
+    private var header: some View {
+        HStack {
+            Image(systemName: "wrench.and.screwdriver")
+                .font(.title2)
+                .foregroundStyle(.secondary)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(operation.name)
+                    .font(.headline)
+                if let subject {
+                    Text(subject)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Spacer()
+        }
+    }
+
+    /// What the statement acts on. An operation that names no object reads as the database it runs
+    /// against, rather than as the table the row it was reached from happened to be.
+    private var subject: String? {
+        operation.target(tableName)?.nilIfEmpty ?? databaseName?.nilIfEmpty
+    }
 
     @ViewBuilder
-    private var operationOptions: some View {
-        switch operation {
-        case "VACUUM" where databaseType == .postgresql || databaseType == .redshift:
-            Toggle(String(localized: "FULL (rewrites entire table, blocks access)"), isOn: $fullVacuum)
-            Toggle(String(localized: "ANALYZE (update statistics after vacuum)"), isOn: $analyzeAfterVacuum)
-            Toggle(String(localized: "VERBOSE (print progress)"), isOn: $verbose)
-        case "CHECK TABLE":
-            Picker(String(localized: "Check mode:"), selection: $checkMode) {
-                Text("QUICK").tag("QUICK")
-                Text("FAST").tag("FAST")
-                Text("MEDIUM").tag("MEDIUM")
-                Text("EXTENDED").tag("EXTENDED")
-                Text("CHANGED").tag("CHANGED")
+    private func optionControl(_ option: PluginMaintenanceOption) -> some View {
+        if let choices = option.choices {
+            Picker(option.label, selection: binding(for: option)) {
+                ForEach(choices, id: \.self) { choice in
+                    Text(choice).tag(choice)
+                }
             }
             .pickerStyle(.menu)
             .frame(width: 200)
-        default:
-            EmptyView()
+        } else {
+            Toggle(option.label, isOn: toggleBinding(for: option))
         }
     }
 
-    // MARK: - SQL Preview
+    private func binding(for option: PluginMaintenanceOption) -> Binding<String> {
+        Binding(
+            get: { values[option.key] ?? option.defaultValue },
+            set: { values[option.key] = $0 }
+        )
+    }
+
+    private func toggleBinding(for option: PluginMaintenanceOption) -> Binding<Bool> {
+        Binding(
+            get: { (values[option.key] ?? option.defaultValue) == "true" },
+            set: { values[option.key] = $0 ? "true" : "false" }
+        )
+    }
 
     private var sqlPreview: String {
-        let options = buildOptions()
-        switch operation {
-        case "VACUUM" where databaseType == .postgresql || databaseType == .redshift:
-            var opts: [String] = []
-            if options["full"] == "true" { opts.append("FULL") }
-            if options["analyze"] == "true" { opts.append("ANALYZE") }
-            if options["verbose"] == "true" { opts.append("VERBOSE") }
-            let optClause = opts.isEmpty ? "" : "(\(opts.joined(separator: ", "))) "
-            return "VACUUM \(optClause)\(tableName)"
-        case "CHECK TABLE":
-            return "CHECK TABLE \(tableName) \(checkMode)"
-        default:
-            return "\(operation) \(tableName)"
-        }
-    }
-
-    private func buildOptions() -> [String: String] {
-        var options: [String: String] = [:]
-        if fullVacuum { options["full"] = "true" }
-        if analyzeAfterVacuum { options["analyze"] = "true" }
-        if verbose { options["verbose"] = "true" }
-        if operation == "CHECK TABLE" { options["mode"] = checkMode }
-        return options
+        preview(values).joined(separator: ";\n")
     }
 }

--- a/TablePro/Views/Sidebar/Menu/DatabaseTreeMenuContext.swift
+++ b/TablePro/Views/Sidebar/Menu/DatabaseTreeMenuContext.swift
@@ -23,7 +23,8 @@ internal struct DatabaseTreeMenuContext {
     internal let isReadOnly: Bool
     internal let supportsImport: Bool
     internal let importFormats: [ImportFormatOption]
-    internal let maintenanceOperations: [String]
+    /// Everything the driver offers. The spec narrows it to the clicked row's own kind.
+    internal let maintenanceOperations: [PluginMaintenanceOperation]
     internal let dropEligibility: ContainerDropEligibility.Context
     internal let renameEligibility: ObjectRenameEligibility.Context
     internal let containerEntityName: String

--- a/TablePro/Views/Sidebar/Menu/DatabaseTreeMenuSpec.swift
+++ b/TablePro/Views/Sidebar/Menu/DatabaseTreeMenuSpec.swift
@@ -159,15 +159,22 @@ internal enum DatabaseTreeMenuSpec {
         ) {
             items.append(.command(String(localized: "Refresh Materialized View…"), .refreshMaterializedView(ref)))
         }
+        let applicable = TableOperationEligibility.maintenanceOperations(
+            context.maintenanceOperations,
+            for: ref.table.type
+        )
         if SidebarContextMenuLogic.maintenanceGroupEnabled(
             isReadOnly: context.isReadOnly,
             hasSelection: true,
-            supportedOperations: context.maintenanceOperations
+            applicableOperations: applicable
         ) {
             items.append(.submenu(
                 title: String(localized: "Maintenance"),
-                items: context.maintenanceOperations.map { operation in
-                    .command(operation, .maintenance(operation: operation, tableName: ref.table.name, ref: ref))
+                items: applicable.map { operation in
+                    .command(
+                        operation.name,
+                        .maintenance(operation: operation, tableName: ref.table.name, ref: ref)
+                    )
                 }
             ))
         }

--- a/TablePro/Views/Sidebar/Menu/SidebarMenuCommand.swift
+++ b/TablePro/Views/Sidebar/Menu/SidebarMenuCommand.swift
@@ -36,7 +36,9 @@ internal enum SidebarMenuCommand: Equatable {
     case exportTables(names: Set<String>, ref: DatabaseTreeTableRef)
     case transferTables(names: Set<String>, ref: DatabaseTreeTableRef)
     case importTables(formatId: String, ref: DatabaseTreeTableRef)
-    case maintenance(operation: String, tableName: String, ref: DatabaseTreeTableRef)
+    /// Carries the whole descriptor rather than the operation's name, because the sheet it opens needs
+    /// the scope and the options to build the statement it shows and the one it runs.
+    case maintenance(operation: PluginMaintenanceOperation, tableName: String, ref: DatabaseTreeTableRef)
     /// Queued rather than run, so these carry every target in full: a queue keyed by name is
     /// resolved against whatever the tab in front points at by the time Save runs.
     case truncateTables(targets: [DatabaseTreeTableRef], ref: DatabaseTreeTableRef)

--- a/TablePro/Views/Sidebar/SidebarContextMenu.swift
+++ b/TablePro/Views/Sidebar/SidebarContextMenu.swift
@@ -38,12 +38,15 @@ enum SidebarContextMenuLogic {
         }
     }
 
+    /// Asked with the operations that apply to the clicked object, not with everything the driver
+    /// offers: on a view PostgreSQL has four operations and none of them works, so the submenu is
+    /// omitted rather than filled with commands that skip or fail.
     static func maintenanceGroupEnabled(
         isReadOnly: Bool,
         hasSelection: Bool,
-        supportedOperations: [String]
+        applicableOperations: [PluginMaintenanceOperation]
     ) -> Bool {
         guard !isReadOnly, hasSelection else { return false }
-        return !supportedOperations.isEmpty
+        return !applicableOperations.isEmpty
     }
 }

--- a/TableProTests/Core/Plugins/PluginKitABIResilienceTests.swift
+++ b/TableProTests/Core/Plugins/PluginKitABIResilienceTests.swift
@@ -31,6 +31,7 @@ struct PluginKitABIResilienceTests {
         #expect(driver.foreignKeyDisableStatements() == nil)
         #expect(driver.foreignKeyEnableStatements() == nil)
         #expect(driver.supportedMaintenanceOperations() == nil)
+        #expect(driver.maintenanceOperations() == nil)
         #expect(driver.buildExplainQuery("SELECT 1") == nil)
         #expect(driver.injectRowLimit("SELECT 1", limit: 100) == nil)
         #expect(driver.defaultExportQuery(table: "users") == nil)
@@ -39,6 +40,17 @@ struct PluginKitABIResilienceTests {
         #expect(driver.unsupportedStructureColumnFields.isEmpty)
         #expect(driver.unsupportedIndexTypes.isEmpty)
         #expect(driver.schemaOperationRefusal(.renameCheckConstraint(from: "a", to: "b")) == nil)
+    }
+
+    @Test("A driver that answers only the older name list has it lifted into table-like descriptors")
+    func legacyMaintenanceNamesAreLifted() {
+        let lifted = PluginMaintenanceOperation.lifting(["VACUUM", "ANALYZE"])
+
+        #expect(lifted.map(\.name) == ["VACUUM", "ANALYZE"])
+        #expect(lifted.allSatisfy { $0.appliesTo == PluginObjectKind.allTableLike })
+        #expect(lifted.allSatisfy { $0.scope == .objectOrDatabase })
+        #expect(lifted.allSatisfy { $0.options.isEmpty })
+        #expect(lifted.allSatisfy { $0.applies(to: .view) })
     }
 
     @Test("A driver that omits defaulted requirements falls back to the documented asynchronous defaults")

--- a/TableProTests/Models/Database/MaintenanceEligibilityTests.swift
+++ b/TableProTests/Models/Database/MaintenanceEligibilityTests.swift
@@ -1,0 +1,96 @@
+//
+//  MaintenanceEligibilityTests.swift
+//  TableProTests
+//
+//  The sidebar, the menu bar and the MCP tool all filter maintenance through one function. Before it
+//  existed each surface offered every operation the driver named on every row, so PostgreSQL VACUUM
+//  reached a view, where the server skips it with a WARNING and still answers the command tag VACUUM.
+//
+
+import Foundation
+@testable import TablePro
+import TableProPluginKit
+import Testing
+
+@Suite("Maintenance eligibility")
+struct MaintenanceEligibilityTests {
+    private func operation(
+        _ name: String,
+        kinds: Set<PluginObjectKind>,
+        scope: PluginMaintenanceScope = .object
+    ) -> PluginMaintenanceOperation {
+        PluginMaintenanceOperation(name: name, appliesTo: kinds, scope: scope, options: [])
+    }
+
+    private var postgresLike: [PluginMaintenanceOperation] {
+        [
+            operation("VACUUM", kinds: [.table, .partitionedTable, .materializedView], scope: .objectOrDatabase),
+            operation("ANALYZE", kinds: [.table, .partitionedTable, .materializedView, .foreignTable], scope: .objectOrDatabase),
+            operation("REINDEX", kinds: [.table, .partitionedTable, .materializedView], scope: .objectOrDatabase),
+            operation("CLUSTER", kinds: [.table, .materializedView])
+        ]
+    }
+
+    @Test("A view keeps only the operations its kind is named in")
+    func viewKeepsNothingItCannotRun() {
+        let offered = TableOperationEligibility.maintenanceOperations(postgresLike, for: .view).map(\.name)
+
+        #expect(offered.isEmpty)
+    }
+
+    @Test("A materialized view keeps every operation but the ones its kind is absent from")
+    func materializedViewKeepsMost() {
+        let offered = TableOperationEligibility.maintenanceOperations(postgresLike, for: .materializedView).map(\.name)
+
+        #expect(offered == ["VACUUM", "ANALYZE", "REINDEX", "CLUSTER"])
+    }
+
+    /// Measured on PostgreSQL 17.11: `ALTER TABLE ... CLUSTER ON` is refused on a partitioned table,
+    /// so CLUSTER can never succeed there however the server answers the CLUSTER statement itself.
+    @Test("A partitioned table keeps everything except CLUSTER")
+    func partitionedTableDropsCluster() {
+        let offered = TableOperationEligibility.maintenanceOperations(postgresLike, for: .partitionedTable).map(\.name)
+
+        #expect(offered == ["VACUUM", "ANALYZE", "REINDEX"])
+        #expect(!offered.contains("CLUSTER"))
+    }
+
+    /// Measured on PostgreSQL 17.11: ANALYZE on a foreign table samples through the FDW and succeeds
+    /// with no warning, while VACUUM skips it.
+    @Test("A foreign table keeps ANALYZE alone")
+    func foreignTableKeepsAnalyze() {
+        let offered = TableOperationEligibility.maintenanceOperations(postgresLike, for: .foreignTable).map(\.name)
+
+        #expect(offered == ["ANALYZE"])
+    }
+
+    /// A database-wide operation names no object, so the row it was reached from cannot disqualify it.
+    /// SQLite's VACUUM is reachable at all only because of this.
+    @Test("A database-wide operation survives every kind, including one it names nowhere")
+    func databaseWideOperationIsAlwaysKept() {
+        let wide = [operation("VACUUM", kinds: [], scope: .database)]
+
+        for type in [TableInfo.TableType.table, .view, .materializedView, .foreignTable, .systemTable, .externalTable] {
+            #expect(TableOperationEligibility.maintenanceOperations(wide, for: type).map(\.name) == ["VACUUM"])
+        }
+    }
+
+    @Test("A row with no known type is treated as a table")
+    func unknownTypeFallsBackToTable() {
+        let offered = TableOperationEligibility.maintenanceOperations(postgresLike, for: nil).map(\.name)
+
+        #expect(offered == ["VACUUM", "ANALYZE", "REINDEX", "CLUSTER"])
+    }
+
+    @Test("Every table-like kind maps to the driver's own spelling")
+    func kindsMapToDriverVocabulary() {
+        #expect(TableOperationEligibility.pluginKind(.table) == .table)
+        #expect(TableOperationEligibility.pluginKind(.partitionedTable) == .partitionedTable)
+        #expect(TableOperationEligibility.pluginKind(.view) == .view)
+        #expect(TableOperationEligibility.pluginKind(.materializedView) == .materializedView)
+        #expect(TableOperationEligibility.pluginKind(.foreignTable) == .foreignTable)
+        #expect(TableOperationEligibility.pluginKind(.systemTable) == .systemTable)
+        #expect(TableOperationEligibility.pluginKind(.externalTable) == .externalTable)
+        #expect(TableOperationEligibility.pluginKind(nil) == .table)
+    }
+}

--- a/TableProTests/Plugins/MaintenanceOperationDescriptorTests.swift
+++ b/TableProTests/Plugins/MaintenanceOperationDescriptorTests.swift
@@ -1,0 +1,316 @@
+//
+//  MaintenanceOperationDescriptorTests.swift
+//  TableProTests
+//
+//  Maintenance used to be a list of bare operation names, so the app offered every one of them on
+//  every object: PostgreSQL skips a VACUUM on a view with a WARNING and still reports the success
+//  command tag VACUUM, and refuses a REINDEX on one outright. The kind sets below are what
+//  PostgreSQL 17.11 and SQLite 3.54.0 actually answered.
+//
+
+import Foundation
+@testable import TablePro
+import TableProPluginKit
+import Testing
+
+@Suite("Maintenance operation descriptors")
+struct MaintenanceOperationDescriptorTests {
+    private func postgres(_ name: String) throws -> PluginMaintenanceOperation {
+        try #require(PostgreSQLMaintenance.operations.first { $0.name == name })
+    }
+
+    private func sqlite(_ name: String) throws -> PluginMaintenanceOperation {
+        try #require(SQLiteMaintenance.operations.first { $0.name == name })
+    }
+
+    private func mysql(_ name: String) throws -> PluginMaintenanceOperation {
+        try #require(MySQLMaintenance.operations.first { $0.name == name })
+    }
+
+    private func postgresStatements(
+        _ operation: String,
+        table: String?,
+        schema: String?,
+        options: [String: String] = [:]
+    ) -> [String]? {
+        PostgreSQLMaintenance.statements(
+            operation: operation,
+            table: table,
+            schema: schema,
+            options: options,
+            connectedDatabase: "app",
+            capabilities: PostgreSQLCapabilities(serverVersion: 170_011)
+        )
+    }
+
+    // MARK: - PostgreSQL kinds
+
+    @Test("CLUSTER is offered on a table and a materialized view and on nothing else")
+    func clusterKinds() throws {
+        let cluster = try postgres("CLUSTER")
+
+        #expect(cluster.applies(to: .table))
+        #expect(cluster.applies(to: .materializedView))
+        #expect(!cluster.applies(to: .partitionedTable))
+        #expect(!cluster.applies(to: .view))
+        #expect(!cluster.applies(to: .foreignTable))
+    }
+
+    @Test("ANALYZE reaches a foreign table and VACUUM does not")
+    func foreignTableTakesAnalyzeOnly() throws {
+        #expect(try postgres("ANALYZE").applies(to: .foreignTable))
+        #expect(try !postgres("VACUUM").applies(to: .foreignTable))
+    }
+
+    @Test("Nothing PostgreSQL offers applies to a view")
+    func noPostgresOperationAppliesToAView() {
+        #expect(PostgreSQLMaintenance.operations.allSatisfy { !$0.applies(to: .view) })
+    }
+
+    @Test("REINDEX covers a partitioned table, which CLUSTER cannot")
+    func partitionedTableKinds() throws {
+        #expect(try postgres("REINDEX").applies(to: .partitionedTable))
+        #expect(try postgres("VACUUM").applies(to: .partitionedTable))
+        #expect(try postgres("ANALYZE").applies(to: .partitionedTable))
+    }
+
+    // MARK: - PostgreSQL statements
+
+    @Test("A PostgreSQL target is qualified with the schema it was handed")
+    func qualifiesTheSchema() {
+        #expect(postgresStatements("REINDEX", table: "orders", schema: "app") == ["REINDEX TABLE \"app\".\"orders\""])
+        #expect(postgresStatements("ANALYZE", table: "orders", schema: "app") == ["ANALYZE \"app\".\"orders\""])
+        #expect(postgresStatements("VACUUM", table: "orders", schema: "app") == ["VACUUM \"app\".\"orders\""])
+        #expect(postgresStatements("CLUSTER", table: "orders", schema: "app") == ["CLUSTER \"app\".\"orders\""])
+    }
+
+    @Test("A schema that is nil or empty leaves the name unqualified")
+    func unqualifiedWithoutASchema() {
+        #expect(postgresStatements("REINDEX", table: "orders", schema: nil) == ["REINDEX TABLE \"orders\""])
+        #expect(postgresStatements("REINDEX", table: "orders", schema: "") == ["REINDEX TABLE \"orders\""])
+    }
+
+    @Test("A quote in a schema or table name is doubled rather than closing the identifier")
+    func quotesAreEscaped() {
+        #expect(
+            postgresStatements("ANALYZE", table: "or\"ders", schema: "a\"pp")
+                == ["ANALYZE \"a\"\"pp\".\"or\"\"ders\""]
+        )
+    }
+
+    @Test("VACUUM renders the flags the descriptor declares")
+    func vacuumFlags() {
+        #expect(
+            postgresStatements(
+                "VACUUM",
+                table: "orders",
+                schema: "app",
+                options: ["full": "true", "analyze": "true", "verbose": "true"]
+            ) == ["VACUUM (FULL, ANALYZE, VERBOSE) \"app\".\"orders\""]
+        )
+        #expect(
+            postgresStatements("VACUUM", table: "orders", schema: "app", options: ["analyze": "true"])
+                == ["VACUUM (ANALYZE) \"app\".\"orders\""]
+        )
+        #expect(
+            postgresStatements("VACUUM", table: "orders", schema: "app", options: ["full": "false"])
+                == ["VACUUM \"app\".\"orders\""]
+        )
+    }
+
+    @Test("REINDEX renders its own VERBOSE flag before the TABLE keyword")
+    func reindexVerbose() {
+        #expect(
+            postgresStatements("REINDEX", table: "orders", schema: "app", options: ["verbose": "true"])
+                == ["REINDEX (VERBOSE) TABLE \"app\".\"orders\""]
+        )
+    }
+
+    @Test("A PostgreSQL operation with no table falls back to the database-wide form")
+    func databaseWideForms() {
+        #expect(postgresStatements("VACUUM", table: nil, schema: "app") == ["VACUUM"])
+        #expect(
+            postgresStatements("VACUUM", table: nil, schema: "app", options: ["analyze": "true"])
+                == ["VACUUM (ANALYZE)"]
+        )
+        #expect(postgresStatements("ANALYZE", table: nil, schema: "app") == ["ANALYZE"])
+        /// From PostgreSQL 16 the database name is optional and the statement reindexes the one it is
+        /// connected to, which is what `PostgreSQLVersionedStatements.reindexDatabase` emits and what
+        /// 17.11 accepted when this was measured. The named form is the 12 to 15 arm, pinned by
+        /// `PostgreSQLVersionedStatementsTests`.
+        #expect(postgresStatements("REINDEX", table: nil, schema: "app") == ["REINDEX DATABASE CONCURRENTLY"])
+        #expect(postgresStatements("CLUSTER", table: nil, schema: "app") == nil)
+    }
+
+    @Test("An operation PostgreSQL does not have produces nothing")
+    func unknownPostgresOperation() {
+        #expect(postgresStatements("OPTIMIZE TABLE", table: "orders", schema: "app") == nil)
+    }
+
+    // MARK: - SQLite
+
+    @Test("SQLite VACUUM and Integrity Check name no object and ignore one")
+    func sqliteDatabaseScoped() throws {
+        let vacuum = try sqlite("VACUUM")
+        let integrity = try sqlite("Integrity Check")
+
+        #expect(vacuum.scope == .database)
+        #expect(integrity.scope == .database)
+        #expect(vacuum.appliesTo.isEmpty)
+        #expect(integrity.appliesTo.isEmpty)
+        #expect(vacuum.target("orders") == nil)
+        #expect(integrity.target("orders") == nil)
+        #expect(SQLiteMaintenance.statements(operation: "VACUUM", table: "orders") == ["VACUUM"])
+        #expect(SQLiteMaintenance.statements(operation: "Integrity Check", table: "orders") == ["PRAGMA integrity_check"])
+    }
+
+    @Test("SQLite ANALYZE and REINDEX are offered on a table and not on a view")
+    func sqliteObjectScoped() throws {
+        for name in ["ANALYZE", "REINDEX"] {
+            let operation = try sqlite(name)
+            #expect(operation.applies(to: .table))
+            #expect(!operation.applies(to: .view))
+            #expect(operation.scope == .objectOrDatabase)
+        }
+        #expect(SQLiteMaintenance.statements(operation: "ANALYZE", table: "orders") == ["ANALYZE `orders`"])
+        #expect(SQLiteMaintenance.statements(operation: "REINDEX", table: nil) == ["REINDEX"])
+    }
+
+    @Test("A backtick in a SQLite object name is doubled")
+    func sqliteQuoting() {
+        #expect(SQLiteMaintenance.statements(operation: "ANALYZE", table: "or`ders") == ["ANALYZE `or``ders`"])
+    }
+
+    // MARK: - MySQL
+
+    @Test("CHECK TABLE is the only MySQL operation offered on a view")
+    func mysqlViewKinds() throws {
+        #expect(try mysql("CHECK TABLE").applies(to: .view))
+        #expect(try !mysql("OPTIMIZE TABLE").applies(to: .view))
+        #expect(try !mysql("ANALYZE TABLE").applies(to: .view))
+        #expect(try !mysql("REPAIR TABLE").applies(to: .view))
+    }
+
+    @Test("CHECK TABLE declares its mode, defaulting to MEDIUM")
+    func mysqlCheckMode() throws {
+        let check = try mysql("CHECK TABLE")
+        let mode = try #require(check.options.first)
+
+        #expect(check.options.count == 1)
+        #expect(mode.key == "mode")
+        #expect(mode.defaultValue == "MEDIUM")
+        #expect(mode.choices == ["QUICK", "FAST", "MEDIUM", "EXTENDED", "CHANGED"])
+        #expect(!mode.isToggle)
+    }
+
+    @Test("A MySQL target is backtick-quoted and qualified only when a schema is handed over")
+    func mysqlStatements() {
+        #expect(
+            MySQLMaintenance.statements(
+                operation: "OPTIMIZE TABLE", table: "orders", schema: nil, options: [:], flavor: .mysql
+            ) == ["OPTIMIZE TABLE `orders`"]
+        )
+        #expect(
+            MySQLMaintenance.statements(
+                operation: "OPTIMIZE TABLE", table: "orders", schema: "shop", options: [:], flavor: .mysql
+            ) == ["OPTIMIZE TABLE `shop`.`orders`"]
+        )
+        #expect(
+            MySQLMaintenance.statements(
+                operation: "CHECK TABLE", table: "orders", schema: nil, options: [:], flavor: .mysql
+            ) == ["CHECK TABLE `orders` MEDIUM"]
+        )
+        #expect(
+            MySQLMaintenance.statements(
+                operation: "CHECK TABLE", table: "orders", schema: nil, options: ["mode": "EXTENDED"], flavor: .mysql
+            ) == ["CHECK TABLE `orders` EXTENDED"]
+        )
+    }
+
+    /// The mode lands in the statement text unquoted and reaches here from an MCP client as well as
+    /// from the sheet's picker, so anything that is not a declared choice falls back to the default.
+    @Test("A check mode outside the declared choices falls back to the default")
+    func mysqlRejectsAnUndeclaredMode() {
+        #expect(
+            MySQLMaintenance.statements(
+                operation: "CHECK TABLE",
+                table: "orders",
+                schema: nil,
+                options: ["mode": "EXTENDED; DROP TABLE orders"],
+                flavor: .mysql
+            ) == ["CHECK TABLE `orders` MEDIUM"]
+        )
+    }
+
+    @Test("A MySQL operation with no table produces nothing, because the engine has no such form")
+    func mysqlNeedsATable() {
+        #expect(MySQLMaintenance.operations.allSatisfy { $0.scope == .object })
+        #expect(
+            MySQLMaintenance.statements(
+                operation: "ANALYZE TABLE", table: nil, schema: "shop", options: [:], flavor: .mysql
+            ) == nil
+        )
+    }
+
+    @Test("TiDB and Databend refuse an operation their flavor does not offer")
+    func flavorGatesTheStatement() {
+        for flavor in [MySQLServerFlavor.tidb(version: nil), .databend] {
+            #expect(
+                MySQLMaintenance.statements(
+                    operation: "REPAIR TABLE", table: "orders", schema: nil, options: [:], flavor: flavor
+                ) == nil
+            )
+            #expect(
+                MySQLMaintenance.statements(
+                    operation: "ANALYZE TABLE", table: "orders", schema: nil, options: [:], flavor: flavor
+                ) != nil
+            )
+        }
+    }
+
+    // MARK: - Every declared option is read
+
+    /// An option the descriptor declares that the statement builder never reads is the hardcoding bug
+    /// in its other direction: the sheet would show a control that changes nothing.
+    @Test("Every option a driver declares changes the statement it is declared on")
+    func everyDeclaredOptionIsRead() throws {
+        for operation in PostgreSQLMaintenance.operations {
+            let base = try #require(postgresStatements(
+                operation.name, table: "orders", schema: "app", options: operation.defaultOptionValues
+            ))
+            for option in operation.options {
+                var changed = operation.defaultOptionValues
+                changed[option.key] = try alternative(to: option)
+                let result = try #require(postgresStatements(
+                    operation.name, table: "orders", schema: "app", options: changed
+                ))
+                #expect(result != base, "\(operation.name) ignores its own '\(option.key)' option")
+            }
+        }
+
+        for operation in MySQLMaintenance.operations {
+            let base = try #require(MySQLMaintenance.statements(
+                operation: operation.name,
+                table: "orders",
+                schema: nil,
+                options: operation.defaultOptionValues,
+                flavor: .mysql
+            ))
+            for option in operation.options {
+                var changed = operation.defaultOptionValues
+                changed[option.key] = try alternative(to: option)
+                let result = try #require(MySQLMaintenance.statements(
+                    operation: operation.name, table: "orders", schema: nil, options: changed, flavor: .mysql
+                ))
+                #expect(result != base, "\(operation.name) ignores its own '\(option.key)' option")
+            }
+        }
+    }
+
+    private func alternative(to option: PluginMaintenanceOption) throws -> String {
+        guard let choices = option.choices else {
+            return option.defaultValue == "true" ? "false" : "true"
+        }
+        return try #require(choices.first { $0 != option.defaultValue })
+    }
+}

--- a/TableProTests/Plugins/MySQLServerFlavorTests.swift
+++ b/TableProTests/Plugins/MySQLServerFlavorTests.swift
@@ -56,8 +56,8 @@ struct MySQLServerFlavorTests {
     @Test("TiDB and Databend offer only the maintenance they support")
     func maintenanceOperations() {
         #expect(MySQLServerFlavor.mysql.maintenanceOperations.count == 4)
-        #expect(MySQLServerFlavor.tidb(version: nil).maintenanceOperations == ["ANALYZE TABLE"])
-        #expect(MySQLServerFlavor.databend.maintenanceOperations == ["ANALYZE TABLE"])
+        #expect(MySQLServerFlavor.tidb(version: nil).maintenanceOperations.map(\.name) == ["ANALYZE TABLE"])
+        #expect(MySQLServerFlavor.databend.maintenanceOperations.map(\.name) == ["ANALYZE TABLE"])
     }
 
     @Test("TiDB sequences cannot be browsed, so they are not listed as tables")

--- a/TableProTests/Views/Main/MaintenanceSheetIdentityTests.swift
+++ b/TableProTests/Views/Main/MaintenanceSheetIdentityTests.swift
@@ -9,17 +9,28 @@
 
 import Foundation
 @testable import TablePro
+import TableProPluginKit
 import Testing
 
 @Suite("Maintenance sheet identity")
 struct MaintenanceSheetIdentityTests {
+    private func operation(_ name: String) -> PluginMaintenanceOperation {
+        PluginMaintenanceOperation(name: name, appliesTo: [.table], scope: .object)
+    }
+
     @Test("The same table in two databases is two different requests")
     func distinguishesTwoDatabases() {
         let online = ActiveSheet.maintenance(
-            operation: "OPTIMIZE TABLE", tableName: "role_ability", database: "banshi_online", schema: nil
+            operation: operation("OPTIMIZE TABLE"),
+            tableName: "role_ability",
+            database: "banshi_online",
+            schema: nil
         )
         let test = ActiveSheet.maintenance(
-            operation: "OPTIMIZE TABLE", tableName: "role_ability", database: "banshi_test", schema: nil
+            operation: operation("OPTIMIZE TABLE"),
+            tableName: "role_ability",
+            database: "banshi_test",
+            schema: nil
         )
 
         #expect(online.id != test.id)
@@ -28,10 +39,10 @@ struct MaintenanceSheetIdentityTests {
     @Test("The same table in two schemas of one database is two different requests")
     func distinguishesTwoSchemas() {
         let publicSchema = ActiveSheet.maintenance(
-            operation: "VACUUM", tableName: "orders", database: "app", schema: "public"
+            operation: operation("VACUUM"), tableName: "orders", database: "app", schema: "public"
         )
         let reporting = ActiveSheet.maintenance(
-            operation: "VACUUM", tableName: "orders", database: "app", schema: "reporting"
+            operation: operation("VACUUM"), tableName: "orders", database: "app", schema: "reporting"
         )
 
         #expect(publicSchema.id != reporting.id)
@@ -40,10 +51,10 @@ struct MaintenanceSheetIdentityTests {
     @Test("The same object is the same request")
     func matchesTheSameObject() {
         let first = ActiveSheet.maintenance(
-            operation: "ANALYZE TABLE", tableName: "orders", database: "app", schema: "public"
+            operation: operation("ANALYZE TABLE"), tableName: "orders", database: "app", schema: "public"
         )
         let second = ActiveSheet.maintenance(
-            operation: "ANALYZE TABLE", tableName: "orders", database: "app", schema: "public"
+            operation: operation("ANALYZE TABLE"), tableName: "orders", database: "app", schema: "public"
         )
 
         #expect(first.id == second.id)
@@ -52,12 +63,37 @@ struct MaintenanceSheetIdentityTests {
     @Test("A request that names no database is not the same as one that does")
     func distinguishesAnUnnamedDatabase() {
         let named = ActiveSheet.maintenance(
-            operation: "OPTIMIZE TABLE", tableName: "orders", database: "app", schema: nil
+            operation: operation("OPTIMIZE TABLE"), tableName: "orders", database: "app", schema: nil
         )
         let unnamed = ActiveSheet.maintenance(
-            operation: "OPTIMIZE TABLE", tableName: "orders", database: nil, schema: nil
+            operation: operation("OPTIMIZE TABLE"), tableName: "orders", database: nil, schema: nil
         )
 
         #expect(named.id != unnamed.id)
+    }
+
+    /// The identity keys on the operation's name, so two requests that differ only in the options the
+    /// descriptor declares are the same sheet. The sheet seeds its own state from those options.
+    @Test("Two descriptors with the same name are the same request")
+    func ignoresDescriptorShape() {
+        let plain = ActiveSheet.maintenance(
+            operation: PluginMaintenanceOperation(name: "VACUUM", appliesTo: [.table], scope: .object),
+            tableName: "orders",
+            database: "app",
+            schema: "public"
+        )
+        let withOptions = ActiveSheet.maintenance(
+            operation: PluginMaintenanceOperation(
+                name: "VACUUM",
+                appliesTo: [.table, .materializedView],
+                scope: .objectOrDatabase,
+                options: [PluginMaintenanceOption(key: "full", label: "FULL", defaultValue: "false")]
+            ),
+            tableName: "orders",
+            database: "app",
+            schema: "public"
+        )
+
+        #expect(plain.id == withOptions.id)
     }
 }

--- a/TableProTests/Views/SidebarContextMenuLogicTests.swift
+++ b/TableProTests/Views/SidebarContextMenuLogicTests.swift
@@ -124,12 +124,16 @@ struct SidebarContextMenuLogicTests {
 
     // MARK: - Maintenance group disabled rule
 
-    @Test("Maintenance group enabled with selection, writable, and supported ops")
+    private func operation(_ name: String) -> PluginMaintenanceOperation {
+        PluginMaintenanceOperation(name: name, appliesTo: [.table], scope: .object)
+    }
+
+    @Test("Maintenance group enabled with selection, writable, and applicable ops")
     func maintenanceEnabledAllConditions() {
         #expect(SidebarContextMenuLogic.maintenanceGroupEnabled(
             isReadOnly: false,
             hasSelection: true,
-            supportedOperations: ["ANALYZE", "OPTIMIZE"]
+            applicableOperations: [operation("ANALYZE"), operation("OPTIMIZE")]
         ))
     }
 
@@ -138,7 +142,7 @@ struct SidebarContextMenuLogicTests {
         #expect(!SidebarContextMenuLogic.maintenanceGroupEnabled(
             isReadOnly: true,
             hasSelection: true,
-            supportedOperations: ["ANALYZE"]
+            applicableOperations: [operation("ANALYZE")]
         ))
     }
 
@@ -147,16 +151,16 @@ struct SidebarContextMenuLogicTests {
         #expect(!SidebarContextMenuLogic.maintenanceGroupEnabled(
             isReadOnly: false,
             hasSelection: false,
-            supportedOperations: ["ANALYZE"]
+            applicableOperations: [operation("ANALYZE")]
         ))
     }
 
-    @Test("Maintenance group disabled when driver exposes no ops")
+    @Test("Maintenance group disabled when nothing the driver offers applies to the clicked object")
     func maintenanceDisabledNoOps() {
         #expect(!SidebarContextMenuLogic.maintenanceGroupEnabled(
             isReadOnly: false,
             hasSelection: true,
-            supportedOperations: []
+            applicableOperations: []
         ))
     }
 

--- a/docs/development/plugin-development.mdx
+++ b/docs/development/plugin-development.mdx
@@ -13,7 +13,7 @@ A plugin is a macOS loadable bundle target with `WRAPPER_EXTENSION = tableplugin
 
 | Key | Type | Required | Purpose |
 |-----|------|----------|---------|
-| `TableProPluginKitVersion` | integer | Yes | The PluginKit ABI the plugin was built against. Current value: 28 |
+| `TableProPluginKitVersion` | integer | Yes | The PluginKit ABI the plugin was built against. Current value: 29 |
 | `TableProProvidesDatabaseTypeIds` | array of strings | Recommended | Database type IDs the plugin serves, which is what makes lazy loading possible |
 | `CFBundleShortVersionString` | string | Yes | Plugin version, read by registry update checks |
 | `TableProMinAppVersion` | string | No | The loader rejects the plugin on an older app |

--- a/docs/development/plugin-registry.mdx
+++ b/docs/development/plugin-registry.mdx
@@ -68,13 +68,13 @@ Themes carry no native code, so they match on architecture alone.
   "binaries": [
     {
       "architecture": "arm64",
-      "pluginKitVersion": 28,
+      "pluginKitVersion": 29,
       "downloadURL": "https://github.com/TableProApp/TablePro/releases/download/plugin-oracle-v1.0.26/OracleDriver-arm64.zip",
       "sha256": "<sha256>"
     },
     {
       "architecture": "x86_64",
-      "pluginKitVersion": 28,
+      "pluginKitVersion": 29,
       "downloadURL": "https://github.com/TableProApp/TablePro/releases/download/plugin-oracle-v1.0.26/OracleDriver-x86_64.zip",
       "sha256": "<sha256>"
     }

--- a/docs/features/table-operations.mdx
+++ b/docs/features/table-operations.mdx
@@ -68,7 +68,9 @@ No other engine has a rename, so the item never appears on Cassandra, DynamoDB, 
 
 ## Maintenance
 
-Right-click a table, choose **Maintenance**, and pick an operation. A sheet shows the operation's options and the exact SQL before it runs.
+Right-click a table, choose **Maintenance**, and pick an operation. The sheet shows the operation's options and the statement the driver will run, rebuilt as each option changes, so what is previewed is what executes.
+
+Each operation lists the object kinds it applies to, so a view offers only the operations its server accepts. On PostgreSQL that means VACUUM and REINDEX are absent on a view, which the server skips or refuses, and CLUSTER is absent on a partitioned table, which can never be clustered. An operation that acts on the whole database, such as SQLite's VACUUM and its integrity check, names the database rather than a table.
 
 | Database | Operations |
 |----------|-----------|
@@ -76,7 +78,7 @@ Right-click a table, choose **Maintenance**, and pick an operation. A sheet show
 | MySQL / MariaDB | OPTIMIZE TABLE, ANALYZE TABLE, CHECK TABLE, REPAIR TABLE |
 | SQLite | VACUUM, ANALYZE, REINDEX, Integrity Check |
 
-PostgreSQL VACUUM carries FULL (rewrites the table and blocks access), ANALYZE, and VERBOSE toggles. MySQL CHECK TABLE offers QUICK, FAST, MEDIUM (the default), EXTENDED, and CHANGED. No other engine reports maintenance operations, so the submenu is hidden there, and in read-only safe mode.
+PostgreSQL VACUUM carries FULL (rewrites the table and blocks access), ANALYZE, and VERBOSE toggles. MySQL CHECK TABLE offers QUICK, FAST, MEDIUM (the default), EXTENDED, and CHANGED. The options come from the driver, so an engine that adds one shows it without an app change. No other engine reports maintenance operations, so the submenu is hidden there, and in read-only safe mode.
 
 ## Views
 

--- a/project.yml
+++ b/project.yml
@@ -491,6 +491,7 @@ targets:
       - Plugins/MySQLDriverPlugin/MySQLSessionFootprint.swift
       - Plugins/MySQLDriverPlugin/MySQLGeneratedColumnClassification.swift
       - Plugins/MySQLDriverPlugin/MySQLKillTarget.swift
+      - Plugins/MySQLDriverPlugin/MySQLMaintenance.swift
       - Plugins/MySQLDriverPlugin/MySQLObjectQueries.swift
       - Plugins/MySQLDriverPlugin/MySQLSelectLimitStatement.swift
       - Plugins/MySQLDriverPlugin/MySQLServerFlavor.swift
@@ -504,6 +505,7 @@ targets:
       - Plugins/SQLiteDriverPlugin/SQLiteCheckConstraintParser.swift
       - Plugins/SQLiteDriverPlugin/SQLiteCreateTableDDL.swift
       - Plugins/SQLiteDriverPlugin/SQLiteDefaultValue.swift
+      - Plugins/SQLiteDriverPlugin/SQLiteMaintenance.swift
       - Plugins/LibSQLDriverPlugin/LibSQLDefaultValue.swift
       - Plugins/LibSQLDriverPlugin/HranaHttpClient.swift
       - Plugins/CloudflareD1DriverPlugin/CloudflareD1DefaultValue.swift
@@ -530,6 +532,7 @@ targets:
       - Plugins/PostgreSQLDriverPlugin/PostgreSQLCommentStatements.swift
       - Plugins/PostgreSQLDriverPlugin/PostgreSQLForeignKeyQueries.swift
       - Plugins/PostgreSQLDriverPlugin/PostgreSQLIndexQueries.swift
+      - Plugins/PostgreSQLDriverPlugin/PostgreSQLMaintenance.swift
       - Plugins/PostgreSQLDriverPlugin/PostgreSQLObjectQueries.swift
       - Plugins/PostgreSQLDriverPlugin/PostgreSQLPrincipalQueries.swift
       - Plugins/PostgreSQLDriverPlugin/PostgreSQLRelationSQL.swift


### PR DESCRIPTION
Part of #2726, found while building the view tools there. Three defects in one feature, because they share a cause: the app asked the driver for a list of operation names, and a bare name cannot say which objects it works on, whether it takes an object at all, or what SQL it becomes.

## What was wrong

**Maintenance was offered on every object kind.** Measured on PostgreSQL 17.11: `VACUUM` on a view answers `WARNING: skipping "vw" --- cannot vacuum non-tables` and still returns the command tag `VACUUM`, so the app reported success over work the server skipped. `REINDEX TABLE "vw"` and `CLUSTER "vw"` fail outright with `"vw" is not a table or materialized view`.

**The statements named no schema.** `maintenanceStatements` never read its own `schema` argument, and the app-facing protocol had no schema parameter at all. Measured with a temp table shadowing a real one: `ANALYZE "Order Items"` analyzed `pg_temp_20.t`, not `app.t`.

**The preview was a second implementation.** The sheet rebuilt the SQL itself, so it printed `REINDEX orders`, which is not valid SQL, where `REINDEX TABLE "orders"` ran. It printed a table name beside SQLite's `VACUUM` and integrity check, which take no object. Its option toggles were gated on a hardcoded `databaseType == .postgresql || .redshift`.

## The fix

`PluginMaintenanceOperation` carries the operation's name, the object kinds it applies to, its scope (object, database, or either) and its options. One new defaulted requirement, `maintenanceOperations()`, whose default lifts the old name list so a driver that never adopts it behaves exactly as today.

The sidebar, the menu bar and the MCP tool all filter through one function, `TableOperationEligibility.maintenanceOperations`. The sheet calls the driver's own statement builder on every option change, and `executeMaintenance` runs the statements that same function returned, so preview and execution are one code path rather than two that agree by review.

### The matrix, measured on PostgreSQL 17.11

| Operation | Table | Partitioned | View | Materialized view | Foreign table |
|---|---|---|---|---|---|
| VACUUM | yes | yes | skipped with a warning | yes | skipped with a warning |
| ANALYZE | yes | yes | skipped with a warning | yes | **yes**, sampled through the FDW |
| REINDEX | yes | yes | error | yes | error |
| CLUSTER | yes | **never succeeds** | error | yes | error |

CLUSTER is absent on a partitioned table because `ALTER TABLE ... CLUSTER ON` is refused there, so no index can ever be marked and the operation can never do anything. ANALYZE is the one operation a foreign table takes.

MySQL and SQLite kind sets are reasoned from their drivers and their documentation, not probed, because neither server is available here. A reviewer should re-check those two before release. SQLite's `VACUUM` and integrity check are `.database`, so they name no object and the sheet shows the database instead.

## PluginKit

`currentPluginKitVersion` 28 to 29, `TableProPluginKitVersion` 29 in all 40 plugin `Info.plist` files, `minimumCompatiblePluginKitVersion` left at 19. `WeaviateDriverPlugin` was at 25, below the shipped baseline, and is brought up with the rest.

`verify.sh abi origin/main` reports additions only: the new requirement with its default, `PluginObjectKind`, `PluginMaintenanceScope`, `PluginMaintenanceOption` and `PluginMaintenanceOperation`, none `@frozen`. Zero symbols removed, so no plugin re-release is needed.

`PluginObjectKind` is a string-backed struct rather than an enum, for the same reason `DatabaseType` is: a plugin may report a kind this framework has never heard of, and an exhaustive switch over one would be a future break.

## Verified

`MaintenanceOperationDescriptorTests`, `MaintenanceEligibilityTests`, `MaintenanceSheetIdentityTests`, `MySQLServerFlavorTests`, `PluginKitABIResilienceTests`, `SidebarContextMenuLogicTests`, `DatabaseTreeMenuSpecTests`: `cases: 150 executed, 150 passed, 0 failed`. Lint clean, `violations: 0`. Docs checks pass.

No `TableProUITests` coverage: the flow needs a live PostgreSQL server with a view, a materialized view and a foreign table, and the UI suites run against the bundled SQLite sample, so it cannot run deterministically on CI.

https://claude.ai/code/session_013prPDi2xCGd2JqrfEnTELn
