### PR TITLE
test(datagrid): measure the strike's length and its ink separately on a selected row

### DIFF
--- a/TableProTests/Views/Results/DataGridPendingChangeMarkTests.swift
+++ b/TableProTests/Views/Results/DataGridPendingChangeMarkTests.swift
@@ -178,6 +178,12 @@ struct DataGridPendingChangeMarkTests {
         return (row, gains[row], markedRows[row].max() ?? 0)
     }
 
+    /// The rule's length is `reach`, and its existence is `gain`. They are separate assertions
+    /// because a selected row admits far less new ink for the same rule: measured over mid grey at a
+    /// text width of 80, the rule reaches 84 whether the row is selected or not, but it adds 57 new
+    /// columns on a plain row against 31 on a selected one, because the selected row's glyphs are
+    /// already white and the rule crossing them inks nothing new. Holding both to half the text
+    /// width read the selected rule as missing when it was drawn in full.
     @Test("A struck-through cell draws a rule its plain twin does not, selected or not")
     func strikeIsDrawn() throws {
         let text = "0123456789"
@@ -189,8 +195,10 @@ struct DataGridPendingChangeMarkTests {
             against: resolve(text: text, onEmphasizedSelection: true)
         )
 
-        #expect(struck.gain > textWidth / 2)
-        #expect(selected.gain > textWidth / 2)
+        #expect(struck.gain > textWidth / 4)
+        #expect(selected.gain > textWidth / 4)
+        #expect(struck.reach >= textWidth)
+        #expect(selected.reach >= textWidth)
     }
 
     /// The two lines have to land in different places, or they are the same cue twice.


### PR DESCRIPTION
`DataGridPendingChangeMarkTests/strikeIsDrawn()` fails on `main`, which fails the Unit tests job for every
pull request:

```
Expectation failed: (selected.gain → 31) > (textWidth / 2 → 40)
```

## The rule is drawn. The metric is the problem.

Measured by rasterising both cells and reading the pixels, at a text width of 80:

| | reach | gain |
|---|---|---|
| plain row | 84 | 57 |
| selected row | 84 | 31 |

`reach` is how far the rule's own ink extends and `gain` is how many columns it adds over the same cell
drawn unmarked. The rule reaches 84 either way, so it is drawn in full on a selected row. It simply adds
less new ink there: the selected row's glyphs are already `alternateSelectedControlTextColor`, which is
white, and a white rule crossing a white glyph inks nothing new. The test's own comment says this, which is
why it measures `reach` separately: "The gain undercounts the rule's length wherever it crosses a glyph the
plain cell already inked".

Holding both rows to half the text width read the selected rule as missing when it was there. The two
properties are now asserted separately: `gain` above a quarter of the text width proves the rule exists, and
`reach` at or past the text width proves it spans the value. The measured numbers are in the test's comment
so the next reader does not have to re-derive them.

## Mutation-checked

Deleting `.strikethroughStyle` from `DataGridCellTextMark.attributes` still fails the test, so the assertion
has not been loosened into something that cannot fail. With the attribute restored, 8 of 8 cases pass.

The test has been red since #2766 introduced it: #2779 fixed its compile error, and this is the assertion
underneath.
