### PR TITLE
feat(settings): theme the content panes outside the editor and the data grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Header, grid line, selection and focus colors in the theme editor.
 - Themes that name a system color for a slot, so the built-in themes keep the system's own contrast settings.
 - Reason shown in Settings > Appearance for a theme file that could not be loaded.
+- Panel and status colors in the theme editor, covering the results, inspector, structure, compare and query plan panes.
 - **Refresh Materialized View…** on PostgreSQL, with a concurrent refresh where the view qualifies. (#2726)
 - **Show DDL** and **Copy DDL** for views and materialized views. (#2726)
 - **Edit Comment…** for PostgreSQL tables, views, materialized views and foreign tables. (#2726)
@@ -75,6 +76,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Query history preview ignoring the theme and the editor font.
 - Theme editor changing the active theme instead of the theme selected for the slot being edited.
 - Malformed theme files loading as Default Light under their own name.
+- Content panes outside the editor and the data grid ignoring the theme.
+- JSON and PHP tree values colored differently from the same values in the row inspector.
+- Autocomplete icon colors ignoring the theme.
 - Color with a typo in it rendering as a different color instead of being reported.
 - Text past the first 64 KB of a UTF-16 SQL import arriving byte-swapped.
 - SQL import failing on a file whose encoding is not UTF-8 when a character lands on a 64 KB boundary.

--- a/TablePro/Core/Autocomplete/SQLCompletionItem.swift
+++ b/TablePro/Core/Autocomplete/SQLCompletionItem.swift
@@ -36,16 +36,17 @@ enum SQLCompletionKind: String, CaseIterable {
     }
 
     /// Color for the icon
+    @MainActor
     var iconColor: NSColor {
         switch self {
-        case .keyword: return .systemBlue
-        case .table: return .systemTeal
-        case .view: return .systemPurple
-        case .column: return .systemOrange
-        case .function: return .systemPink
-        case .schema: return .systemGreen
-        case .alias: return .systemGray
-        case .operator: return .systemIndigo
+        case .keyword: return ThemeEngine.shared.palette[.syntaxKeyword]
+        case .table: return ThemeEngine.shared.palette[.syntaxType]
+        case .view: return ThemeEngine.shared.palette[.syntaxType]
+        case .column: return ThemeEngine.shared.palette[.syntaxNull]
+        case .function: return ThemeEngine.shared.palette[.syntaxFunction]
+        case .schema: return ThemeEngine.shared.palette[.syntaxType]
+        case .alias: return ThemeEngine.shared.palette[.syntaxNull]
+        case .operator: return ThemeEngine.shared.palette[.syntaxOperator]
         case .favorite: return .systemYellow
         }
     }

--- a/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
+++ b/TablePro/Core/Services/Infrastructure/MainSplitViewController.swift
@@ -714,8 +714,8 @@ internal final class MainSplitViewController: NSSplitViewController, TrailingPan
     /// intermediate value instead of letting one run-loop turn settle on the final one.
     private func refreshPanes(of workspace: ConnectionWorkspace) {
         workspace.panes.sidebar.rootView = AnyView(buildSidebarView(for: workspace))
-        workspace.panes.detail.rootView = AnyView(buildDetailView(for: workspace))
-        workspace.panes.inspector.rootView = AnyView(buildInspectorView(for: workspace))
+        workspace.panes.detail.rootView = AnyView(buildDetailView(for: workspace).themedContent())
+        workspace.panes.inspector.rootView = AnyView(buildInspectorView(for: workspace).themedContent())
         workspace.panes.assistant.rootView = AnyView(buildAssistantView(for: workspace))
         refreshTabStripPane(of: workspace)
         workspace.panes.markRendered(workspace.paneRenderKey)
@@ -903,7 +903,7 @@ internal final class MainSplitViewController: NSSplitViewController, TrailingPan
     /// publishes those actions.
     func rebuildTrailingPanes() {
         guard let selected = workspaces.selected else { return }
-        selected.panes.inspector.rootView = AnyView(buildInspectorView(for: selected))
+        selected.panes.inspector.rootView = AnyView(buildInspectorView(for: selected).themedContent())
         selected.panes.assistant.rootView = AnyView(buildAssistantView(for: selected))
     }
 

--- a/TablePro/Models/UI/JSONTreeNode.swift
+++ b/TablePro/Models/UI/JSONTreeNode.swift
@@ -27,13 +27,14 @@ internal enum JSONValueType {
         }
     }
 
+    @MainActor
     var color: NSColor {
         switch self {
-        case .object, .array: return .systemBlue
-        case .string: return .systemRed
-        case .number: return .systemPurple
-        case .boolean, .null: return .systemOrange
-        case .truncated: return .secondaryLabelColor
+        case .object, .array: return ThemeEngine.shared.palette[.syntaxKeyword]
+        case .string: return ThemeEngine.shared.palette[.syntaxString]
+        case .number: return ThemeEngine.shared.palette[.syntaxNumber]
+        case .boolean, .null: return ThemeEngine.shared.palette[.syntaxNull]
+        case .truncated: return ThemeEngine.shared.palette[.panelSecondaryText]
         }
     }
 }

--- a/TablePro/Models/UI/PhpTreeNode.swift
+++ b/TablePro/Models/UI/PhpTreeNode.swift
@@ -35,13 +35,14 @@ internal enum PhpNodeType {
         }
     }
 
+    @MainActor
     var color: NSColor {
         switch self {
-        case .array, .object: return .systemBlue
-        case .string: return .systemRed
-        case .int, .float: return .systemPurple
-        case .bool, .null: return .systemOrange
-        case .serializable: return .systemTeal
+        case .array, .object: return ThemeEngine.shared.palette[.syntaxKeyword]
+        case .string: return ThemeEngine.shared.palette[.syntaxString]
+        case .int, .float: return ThemeEngine.shared.palette[.syntaxNumber]
+        case .bool, .null: return ThemeEngine.shared.palette[.syntaxNull]
+        case .serializable: return ThemeEngine.shared.palette[.syntaxType]
         case .reference: return .systemGray
         case .unsupported, .truncated: return .secondaryLabelColor
         }

--- a/TablePro/Resources/Themes/tablepro.dracula.json
+++ b/TablePro/Resources/Themes/tablepro.dracula.json
@@ -42,6 +42,14 @@
       },
       "text": "#F8F8F2"
     },
