### PR TITLE
refactor(settings): group the Editor pane, name the theme color wells, and unbreak lint on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Beancount connections held at Safe Mode Read-Only. (#2030)
 - MySQL sessions on the server's default `utf8mb4` collation.
 - Theme file format 2. Themes written for earlier versions are not read and need to be recreated.
+- Settings > Editor grouped into Display, Gutter and Editing.
 - Editor Font and Data Grid Font moved to Settings > Editor and Settings > Data & Results, and kept per Mac.
 - Editor font size range of 10 to 24 points everywhere, including zoom.
 - Structure editor options the connected PostgreSQL server does not support left out: generated columns before 12, BRIN before 9.5, and the MySQL-only FULLTEXT and SPATIAL index types.
@@ -79,6 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Content panes outside the editor and the data grid ignoring the theme.
 - JSON and PHP tree values colored differently from the same values in the row inspector.
 - Autocomplete icon colors ignoring the theme.
+- Theme color wells and the theme preview unreadable to VoiceOver.
 - Color with a typo in it rendering as a different color instead of being reported.
 - Text past the first 64 KB of a UTF-16 SQL import arriving byte-swapped.
 - SQL import failing on a file whose encoding is not UTF-8 when a character lands on a 64 KB boundary.

--- a/TablePro/Theme/ThemeDefinition.swift
+++ b/TablePro/Theme/ThemeDefinition.swift
@@ -209,7 +209,6 @@ internal enum ThemeSlot: String, CaseIterable, Sendable {
         case .statusSuccess: return \.status.success
         case .statusWarning: return \.status.warning
         case .statusError: return \.status.error
-
         }
     }
 

--- a/TablePro/Views/Results/DataGridCoordinator.swift
+++ b/TablePro/Views/Results/DataGridCoordinator.swift
@@ -507,7 +507,7 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
     var settingsCancellable: AnyCancellable?
     var themeCancellable: AnyCancellable?
     var systemTimeZoneCancellable: AnyCancellable?
-    private var accessibilityActivationObserver: (any NSObjectProtocol)?
+    internal var accessibilityActivationObserver: (any NSObjectProtocol)?
     private var accessibilityMountedRows = NSRange(location: 0, length: 0)
     private var lastDataGridSettings: DataGridSettings
 
@@ -592,72 +592,6 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
                 self.applyDataGridSettingsChange(from: prev, to: settings)
             }
     }
-
-    func applyDataGridSettingsChange(from previous: DataGridSettings, to settings: DataGridSettings) {
-        guard let tableView else { return }
-        let newRowHeight = CGFloat(settings.rowHeight.rawValue)
-        if tableView.rowHeight != newRowHeight {
-            tableView.rowHeight = newRowHeight
-            tableView.tile()
-            repaintRowGutter()
-        }
-
-        let dataChanged = previous.dateFormat != settings.dateFormat
-            || previous.nullDisplay != settings.nullDisplay
-            || previous.enableSmartValueDetection != settings.enableSmartValueDetection
-
-        if dataChanged {
-            reformatDisplayedText()
-        }
-    }
-
-    func observeThemeChanges() {
-        themeCancellable = AppEvents.shared.themeChanged
-            .receive(on: RunLoop.main)
-            .sink { [weak self] _ in
-                if let tableView = self?.tableView {
-                    DataGridBodyChrome.applyBackground(to: tableView)
-                    tableView.headerView?.needsDisplay = true
-                    tableView.cornerView?.needsDisplay = true
-                }
-                self?.reloadVisibleRowsAndStates()
-                /// The row-number font is a theme value and it decides the column's width, which
-                /// the pinned gutter mirrors. Nothing re-measured it on a theme change before, so
-                /// the width was already going stale here.
-                self?.resizeRowNumberColumnForCurrentRange()
-                self?.repaintRowGutter()
-                self?.selectionController.overlay?.needsDisplay = true
-            }
-    }
-
-    /// The grid mounts no view for a data cell, so a client that attaches mid-session finds a table
-    /// of empty cells until the visible rows are built again. The remount is deferred off the
-    /// accessibility query that raised the flag, because rebuilding rows inside it would re-enter
-    /// the tree AppKit is walking.
-    private func observeAccessibilityActivation() {
-        accessibilityActivationObserver = NotificationCenter.default.addObserver(
-            forName: DataGridAccessibility.didActivateNotification,
-            object: nil,
-            queue: nil
-        ) { [weak self] _ in
-            Task { @MainActor [weak self] in
-                self?.remountAccessibilityCells()
-            }
-        }
-    }
-
-    /// Registered for the life of the coordinator, so it has to come off when the grid goes.
-    ///
-    /// `NotificationCenter` retains a block observer's closure, and a coordinator is built fresh on
-    /// every mount, so an entry left behind at teardown is never fired again and never reclaimed.
-    /// The closure captures `self` weakly, so this leaks the registration rather than the grid.
-    func detachAccessibilityActivationObserver() {
-        guard let accessibilityActivationObserver else { return }
-        NotificationCenter.default.removeObserver(accessibilityActivationObserver)
-        self.accessibilityActivationObserver = nil
-    }
-
-    var hasAccessibilityActivationObserver: Bool { accessibilityActivationObserver != nil }
 
     /// Whether this row is one an assistive client can be reading right now.
     ///

