### PR TITLE
docs(weaviate): name the filter operators the way the filtering page does

### DIFF
--- a/docs/databases/weaviate.mdx
+++ b/docs/databases/weaviate.mdx
@@ -48,15 +48,15 @@ Unfiltered pages load through `GET /v1/objects`. A column filter or a sort becom
 
 Filter values are typed from the collection schema: an `int` property filters as a number, a `date` property needs a full RFC 3339 timestamp such as `2024-01-31T00:00:00Z`, and an array property filters on one element.
 
-| Operator | What Weaviate runs |
+| Operators | What Weaviate runs |
 |----------|--------------------|
-| **=**, **!=** | `Equal`, `NotEqual` |
-| **>**, **>=**, **<**, **<=** | Numbers and dates only |
-| **CONTAINS**, **NOT CONTAINS**, **STARTS WITH**, **ENDS WITH** | `Like` with `*` wildcards, text properties only |
-| **IN**, **NOT IN** | `ContainsAny`, `ContainsNone` over a comma-separated list |
-| **BETWEEN** | Two bounds, both inclusive |
-| **IS NULL**, **IS NOT NULL** | `IsNull`, which needs `indexNullState` on the collection |
-| **IS EMPTY**, **IS NOT EMPTY** | `len()`, which needs `indexPropertyLength` on the collection |
+| equals, not equals | `Equal`, `NotEqual` |
+| greater than, greater or equal, less than, less or equal | Numbers and dates only |
+| contains, not contains, starts with, ends with | `Like` with `*` wildcards, text properties only |
+| in list, not in list | `ContainsAny`, `ContainsNone` over a comma-separated list |
+| between | Two bounds, both inclusive |
+| is NULL, is not NULL | `IsNull`, which needs `indexNullState` on the collection |
+| is empty, is not empty | `len()`, which needs `indexPropertyLength` on the collection |
 
 **REGEX** has no Weaviate equivalent, and a filter Weaviate cannot run reports why instead of returning the whole collection.
 


### PR DESCRIPTION
The Docs job has been red on `main` since #2742. `mint validate` fails with:

```
warning - parsing error ./databases/weaviate.mdx:54:21 - Unexpected character `*` (U+002A) before name,
          expected a character that can start a name, such as a letter, `$`, or `_`
error Build validation failed with 1 warning(s).
```

MDX reads the `<` in `**<**` as the start of a JSX tag, and `*` cannot begin a tag name. The page was
writing TablePro's filter operators as bold symbols; `docs/features/filtering.mdx` already names the same
operators in words, with only the SQL in backticks. This page now matches it, which removes the bare `<`.

`mint validate` passes, as do `check-writing-style.sh`, `check-docs-against-source.py` and `check-links.py`.
