### PR TITLE
build(ios): compile the PostgreSQL literal quoting the shared foreign key read calls

### DIFF
--- a/TableProMobile/project.yml
+++ b/TableProMobile/project.yml
@@ -63,8 +63,12 @@ targets:
       - ../Plugins/MySQLDriverPlugin/MySQLConnectionEncoding.swift
       - ../Plugins/MySQLDriverPlugin/MySQLLatin1.swift
       - ../Plugins/MySQLDriverPlugin/MySQLServerFlavor.swift
-      # Foreign key catalog read the iOS PostgreSQL driver shares with the macOS plugin.
+      # Foreign key catalog read the iOS PostgreSQL driver shares with the macOS plugin, plus the
+      # single owner of the plugin's literal quoting that it builds its SQL with, and the version
+      # gate that owner projects against.
       - ../Plugins/PostgreSQLDriverPlugin/PostgreSQLCatalogForeignKeys.swift
+      - ../Plugins/PostgreSQLDriverPlugin/PostgreSQLObjectQueries.swift
+      - ../Plugins/PostgreSQLDriverPlugin/PostgreSQLCapabilities.swift
       # libpq COPY handling the iOS PostgreSQL driver shares with the macOS plugin.
       - ../Plugins/PostgreSQLDriverPlugin/LibPQPendingResultDrain.swift
       - ../Plugins/PostgreSQLDriverPlugin/LibPQCopyState.swift


### PR DESCRIPTION
The iOS Tests job has been red on `main` since #2777. `TableProMobile` fails to compile with:

```
cannot find 'PostgreSQLObjectQueries' in scope
  SwiftCompile normal arm64 Plugins/PostgreSQLDriverPlugin/PostgreSQLCatalogForeignKeys.swift
  (in target 'TableProMobile' from project 'TableProMobile')
```

`PostgreSQLCatalogForeignKeys.swift` is one of the plugin files the iOS driver shares, listed in
`TableProMobile/project.yml`. #2777 routed its literal quoting through `PostgreSQLObjectQueries.quoteLiteral`,
which is the right call: that type's own comment names it the single owner of literal quoting for the plugin.
But the file it lives in is not in the mobile target, so only macOS got it.

This adds `PostgreSQLObjectQueries.swift` and, because it projects against a server-version gate,
`PostgreSQLCapabilities.swift`. Those two close it: nothing further cascades.

## Verified

A full iOS build cannot run on this machine, because the only Xcode installed is a beta whose macro plugin
fails on oracle-nio's `@TaskLocal` (`unknown attribute 'usableFromInlinenonisolated'`), which is unrelated and
pre-existing. So the symbol resolution was proved directly instead:

```
swiftc -typecheck PostgreSQLCatalogForeignKeys.swift                                  -> 6 errors,
                                                                 all "cannot find 'PostgreSQLObjectQueries'"
swiftc -typecheck PostgreSQLCatalogForeignKeys.swift PostgreSQLObjectQueries.swift    -> 2 errors,
                                                                 "cannot find type 'PostgreSQLCapabilities'"
swiftc -typecheck  ... + PostgreSQLCapabilities.swift                                 -> clean
```

The regenerated `TableProMobile.xcodeproj` lists both new files in the `TableProMobile` target. CI is the
remaining check.

No CHANGELOG entry: #2777 is itself unreleased.