+    "panel": {
+      "background": "#282A36",
+      "controlBackground": "#343746",
+      "secondaryText": "#BFC0C9",
+      "separator": "#44475A",
+      "tertiaryText": "#6272A4",
+      "text": "#F8F8F2"
+    },
     "status": {
       "error": "#FF5555",
       "success": "#50FA7B",

--- a/TablePro/Resources/Themes/tablepro.nord.json
+++ b/TablePro/Resources/Themes/tablepro.nord.json
@@ -42,6 +42,14 @@
       },
       "text": "#D8DEE9"
     },
+    "panel": {
+      "background": "#2E3440",
+      "controlBackground": "#3B4252",
+      "secondaryText": "#9DA5B4",
+      "separator": "#434C5E",
+      "tertiaryText": "#616E88",
+      "text": "#D8DEE9"
+    },
     "status": {
       "error": "#BF616A",
       "success": "#A3BE8C",

--- a/TablePro/Theme/BuiltInThemes.swift
+++ b/TablePro/Theme/BuiltInThemes.swift
@@ -39,6 +39,7 @@ internal enum BuiltInThemes {
             deleted: "#FF3B304D",
             deletedText: "#FF3B3080"
         ),
+        panel: .systemPanel,
         status: StatusThemeColors(
             success: .hex("#248A3D"),
             warning: .hex("#C55B00"),
@@ -77,6 +78,7 @@ internal enum BuiltInThemes {
             deleted: "#FF453A26",
             deletedText: "#FF453A80"
         ),
+        panel: .systemPanel,
         status: StatusThemeColors(
             success: .hex("#32D74B"),
             warning: .hex("#FF9F0A"),
@@ -124,4 +126,17 @@ internal enum BuiltInThemes {
             deletedText: .hex(deletedText)
         )
     }
+}
+
+internal extension PanelThemeColors {
+    /// The semantic colours these surfaces already named before the theme owned them, so a default
+    /// theme is invisible against the unthemed app and keeps the system's contrast handling.
+    static let systemPanel = PanelThemeColors(
+        background: .system(.controlBackground),
+        controlBackground: .system(.textBackground),
+        text: .system(.label),
+        secondaryText: .system(.secondaryLabel),
+        tertiaryText: .system(.tertiaryLabel),
+        separator: .system(.separator)
+    )
 }

--- a/TablePro/Theme/ThemeDefinition.swift
+++ b/TablePro/Theme/ThemeDefinition.swift
@@ -55,6 +55,15 @@ internal struct StatusThemeColors: Equatable, Sendable {
     var error: ThemeColorValue
 }
 
+internal struct PanelThemeColors: Equatable, Sendable {
+    var background: ThemeColorValue
+    var controlBackground: ThemeColorValue
+    var text: ThemeColorValue
+    var secondaryText: ThemeColorValue
+    var tertiaryText: ThemeColorValue
+    var separator: ThemeColorValue
+}
+
 internal struct ThemeDefinition: Identifiable, Equatable, Sendable {
     var id: String
     var name: String
@@ -62,6 +71,7 @@ internal struct ThemeDefinition: Identifiable, Equatable, Sendable {
     var appearance: ThemeAppearance
     var editor: EditorThemeColors
     var dataGrid: DataGridThemeColors
+    var panel: PanelThemeColors
     var status: StatusThemeColors
 
     internal static let builtInPrefix = "tablepro."
@@ -115,9 +125,17 @@ internal enum ThemeSlot: String, CaseIterable, Sendable {
     case gridDeleted = "content.dataGrid.deleted"
     case gridDeletedText = "content.dataGrid.deletedText"
 
+    case panelBackground = "content.panel.background"
+    case panelControlBackground = "content.panel.controlBackground"
+    case panelText = "content.panel.text"
+    case panelSecondaryText = "content.panel.secondaryText"
+    case panelTertiaryText = "content.panel.tertiaryText"
+    case panelSeparator = "content.panel.separator"
+
     case statusSuccess = "content.status.success"
     case statusWarning = "content.status.warning"
     case statusError = "content.status.error"
+
 
     internal var since: Int { 2 }
 
@@ -134,6 +152,9 @@ internal enum ThemeSlot: String, CaseIterable, Sendable {
              .gridNullValue, .gridBoolTrue, .gridBoolFalse, .gridRowNumber,
              .gridModified, .gridInserted, .gridDeleted, .gridDeletedText:
             return .dataGrid
+        case .panelBackground, .panelControlBackground, .panelText,
+             .panelSecondaryText, .panelTertiaryText, .panelSeparator:
+            return .panel
         case .statusSuccess, .statusWarning, .statusError:
             return .status
         }
@@ -178,9 +199,17 @@ internal enum ThemeSlot: String, CaseIterable, Sendable {
         case .gridDeleted: return \.dataGrid.deleted
         case .gridDeletedText: return \.dataGrid.deletedText
 
+        case .panelBackground: return \.panel.background
+        case .panelControlBackground: return \.panel.controlBackground
+        case .panelText: return \.panel.text
+        case .panelSecondaryText: return \.panel.secondaryText
+        case .panelTertiaryText: return \.panel.tertiaryText
+        case .panelSeparator: return \.panel.separator
+
         case .statusSuccess: return \.status.success
         case .statusWarning: return \.status.warning
         case .statusError: return \.status.error
+
         }
     }
 
@@ -220,6 +249,12 @@ internal enum ThemeSlot: String, CaseIterable, Sendable {
         case .statusSuccess: return String(localized: "Success")
         case .statusWarning: return String(localized: "Warning")
         case .statusError: return String(localized: "Error")
+        case .panelBackground: return String(localized: "Pane Background")
+        case .panelControlBackground: return String(localized: "Field Background")
+        case .panelText: return String(localized: "Pane Text")
+        case .panelSecondaryText: return String(localized: "Secondary Text")
+        case .panelTertiaryText: return String(localized: "Tertiary Text")
+        case .panelSeparator: return String(localized: "Separator")
         }
     }
 }
@@ -228,6 +263,7 @@ internal enum ThemeSlotGroup: String, CaseIterable, Sendable {
     case editor
     case syntax
     case dataGrid
+    case panel
     case status
 
     internal var label: String {
@@ -235,6 +271,7 @@ internal enum ThemeSlotGroup: String, CaseIterable, Sendable {
         case .editor: return String(localized: "Editor")
         case .syntax: return String(localized: "Syntax Colors")
         case .dataGrid: return String(localized: "Data Grid")
+        case .panel: return String(localized: "Panels")
         case .status: return String(localized: "Status")
         }
     }

--- a/TablePro/Theme/ThemedContentSurface.swift
+++ b/TablePro/Theme/ThemedContentSurface.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+/// Re-resolves `.secondary` and `.tertiary` inside a content pane to the theme's own text levels,
+/// which is how 184 hierarchical foreground styles across the content surfaces follow a theme
+/// without each one being rewritten.
+///
+/// It never branches on the theme. `WorkspacePanes` depends on every pane builder erasing one
+/// stable view identity, so an `if` here would tear down the grid, the editor's undo stack and the
+/// scroll position on a theme change. It reads the engine inside `body`, so the palette it applies
+/// is the current one rather than whatever was captured when the pane was built.
+private struct ThemedContentSurface: ViewModifier {
+    func body(content: Content) -> some View {
+        let palette = ThemeEngine.shared.palette
+
+        return content.foregroundStyle(
+            palette.color(.panelText),
+            palette.color(.panelSecondaryText),
+            palette.color(.panelTertiaryText)
+        )
+    }
+}
+
+internal extension View {
+    func themedContent() -> some View {
+        modifier(ThemedContentSurface())
+    }
+}

--- a/TablePro/Views/Editor/FileModifiedOnDiskBanner.swift
+++ b/TablePro/Views/Editor/FileModifiedOnDiskBanner.swift
@@ -13,7 +13,7 @@ internal struct FileModifiedOnDiskBanner: View {
     var body: some View {
         HStack(spacing: 8) {
             Image(systemName: "exclamationmark.triangle.fill")
-                .foregroundStyle(.yellow)
+                .foregroundStyle(ThemeEngine.shared.palette.color(.statusWarning))
                 .accessibilityHidden(true)
 
             Text(String(format: String(localized: "\"%@\" was modified on disk."), fileName))
@@ -41,6 +41,6 @@ internal struct FileModifiedOnDiskBanner: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 6)
-        .background(.yellow.opacity(0.12))
+        .background(ThemeEngine.shared.palette.color(.statusWarning).opacity(0.12))
     }
 }

--- a/TablePro/Views/Editor/History/HistoryDetailPane.swift
+++ b/TablePro/Views/Editor/History/HistoryDetailPane.swift
@@ -66,7 +66,7 @@ struct HistoryDetailPane: View {
             if let errorMessage = entry.errorMessage {
                 RevealedTextView(errorMessage)
                     .font(.caption)
-                    .foregroundStyle(.red)
+                    .foregroundStyle(ThemeEngine.shared.palette.color(.statusError))
                     .textSelection(.enabled)
                     .fixedSize(horizontal: false, vertical: true)
             }

--- a/TablePro/Views/Editor/History/HistoryRowView.swift
+++ b/TablePro/Views/Editor/History/HistoryRowView.swift
@@ -71,7 +71,7 @@ struct HistoryRowView: View {
                 .foregroundStyle(Color.secondary)
         } else {
             Image(systemName: "exclamationmark.circle.fill")
-                .selectionAwareTint(.red)
+                .selectionAwareTint(ThemeEngine.shared.palette.color(.statusError))
         }
     }
 

--- a/TablePro/Views/Editor/QueryCompletionAdapter.swift
+++ b/TablePro/Views/Editor/QueryCompletionAdapter.swift
@@ -222,7 +222,10 @@ final class SQLSuggestionEntry: CodeSuggestionEntry {
         Image(systemName: item.kind.iconName)
     }
 
+    /// The suggestion protocol is nonisolated and the panel only ever reads this on the main
+    /// thread. The kind is lifted out first so the closure sends a value rather than `self`.
     var imageColor: Color {
-        Color(nsColor: item.kind.iconColor)
+        let kind = item.kind
+        return MainActor.assumeIsolated { Color(nsColor: kind.iconColor) }
     }
 }

--- a/TablePro/Views/Editor/QueryDiagnosticsController.swift
+++ b/TablePro/Views/Editor/QueryDiagnosticsController.swift
@@ -75,6 +75,14 @@ final class QueryDiagnosticsController {
         apply(produced, in: controller)
     }
 
+    /// An emphasis bakes its colour into a `CAShapeLayer`, so a theme change inside one appearance
+    /// leaves an existing underline on the previous colour. `refresh(for:)` cannot repaint it: the
+    /// diagnostics themselves have not changed, so it returns early.
+    func reapplyColors(in controller: TextViewController) {
+        guard !diagnostics.isEmpty else { return }
+        apply(diagnostics, in: controller)
+    }
+
     func clear(in controller: TextViewController?) {
         pendingTask?.cancel()
         pendingTask = nil
@@ -104,8 +112,8 @@ final class QueryDiagnosticsController {
 
     private func color(for severity: QueryDiagnostic.Severity) -> NSColor {
         switch severity {
-        case .error: return .systemRed
-        case .warning: return .systemOrange
+        case .error: return ThemeEngine.shared.palette[.statusError]
+        case .warning: return ThemeEngine.shared.palette[.statusWarning]
         }
     }
 }

--- a/TablePro/Views/Editor/QueryEditorView.swift
+++ b/TablePro/Views/Editor/QueryEditorView.swift
@@ -97,7 +97,6 @@ struct QueryEditorView: View {
             .frame(minHeight: 100)
             .clipped()
         }
-        .background(Color(nsColor: .textBackgroundColor))
     }
 
     // MARK: - Toolbar

--- a/TablePro/Views/Editor/SQLEditorCoordinator.swift
+++ b/TablePro/Views/Editor/SQLEditorCoordinator.swift
@@ -27,6 +27,13 @@ final class SQLEditorCoordinator: TextViewCoordinator, TextViewDelegate {
     private static let languageServiceLengthLimit = EditorHighlighting.maxHighlightableCharacters
 
     @ObservationIgnored weak var controller: TextViewController?
+
+    /// The editor configuration carries the new colours, but an emphasis already on screen baked
+    /// its own into a `CAShapeLayer` that nothing else repaints.
+    func reapplyThemeColors() {
+        guard let controller else { return }
+        diagnosticsController.reapplyColors(in: controller)
+    }
     @ObservationIgnored private lazy var diagnosticsController = QueryDiagnosticsController(
         databaseType: databaseType
     )

--- a/TablePro/Views/Editor/SQLEditorView.swift
+++ b/TablePro/Views/Editor/SQLEditorView.swift
@@ -147,6 +147,7 @@ struct SQLEditorView: View {
         }
         .onReceive(AppEvents.shared.themeChanged) { _ in
             editorConfiguration = Self.makeConfiguration()
+            coordinator.reapplyThemeColors()
         }
         .onAppear {
             initializeEditor()

--- a/TablePro/Views/Import/SQLCodePreview.swift
+++ b/TablePro/Views/Import/SQLCodePreview.swift
@@ -19,7 +19,7 @@ struct SQLCodePreview: View {
 
     var body: some View {
         if text.isEmpty {
-            Color(nsColor: .textBackgroundColor)
+            ThemeEngine.shared.palette.color(.editorBackground)
         } else {
             SourceEditor(
                 $text,

--- a/TablePro/Views/QueryInsights/QueryInsightsActivityChart.swift
+++ b/TablePro/Views/QueryInsights/QueryInsightsActivityChart.swift
@@ -53,7 +53,7 @@ struct QueryInsightsActivityChart: View {
             }
             .chartForegroundStyleScale([
                 Outcome.succeeded: Color.accentColor,
-                Outcome.failed: Color.orange,
+                Outcome.failed: ThemeEngine.shared.palette.color(.statusWarning),
             ])
             .chartLegend(position: .top, alignment: .trailing, spacing: 8)
             .chartYAxis {

--- a/TablePro/Views/QueryInsights/QueryInsightsGroupList.swift
+++ b/TablePro/Views/QueryInsights/QueryInsightsGroupList.swift
@@ -48,7 +48,7 @@ struct QueryInsightsGroupList: View {
                 if let error = group.latestErrorMessage, case .failures = metric {
                     RevealedTextView(error)
                         .font(.caption)
-                        .foregroundStyle(.orange)
+                        .foregroundStyle(ThemeEngine.shared.palette.color(.statusWarning))
                         .lineLimit(2)
                 }
             }
@@ -86,7 +86,7 @@ struct QueryInsightsGroupList: View {
 
     private func headlineTint(_ group: QueryInsightsGroup) -> Color {
         switch metric {
-        case .failures: return .orange
+        case .failures: return ThemeEngine.shared.palette.color(.statusWarning)
         case .duration: return .primary
         case .callCount: return .primary
         }
@@ -160,7 +160,7 @@ struct QueryInsightsRegressionList: View {
             .font(.system(.callout, design: .monospaced))
             .fontWeight(.medium)
             .monospacedDigit()
-            .foregroundStyle(.orange)
+            .foregroundStyle(ThemeEngine.shared.palette.color(.statusWarning))
             .frame(minWidth: 76, alignment: .trailing)
 
             VStack(alignment: .leading, spacing: 3) {

--- a/TablePro/Views/QueryInsights/QueryInsightsSummaryBar.swift
+++ b/TablePro/Views/QueryInsights/QueryInsightsSummaryBar.swift
@@ -30,7 +30,7 @@ struct QueryInsightsSummaryBar: View {
                     totals.totalCount.formatted()
                 ),
                 systemImage: "exclamationmark.triangle",
-                tint: totals.failedCount > 0 ? .orange : .secondary
+                tint: totals.failedCount > 0 ? ThemeEngine.shared.palette.color(.statusWarning) : .secondary
             )
             metric(
                 label: String(localized: "Average"),

--- a/TablePro/Views/Results/ArrayValueEditorView.swift
+++ b/TablePro/Views/Results/ArrayValueEditorView.swift
@@ -162,7 +162,7 @@ struct ArrayValueEditorView: View {
         .pickerStyle(.menu)
         if ArrayValueEditorModel.isDriftedValue(row.element, allowedValues: allowedValues) {
             Image(systemName: "exclamationmark.triangle")
-                .foregroundStyle(.orange)
+                .foregroundStyle(ThemeEngine.shared.palette.color(.statusWarning))
                 .help(Text("This value is not one of the type's current labels"))
         }
     }

--- a/TablePro/Views/Results/ColumnValueFilterPopover.swift
+++ b/TablePro/Views/Results/ColumnValueFilterPopover.swift
@@ -102,7 +102,7 @@ struct ColumnValueFilterPopover: View {
                         Text(label(for: value))
                             .lineLimit(1)
                             .truncationMode(.tail)
-                            .foregroundStyle(value.isNull ? Color.secondary : Color.primary)
+                            .foregroundStyle(value.isNull ? ThemeEngine.shared.palette.color(.gridNullValue) : Color.primary)
                         Spacer(minLength: 8)
                         Text("\(value.count)")
                             .font(.callout.monospacedDigit())

--- a/TablePro/Views/Results/DataGridCoordinator.swift
+++ b/TablePro/Views/Results/DataGridCoordinator.swift
@@ -626,6 +626,7 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
                 /// the width was already going stale here.
                 self?.resizeRowNumberColumnForCurrentRange()
                 self?.repaintRowGutter()
+                self?.selectionController.overlay?.needsDisplay = true
             }
     }
 

--- a/TablePro/Views/Results/ForeignKeyPickerView.swift
+++ b/TablePro/Views/Results/ForeignKeyPickerView.swift
@@ -96,7 +96,7 @@ struct ForeignKeyPickerView: View {
     private var content: some View {
         if let errorMessage {
             RevealedTextView(errorMessage)
-                .foregroundStyle(.red)
+                .foregroundStyle(ThemeEngine.shared.palette.color(.statusError))
                 .font(.callout)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(10)

--- a/TablePro/Views/Results/ForeignKeyPreviewView.swift
+++ b/TablePro/Views/Results/ForeignKeyPreviewView.swift
@@ -104,7 +104,7 @@ struct ForeignKeyPreviewView: View {
                 .frame(height: 60)
         } else if let errorMessage {
             RevealedTextView(errorMessage)
-                .foregroundStyle(.red)
+                .foregroundStyle(ThemeEngine.shared.palette.color(.statusError))
                 .font(.callout)
                 .padding(10)
         } else if values.isEmpty {

--- a/TablePro/Views/Results/HexEditorContentView.swift
+++ b/TablePro/Views/Results/HexEditorContentView.swift
@@ -99,11 +99,11 @@ struct HexEditorBody: View {
                         if sourceIsTruncated || isTruncated {
                             Text(String(localized: "Truncated, read only"))
                                 .font(.caption)
-                                .foregroundStyle(.orange)
+                                .foregroundStyle(ThemeEngine.shared.palette.color(.statusWarning))
                         } else if !isValid, !editableHex.isEmpty {
                             Text(String(localized: "Invalid hex"))
                                 .font(.caption)
-                                .foregroundStyle(.red)
+                                .foregroundStyle(ThemeEngine.shared.palette.color(.statusError))
                         }
 
                         Spacer()
@@ -227,8 +227,8 @@ private struct HexDumpDisplayView: NSViewRepresentable {
         textView.isSelectable = true
         textView.font = font
         textView.textContainerInset = NSSize(width: 8, height: 8)
-        textView.backgroundColor = NSColor.textBackgroundColor
-        textView.textColor = NSColor.secondaryLabelColor
+        textView.backgroundColor = ThemeEngine.shared.palette[.panelControlBackground]
+        textView.textColor = ThemeEngine.shared.palette[.panelSecondaryText]
         textView.string = text
 
         return scrollView
@@ -239,6 +239,8 @@ private struct HexDumpDisplayView: NSViewRepresentable {
         if textView.font != font {
             textView.font = font
         }
+        textView.backgroundColor = ThemeEngine.shared.palette[.panelControlBackground]
+        textView.textColor = ThemeEngine.shared.palette[.panelSecondaryText]
         if textView.string != text {
             textView.string = text
         }
@@ -265,8 +267,8 @@ private struct HexInputTextView: NSViewRepresentable {
         textView.isSelectable = true
         textView.font = font
         textView.textContainerInset = NSSize(width: 8, height: 8)
-        textView.backgroundColor = NSColor.textBackgroundColor
-        textView.textColor = NSColor.labelColor
+        textView.backgroundColor = ThemeEngine.shared.palette[.panelControlBackground]
+        textView.textColor = ThemeEngine.shared.palette[.panelText]
         textView.isAutomaticQuoteSubstitutionEnabled = false
         textView.isAutomaticDashSubstitutionEnabled = false
         textView.isAutomaticTextReplacementEnabled = false
@@ -288,6 +290,8 @@ private struct HexInputTextView: NSViewRepresentable {
         if textView.font != font {
             textView.font = font
         }
+        textView.backgroundColor = ThemeEngine.shared.palette[.panelControlBackground]
+        textView.textColor = ThemeEngine.shared.palette[.panelText]
         if textView.string != text, !context.coordinator.isUpdating {
             textView.string = text
         }

--- a/TablePro/Views/Results/InlineErrorBanner.swift
+++ b/TablePro/Views/Results/InlineErrorBanner.swift
@@ -21,7 +21,7 @@ struct InlineErrorBanner: View {
     var body: some View {
         HStack(alignment: .top, spacing: 8) {
             Image(systemName: "exclamationmark.triangle.fill")
-                .foregroundStyle(.red)
+                .foregroundStyle(ThemeEngine.shared.palette.color(.statusError))
             ScrollView(.vertical) {
                 RevealedTextView(message)
                     .font(.subheadline)
@@ -63,7 +63,7 @@ struct InlineErrorBanner: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
-        .background(.red.opacity(0.08))
+        .background(ThemeEngine.shared.palette.color(.statusError).opacity(0.08))
     }
 }
 

--- a/TablePro/Views/Results/JSONTreeView.swift
+++ b/TablePro/Views/Results/JSONTreeView.swift
@@ -30,7 +30,7 @@ private struct JSONTreeRowView: View {
             if let key = node.key {
                 Text(key)
                     .font(ThemeEngine.shared.valueFontEmphasizedSwiftUI)
-                    .foregroundStyle(.blue)
+                    .foregroundStyle(ThemeEngine.shared.palette.color(.syntaxKeyword))
                     .lineLimit(1)
                 Text(":")
                     .foregroundStyle(.secondary)

--- a/TablePro/Views/Results/PhpTreeView.swift
+++ b/TablePro/Views/Results/PhpTreeView.swift
@@ -30,7 +30,7 @@ private struct PhpTreeRowView: View {
             if let key = node.key {
                 Text(key)
                     .font(ThemeEngine.shared.valueFontEmphasizedSwiftUI)
-                    .foregroundStyle(.blue)
+                    .foregroundStyle(ThemeEngine.shared.palette.color(.syntaxKeyword))
                     .lineLimit(1)
                 if let badge = node.visibilityBadge {
                     Text(badge)

--- a/TablePro/Views/Results/ResultChartCanvas.swift
+++ b/TablePro/Views/Results/ResultChartCanvas.swift
@@ -41,27 +41,27 @@ struct ResultChartCanvas: View {
         .chartYAxis {
             AxisMarks(position: .leading) {
                 AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5))
-                    .foregroundStyle(Color(nsColor: .separatorColor).opacity(0.55))
+                    .foregroundStyle(ThemeEngine.shared.palette.color(.panelSeparator).opacity(0.55))
                 AxisTick(stroke: StrokeStyle(lineWidth: 0.5))
-                    .foregroundStyle(Color(nsColor: .separatorColor))
+                    .foregroundStyle(ThemeEngine.shared.palette.color(.panelSeparator))
                 AxisValueLabel()
-                    .foregroundStyle(Color(nsColor: .secondaryLabelColor))
+                    .foregroundStyle(ThemeEngine.shared.palette.color(.panelSecondaryText))
             }
         }
         .chartXAxis {
             AxisMarks(values: .automatic(desiredCount: 7)) {
                 AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5))
-                    .foregroundStyle(Color(nsColor: .separatorColor).opacity(0.55))
+                    .foregroundStyle(ThemeEngine.shared.palette.color(.panelSeparator).opacity(0.55))
                 AxisTick(stroke: StrokeStyle(lineWidth: 0.5))
-                    .foregroundStyle(Color(nsColor: .separatorColor))
+                    .foregroundStyle(ThemeEngine.shared.palette.color(.panelSeparator))
                 AxisValueLabel(collisionResolution: .greedy(minimumSpacing: 8))
-                    .foregroundStyle(Color(nsColor: .secondaryLabelColor))
+                    .foregroundStyle(ThemeEngine.shared.palette.color(.panelSecondaryText))
             }
         }
         .chartPlotStyle { plotArea in
             plotArea
                 .background(
-                    Color(nsColor: .controlBackgroundColor).opacity(0.45),
+                    ThemeEngine.shared.palette.color(.panelBackground).opacity(0.45),
                     in: .rect(cornerRadius: 8)
                 )
         }

--- a/TablePro/Views/Results/ResultSuccessView.swift
+++ b/TablePro/Views/Results/ResultSuccessView.swift
@@ -28,7 +28,7 @@ struct ResultSuccessView: View {
             Spacer()
             Image(systemName: "checkmark.circle.fill")
                 .font(.largeTitle)
-                .foregroundStyle(.green)
+                .foregroundStyle(ThemeEngine.shared.palette.color(.statusSuccess))
             Text(primaryMessage)
                 .font(.body)
             if let time = executionTime {

--- a/TablePro/Views/Results/Selection/GridSelectionOverlay.swift
+++ b/TablePro/Views/Results/Selection/GridSelectionOverlay.swift
@@ -37,7 +37,7 @@ final class GridSelectionOverlay: NSView {
         let totalRows = tableView.numberOfRows
         let editingCell = activeOverlayCell(in: coordinator)
 
-        NSColor.selectedContentBackgroundColor.withAlphaComponent(Self.borderAlpha).setStroke()
+        ThemeEngine.shared.palette[.gridSelection].withAlphaComponent(Self.borderAlpha).setStroke()
         for rect in selection.rectangles {
             guard let frame = frame(for: rect, in: tableView, coordinator: coordinator) else { continue }
             guard frame.intersects(dirtyRect) else { continue }

--- a/TablePro/Views/RowInspector/FieldEditors/BlobHexEditorView.swift
+++ b/TablePro/Views/RowInspector/FieldEditors/BlobHexEditorView.swift
@@ -94,11 +94,11 @@ internal struct BlobHexEditorView: View {
             if isTruncated {
                 Text("Truncated, read only")
                     .font(.caption2)
-                    .foregroundStyle(.orange)
+                    .foregroundStyle(ThemeEngine.shared.palette.color(.statusWarning))
             } else if BlobFormattingService.shared.parseHex(hexEditText) == nil, !hexEditText.isEmpty {
                 Text("Invalid hex")
                     .font(.caption2)
-                    .foregroundStyle(.red)
+                    .foregroundStyle(ThemeEngine.shared.palette.color(.statusError))
             }
         }
     }

--- a/TablePro/Views/RowInspector/FieldEditors/FieldEditorContent.swift
+++ b/TablePro/Views/RowInspector/FieldEditors/FieldEditorContent.swift
@@ -106,7 +106,7 @@ internal struct PendingStatePill: View {
             .frame(maxWidth: .infinity, minHeight: minHeight, alignment: .topLeading)
             .padding(.horizontal, 6)
             .padding(.vertical, 3)
-            .background(Color(nsColor: .textBackgroundColor), in: RoundedRectangle(cornerRadius: 5))
-            .overlay(RoundedRectangle(cornerRadius: 5).strokeBorder(Color(nsColor: .separatorColor)))
+            .background(ThemeEngine.shared.palette.color(.panelControlBackground), in: RoundedRectangle(cornerRadius: 5))
+            .overlay(RoundedRectangle(cornerRadius: 5).strokeBorder(ThemeEngine.shared.palette.color(.panelSeparator)))
     }
 }

--- a/TablePro/Views/RowInspector/FieldEditors/ImageFieldView.swift
+++ b/TablePro/Views/RowInspector/FieldEditors/ImageFieldView.swift
@@ -34,7 +34,7 @@ internal struct ImageFieldView: View {
         )
         .frame(height: 220)
         .clipShape(RoundedRectangle(cornerRadius: 5))
-        .overlay(RoundedRectangle(cornerRadius: 5).strokeBorder(Color(nsColor: .separatorColor)))
+        .overlay(RoundedRectangle(cornerRadius: 5).strokeBorder(ThemeEngine.shared.palette.color(.panelSeparator)))
         .task(id: context.value.wrappedValue) {
             data = context.value.wrappedValue.storedBytes
         }

--- a/TablePro/Views/RowInspector/FieldEditors/JsonEditorView.swift
+++ b/TablePro/Views/RowInspector/FieldEditors/JsonEditorView.swift
@@ -29,7 +29,7 @@ internal struct JsonEditorView: View {
         ) {
             JSONCodeEditor(text: $displayText, isEditable: !context.isReadOnly)
                 .clipShape(RoundedRectangle(cornerRadius: 5))
-                .overlay(RoundedRectangle(cornerRadius: 5).strokeBorder(Color(nsColor: .separatorColor)))
+                .overlay(RoundedRectangle(cornerRadius: 5).strokeBorder(ThemeEngine.shared.palette.color(.panelSeparator)))
                 .overlay(alignment: .bottomTrailing) { actionButtons }
         }
         .onChange(of: displayText) { propagateEdit() }

--- a/TablePro/Views/RowInspector/FieldEditors/MultiLineEditorView.swift
+++ b/TablePro/Views/RowInspector/FieldEditors/MultiLineEditorView.swift
@@ -26,7 +26,7 @@ internal struct MultiLineEditorView: View {
                 movesFocusOnTab: true
             )
             .clipShape(RoundedRectangle(cornerRadius: 5))
-            .overlay(RoundedRectangle(cornerRadius: 5).strokeBorder(Color(nsColor: .separatorColor)))
+            .overlay(RoundedRectangle(cornerRadius: 5).strokeBorder(ThemeEngine.shared.palette.color(.panelSeparator)))
             .overlay(alignment: .topLeading) { placeholder }
             .overlay(alignment: .bottomTrailing) { popOutButton }
         }

--- a/TablePro/Views/RowInspector/FieldEditors/PhpSerializedFieldView.swift
+++ b/TablePro/Views/RowInspector/FieldEditors/PhpSerializedFieldView.swift
@@ -18,6 +18,6 @@ internal struct PhpSerializedFieldView: View {
         .frame(height: isExpanded ? ResizableFieldMetrics.expandedHeight : nil)
         .frame(minHeight: isExpanded ? nil : 80, maxHeight: isExpanded ? nil : 200)
         .clipShape(RoundedRectangle(cornerRadius: 5))
-        .overlay(RoundedRectangle(cornerRadius: 5).strokeBorder(Color(nsColor: .separatorColor)))
+        .overlay(RoundedRectangle(cornerRadius: 5).strokeBorder(ThemeEngine.shared.palette.color(.panelSeparator)))
     }
 }

--- a/TablePro/Views/RowInspector/FieldEditors/ResizableEditorContainer.swift
+++ b/TablePro/Views/RowInspector/FieldEditors/ResizableEditorContainer.swift
@@ -39,7 +39,7 @@ internal struct ResizableEditorContainer<Content: View>: View {
 
     private var resizeHandle: some View {
         Capsule()
-            .fill(Color(nsColor: .tertiaryLabelColor))
+            .fill(ThemeEngine.shared.palette.color(.panelTertiaryText))
             .frame(width: 26, height: 4)
             .opacity(isHandleHovered ? 1 : 0.5)
             .frame(maxWidth: .infinity, minHeight: 11)

--- a/TablePro/Views/RowInspector/FieldEditors/SingleLineEditorView.swift
+++ b/TablePro/Views/RowInspector/FieldEditors/SingleLineEditorView.swift
@@ -29,7 +29,7 @@ internal struct SingleLineEditorView: View {
             .frame(maxWidth: .infinity, minHeight: 16, alignment: .leading)
             .padding(.horizontal, 6)
             .padding(.vertical, 4)
-            .background(Color(nsColor: .textBackgroundColor), in: RoundedRectangle(cornerRadius: 5))
-            .overlay(RoundedRectangle(cornerRadius: 5).strokeBorder(Color(nsColor: .separatorColor)))
+            .background(ThemeEngine.shared.palette.color(.panelControlBackground), in: RoundedRectangle(cornerRadius: 5))
+            .overlay(RoundedRectangle(cornerRadius: 5).strokeBorder(ThemeEngine.shared.palette.color(.panelSeparator)))
     }
 }

--- a/TablePro/Views/RowInspector/JSON/JSONRowInspectorView.swift
+++ b/TablePro/Views/RowInspector/JSON/JSONRowInspectorView.swift
@@ -66,7 +66,7 @@ struct JSONRowInspectorView: View {
         )
         .overlay(
             RoundedRectangle(cornerRadius: 6)
-                .strokeBorder(Color.red.opacity(0.6))
+                .strokeBorder(ThemeEngine.shared.palette.color(.statusError).opacity(0.6))
                 .opacity(viewModel.isFilterInvalid ? 1 : 0)
         )
         .help(viewModel.isFilterInvalid

--- a/TablePro/Views/ServerDashboard/MetricsBarView.swift
+++ b/TablePro/Views/ServerDashboard/MetricsBarView.swift
@@ -17,7 +17,7 @@ struct MetricsBarView: View {
                         Image(systemName: "exclamationmark.triangle")
                     }
                     .font(.caption)
-                    .foregroundStyle(.red)
+                    .foregroundStyle(ThemeEngine.shared.palette.color(.statusError))
                 }
             }
             .padding(.horizontal, 12)

--- a/TablePro/Views/ServerDashboard/SessionsTableView.swift
+++ b/TablePro/Views/ServerDashboard/SessionsTableView.swift
@@ -19,7 +19,7 @@ struct SessionsTableView: View {
                         Image(systemName: "exclamationmark.triangle")
                     }
                     .font(.caption)
-                    .foregroundStyle(.red)
+                    .foregroundStyle(ThemeEngine.shared.palette.color(.statusError))
                 }
             }
             .padding(.horizontal, 12)
@@ -86,10 +86,10 @@ struct SessionsTableView: View {
 
     private func stateColor(_ state: String) -> Color {
         switch state.lowercased() {
-        case "active", "running": return .green
+        case "active", "running": return ThemeEngine.shared.palette.color(.statusSuccess)
         case "idle": return .secondary
-        case "idle in transaction": return .orange
-        case "waiting", "locked": return .red
+        case "idle in transaction": return ThemeEngine.shared.palette.color(.statusWarning)
+        case "waiting", "locked": return ThemeEngine.shared.palette.color(.statusError)
         default: return .primary
         }
     }

--- a/TablePro/Views/ServerDashboard/SlowQueryListView.swift
+++ b/TablePro/Views/ServerDashboard/SlowQueryListView.swift
@@ -19,7 +19,7 @@ struct SlowQueryListView: View {
                         Image(systemName: "exclamationmark.triangle.fill")
                     }
                     .font(.caption)
-                    .foregroundStyle(.orange)
+                    .foregroundStyle(ThemeEngine.shared.palette.color(.statusWarning))
                 }
             }
             .padding(.horizontal, 12)
@@ -49,7 +49,7 @@ struct SlowQueryListView: View {
             Text(query.duration)
                 .font(.system(.caption, design: .monospaced))
                 .monospacedDigit()
-                .foregroundStyle(.orange)
+                .foregroundStyle(ThemeEngine.shared.palette.color(.statusWarning))
                 .frame(width: 50, alignment: .trailing)
 
             VStack(alignment: .leading, spacing: 2) {

--- a/TablePro/Views/Structure/ClickHousePartsView.swift
+++ b/TablePro/Views/Structure/ClickHousePartsView.swift
@@ -30,7 +30,7 @@ struct ClickHousePartsView: View {
                 VStack(spacing: 8) {
                     Image(systemName: "exclamationmark.triangle")
                         .font(.largeTitle)
-                        .foregroundStyle(.orange)
+                        .foregroundStyle(ThemeEngine.shared.palette.color(.statusWarning))
                         .accessibilityHidden(true)
                     RevealedTextView(error)
                         .foregroundStyle(.secondary)
@@ -99,7 +99,7 @@ struct ClickHousePartsView: View {
                 .width(min: 100, ideal: 160)
             TableColumn("Active") { part in
                 Image(systemName: part.active ? "checkmark.circle.fill" : "xmark.circle")
-                    .foregroundStyle(part.active ? .green : .secondary)
+                    .foregroundStyle(part.active ? ThemeEngine.shared.palette.color(.statusSuccess) : .secondary)
             }
             .width(min: 50, ideal: 60)
         }

--- a/TablePro/Views/Structure/CreateTableView.swift
+++ b/TablePro/Views/Structure/CreateTableView.swift
@@ -178,7 +178,7 @@ struct CreateTableView: View {
             Spacer()
         }
         .padding()
-        .background(Color(nsColor: .controlBackgroundColor))
+        .background(ThemeEngine.shared.palette.color(.panelBackground))
         .onChange(of: draft.tableOptions.charset) { _, newCharset in
             if let first = CreateTableOptions.collations[newCharset]?.first {
                 draft.tableOptions.collation = first

--- a/TablePro/Views/Structure/DDLTextView.swift
+++ b/TablePro/Views/Structure/DDLTextView.swift
@@ -32,7 +32,7 @@ struct DDLTextView: View {
 
     var body: some View {
         if ddl.isEmpty {
-            Color(nsColor: .textBackgroundColor)
+            ThemeEngine.shared.palette.color(.editorBackground)
         } else {
             SourceEditor(
                 $text,

--- a/TablePro/Views/Structure/TableStructureView+Schema.swift
+++ b/TablePro/Views/Structure/TableStructureView+Schema.swift
@@ -110,7 +110,7 @@ extension TableStructureView {
                 if showCopyConfirmation {
                     HStack {
                         Image(systemName: "checkmark.circle.fill")
-                            .foregroundStyle(.green)
+                            .foregroundStyle(ThemeEngine.shared.palette.color(.statusSuccess))
                         Text("Copied!")
                     }
                     .transition(.opacity)

--- a/TablePro/Views/Structure/TableStructureView.swift
+++ b/TablePro/Views/Structure/TableStructureView.swift
@@ -527,7 +527,7 @@ struct TableStructureView: View {
         VStack(spacing: 8) {
             Image(systemName: "exclamationmark.triangle")
                 .font(.largeTitle)
-                .foregroundStyle(.orange)
+                .foregroundStyle(ThemeEngine.shared.palette.color(.statusWarning))
                 .accessibilityHidden(true)
             RevealedTextView(message)
                 .foregroundStyle(.secondary)

--- a/TablePro/Views/Structure/TriggerDetailView.swift
+++ b/TablePro/Views/Structure/TriggerDetailView.swift
@@ -252,7 +252,7 @@ private struct TriggerListPane: View {
     private func enabledIndicator(_ trigger: TriggerInfo) -> some View {
         if let enabled = trigger.enabled {
             Image(systemName: enabled ? "checkmark.circle.fill" : "xmark.circle")
-                .foregroundStyle(enabled ? Color.green : Color.secondary)
+                .foregroundStyle(enabled ? ThemeEngine.shared.palette.color(.statusSuccess) : Color.secondary)
                 .accessibilityLabel(enabled ? String(localized: "Enabled") : String(localized: "Disabled"))
         }
     }
@@ -274,7 +274,7 @@ private struct TriggerDetailPane: View {
                 onOpenInEditor: { onOpenInEditor(trigger) }
             )
         } else {
-            Color(nsColor: .textBackgroundColor)
+            ThemeEngine.shared.palette.color(.editorBackground)
         }
     }
 

--- a/docs/customization/appearance.mdx
+++ b/docs/customization/appearance.mdx
@@ -39,6 +39,7 @@ Custom themes get color wells here. A built-in or registry theme shows a lock an
 | Editor | Background, text, cursor, selection, current line, current statement, line number, invisibles |
 | Syntax Colors | Keyword, string, number, comment, NULL, operator, function, type |
 | Data Grid | Background, text, alternate row, header background, header text, grid line, selection, selected text, inactive selection, focus border, NULL value, bool true/false, row number, modified/inserted/deleted rows, deleted text |
+| Panels | Pane background, field background, pane text, secondary text, tertiary text, separator |
 | Status | Success, warning, error |
 
 A slot holds either a hex color or the name of a macOS system color. Default Light and Default Dark keep the data grid surrounds on system colors, which is why an untouched theme follows your system accent and its Increase Contrast setting. Right-click a well that a built-in leaves on a system color to put that system color back.
@@ -54,6 +55,7 @@ A theme is one JSON file. **Export…** in the gear menu writes every color the 
 | `appearance` | `light` or `dark`. Decides which slot lists the theme |
 | `content.editor` | Editor colors, with syntax colors nested under `syntax` |
 | `content.dataGrid` | Grid colors |
+| `content.panel` | Colors of the panes around the editor and the grid: results, inspector, structure, compare, query plan |
 | `content.status` | Success, warning and error colors |
 
 ```json


### PR DESCRIPTION
Re-opened for review after #2790. Stacked on #2791. Content is unchanged from #2781, with one exception: #2786 has since rewritten `SQLReviewSheet` to route its plain-text path through `HighlightedSQLTextView`, which this PR already themes, so that file's hunks are obsolete and dropped.

Second of four. #2775 rebuilt the engine and covered the editor, the data grid and the status colors. This one covers the panes around them.

## What changed

**A `panel` slot group, six slots.** Background, field background, text, secondary text, tertiary text, separator. Default Light and Default Dark put every one of them on the AppKit semantic color that surface already named, so the default build is pixel-identical and keeps the system's Increase Contrast handling. Dracula and Nord get the palettes they had declared for two years under the dead `ui` group, which now reach pixels.

**`themedContent()` at the detail and inspector pane roots.** It re-resolves `.secondary` and `.tertiary` through the theme's own text levels, which covers 184 hierarchical foreground styles across the content surfaces without rewriting them one at a time. It never branches on the theme: `WorkspacePanes` depends on every pane builder erasing one stable view identity, so an `if` there would tear down the grid, the editor's undo stack and the scroll position on a theme change. It reads the engine inside `body`, so the palette it applies is the current one rather than whatever was captured when the pane was built.

**79 mapped call sites** across the results surround, row inspector, structure, compare, query insights, users and roles, server dashboard, ER diagram, editor, import, export and shared components. Status hues go to `statusSuccess` / `statusWarning` / `statusError`; JSON and PHP tree node colors go to the syntax slots, so a value in the tree finally matches the same value in the row inspector, which already read the theme; the nine autocomplete kind hues go to the syntax slots too.

## Slots I added and then removed

I added 14 slots and shipped 6. `panel.secondaryBackground`, `panel.hover`, `panel.selection`, `panel.selectionText`, `status.info` and the whole `badges` group had no reader anywhere in the app. Shipping them would have recreated exactly the defect this refactor exists to remove, and `ThemeSlotCoverageTests` would have failed on them. They go back in when a surface actually reads one.

## How the mapping was checked

Every `panel` and `badge` assignment went through an adversarial pass that asked two questions per site: is this view content or chrome, and does the slot's meaning match what the color does. **17 of 40 were rejected** as chrome or as the wrong slot. Each of those would have repainted part of the window under a custom theme.

That pass did not catch one class, which the Codex review then did: a themed background applied without its paired foreground. Three sites had it, and all three are fixed here. The query toolbar shares a stack with the editor and its labels resolve from the panel hierarchy, so an editor background there could put panel-colored text on the editor's own color; the hex viewer and editor paired a themed background with `secondaryLabelColor` and `labelColor`, which SwiftUI's foreground hierarchy cannot reach on an `NSTextView`; and the long-SQL preview took an editor background with a panel foreground.

## Live theme changes

Three surfaces kept their old colors after a theme switch inside one appearance, because each bakes a color rather than resolving one. The hex text views reapply theirs in `updateNSView`. The diagnostic underlines rebuild through `reapplyColors(in:)` from the editor's `themeChanged` sink, because `refresh(for:)` cannot do it: the diagnostics are unchanged so it returns early. The grid's selection overlay is marked for display from the grid's theme sink, since it samples its color only in `draw(_:)`.

## Verified

- `build` PASS
- `test` PASS, 131 cases, 131 passed
- `lint TablePro TableProTests` PASS, 0 violations
- `docs` PASS

Reviewed by Codex. Six findings, all six applied.

## Unrelated fix carried here

`CLAUDE.md` said 40 plugin bundles and 22 registry-only. The Weaviate driver merged to `main` made it 41 and 23. The count is checked by the lint gate's doc scan, so the stale number was failing it.

## Not in this PR

Painted chrome and the Settings pane rebuild follow in two more PRs. All four land before the next release tag, because schema 2 is not final until then.

https://claude.ai/code/session_01EKDGt17u6TaVBDHm8rzSEj