--- a/TablePro/Views/Results/Extensions/TableViewCoordinator+Observation.swift
+++ b/TablePro/Views/Results/Extensions/TableViewCoordinator+Observation.swift
@@ -1,0 +1,75 @@
+//
+//  TableViewCoordinator+Observation.swift
+//  TablePro
+//
+
+import AppKit
+import Combine
+
+internal extension TableViewCoordinator {
+    func applyDataGridSettingsChange(from previous: DataGridSettings, to settings: DataGridSettings) {
+        guard let tableView else { return }
+        let newRowHeight = CGFloat(settings.rowHeight.rawValue)
+        if tableView.rowHeight != newRowHeight {
+            tableView.rowHeight = newRowHeight
+            tableView.tile()
+            repaintRowGutter()
+        }
+
+        let dataChanged = previous.dateFormat != settings.dateFormat
+            || previous.nullDisplay != settings.nullDisplay
+            || previous.enableSmartValueDetection != settings.enableSmartValueDetection
+
+        if dataChanged {
+            reformatDisplayedText()
+        }
+    }
+
+    func observeThemeChanges() {
+        themeCancellable = AppEvents.shared.themeChanged
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                if let tableView = self?.tableView {
+                    DataGridBodyChrome.applyBackground(to: tableView)
+                    tableView.headerView?.needsDisplay = true
+                    tableView.cornerView?.needsDisplay = true
+                }
+                self?.reloadVisibleRowsAndStates()
+                /// The row-number font is a theme value and it decides the column's width, which
+                /// the pinned gutter mirrors. Nothing re-measured it on a theme change before, so
+                /// the width was already going stale here.
+                self?.resizeRowNumberColumnForCurrentRange()
+                self?.repaintRowGutter()
+                self?.selectionController.overlay?.needsDisplay = true
+            }
+    }
+
+    /// The grid mounts no view for a data cell, so a client that attaches mid-session finds a table
+    /// of empty cells until the visible rows are built again. The remount is deferred off the
+    /// accessibility query that raised the flag, because rebuilding rows inside it would re-enter
+    /// the tree AppKit is walking.
+    func observeAccessibilityActivation() {
+        accessibilityActivationObserver = NotificationCenter.default.addObserver(
+            forName: DataGridAccessibility.didActivateNotification,
+            object: nil,
+            queue: nil
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.remountAccessibilityCells()
+            }
+        }
+    }
+
+    /// Registered for the life of the coordinator, so it has to come off when the grid goes.
+    ///
+    /// `NotificationCenter` retains a block observer's closure, and a coordinator is built fresh on
+    /// every mount, so an entry left behind at teardown is never fired again and never reclaimed.
+    /// The closure captures `self` weakly, so this leaks the registration rather than the grid.
+    func detachAccessibilityActivationObserver() {
+        guard let accessibilityActivationObserver else { return }
+        NotificationCenter.default.removeObserver(accessibilityActivationObserver)
+        self.accessibilityActivationObserver = nil
+    }
+
+    var hasAccessibilityActivationObserver: Bool { accessibilityActivationObserver != nil }
+}

