### PR TITLE
test(plugins): read the PluginKit ABI from the source of truth in the Weaviate manifest test

### DIFF
--- a/TableProTests/Plugins/WeaviateConnectionFieldsTests.swift
+++ b/TableProTests/Plugins/WeaviateConnectionFieldsTests.swift
@@ -127,7 +127,7 @@ struct WeaviateFieldParityTests {
 
 @Suite("Weaviate plugin manifest")
 struct WeaviatePluginManifestTests {
-    @Test("Info.plist declares PluginKit 25 and the Weaviate type id")
+    @Test("Info.plist declares the current PluginKit ABI and the Weaviate type id")
     func plistDeclaresType() throws {
         let url = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
@@ -135,7 +135,7 @@ struct WeaviatePluginManifestTests {
             .deletingLastPathComponent()
             .appendingPathComponent("Plugins/WeaviateDriverPlugin/Info.plist")
         let plist = try #require(NSDictionary(contentsOf: url) as? [String: Any])
-        #expect(plist["TableProPluginKitVersion"] as? Int == 25)
+        #expect(plist["TableProPluginKitVersion"] as? Int == PluginManager.currentPluginKitVersion)
         #expect(plist["TableProProvidesDatabaseTypeIds"] as? [String] == ["Weaviate"])
     }
 }


### PR DESCRIPTION
`main` is red on one unit test. `WeaviatePluginManifestTests` asserted `TableProPluginKitVersion == 25`, but the plugin `Info.plist` files went to 29 at the last ABI bump, so the suite has been failing every push since:

```
Recorded an issue (Expectation failed: (plist["TableProPluginKitVersion"] as? Int → 29) == 25)
Suite "Weaviate plugin manifest" failed after 0.003 seconds with 1 issue(s)
```

That was the only failure in run 34682055787. The `** TEST EXECUTE FAILED **` line has nothing else behind it, and every other suite in the job passed.

The test now reads `PluginManager.currentPluginKitVersion`, so the next bump carries it along. This is the defect the sibling Typesense suite already has a comment about ("Hardcoding the number left this suite asserting 21 after the plists went to 22"); Weaviate was the one copy that did not follow it.

It is the last hardcoded version assertion in `TableProTests`. The `13` in `PluginInstallerHelpersTests` and the `11` in `RegistryBinarySelectionTests` are deliberate stale-bundle fixtures for rejection paths and stay as they are.

No CHANGELOG entry: nothing user-facing changed.

## Verification

- `verify.sh test WeaviatePluginManifestTests TypesensePluginManifestTests`: `** TEST SUCCEEDED **`, exit 0, 4 executed, 4 passed.
- `verify.sh lint TableProTests/Plugins/WeaviateConnectionFieldsTests.swift`: 0 violations.

https://claude.ai/code/session_01356tNWPbEpQ65hY7VxXr6n
