### PR TITLE
fix(datagrid): key a foreign key's target on the container its engine actually names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,6 +198,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Garbled or double-encoded non-ASCII text on iOS with PostgreSQL databases not encoded in UTF-8.
 - Garbled non-ASCII text when restoring a PostgreSQL SQL export into a database not encoded in UTF-8.
 - Display As formats and foreign key labels lost on a rename, and kept with column layouts after deleting a connection.
+- Foreign key value picker failing to read a referenced table in another MySQL database. (#2768)
+- MySQL table reached through a foreign key keeping its own filters, column layout, highlight rules and Display As formats. (#2768)
+- Referenced database shown as a schema in a MySQL tab title and in the foreign key picker's header. (#2768)
 - Composite foreign keys listing mismatched column pairs on iOS, CockroachDB and Redshift.
 - Foreign keys missing on iOS for a PostgreSQL role that does not own the table.
 - Redshift foreign keys from other schemas shown on a table.
@@ -207,7 +210,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Edit View Definition** in the Database menu opening a same-named view from the browsed schema. (#2726)
 - **Edit View Definition** enabled in the Database menu on a read-only connection. (#2726)
 - Enum types and sequences written in front of a PostgreSQL view's DDL. (#2726)
-- Display As formats lost on a rename, and kept with column layouts after deleting a connection.
 - Garbled ClickHouse text whenever another value in the same result held binary data.
 - Carriage returns, quotes, NUL bytes and Enum type names shown with backslash escapes on ClickHouse.
 - Edits and deletes matching no row on ClickHouse tables with a binary value in the row.

--- a/TablePro/Core/ObjectCopy/ObjectCopyNamespace.swift
+++ b/TablePro/Core/ObjectCopy/ObjectCopyNamespace.swift
@@ -21,17 +21,22 @@ internal enum ObjectCopyNamespace {
     /// What this engine calls the namespace of the objects at `endpoint`.
     ///
     /// A schema where the engine has schemas, the database where it has databases but no schemas,
-    /// and nothing at all where it has neither. Derived from the two capabilities the plugin
-    /// registry already publishes rather than from a list of engine names, so a driver added later
-    /// answers without being enumerated here.
+    /// and nothing at all where it has neither. The choice itself is `EngineNamespaceSlot`, shared
+    /// with every other caller that has to make it, so a capability change cannot move one of them
+    /// and leave the other behind.
     internal static func name(
         for endpoint: DatabaseEndpoint,
         supportsSchemas: Bool,
         supportsDatabases: Bool
     ) -> String? {
-        if supportsSchemas { return endpoint.schema?.nilIfEmpty }
-        guard supportsDatabases else { return nil }
-        return endpoint.database.nilIfEmpty
+        switch EngineNamespaceSlot(supportsSchemas: supportsSchemas, supportsDatabases: supportsDatabases) {
+        case .schema:
+            return endpoint.schema?.nilIfEmpty
+        case .database:
+            return endpoint.database.nilIfEmpty
+        case .unqualified:
+            return nil
+        }
     }
 
     /// Whether two endpoints put their objects in the same namespace, which is what decides

--- a/TablePro/Core/Plugins/EngineNamespaceSlot.swift
+++ b/TablePro/Core/Plugins/EngineNamespaceSlot.swift
@@ -1,0 +1,41 @@
+//
+//  EngineNamespaceSlot.swift
+//  TablePro
+//
+//  Which container an engine qualifies its object names with.
+//
+//  Not the same question as "which container is selected". MySQL and MariaDB have no schemas at
+//  all, yet `information_schema` reports the database in every column named for a schema, so a
+//  foreign key, a routine or a trigger comes back qualified by the database name. A value read out
+//  of a schema-named column therefore belongs in the database slot on those engines, and reading it
+//  as a schema gives the same object two identities.
+//
+//  One answer, shared by everything that has to make the choice, so a capability change cannot move
+//  one of them and leave the other behind.
+//
+
+import Foundation
+
+internal enum EngineNamespaceSlot {
+    case schema
+    case database
+    case unqualified
+
+    internal init(supportsSchemas: Bool, supportsDatabases: Bool) {
+        if supportsSchemas {
+            self = .schema
+            return
+        }
+        self = supportsDatabases ? .database : .unqualified
+    }
+}
+
+@MainActor
+internal extension EngineNamespaceSlot {
+    init(databaseType: DatabaseType) {
+        self.init(
+            supportsSchemas: PluginManager.shared.supportsSchemaSwitching(for: databaseType),
+            supportsDatabases: PluginManager.shared.supportsDatabaseSwitching(for: databaseType)
+        )
+    }
+}

--- a/TablePro/Core/Services/Query/ForeignKeyLookupService.swift
+++ b/TablePro/Core/Services/Query/ForeignKeyLookupService.swift
@@ -28,11 +28,12 @@ enum ForeignKeyLookupService {
     /// A metadata read, so it goes through `withMetadataDriver` like every other one.
     static func referencedColumns(
         in origin: DatabaseScope,
+        databaseType: DatabaseType,
         reference: ForeignKeyInfo
     ) async throws -> [ForeignKeyLookupColumn] {
-        let scope = targetScope(from: origin, reference: reference)
+        let scope = targetScope(from: origin, databaseType: databaseType, reference: reference)
         let table = reference.referencedTable
-        let schema = reference.referencedSchema
+        let schema = scope.schema
         let columns = try await DatabaseManager.shared.withMetadataDriver(scope: scope) { driver in
             try await driver.fetchColumns(table: table, schema: schema)
         }
@@ -61,8 +62,12 @@ enum ForeignKeyLookupService {
         guard let dialect = PluginManager.shared.sqlDialect(for: databaseType) else {
             throw LookupFailure.noDialect
         }
-        let scope = targetScope(from: origin, reference: reference)
+        let scope = targetScope(from: origin, databaseType: databaseType, reference: reference)
         let table = reference.referencedTable
+        /// Routed to the referenced table's own container and named in full as well. The qualifier
+        /// costs nothing and a pooled session can still be moved out from under the read: startup
+        /// commands run after the pool connects, so a connection carrying `USE other` answers from
+        /// `other` however the scope was resolved.
         let schema = reference.referencedSchema
 
         return try await DatabaseManager.shared.withMetadataDriver(scope: scope) { driver in
@@ -99,18 +104,31 @@ enum ForeignKeyLookupService {
     /// ambient browse state: a tab stays on the database it opened, while the sidebar and other
     /// windows move, and resolving the database from session state is how a tab's read lands on
     /// another database.
-    nonisolated static func targetScope(from origin: DatabaseScope, reference: ForeignKeyInfo) -> DatabaseScope {
-        guard let schema = reference.referencedSchema, !schema.isEmpty else { return origin }
-        return DatabaseScope(connectionId: origin.connectionId, database: origin.database, schema: schema)
+    ///
+    /// The read is routed to the referenced table's own container rather than left to a qualifier
+    /// alone, because `fetchColumns` reaches the catalog through helpers of its own that take no
+    /// schema: MySQL's generated-column read names `activeDatabaseName` directly, so a qualified
+    /// `SHOW FULL COLUMNS` would still collect generation expressions from the wrong database.
+    static func targetScope(
+        from origin: DatabaseScope,
+        databaseType: DatabaseType,
+        reference: ForeignKeyInfo
+    ) -> DatabaseScope {
+        ForeignKeyTargetScope.resolve(
+            origin: origin, referencedSchema: reference.referencedSchema, databaseType: databaseType
+        )
     }
 
-    nonisolated static func tableScope(from origin: DatabaseScope, reference: ForeignKeyInfo) -> TableScope {
-        let scope = targetScope(from: origin, reference: reference)
-        return TableScope(
-            connectionId: scope.connectionId,
-            database: scope.database,
-            schema: scope.schema,
-            table: reference.referencedTable
+    static func tableScope(
+        from origin: DatabaseScope,
+        databaseType: DatabaseType,
+        reference: ForeignKeyInfo
+    ) -> TableScope {
+        ForeignKeyTargetScope.tableScope(
+            origin: origin,
+            referencedSchema: reference.referencedSchema,
+            referencedTable: reference.referencedTable,
+            databaseType: databaseType
         )
     }
 

--- a/TablePro/Core/Services/Query/ForeignKeyTargetScope.swift
+++ b/TablePro/Core/Services/Query/ForeignKeyTargetScope.swift
@@ -1,0 +1,87 @@
+//
+//  ForeignKeyTargetScope.swift
+//  TablePro
+//
+//  Where a foreign key points, in the vocabulary the rest of the app keys on.
+//
+
+import Foundation
+import TableProPluginKit
+
+/// The referenced table's own scope, resolved once and used for every question about it: which
+/// connection to route the lookup through, which key its remembered settings hang on, and which
+/// database and schema a tab opened on it carries.
+///
+/// `ForeignKeyInfo.referencedSchema` is whatever the engine's catalog puts in its schema column,
+/// which on an engine with no schema layer is a database name. Every other per-table setting builds
+/// its `TableScope` from the tab's own schema, which is nil there, so writing the raw value into the
+/// schema slot gave one table two keys and left its foreign key label behind on a rename. The same
+/// value reached tab identity, where it split a table reached through a key from the same table
+/// opened from the sidebar.
+internal enum ForeignKeyTargetScope {
+    internal static func resolve(
+        origin: DatabaseScope,
+        referencedSchema: String?,
+        slot: EngineNamespaceSlot
+    ) -> DatabaseScope {
+        guard let referenced = referencedSchema?.nilIfEmpty else { return origin }
+        switch slot {
+        case .schema:
+            return DatabaseScope(
+                connectionId: origin.connectionId, database: origin.database, schema: referenced
+            )
+        case .database:
+            return DatabaseScope(
+                connectionId: origin.connectionId, database: referenced, schema: nil
+            )
+        case .unqualified:
+            return DatabaseScope(
+                connectionId: origin.connectionId, database: origin.database, schema: nil
+            )
+        }
+    }
+
+    internal static func tableScope(
+        origin: DatabaseScope,
+        referencedSchema: String?,
+        referencedTable: String,
+        slot: EngineNamespaceSlot
+    ) -> TableScope {
+        let scope = resolve(origin: origin, referencedSchema: referencedSchema, slot: slot)
+        return TableScope(
+            connectionId: scope.connectionId,
+            database: scope.database.nilIfEmpty,
+            schema: scope.schema,
+            table: referencedTable
+        )
+    }
+}
+
+@MainActor
+internal extension ForeignKeyTargetScope {
+    static func resolve(
+        origin: DatabaseScope,
+        referencedSchema: String?,
+        databaseType: DatabaseType
+    ) -> DatabaseScope {
+        resolve(
+            origin: origin,
+            referencedSchema: referencedSchema,
+            slot: EngineNamespaceSlot(databaseType: databaseType)
+        )
+    }
+
+    static func tableScope(
+        origin: DatabaseScope,
+        referencedSchema: String?,
+        referencedTable: String,
+        databaseType: DatabaseType
+    ) -> TableScope {
+        tableScope(
+            origin: origin,
+            referencedSchema: referencedSchema,
+            referencedTable: referencedTable,
+            slot: EngineNamespaceSlot(databaseType: databaseType)
+        )
+    }
+}

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+FKNavigation.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+FKNavigation.swift
@@ -51,12 +51,20 @@ extension MainContentCoordinator {
             return
         }
 
-        let currentDatabase = sourceScope.database
-        let targetSchema = fkInfo.referencedSchema.flatMap { $0.isEmpty ? nil : $0 } ?? sourceScope.schema
+        /// The referenced table's own database and schema, not the raw catalog value. An engine
+        /// with no schema layer names the referenced database in the slot its catalog calls a
+        /// schema, and carrying that through gave a table reached by a key a different identity
+        /// from the same table opened from the sidebar: its own filters, its own column layout, no
+        /// tab to reuse, and a rename that never found it.
+        let target = ForeignKeyTargetScope.resolve(
+            origin: sourceScope, referencedSchema: fkInfo.referencedSchema, databaseType: connection.type
+        )
+        let targetDatabase = target.database
+        let targetSchema = target.schema
 
         if !openInNewTab,
            let current = tabManager.selectedTab,
-           matchesFKTarget(current, table: referencedTable, database: currentDatabase, schema: targetSchema) {
+           matchesFKTarget(current, table: referencedTable, database: targetDatabase, schema: targetSchema) {
             /// Re-filtering the tab in place is a jump like any other, so it goes on the history.
             /// Clicking the reference the tab is already showing is not, and recording it would
             /// stack identical entries a reader has to press Back through.
@@ -70,7 +78,7 @@ extension MainContentCoordinator {
             replaceSelectedTabWithFKTarget(
                 referencedTable: referencedTable,
                 filter: filter,
-                databaseName: currentDatabase,
+                databaseName: targetDatabase,
                 schemaName: targetSchema
             )
             return
@@ -79,7 +87,7 @@ extension MainContentCoordinator {
         if !openInNewTab,
            let existing = openFKTargetTab(
                table: referencedTable,
-               database: currentDatabase,
+               database: targetDatabase,
                schema: targetSchema,
                filter: filter
            ) {
@@ -91,7 +99,7 @@ extension MainContentCoordinator {
         let payload = makeFKReferencePayload(
             filter: filter,
             referencedTable: referencedTable,
-            databaseName: currentDatabase,
+            databaseName: targetDatabase,
             schemaName: targetSchema
         )
         openTabInNewWindow(payload)

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Navigation.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Navigation.swift
@@ -41,10 +41,14 @@ extension MainContentCoordinator {
         )
     }
 
+    /// `database` names the target when the caller knows it, which a foreign key does and the
+    /// sidebar does not: a reference can point into another database, and taking the browse cursor
+    /// there opens a tab on whichever one the sidebar happens to be showing.
     @discardableResult
     func openTableTab(
         _ tableName: String,
         schema: String? = nil,
+        database: String? = nil,
         showStructure: Bool = false,
         isView: Bool = false,
         objectType: TableInfo.TableType? = nil,
@@ -63,7 +67,7 @@ extension MainContentCoordinator {
             }
             currentDatabase = String(tableName.dropFirst(2))
         } else {
-            currentDatabase = browseDatabaseName
+            currentDatabase = database?.nilIfEmpty ?? browseDatabaseName
         }
 
         let resolvedSchema = DatabaseManager.shared.resolvedSchemaName(schema, for: connectionId)

--- a/TablePro/Views/Results/ForeignKeyPickerView.swift
+++ b/TablePro/Views/Results/ForeignKeyPickerView.swift
@@ -52,9 +52,27 @@ struct ForeignKeyPickerView: View {
 
     // MARK: - Header
 
+    /// An engine with schemas qualifies by schema as it always has. One without has no schema to
+    /// show, and naming the referenced database only says something when it is not the database the
+    /// reader is already looking at: every MySQL reference carries one, so spelling it out
+    /// unconditionally put `shop.users` in front of someone browsing `shop`.
     private var referencedTableDisplay: String {
-        guard let schema = fkInfo.referencedSchema, !schema.isEmpty else { return fkInfo.referencedTable }
-        return "\(schema).\(fkInfo.referencedTable)"
+        let target = targetScope
+        if let schema = target.schema {
+            return "\(schema).\(fkInfo.referencedTable)"
+        }
+        guard target.database != scope.database, !target.database.isEmpty else {
+            return fkInfo.referencedTable
+        }
+        return "\(target.database).\(fkInfo.referencedTable)"
+    }
+
+    private var targetScope: DatabaseScope {
+        ForeignKeyLookupService.targetScope(from: scope, databaseType: databaseType, reference: fkInfo)
+    }
+
+    private var referencedTableScope: TableScope {
+        ForeignKeyLookupService.tableScope(from: scope, databaseType: databaseType, reference: fkInfo)
     }
 
     private var header: some View {
@@ -218,10 +236,7 @@ struct ForeignKeyPickerView: View {
             get: { labelColumnName },
             set: { newValue in
                 labelColumnName = newValue
-                ForeignKeyLabelColumnStore.shared.setLabelColumn(
-                    newValue,
-                    for: ForeignKeyLookupService.tableScope(from: scope, reference: fkInfo)
-                )
+                ForeignKeyLabelColumnStore.shared.setLabelColumn(newValue, for: referencedTableScope)
             }
         )
     }
@@ -276,11 +291,11 @@ struct ForeignKeyPickerView: View {
 
     private func loadColumns() async {
         do {
-            let fetched = try await ForeignKeyLookupService.referencedColumns(in: scope, reference: fkInfo)
-            guard !Task.isCancelled else { return }
-            let stored = ForeignKeyLabelColumnStore.shared.labelColumn(
-                for: ForeignKeyLookupService.tableScope(from: scope, reference: fkInfo)
+            let fetched = try await ForeignKeyLookupService.referencedColumns(
+                in: scope, databaseType: databaseType, reference: fkInfo
             )
+            guard !Task.isCancelled else { return }
+            let stored = ForeignKeyLabelColumnStore.shared.labelColumn(for: referencedTableScope)
             labelColumnName = ForeignKeyLabelColumn.resolve(
                 columns: fetched,
                 keyColumn: fkInfo.referencedColumn,

--- a/TablePro/Views/Structure/StructureGridDelegate.swift
+++ b/TablePro/Views/Structure/StructureGridDelegate.swift
@@ -757,9 +757,22 @@ final class StructureGridDelegate: DataGridViewDelegate {
         }
     }
 
+    /// The row names its target in whatever the engine's catalog calls a schema, which on an engine
+    /// with no schema layer is a database. Resolving it against the tab's own scope is what keeps
+    /// the tab this opens identical to the one the sidebar opens for the same table.
     private func handleNavigateToFK(_ row: Int) {
         guard row < structureChangeManager.workingForeignKeys.count else { return }
+        guard let coordinator else { return }
         let fk = structureChangeManager.workingForeignKeys[row]
-        coordinator?.openTableTab(fk.referencedTable, schema: fk.referencedSchema)
+        guard let origin = coordinator.selectedTabScope else {
+            coordinator.openTableTab(fk.referencedTable, schema: fk.referencedSchema)
+            return
+        }
+        let target = ForeignKeyTargetScope.resolve(
+            origin: origin, referencedSchema: fk.referencedSchema, databaseType: connection.type
+        )
+        coordinator.openTableTab(
+            fk.referencedTable, schema: target.schema, database: target.database
+        )
     }
 }

--- a/TableProTests/Core/Services/ForeignKeyTargetScopeTests.swift
+++ b/TableProTests/Core/Services/ForeignKeyTargetScopeTests.swift
@@ -1,0 +1,128 @@
+//
+//  ForeignKeyTargetScopeTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("Foreign key target scope")
+struct ForeignKeyTargetScopeTests {
+    private let connectionId = UUID()
+
+    private func origin(database: String = "shop", schema: String? = nil) -> DatabaseScope {
+        DatabaseScope(connectionId: connectionId, database: database, schema: schema)
+    }
+
+    // MARK: - Slot
+
+    @Test("An engine with schemas qualifies by schema, one without qualifies by database")
+    func slotFollowsCapabilities() {
+        #expect(EngineNamespaceSlot(supportsSchemas: true, supportsDatabases: true) == .schema)
+        #expect(EngineNamespaceSlot(supportsSchemas: true, supportsDatabases: false) == .schema)
+        #expect(EngineNamespaceSlot(supportsSchemas: false, supportsDatabases: true) == .database)
+        #expect(EngineNamespaceSlot(supportsSchemas: false, supportsDatabases: false) == .unqualified)
+    }
+
+    // MARK: - Resolution
+
+    /// DuckDB, Trino, BigQuery, SurrealDB and CloudflareR2SQL all declare schemas and never report a
+    /// referenced one, so the origin has to supply it. Dropping this arm breaks all five.
+    @Test("A reference that names nothing keeps the origin untouched", arguments: [String?.none, ""])
+    func absentReferenceKeepsOrigin(referenced: String?) {
+        let source = origin(schema: "public")
+        for slot in [EngineNamespaceSlot.schema, .database, .unqualified] {
+            #expect(
+                ForeignKeyTargetScope.resolve(
+                    origin: source, referencedSchema: referenced, slot: slot
+                ) == source
+            )
+        }
+    }
+
+    @Test("A schema engine puts the reference in the schema slot and stays on the database")
+    func schemaEngineKeepsDatabase() {
+        let resolved = ForeignKeyTargetScope.resolve(
+            origin: origin(schema: "public"), referencedSchema: "audit", slot: .schema
+        )
+        #expect(resolved.database == "shop")
+        #expect(resolved.schema == "audit")
+    }
+
+    /// MySQL reports `REFERENCED_TABLE_SCHEMA`, which names the referenced database.
+    @Test("A schema-less engine puts the reference in the database slot and clears the schema")
+    func schemaLessEngineMovesToDatabase() {
+        let resolved = ForeignKeyTargetScope.resolve(
+            origin: origin(), referencedSchema: "warehouse", slot: .database
+        )
+        #expect(resolved.database == "warehouse")
+        #expect(resolved.schema == nil)
+    }
+
+    @Test("A reference to the origin's own database resolves back to the origin")
+    func sameDatabaseReferenceResolvesToOrigin() {
+        let source = origin()
+        #expect(
+            ForeignKeyTargetScope.resolve(
+                origin: source, referencedSchema: "shop", slot: .database
+            ) == source
+        )
+    }
+
+    @Test("An engine with no containers at all drops the reference rather than inventing a database")
+    func containerlessEngineDropsTheReference() {
+        let resolved = ForeignKeyTargetScope.resolve(
+            origin: origin(), referencedSchema: "ignored", slot: .unqualified
+        )
+        #expect(resolved.database == "shop")
+        #expect(resolved.schema == nil)
+    }
+
+    // MARK: - Agreement with the canonical table scope
+
+    /// The invariant #2768 broke. A foreign key label, a filter, a column layout, a highlight rule
+    /// and a Display As format all hang on a `TableScope`, so the scope the picker writes under has
+    /// to be the one the tab builds and the one a rename moves. Comparing them directly is the
+    /// guard: a second scope-building function that disagrees fails here rather than shipping.
+    @Test("The referenced table's scope is the scope its own tab would build, on both engine families")
+    func referencedScopeMatchesTheTabScope() throws {
+        let schemaLess = ForeignKeyTargetScope.tableScope(
+            origin: origin(), referencedSchema: "shop", referencedTable: "users", slot: .database
+        )
+        #expect(try schemaLess == tabScope(database: "shop", schema: nil, table: "users"))
+
+        let crossDatabase = ForeignKeyTargetScope.tableScope(
+            origin: origin(), referencedSchema: "warehouse", referencedTable: "users", slot: .database
+        )
+        #expect(try crossDatabase == tabScope(database: "warehouse", schema: nil, table: "users"))
+
+        let schemaful = ForeignKeyTargetScope.tableScope(
+            origin: origin(schema: "public"),
+            referencedSchema: "audit",
+            referencedTable: "users",
+            slot: .schema
+        )
+        #expect(crossDatabase != schemaLess)
+        #expect(try schemaful == tabScope(database: "shop", schema: "audit", table: "users"))
+    }
+
+    @Test("A table scope from an unbound connection carries no database rather than an empty one")
+    func unboundConnectionCarriesNoDatabase() {
+        let scope = ForeignKeyTargetScope.tableScope(
+            origin: origin(database: ""), referencedSchema: nil, referencedTable: "users", slot: .database
+        )
+        #expect(scope.database == nil)
+        #expect(scope.schema == nil)
+    }
+
+    /// The canonical builder itself, not a copy of it: a divergence only counts if it is measured
+    /// against what the tab really writes.
+    private func tabScope(database: String, schema: String?, table: String) throws -> TableScope {
+        var context = TabTableContext()
+        context.tableName = table
+        context.databaseName = database
+        context.schemaName = schema
+        return try #require(context.scope(connectionId: connectionId))
+    }
+}

--- a/TableProTests/Helpers/TestFixtures.swift
+++ b/TableProTests/Helpers/TestFixtures.swift
@@ -261,6 +261,7 @@ enum TestFixtures {
         column: String = "user_id",
         referencedTable: String = "users",
         referencedColumn: String = "id",
+        referencedSchema: String? = nil,
         onDelete: String = "CASCADE",
         onUpdate: String = "NO ACTION"
     ) -> ForeignKeyInfo {
@@ -269,6 +270,7 @@ enum TestFixtures {
             column: column,
             referencedTable: referencedTable,
             referencedColumn: referencedColumn,
+            referencedSchema: referencedSchema,
             onDelete: onDelete,
             onUpdate: onUpdate
         )

--- a/TableProTests/Views/Main/FKNavigationTests.swift
+++ b/TableProTests/Views/Main/FKNavigationTests.swift
@@ -921,4 +921,134 @@ struct FKNavigationTests {
         let cachedAfter = coordinator.queryExecutionCoordinator.isMetadataCached(tabId: tabId, tableName: "orders")
         #expect(cachedAfter)
     }
+
+    // MARK: - The referenced namespace
+
+    /// MySQL reports `REFERENCED_TABLE_SCHEMA`, which names the referenced DATABASE, so carrying it
+    /// into `schemaName` gave the table a second identity: its own filters, column layout, highlight
+    /// rules and Display As, a title reading `db_a.users`, and no tab for the sidebar to reuse.
+    @Test("A schema-less engine keeps the referenced database out of the tab's schema")
+    @MainActor
+    func schemaLessReferenceLeavesSchemaEmpty() throws {
+        let connection = TestFixtures.makeConnection(database: "db_a", type: .mysql)
+        let tabManager = QueryTabManager()
+        let coordinator = MainContentCoordinator(
+            connection: connection,
+            tabManager: tabManager,
+            changeManager: DataChangeManager(),
+            toolbarState: ConnectionToolbarState()
+        )
+        defer { coordinator.teardown() }
+
+        try tabManager.addTableTab(
+            tableName: "orders",
+            databaseType: connection.type,
+            databaseName: coordinator.browseDatabaseName
+        )
+
+        let fkInfo = TestFixtures.makeForeignKeyInfo(
+            referencedTable: "users", referencedColumn: "id", referencedSchema: "db_a"
+        )
+        coordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, openInNewTab: false)
+
+        let context = try #require(tabManager.selectedTab?.tableContext)
+        #expect(context.tableName == "users")
+        #expect(context.schemaName == nil)
+        #expect(context.databaseName == "db_a")
+    }
+
+    @Test("A schema-less engine follows a reference into another database")
+    @MainActor
+    func schemaLessReferenceCrossesDatabases() throws {
+        let connection = TestFixtures.makeConnection(database: "db_a", type: .mysql)
+        let tabManager = QueryTabManager()
+        let coordinator = MainContentCoordinator(
+            connection: connection,
+            tabManager: tabManager,
+            changeManager: DataChangeManager(),
+            toolbarState: ConnectionToolbarState()
+        )
+        defer { coordinator.teardown() }
+
+        try tabManager.addTableTab(
+            tableName: "orders",
+            databaseType: connection.type,
+            databaseName: coordinator.browseDatabaseName
+        )
+
+        let fkInfo = TestFixtures.makeForeignKeyInfo(
+            referencedTable: "tenants", referencedColumn: "id", referencedSchema: "billing"
+        )
+        coordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, openInNewTab: false)
+
+        let context = try #require(tabManager.selectedTab?.tableContext)
+        #expect(context.tableName == "tenants")
+        #expect(context.databaseName == "billing")
+        #expect(context.schemaName == nil)
+    }
+
+    @Test("An engine with schemas still carries the referenced schema")
+    @MainActor
+    func schemaEngineKeepsTheReferencedSchema() throws {
+        let connection = TestFixtures.makeConnection(database: "db_a", type: .postgresql)
+        let tabManager = QueryTabManager()
+        let coordinator = MainContentCoordinator(
+            connection: connection,
+            tabManager: tabManager,
+            changeManager: DataChangeManager(),
+            toolbarState: ConnectionToolbarState()
+        )
+        defer { coordinator.teardown() }
+
+        try tabManager.addTableTab(
+            tableName: "orders",
+            databaseType: connection.type,
+            databaseName: coordinator.browseDatabaseName,
+            schemaName: "public"
+        )
+
+        let fkInfo = TestFixtures.makeForeignKeyInfo(
+            referencedTable: "users", referencedColumn: "id", referencedSchema: "audit"
+        )
+        coordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, openInNewTab: false)
+
+        let context = try #require(tabManager.selectedTab?.tableContext)
+        #expect(context.tableName == "users")
+        #expect(context.schemaName == "audit")
+        #expect(context.databaseName == "db_a")
+    }
+
+    /// A tab persisted before the referenced database stopped being read as a schema still carries
+    /// one. Coalescing the resolved schema with the source's put that stale value straight back on
+    /// the next hop, so the identity the resolver had just cleared returned one navigation later.
+    @Test("A stale schema on the source tab does not reach the table a key opens")
+    @MainActor
+    func staleSourceSchemaIsNotCarriedForward() throws {
+        let connection = TestFixtures.makeConnection(database: "db_a", type: .mysql)
+        let tabManager = QueryTabManager()
+        let coordinator = MainContentCoordinator(
+            connection: connection,
+            tabManager: tabManager,
+            changeManager: DataChangeManager(),
+            toolbarState: ConnectionToolbarState()
+        )
+        defer { coordinator.teardown() }
+
+        try tabManager.addTableTab(
+            tableName: "orders",
+            databaseType: connection.type,
+            databaseName: coordinator.browseDatabaseName,
+            schemaName: "db_a"
+        )
+
+        let fkInfo = TestFixtures.makeForeignKeyInfo(
+            referencedTable: "tenants", referencedColumn: "id", referencedSchema: "billing"
+        )
+        coordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, openInNewTab: false)
+
+        let context = try #require(tabManager.selectedTab?.tableContext)
+        #expect(context.tableName == "tenants")
+        #expect(context.databaseName == "billing")
+        #expect(context.schemaName == nil)
+    }
 }


### PR DESCRIPTION
Fixes #2768.

## Root cause

`ForeignKeyInfo.referencedSchema` carries whatever the engine's catalog puts in its *schema* column, and on an engine with no schema layer that is a **database name**. MySQL, MariaDB and TiDB report `information_schema.KEY_COLUMN_USAGE.REFERENCED_TABLE_SCHEMA` there (`MySQLPluginDriver.swift:730`) while declaring `supportsSchemas == false` (`:76`). Four call sites wrote it straight into a schema-typed slot, so the referenced table picked up a second identity that no other per-table setting shared.

The repository had already met this defect once and fixed it in one place: `ObjectCopyNamespace.swift:5-15` documents it in almost these words. The foreign key paths never learned it.

Verified across all 27 driver plugins. 11 report a real schema, 15 never set `referencedSchema`, and the MySQL plugin alone reports a database name under `supportsSchemas == false`. The iOS fork omits the column from its `SELECT` entirely, so it is unaffected.

## What it cost

| Site | On MySQL |
|---|---|
| `ForeignKeyLookupService.tableScope` | the reported bug: the label keyed `<conn>.shop.shop.users` while filters, column layout, highlight rules and Display As keyed `<conn>.shop..users`, so `renameTable` moved a key that was not there and `KeyValueStore.moveValue`'s source guard made it a silent no-op |
| `ForeignKeyLookupService.referencedColumns` | a reference into another database could not be read at all |
| `MainContentCoordinator+FKNavigation.swift:55` | a table reached by following a key was a different `TableTabIdentity` from the same table opened from the sidebar: its own filters, layout, highlight rules and Display As, no tab for the sidebar to reuse, a title reading `shop.users`, and a rename that never found it |
| `StructureGridDelegate.handleNavigateToFK` | the same, from the structure editor's foreign key list |

## The fix

`EngineNamespaceSlot` answers "which container does this engine qualify its object names with" once, from the two capabilities `ObjectCopyNamespace` already read. Both it and the new `ForeignKeyTargetScope` switch on it, so the two cannot drift apart.

`ForeignKeyTargetScope.resolve` turns a reference into the referenced table's own `DatabaseScope`, and everything derives from that: the storage key, the metadata route, and the database and schema a tab carries. A reference that names nothing returns the origin untouched, which is what keeps DuckDB, Trino, BigQuery, SurrealDB and CloudflareR2SQL correct: all five declare schemas and none of them sets `referencedSchema`.

**Route, and keep qualifying.** The metadata read now goes to the referenced table's own database. Routing is what the column read needs, because `MySQLPluginDriver.fetchColumns` reaches generation expressions through a helper of its own (`:561-571`) that names `activeDatabaseName` directly, so a qualified `SHOW FULL COLUMNS` would still collect them from the wrong database. The row search keeps its qualifier on top of that: a pooled session can be moved out from under a read, since startup commands run after the pool connects and a connection carrying `USE other` answers from `other` whatever scope asked. The ordinary same-database reference now resolves to the browse scope, which also removes a second pooled connection that used to open for every foreign key read.

## Measured, on MariaDB 12.3.3

A cross-database `FOREIGN KEY` is legal and `REFERENCED_TABLE_SCHEMA` holds the other database:

```
| CONSTRAINT_NAME | TABLE_SCHEMA | REFERENCED_TABLE_SCHEMA | REFERENCED_TABLE_NAME |
| fk_cross        | test_2768a   | test_2768b              | users                 |
| fk_local        | test_2768a   | test_2768a              | same_users            |
```

Before, routed to the origin's database:

```
$ mysql test_2768a -e 'SHOW FULL COLUMNS FROM `users`'
ERROR 1146 (42S02): Table 'test_2768a.users' doesn't exist
```

After, routed to the reference's own database, the same statement returns `id` and `name`.

## Two corrections to the issue

- The **database-rename half is not reachable**. MySQL, MariaDB, TiDB and Databend all declare `supportsRenameDatabase: false`, and `ObjectRenameEligibility` gates the sidebar menu on it, so no MySQL-family database can be renamed from the app. The reachable loss is the table rename, where the label is orphaned rather than moved to a dead key.
- `CHANGELOG.md` `[Unreleased]` carried #2746's entry twice, once claiming foreign key labels survive a rename and once not. The duplicate is removed and the surviving entry is true again, which is what #2752 asked for.

## Labels already saved

Not migrated, deliberately. The same divergent key also holds a foreign-key-opened tab's filters, column layout, highlight rules and Display As, and migrating one of five identically affected stores would be arbitrary; migrating all five runs into the ambiguity the issue names, where a MySQL key `<conn>.shop.shop.users` cannot be told from a PostgreSQL key whose schema is literally `shop`. Re-picking a label column is one interaction.

For the same reason a tab already persisted with the database in its `schemaName` is left alone. Its query is qualified with that value and reads the right rows, and its settings were saved under the same key, so it is self-consistent; it takes the canonical identity when the table is next opened.

## Verification

| Step | Result |
|---|---|
| `verify.sh build` | PASS |
| `verify.sh test` over the 13 suites owning the changed types | PASS, 155 cases |
| `verify.sh lint TablePro TableProTests` | PASS, 0 violations |

`ForeignKeyTargetScopeTests` covers every arm of the resolver on both engine families, and its agreement test compares the scope a reference resolves to against the scope `TabTableContext.scope(connectionId:)` really builds for that table. That comparison is the invariant this broke, and it is the guard: a second scope-building function that disagrees fails there rather than shipping. `FKNavigationTests` gains four cases over the tab context a reference opens, including the stale-schema case below.

No UI automation. The foreign key picker and foreign key navigation are both reachable only by clicking a data grid cell, and since #2381 the grid draws its cells with CoreText and takes no synthetic input at all, so neither flow can be driven deterministically from a UI test without a live MySQL server carrying a cross-database constraint. For the same reason there are no before/after screenshots of the picker header or the tab title: the states cannot be reached by script.

## Review

Codex reviewed the working tree and found a real defect in the first draft: `targetSchema = target.schema ?? sourceScope.schema` put a stale schema straight back after the resolver had cleared it, so a tab persisted under the old behaviour re-infected the next hop. Removed, with `staleSourceSchemaIsNotCarriedForward` pinning it.

Its second finding, migrating persisted identities, is the "accept the loss" decision above.

The adversarial pass then found that dropping the search query's qualifier made that read newly dependent on the pooled session staying where it connected, which a `USE` in a connection's startup commands defeats. The qualifier is back; routing and qualifying are kept together. Its three remaining findings are pre-existing defects outside this change and are reported with the rest of the register.


https://claude.ai/code/session_01AJc1W7uFR36m7Stzscf55H
