### PR TITLE
style(datagrid): bring the theme slot switch and the grid coordinator back under the lint limits

### DIFF
--- a/TablePro/Theme/ThemeDefinition.swift
+++ b/TablePro/Theme/ThemeDefinition.swift
@@ -209,7 +209,6 @@ internal enum ThemeSlot: String, CaseIterable, Sendable {
         case .statusSuccess: return \.status.success
         case .statusWarning: return \.status.warning
         case .statusError: return \.status.error
-
         }
     }
 

--- a/TablePro/Views/Results/DataGridCoordinator.swift
+++ b/TablePro/Views/Results/DataGridCoordinator.swift
@@ -1419,17 +1419,6 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
         fkColumns = fkSet
     }
 
-    // MARK: - Row Visual State
-
-    func visualState(for row: Int) -> RowVisualState {
-        if let delegateState = delegate?.dataGridVisualState(forRow: row) {
-            return delegateState
-        }
-        guard !visualIndex.isEmpty || !highlightRuleSet.isEmpty,
-              let displayed = displayRow(at: row) else { return .empty }
-        return visualState(of: displayed, atDisplayRow: row)
-    }
-
     // MARK: - NSTableViewDataSource
 
     func numberOfRows(in tableView: NSTableView) -> Int {

--- a/TablePro/Views/Results/Extensions/DataGridView+RowIdentity.swift
+++ b/TablePro/Views/Results/Extensions/DataGridView+RowIdentity.swift
@@ -20,6 +20,17 @@ extension TableViewCoordinator {
         visualIndex.updateRow(rowID, from: changeManager)
     }
 
+    /// The row's marks when the caller has only its display position, which is what AppKit hands a
+    /// delegate callback.
+    func visualState(for row: Int) -> RowVisualState {
+        if let delegateState = delegate?.dataGridVisualState(forRow: row) {
+            return delegateState
+        }
+        guard !visualIndex.isEmpty || !highlightRuleSet.isEmpty,
+              let displayed = displayRow(at: row) else { return .empty }
+        return visualState(of: displayed, atDisplayRow: row)
+    }
+
     /// The row's marks for a caller that has already resolved it, which every drawn cell has:
     /// resolving it again costs a `TableRows` copy per cell.
     func visualState(of displayed: Row, atDisplayRow row: Int) -> RowVisualState {


### PR DESCRIPTION
`swiftlint lint --strict` fails on `main` with two errors from #2781:

```
TablePro/Theme/ThemeDefinition.swift:212:1: error: Vertical Whitespace before Closing Braces
TablePro/Views/Results/DataGridCoordinator.swift:32:7: error: Type Body Length: Class body should
    span 1100 lines or less excluding comments and whitespace: currently spans 1101 lines
```

PR CI never runs that. The `lint` job lives in `build.yml`, which only fires on a `v*` tag, so this is
waiting at the next release rather than on any pull request.

The blank line goes. For the coordinator, `visualState(for:)` moves next to `visualState(of:atDisplayRow:)`,
which already lives in `DataGridView+RowIdentity.swift`: the two are the same question asked with and
without a resolved row, so the pair belongs together and the class drops back under the limit without a
line being invented or deleted.

`swiftlint lint --strict` is clean and the app builds.