--- a/TablePro/Views/Settings/Appearance/ThemeEditorColorsSection.swift
+++ b/TablePro/Views/Settings/Appearance/ThemeEditorColorsSection.swift
@@ -45,6 +45,7 @@ internal struct ThemeEditorColorsSection: View {
 
                 ColorPicker("", selection: binding(for: slot), supportsOpacity: true)
                     .labelsHidden()
+                    .accessibilityLabel(Text(slot.label))
             }
             .contextMenu {
                 if case .hex = value, case let .system(name) = BuiltInThemes.default(for: theme.appearance)[keyPath: slot.keyPath] {

--- a/TablePro/Views/Settings/EditorSettingsView.swift
+++ b/TablePro/Views/Settings/EditorSettingsView.swift
@@ -13,16 +13,22 @@ struct EditorSettingsView: View {
         Form {
             TypographySection(domain: .editor, settings: $typography)
 
-            Section("SQL Editor") {
+            Section("Display") {
                 Toggle("Show line numbers", isOn: $settings.showLineNumbers)
                 Toggle("Highlight current line", isOn: $settings.highlightCurrentLine)
                 Toggle("Highlight current statement", isOn: $settings.highlightCurrentStatement)
+                Toggle("Show invisible characters", isOn: $settings.showInvisibleCharacters)
                 Toggle("Word wrap", isOn: $settings.wordWrap)
+            }
+
+            Section("Gutter") {
                 Toggle("Code folding", isOn: $settings.codeFoldingEnabled)
                 Toggle("Run button beside each statement", isOn: $settings.showStatementRunControls)
                     .disabled(!settings.showLineNumbers)
                     .help(Text("The run button sits in the gutter, which needs line numbers."))
-                Toggle("Show invisible characters", isOn: $settings.showInvisibleCharacters)
+            }
+
+            Section("Editing") {
                 Picker("Tab width:", selection: $settings.tabWidth) {
                     Text("2 spaces").tag(2)
                     Text("4 spaces").tag(4)

--- a/TablePro/Views/Settings/Sections/TypographySection.swift
+++ b/TablePro/Views/Settings/Sections/TypographySection.swift
@@ -29,7 +29,7 @@ internal struct TypographySection: View {
     @Binding internal var settings: TypographySettings
 
     internal var body: some View {
-        Section(domain.title) {
+        Section {
             Picker(String(localized: "Family:"), selection: familyBinding) {
                 ForEach(EditorFontResolver.availableMonospacedFamilies) { family in
                     Text(family.displayName).tag(family.id)
@@ -41,10 +41,10 @@ internal struct TypographySection: View {
                     Text(verbatim: "\(size) pt").tag(size)
                 }
             }
-
+        } header: {
+            Text(domain.title)
+        } footer: {
             Text(domain.caption)
-                .font(.caption)
-                .foregroundStyle(.secondary)
         }
     }
 

--- a/TablePro/Views/Settings/ThemePreviewCard.swift
+++ b/TablePro/Views/Settings/ThemePreviewCard.swift
@@ -91,7 +91,14 @@ struct ThemePreviewCard: View {
         size == .compact ? 14 : 28
     }
 
+    /// A miniature of the theme's own colors. The name and kind beside it carry the meaning, so
+    /// the shapes are decorative and say nothing.
     private var thumbnail: some View {
+        thumbnailContent
+            .accessibilityHidden(true)
+    }
+
+    private var thumbnailContent: some View {
         HStack(spacing: 0) {
             sidebarStrip
                 .frame(width: sidebarStripWidth)

--- a/docs/customization/editor-settings.mdx
+++ b/docs/customization/editor-settings.mdx
@@ -20,16 +20,27 @@ The font here is set per Mac, not per theme, and is not synced.
 
 The picker lists the monospaced families installed on your Mac, at 10 to 24 pt. `Cmd+=` and `Cmd+-` change the size over the same range.
 
-## SQL editor
+## Display
 
 | Setting | Default | Notes |
 |---------|---------|-------|
 | Show line numbers | On | Turning this off also hides the per-statement run button |
 | Highlight current line | On | |
 | Highlight current statement | On | A faint band behind the statement the cursor is in. See [Statement markers](/features/sql-editor#statement-markers) |
+| Show invisible characters | Off | See [Invisible characters](/features/sql-editor#invisible-characters) |
 | Word wrap | Off | Off means long lines scroll horizontally |
+
+## Gutter
+
+| Setting | Default | Notes |
+|---------|---------|-------|
 | Code folding | On | Shows the fold ribbon in the gutter. See [Code Folding](/features/code-folding) |
 | Run button beside each statement | On | Gutter run buttons, revealed when the pointer is over the gutter. Needs line numbers on |
+
+## Editing
+
+| Setting | Default | Notes |
+|---------|---------|-------|
 | Tab width | 4 spaces | 2, 4, or 8 |
 | Auto-uppercase keywords | Off | Uppercases SQL keywords on word boundaries. Strings, comments, and quoted identifiers are untouched |
 | Query parameters (`:name` syntax) | On | Detects `:name` placeholders and shows the parameter panel. See [Query Parameters](/features/query-parameters) |


### PR DESCRIPTION
Last of four, stacked on #2793. #2791 rebuilds the engine, #2792 themes the content panes, #2793 records why chrome stays on the macOS appearance. This one is the settings work plus two defects #2792 would otherwise carry.

## Two defects from #2792

**SwiftLint would be red.** The slot removal in #2792 leaves a blank line before a closing brace, and the one line it adds to the data grid's theme subscriber pushes `TableViewCoordinator` to 1101 lines against the 1100 limit. Both fail `swiftlint --strict`.

The blank line is deleted. The length is fixed the way `CLAUDE.md` prescribes rather than by deleting a line: everything that wires one grid to an app-wide change moves into `Views/Results/Extensions/TableViewCoordinator+Observation.swift`, next to the `DataGridView+*` extensions already there. That is `applyDataGridSettingsChange`, `observeThemeChanges`, `observeAccessibilityActivation`, `detachAccessibilityActivationObserver` and `hasAccessibilityActivationObserver`, one cohesive group rather than an arbitrary cut. `accessibilityActivationObserver` widens from `private` to `internal`, which is what moving members out of a file costs.

## Settings and accessibility

**The Editor pane was eleven controls in one section.** Now three: Display (line numbers, current line, current statement, invisible characters, word wrap), Gutter (code folding, the per-statement run button), Editing (tab width, auto-uppercase, query parameters, vim mode).

**The 43 theme color wells were unnamed to VoiceOver.** `LabeledContent` puts a visible label beside each `ColorPicker`, but that does not name the control itself, and the picker's own label is empty and hidden. Each well now carries its slot's name.

**The theme preview thumbnail spoke as a stack of shapes.** It is decorative; the name and kind beside it carry the meaning, so it is hidden from VoiceOver.

**The font pickers' explanatory line was hand-styled** with `.font(.caption)` and `.foregroundStyle(.secondary)`. It is a `Section` footer now, which the system styles correctly in a grouped `Form`.

## Docs

The Editor settings page follows the new grouping, and gains the **Show invisible characters** row it never had.

## Verified

- `build` PASS
- `test` PASS, 144 cases, 144 passed
- `swiftlint --strict` 0 violations, against 2 without this PR
- `docs` PASS

Reviewed by Codex; both findings applied, each a `CLAUDE.md` source-style rule: a comment that narrated the refactor instead of recording an invariant, and an `internal` on a member whose extension already declares it.

One flake seen and not reproduced: `ThemeSlotCoverageTests/everySlotHasAReader` failed once at 0.000 seconds with no message, then passed alone (9 of 9) and passed again in the same twelve-suite combination (144 of 144).

https://claude.ai/code/session_01EKDGt17u6TaVBDHm8rzSEj
