### PR TITLE
fix(plugin-mysql): name the database a catalog read means instead of using the session's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- MySQL and MariaDB reads of an object in another database answering about the current database's same-named one, including the foreign key picker's column list. (#2769)
 - Select All painting the whole column header row as selected, and leaving a cell cursor on the first cell.
 - Column header shown as selected after a cell drag reached the first and last row of the page.
 - No outline around a swept cell block whose rows reached both ends of the page.

--- a/Plugins/MySQLDriverPlugin/MySQLObjectQueries.swift
+++ b/Plugins/MySQLDriverPlugin/MySQLObjectQueries.swift
@@ -2,25 +2,47 @@
 //  MySQLObjectQueries.swift
 //  MySQLDriverPlugin
 //
-//  Catalog SQL for routines and triggers. Pure, so it is testable without a server.
+//  Catalog SQL for routines and triggers, and the rule every catalog read shares for naming the
+//  database it means. Pure, so it is testable without a server.
 //
 
 import Foundation
 
 public enum MySQLObjectQueries {
     public static func escapeLiteral(_ value: String) -> String {
-        value
-            .replacingOccurrences(of: "\\", with: "\\\\")
-            .replacingOccurrences(of: "'", with: "''")
+        mysqlEscapeStringLiteral(value)
     }
 
     public static func quoteIdentifier(_ value: String) -> String {
         "`\(value.replacingOccurrences(of: "`", with: "``"))`"
     }
 
+    /// The database a catalog read means.
+    ///
+    /// These engines have no schema layer, so every `schema:` the driver protocol hands them is a
+    /// database name, and a caller that names none means the one the connection is already on. That
+    /// fallback is the whole rule: an unqualified name resolves against the session's current
+    /// database, so a read that drops the caller's schema silently answers about a same-named table
+    /// somewhere else.
+    public static func effectiveSchema(_ schema: String?, activeDatabase: String) -> String {
+        guard let schema, !schema.isEmpty else { return activeDatabase }
+        return schema
+    }
+
+    /// Quoting is the caller's, not this file's: Databend answers the same protocol through the same
+    /// driver and escapes a backtick-bearing name by switching to double quotes, so rendering one
+    /// here with the MySQL quoter would corrupt it.
+    public static func qualifiedIdentifier(
+        schema: String?,
+        name: String,
+        quote: (String) -> String
+    ) -> String {
+        guard let schema, !schema.isEmpty else { return quote(name) }
+        return "\(quote(schema)).\(quote(name))"
+    }
+
     public static func qualifiedIdentifier(schema: String?, name: String) -> String {
-        guard let schema, !schema.isEmpty else { return quoteIdentifier(name) }
-        return "\(quoteIdentifier(schema)).\(quoteIdentifier(name))"
+        qualifiedIdentifier(schema: schema, name: name, quote: quoteIdentifier)
     }
 
     /// The parameter list comes from information_schema.PARAMETERS, where ordinal 0 is a function's

--- a/Plugins/MySQLDriverPlugin/MySQLPluginDriver+Databend.swift
+++ b/Plugins/MySQLDriverPlugin/MySQLPluginDriver+Databend.swift
@@ -14,13 +14,14 @@ extension MySQLPluginDriver {
         .cancelQuery,
     ]
 
-    func databendColumns(table: String) async throws -> [PluginColumnInfo] {
-        let result = try await execute(query: DatabendCatalog.columnsQuery(database: activeDatabaseName, table: table))
+    func databendColumns(table: String, schema: String?) async throws -> [PluginColumnInfo] {
+        let query = DatabendCatalog.columnsQuery(database: effectiveSchema(schema), table: table)
+        let result = try await execute(query: query)
         return result.rows.compactMap { DatabendCatalog.column(from: $0) }
     }
 
-    func databendAllColumns() async throws -> [String: [PluginColumnInfo]] {
-        let result = try await execute(query: DatabendCatalog.allColumnsQuery(database: activeDatabaseName))
+    func databendAllColumns(schema: String?) async throws -> [String: [PluginColumnInfo]] {
+        let result = try await execute(query: DatabendCatalog.allColumnsQuery(database: effectiveSchema(schema)))
         var columns: [String: [PluginColumnInfo]] = [:]
         for row in result.rows {
             guard let table = row[safe: 0]?.asText,
@@ -30,8 +31,8 @@ extension MySQLPluginDriver {
         return columns
     }
 
-    func databendCheckConstraints(table: String) async throws -> [PluginCheckConstraintInfo] {
-        let query = DatabendCatalog.checkConstraintsQuery(database: activeDatabaseName, table: table)
+    func databendCheckConstraints(table: String, schema: String?) async throws -> [PluginCheckConstraintInfo] {
+        let query = DatabendCatalog.checkConstraintsQuery(database: effectiveSchema(schema), table: table)
         let result = try await execute(query: query)
         return result.rows.compactMap { row in
             guard let name = row[safe: 0]?.asText,
@@ -40,16 +41,16 @@ extension MySQLPluginDriver {
         }
     }
 
-    func databendViewDefinition(view: String) async throws -> String {
-        let result = try await execute(query: "SHOW CREATE TABLE \(quoteIdentifier(view))")
+    func databendViewDefinition(view: String, schema: String?) async throws -> String {
+        let result = try await execute(query: "SHOW CREATE TABLE \(qualifiedName(view, schema: schema))")
         guard let definition = result.rows.first?[safe: 1]?.asText else {
             throw MariaDBPluginError(code: 0, message: "Failed to fetch definition for view '\(view)'", sqlState: nil)
         }
         return definition
     }
 
-    func databendTableMetadata(table: String) async throws -> PluginTableMetadata {
-        let query = DatabendCatalog.tableMetadataQuery(database: activeDatabaseName, table: table)
+    func databendTableMetadata(table: String, schema: String?) async throws -> PluginTableMetadata {
+        let query = DatabendCatalog.tableMetadataQuery(database: effectiveSchema(schema), table: table)
         let result = try await execute(query: query)
         guard let row = result.rows.first, let metadata = DatabendCatalog.tableMetadata(from: row) else {
             return PluginTableMetadata(tableName: table)

--- a/Plugins/MySQLDriverPlugin/MySQLPluginDriver+Flavor.swift
+++ b/Plugins/MySQLDriverPlugin/MySQLPluginDriver+Flavor.swift
@@ -64,8 +64,8 @@ extension MySQLPluginDriver {
         return flavor.killTarget(connectionIdentifier: identifier)
     }
 
-    func tidbCheckConstraints(table: String) async throws -> [PluginCheckConstraintInfo] {
-        let result = try await execute(query: "SHOW CREATE TABLE \(quoteIdentifier(table))")
+    func tidbCheckConstraints(table: String, schema: String?) async throws -> [PluginCheckConstraintInfo] {
+        let result = try await execute(query: "SHOW CREATE TABLE \(qualifiedName(table, schema: schema))")
         guard let createTable = result.rows.first?[safe: 1]?.asText else { return [] }
         return TiDBCheckConstraints.parse(createTable: createTable)
     }

--- a/Plugins/MySQLDriverPlugin/MySQLPluginDriver+Routines.swift
+++ b/Plugins/MySQLDriverPlugin/MySQLPluginDriver+Routines.swift
@@ -125,7 +125,6 @@ extension MySQLPluginDriver {
     }
 
     func routineSchema(_ schema: String?) -> String {
-        guard let schema, !schema.isEmpty else { return activeDatabaseName }
-        return schema
+        effectiveSchema(schema)
     }
 }

--- a/Plugins/MySQLDriverPlugin/MySQLPluginDriver+Schema.swift
+++ b/Plugins/MySQLDriverPlugin/MySQLPluginDriver+Schema.swift
@@ -1,0 +1,234 @@
+//
+//  MySQLPluginDriver+Schema.swift
+//  MySQLDriverPlugin
+//
+//  The column reads, and the rule they share for naming the database they mean.
+//
+
+import Foundation
+import TableProPluginKit
+
+internal extension MySQLPluginDriver {
+    func effectiveSchema(_ schema: String?) -> String {
+        MySQLObjectQueries.effectiveSchema(schema, activeDatabase: activeDatabaseName)
+    }
+
+    /// The same answer as a literal, for a catalog query that filters on a `TABLE_SCHEMA` column
+    /// rather than naming the object.
+    func effectiveSchemaLiteral(_ schema: String?) -> String {
+        mysqlEscapeStringLiteral(effectiveSchema(schema))
+    }
+
+    /// An object name qualified by the database the caller meant.
+    ///
+    /// A connection with no database selected has nothing to qualify against, and an unqualified
+    /// name is then the only form the server will take, so an empty answer falls back to the bare
+    /// name rather than rendering an empty qualifier.
+    func qualifiedName(_ name: String, schema: String?) -> String {
+        MySQLObjectQueries.qualifiedIdentifier(
+            schema: effectiveSchema(schema).nilIfEmpty,
+            name: name,
+            quote: quoteIdentifier
+        )
+    }
+
+    /// `SHOW TABLE STATUS` is the one statement here that cannot take a dotted name: its grammar
+    /// puts the database in a `FROM` clause of its own, and the `WHERE` then matches the bare name.
+    func showTableStatus(matching escapedTable: String, schema: String?) -> String {
+        let database = effectiveSchema(schema).nilIfEmpty
+        let from = database.map { " FROM \(quoteIdentifier($0))" } ?? ""
+        return "SHOW TABLE STATUS\(from) WHERE Name = '\(escapedTable)'"
+    }
+
+    func fetchColumns(table: String, schema: String?) async throws -> [PluginColumnInfo] {
+        guard !flavor.isDatabend else {
+            return try await databendColumns(table: table, schema: schema)
+        }
+        let result = try await execute(query: "SHOW FULL COLUMNS FROM \(qualifiedName(table, schema: schema))")
+        let generationExpressions = try await fetchGenerationExpressions(table: table, schema: schema)
+
+        return result.rows.compactMap { row in
+            guard let name = row[safe: 0]?.asText,
+                  let dataType = row[safe: 1]?.asText
+            else { return nil }
+
+            let collation = row[safe: 2]?.asText
+            let isNullable = (row[safe: 3]?.asText) == "YES"
+            let isPrimaryKey = (row[safe: 4]?.asText) == "PRI"
+            let rawDefault = row[safe: 5]?.asText
+            let extra = row[safe: 6]?.asText
+            let comment = row[safe: 8]?.asText
+
+            let charset: String? = {
+                guard let coll = collation, coll != "NULL" else { return nil }
+                return coll.components(separatedBy: "_").first
+            }()
+
+            let upperType = dataType.uppercased()
+            let normalizedType = (upperType.hasPrefix("ENUM(") || upperType.hasPrefix("SET("))
+                ? dataType : upperType
+            let allowedValues = EnumValueParser.parseMySQLEnumOrSet(from: normalizedType)
+            let defaultValue = mysqlDefaultValueFromCatalog(
+                rawDefault, extra: extra, dataType: normalizedType, quotesLiterals: catalogQuotesDefaults
+            )
+
+            return PluginColumnInfo(
+                name: name,
+                dataType: normalizedType,
+                isNullable: isNullable,
+                isPrimaryKey: isPrimaryKey,
+                defaultValue: defaultValue,
+                extra: extra,
+                charset: charset,
+                collation: collation == "NULL" ? nil : collation,
+                comment: comment?.isEmpty == false ? comment : nil,
+                identityKind: mysqlIdentityKind(extra: extra),
+                isGenerated: mysqlColumnIsGenerated(extra: extra),
+                allowedValues: allowedValues,
+                generationExpression: generationExpressions[name],
+                generationKind: mysqlGenerationKind(extra: extra)
+            )
+        }
+    }
+
+    /// Merged into the `SHOW FULL COLUMNS` rows by column name alone, so this has to read the same
+    /// database that statement did. Reading the session's instead grafts one table's generation
+    /// expressions onto another's columns wherever the two databases share a column name.
+    private func fetchGenerationExpressions(table: String, schema: String?) async throws -> [String: String] {
+        guard MySQLServerVersion.hasGenerationExpression(banner: _serverVersion, flavor: flavor) else {
+            return [:]
+        }
+        let query = """
+            SELECT COLUMN_NAME, GENERATION_EXPRESSION
+            FROM INFORMATION_SCHEMA.COLUMNS
+            WHERE TABLE_SCHEMA = \'\(effectiveSchemaLiteral(schema))\'
+                AND TABLE_NAME = \'\(mysqlEscapeStringLiteral(table))\'
+                AND GENERATION_EXPRESSION <> \'\'
+            """
+        let result = try await execute(query: query)
+        var expressions: [String: String] = [:]
+        for row in result.rows {
+            guard let name = row[safe: 0]?.asText,
+                  let expression = row[safe: 1]?.asText?.nilIfEmpty else { continue }
+            expressions[name] = expression
+        }
+        return expressions
+    }
+
+    /// MySQL and MariaDB disagree on this catalog: MySQL 8 has no TABLE_NAME on CHECK_CONSTRAINTS
+    /// and must join TABLE_CONSTRAINTS to find the owning table, while MariaDB carries TABLE_NAME
+    /// directly. Neither exposes the columns a check touches, so `columns` stays empty rather than
+    /// being guessed from the expression.
+    func fetchCheckConstraints(table: String, schema: String?) async throws -> [PluginCheckConstraintInfo] {
+        let flavor = self.flavor
+        guard !flavor.isDatabend else {
+            return try await databendCheckConstraints(table: table, schema: schema)
+        }
+        guard MySQLServerVersion.hasCheckConstraints(banner: _serverVersion, flavor: flavor) else {
+            return []
+        }
+        guard !flavor.isTiDB else { return try await tidbCheckConstraints(table: table, schema: schema) }
+        let database = effectiveSchemaLiteral(schema)
+        let safeTable = mysqlEscapeStringLiteral(table)
+        let query: String
+        if flavor.isMariaDB {
+            query = """
+                SELECT CONSTRAINT_NAME, CHECK_CLAUSE
+                FROM INFORMATION_SCHEMA.CHECK_CONSTRAINTS
+                WHERE CONSTRAINT_SCHEMA = \'\(database)\' AND TABLE_NAME = \'\(safeTable)\'
+                ORDER BY CONSTRAINT_NAME
+                """
+        } else {
+            query = """
+                SELECT cc.CONSTRAINT_NAME, cc.CHECK_CLAUSE
+                FROM INFORMATION_SCHEMA.CHECK_CONSTRAINTS cc
+                JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc
+                    ON tc.CONSTRAINT_SCHEMA = cc.CONSTRAINT_SCHEMA
+                    AND tc.CONSTRAINT_NAME = cc.CONSTRAINT_NAME
+                WHERE cc.CONSTRAINT_SCHEMA = \'\(database)\' AND tc.TABLE_NAME = \'\(safeTable)\'
+                ORDER BY cc.CONSTRAINT_NAME
+                """
+        }
+        let result = try await execute(query: query)
+        return result.rows.compactMap { row in
+            guard let name = row[safe: 0]?.asText,
+                  let clause = row[safe: 1]?.asText else { return nil }
+            return PluginCheckConstraintInfo(name: name, expression: clause)
+        }
+    }
+
+    var providesBulkColumnFetch: Bool { true }
+
+    /// `GENERATION_EXPRESSION` is projected here rather than looked up per table, because a caller
+    /// that takes the bulk list has to receive what `fetchColumns` would have given it. Without the
+    /// column the two reads disagree on generated columns alone, and a schema comparison built on
+    /// the bulk read reports a changed generation expression as no difference at all.
+    func fetchAllColumns(schema: String?) async throws -> [String: [PluginColumnInfo]] {
+        guard !flavor.isDatabend else { return try await databendAllColumns(schema: schema) }
+        let escapedDb = effectiveSchemaLiteral(schema)
+        let hasGenerationExpression = MySQLServerVersion.hasGenerationExpression(
+            banner: _serverVersion, flavor: flavor
+        )
+        let generationProjection = hasGenerationExpression ? "GENERATION_EXPRESSION" : "NULL"
+        let query = """
+            SELECT
+                TABLE_NAME, COLUMN_NAME, COLUMN_TYPE, COLLATION_NAME,
+                IS_NULLABLE, COLUMN_KEY, COLUMN_DEFAULT, EXTRA, COLUMN_COMMENT,
+                \(generationProjection)
+            FROM INFORMATION_SCHEMA.COLUMNS
+            WHERE TABLE_SCHEMA = '\(escapedDb)'
+            ORDER BY TABLE_NAME, ORDINAL_POSITION
+            """
+
+        let result = try await execute(query: query)
+
+        var allColumns: [String: [PluginColumnInfo]] = [:]
+        for row in result.rows {
+            guard let tableName = row[safe: 0]?.asText,
+                  let name = row[safe: 1]?.asText,
+                  let dataType = row[safe: 2]?.asText
+            else { continue }
+
+            let collation = row[safe: 3]?.asText
+            let isNullable = (row[safe: 4]?.asText) == "YES"
+            let isPrimaryKey = (row[safe: 5]?.asText) == "PRI"
+            let rawDefault = row[safe: 6]?.asText
+            let extra = row[safe: 7]?.asText
+            let comment = row[safe: 8]?.asText
+
+            let charset: String? = {
+                guard let coll = collation, coll != "NULL" else { return nil }
+                return coll.components(separatedBy: "_").first
+            }()
+
+            let upperType = dataType.uppercased()
+            let normalizedType = (upperType.hasPrefix("ENUM(") || upperType.hasPrefix("SET("))
+                ? dataType : upperType
+            let allowedValues = EnumValueParser.parseMySQLEnumOrSet(from: normalizedType)
+            let defaultValue = mysqlDefaultValueFromCatalog(
+                rawDefault, extra: extra, dataType: normalizedType, quotesLiterals: catalogQuotesDefaults
+            )
+
+            let column = PluginColumnInfo(
+                name: name,
+                dataType: normalizedType,
+                isNullable: isNullable,
+                isPrimaryKey: isPrimaryKey,
+                defaultValue: defaultValue,
+                extra: extra,
+                charset: charset,
+                collation: collation == "NULL" ? nil : collation,
+                comment: comment?.isEmpty == false ? comment : nil,
+                identityKind: mysqlIdentityKind(extra: extra),
+                isGenerated: mysqlColumnIsGenerated(extra: extra),
+                allowedValues: allowedValues,
+                generationExpression: row[safe: 9]?.asText?.nilIfEmpty,
+                generationKind: mysqlGenerationKind(extra: extra)
+            )
+
+            allColumns[tableName, default: []].append(column)
+        }
+
+        return allColumns
+    }
+}

--- a/Plugins/MySQLDriverPlugin/MySQLPluginDriver.swift
+++ b/Plugins/MySQLDriverPlugin/MySQLPluginDriver.swift
@@ -12,7 +12,7 @@ import TableProPluginKit
 final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     private let config: DriverConnectionConfig
     private var mariadbConnection: MariaDBPluginConnection?
-    private var _serverVersion: String?
+    internal var _serverVersion: String?
     private var _activeDatabase: String
 
     /// The database a metadata read is scoped to. MySQL has no schema level, so this is what a
@@ -70,7 +70,7 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     var currentSchema: String? { nil }
     var serverVersion: String? { _serverVersion }
 
-    private var catalogQuotesDefaults: Bool {
+    internal var catalogQuotesDefaults: Bool {
         MySQLServerVersion.quotesColumnDefault(banner: _serverVersion, flavor: flavor)
     }
     var supportsSchemas: Bool { false }
@@ -494,7 +494,7 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         let query = """
         SELECT TABLE_NAME, TABLE_TYPE, TABLE_COMMENT
         FROM information_schema.TABLES
-        WHERE TABLE_SCHEMA = DATABASE()
+        WHERE TABLE_SCHEMA = '\(effectiveSchemaLiteral(schema))'
         """
         let result = try await execute(query: query)
 
@@ -509,195 +509,9 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         }.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
     }
 
-    func fetchColumns(table: String, schema: String?) async throws -> [PluginColumnInfo] {
-        guard !flavor.isDatabend else { return try await databendColumns(table: table) }
-        let result = try await execute(query: "SHOW FULL COLUMNS FROM \(quoteIdentifier(table))")
-        let generationExpressions = try await fetchGenerationExpressions(table: table)
-
-        return result.rows.compactMap { row in
-            guard let name = row[safe: 0]?.asText,
-                  let dataType = row[safe: 1]?.asText
-            else { return nil }
-
-            let collation = row[safe: 2]?.asText
-            let isNullable = (row[safe: 3]?.asText) == "YES"
-            let isPrimaryKey = (row[safe: 4]?.asText) == "PRI"
-            let rawDefault = row[safe: 5]?.asText
-            let extra = row[safe: 6]?.asText
-            let comment = row[safe: 8]?.asText
-
-            let charset: String? = {
-                guard let coll = collation, coll != "NULL" else { return nil }
-                return coll.components(separatedBy: "_").first
-            }()
-
-            let upperType = dataType.uppercased()
-            let normalizedType = (upperType.hasPrefix("ENUM(") || upperType.hasPrefix("SET("))
-                ? dataType : upperType
-            let allowedValues = EnumValueParser.parseMySQLEnumOrSet(from: normalizedType)
-            let defaultValue = mysqlDefaultValueFromCatalog(
-                rawDefault, extra: extra, dataType: normalizedType, quotesLiterals: catalogQuotesDefaults
-            )
-
-            return PluginColumnInfo(
-                name: name,
-                dataType: normalizedType,
-                isNullable: isNullable,
-                isPrimaryKey: isPrimaryKey,
-                defaultValue: defaultValue,
-                extra: extra,
-                charset: charset,
-                collation: collation == "NULL" ? nil : collation,
-                comment: comment?.isEmpty == false ? comment : nil,
-                identityKind: mysqlIdentityKind(extra: extra),
-                isGenerated: mysqlColumnIsGenerated(extra: extra),
-                allowedValues: allowedValues,
-                generationExpression: generationExpressions[name],
-                generationKind: mysqlGenerationKind(extra: extra)
-            )
-        }
-    }
-
-    private func fetchGenerationExpressions(table: String) async throws -> [String: String] {
-        guard MySQLServerVersion.hasGenerationExpression(banner: _serverVersion, flavor: flavor) else {
-            return [:]
-        }
-        let query = """
-            SELECT COLUMN_NAME, GENERATION_EXPRESSION
-            FROM INFORMATION_SCHEMA.COLUMNS
-            WHERE TABLE_SCHEMA = \'\(mysqlEscapeStringLiteral(activeDatabaseName))\'
-                AND TABLE_NAME = \'\(mysqlEscapeStringLiteral(table))\'
-                AND GENERATION_EXPRESSION <> \'\'
-            """
-        let result = try await execute(query: query)
-        var expressions: [String: String] = [:]
-        for row in result.rows {
-            guard let name = row[safe: 0]?.asText,
-                  let expression = row[safe: 1]?.asText?.nilIfEmpty else { continue }
-            expressions[name] = expression
-        }
-        return expressions
-    }
-
-    /// MySQL and MariaDB disagree on this catalog: MySQL 8 has no TABLE_NAME on CHECK_CONSTRAINTS
-    /// and must join TABLE_CONSTRAINTS to find the owning table, while MariaDB carries TABLE_NAME
-    /// directly. Neither exposes the columns a check touches, so `columns` stays empty rather than
-    /// being guessed from the expression.
-    func fetchCheckConstraints(table: String, schema: String?) async throws -> [PluginCheckConstraintInfo] {
-        let flavor = self.flavor
-        guard !flavor.isDatabend else { return try await databendCheckConstraints(table: table) }
-        guard MySQLServerVersion.hasCheckConstraints(banner: _serverVersion, flavor: flavor) else {
-            return []
-        }
-        guard !flavor.isTiDB else { return try await tidbCheckConstraints(table: table) }
-        let database = mysqlEscapeStringLiteral(activeDatabaseName)
-        let safeTable = mysqlEscapeStringLiteral(table)
-        let query: String
-        if flavor.isMariaDB {
-            query = """
-                SELECT CONSTRAINT_NAME, CHECK_CLAUSE
-                FROM INFORMATION_SCHEMA.CHECK_CONSTRAINTS
-                WHERE CONSTRAINT_SCHEMA = \'\(database)\' AND TABLE_NAME = \'\(safeTable)\'
-                ORDER BY CONSTRAINT_NAME
-                """
-        } else {
-            query = """
-                SELECT cc.CONSTRAINT_NAME, cc.CHECK_CLAUSE
-                FROM INFORMATION_SCHEMA.CHECK_CONSTRAINTS cc
-                JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc
-                    ON tc.CONSTRAINT_SCHEMA = cc.CONSTRAINT_SCHEMA
-                    AND tc.CONSTRAINT_NAME = cc.CONSTRAINT_NAME
-                WHERE cc.CONSTRAINT_SCHEMA = \'\(database)\' AND tc.TABLE_NAME = \'\(safeTable)\'
-                ORDER BY cc.CONSTRAINT_NAME
-                """
-        }
-        let result = try await execute(query: query)
-        return result.rows.compactMap { row in
-            guard let name = row[safe: 0]?.asText,
-                  let clause = row[safe: 1]?.asText else { return nil }
-            return PluginCheckConstraintInfo(name: name, expression: clause)
-        }
-    }
-
-    var providesBulkColumnFetch: Bool { true }
-
-    /// `GENERATION_EXPRESSION` is projected here rather than looked up per table, because a caller
-    /// that takes the bulk list has to receive what `fetchColumns` would have given it. Without the
-    /// column the two reads disagree on generated columns alone, and a schema comparison built on
-    /// the bulk read reports a changed generation expression as no difference at all.
-    func fetchAllColumns(schema: String?) async throws -> [String: [PluginColumnInfo]] {
-        guard !flavor.isDatabend else { return try await databendAllColumns() }
-        let dbName = activeDatabaseName
-        let escapedDb = dbName.replacingOccurrences(of: "'", with: "''")
-        let hasGenerationExpression = MySQLServerVersion.hasGenerationExpression(
-            banner: _serverVersion, flavor: flavor
-        )
-        let generationProjection = hasGenerationExpression ? "GENERATION_EXPRESSION" : "NULL"
-        let query = """
-            SELECT
-                TABLE_NAME, COLUMN_NAME, COLUMN_TYPE, COLLATION_NAME,
-                IS_NULLABLE, COLUMN_KEY, COLUMN_DEFAULT, EXTRA, COLUMN_COMMENT,
-                \(generationProjection)
-            FROM INFORMATION_SCHEMA.COLUMNS
-            WHERE TABLE_SCHEMA = '\(escapedDb)'
-            ORDER BY TABLE_NAME, ORDINAL_POSITION
-            """
-
-        let result = try await execute(query: query)
-
-        var allColumns: [String: [PluginColumnInfo]] = [:]
-        for row in result.rows {
-            guard let tableName = row[safe: 0]?.asText,
-                  let name = row[safe: 1]?.asText,
-                  let dataType = row[safe: 2]?.asText
-            else { continue }
-
-            let collation = row[safe: 3]?.asText
-            let isNullable = (row[safe: 4]?.asText) == "YES"
-            let isPrimaryKey = (row[safe: 5]?.asText) == "PRI"
-            let rawDefault = row[safe: 6]?.asText
-            let extra = row[safe: 7]?.asText
-            let comment = row[safe: 8]?.asText
-
-            let charset: String? = {
-                guard let coll = collation, coll != "NULL" else { return nil }
-                return coll.components(separatedBy: "_").first
-            }()
-
-            let upperType = dataType.uppercased()
-            let normalizedType = (upperType.hasPrefix("ENUM(") || upperType.hasPrefix("SET("))
-                ? dataType : upperType
-            let allowedValues = EnumValueParser.parseMySQLEnumOrSet(from: normalizedType)
-            let defaultValue = mysqlDefaultValueFromCatalog(
-                rawDefault, extra: extra, dataType: normalizedType, quotesLiterals: catalogQuotesDefaults
-            )
-
-            let column = PluginColumnInfo(
-                name: name,
-                dataType: normalizedType,
-                isNullable: isNullable,
-                isPrimaryKey: isPrimaryKey,
-                defaultValue: defaultValue,
-                extra: extra,
-                charset: charset,
-                collation: collation == "NULL" ? nil : collation,
-                comment: comment?.isEmpty == false ? comment : nil,
-                identityKind: mysqlIdentityKind(extra: extra),
-                isGenerated: mysqlColumnIsGenerated(extra: extra),
-                allowedValues: allowedValues,
-                generationExpression: row[safe: 9]?.asText?.nilIfEmpty,
-                generationKind: mysqlGenerationKind(extra: extra)
-            )
-
-            allColumns[tableName, default: []].append(column)
-        }
-
-        return allColumns
-    }
-
     func fetchIndexes(table: String, schema: String?) async throws -> [PluginIndexInfo] {
         guard !flavor.isDatabend else { return [] }
-        let result = try await execute(query: "SHOW INDEX FROM \(quoteIdentifier(table))")
+        let result = try await execute(query: "SHOW INDEX FROM \(qualifiedName(table, schema: schema))")
 
         let rows = result.rows.compactMap { row -> MySQLIndexRow? in
             guard let indexName = row[safe: 2]?.asText,
@@ -717,9 +531,8 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
 
     func fetchForeignKeys(table: String, schema: String?) async throws -> [PluginForeignKeyInfo] {
         guard !flavor.isDatabend else { return [] }
-        let dbName = activeDatabaseName
-        let escapedDb = dbName.replacingOccurrences(of: "'", with: "''")
-        let escapedTable = table.replacingOccurrences(of: "'", with: "''")
+        let escapedDb = effectiveSchemaLiteral(schema)
+        let escapedTable = mysqlEscapeStringLiteral(table)
 
         let query = """
             SELECT
@@ -757,14 +570,14 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
                 onUpdate: (row[safe: 6]?.asText) ?? "NO ACTION"
             )
         }
-        Self.logger.info("[fk] mysql fetchForeignKeys db=\(dbName, privacy: .public) table=\(table, privacy: .public) rows=\(result.rows.count) parsed=\(foreignKeys.count)")
+        Self.logger.info("[fk] mysql fetchForeignKeys db=\(self.effectiveSchema(schema), privacy: .public) table=\(table, privacy: .public) rows=\(result.rows.count) parsed=\(foreignKeys.count)")
         return foreignKeys
     }
 
     /// The same builder the schema-wide list uses, with one more predicate.
     func fetchTriggers(table: String, schema: String?) async throws -> [PluginTriggerInfo] {
         guard !flavor.isDatabend else { return [] }
-        let dbName = schema?.isEmpty == false ? (schema ?? activeDatabaseName) : activeDatabaseName
+        let dbName = effectiveSchema(schema)
         let triggers = try await triggerList(schema: dbName, table: table)
         Self.logger.info("[trigger] mysql fetchTriggers db=\(dbName, privacy: .public) table=\(table, privacy: .public) parsed=\(triggers.count)")
         return triggers
@@ -773,8 +586,8 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     func createTriggerTemplate(table: String, schema: String?) -> String? {
         guard !flavor.isDatabend else { return nil }
         return """
-        CREATE TRIGGER \(quoteIdentifier("trigger_name")) BEFORE INSERT
-        ON \(quoteIdentifier(table)) FOR EACH ROW
+        CREATE TRIGGER \(qualifiedName("trigger_name", schema: schema)) BEFORE INSERT
+        ON \(qualifiedName(table, schema: schema)) FOR EACH ROW
         BEGIN
             -- SET NEW.column = ...;
         END
@@ -782,7 +595,7 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     }
 
     func generateDropTriggerSQL(name: String, table: String, schema: String?) -> String? {
-        "DROP TRIGGER \(quoteIdentifier(name))"
+        "DROP TRIGGER \(qualifiedName(name, schema: schema))"
     }
 
     var providesBulkForeignKeyFetch: Bool { true }
@@ -791,8 +604,7 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
 
     func fetchAllForeignKeys(schema: String?) async throws -> [String: [PluginForeignKeyInfo]] {
         guard !flavor.isDatabend else { return [:] }
-        let dbName = activeDatabaseName
-        let escapedDb = dbName.replacingOccurrences(of: "'", with: "''")
+        let escapedDb = effectiveSchemaLiteral(schema)
 
         let query = """
             SELECT
@@ -836,9 +648,8 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     }
 
     func fetchApproximateRowCount(table: String, schema: String?) async throws -> Int? {
-        let dbName = activeDatabaseName
-        let escapedDb = dbName.replacingOccurrences(of: "'", with: "''")
-        let escapedTable = table.replacingOccurrences(of: "'", with: "''")
+        let escapedDb = effectiveSchemaLiteral(schema)
+        let escapedTable = mysqlEscapeStringLiteral(table)
 
         let query = """
             SELECT TABLE_ROWS
@@ -857,7 +668,7 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     }
 
     func fetchTableDDL(table: String, schema: String?) async throws -> String {
-        let result = try await execute(query: "SHOW CREATE TABLE \(quoteIdentifier(table))")
+        let result = try await execute(query: "SHOW CREATE TABLE \(qualifiedName(table, schema: schema))")
 
         guard let firstRow = result.rows.first,
               let ddl = firstRow[safe: 1]?.asText
@@ -875,7 +686,7 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         let result = try await execute(query: """
             SELECT EVENT_NAME, EVENT_TYPE, STATUS, EVENT_SCHEMA
             FROM information_schema.EVENTS
-            WHERE EVENT_SCHEMA = DATABASE()
+            WHERE EVENT_SCHEMA = '\(effectiveSchemaLiteral(schema))'
             ORDER BY EVENT_NAME
             """)
         return result.rows.compactMap { row in
@@ -890,8 +701,7 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     }
 
     func fetchEventDDL(_ event: PluginEventInfo) async throws -> String {
-        let safeName = event.name.replacingOccurrences(of: "`", with: "``")
-        let result = try await execute(query: "SHOW CREATE EVENT `\(safeName)`")
+        let result = try await execute(query: "SHOW CREATE EVENT \(qualifiedName(event.name, schema: event.schema))")
         guard let row = result.rows.first, let ddl = row[safe: 3]?.asText else {
             throw PluginObjectSourceError.unsupported(event.name)
         }
@@ -899,9 +709,8 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     }
 
     func fetchViewDefinition(view: String, schema: String?) async throws -> String {
-        guard !flavor.isDatabend else { return try await databendViewDefinition(view: view) }
-        let safeView = view.replacingOccurrences(of: "`", with: "``")
-        let result = try await execute(query: "SHOW CREATE VIEW `\(safeView)`")
+        guard !flavor.isDatabend else { return try await databendViewDefinition(view: view, schema: schema) }
+        let result = try await execute(query: "SHOW CREATE VIEW \(qualifiedName(view, schema: schema))")
 
         guard let firstRow = result.rows.first,
               let ddl = firstRow[safe: 1]?.asText
@@ -913,9 +722,9 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     }
 
     func fetchTableMetadata(table: String, schema: String?) async throws -> PluginTableMetadata {
-        guard !flavor.isDatabend else { return try await databendTableMetadata(table: table) }
-        let escapedTable = table.replacingOccurrences(of: "'", with: "''")
-        let result = try await execute(query: "SHOW TABLE STATUS WHERE Name = '\(escapedTable)'")
+        guard !flavor.isDatabend else { return try await databendTableMetadata(table: table, schema: schema) }
+        let escapedTable = mysqlEscapeStringLiteral(table)
+        let result = try await execute(query: showTableStatus(matching: escapedTable, schema: schema))
 
         guard let row = result.rows.first else {
             return PluginTableMetadata(tableName: table)
@@ -956,7 +765,7 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
     }
 
     func fetchDatabaseMetadata(_ database: String) async throws -> PluginDatabaseMetadata {
-        let escapedDb = database.replacingOccurrences(of: "'", with: "''")
+        let escapedDb = mysqlEscapeStringLiteral(database)
 
         let query = """
             SELECT COUNT(*), COALESCE(SUM(DATA_LENGTH + INDEX_LENGTH), 0)
@@ -1266,7 +1075,7 @@ final class MySQLPluginDriver: PluginDatabaseDriver, @unchecked Sendable {
         FROM information_schema.TABLES
         LEFT JOIN information_schema.COLLATION_CHARACTER_SET_APPLICABILITY CCSA
             ON TABLE_COLLATION = CCSA.COLLATION_NAME
-        WHERE TABLE_SCHEMA = DATABASE()
+        WHERE TABLE_SCHEMA = '\(effectiveSchemaLiteral(schema))'
         ORDER BY TABLE_NAME
         """
     }

--- a/TablePro/Core/Plugins/ExportDataSourceAdapter.swift
+++ b/TablePro/Core/Plugins/ExportDataSourceAdapter.swift
@@ -352,13 +352,18 @@ final class ExportDataSourceAdapter: PluginExportDataSource, @unchecked Sendable
     // MARK: - Helpers
 
     /// The export tree names every group after a schema on a schema-aware engine and after a
-    /// database everywhere else, so only a schema-aware driver can read that name as its
-    /// schema. An empty name means the engine's implicit schema where it has one, and the
+    /// database everywhere else. Either way the name is the container the driver has to read in,
+    /// which is what `schema:` means to a driver with no schema layer of its own: withholding it
+    /// there left a MySQL dump reading its DDL and column metadata from whichever database the
+    /// connection happened to be on while `streamRows` qualified the rows by the name the export
+    /// actually named. An empty name means the engine's implicit schema where it has one, and the
     /// driver's own container everywhere else.
     func exportSchema(for databaseName: String) -> String? {
         guard let pluginDriver else { return nil }
-        guard pluginDriver.supportsSchemas else { return pluginDriver.currentSchema }
-        guard !databaseName.isEmpty else { return implicitSchemaName ?? pluginDriver.currentSchema }
+        guard !databaseName.isEmpty else {
+            guard pluginDriver.supportsSchemas else { return pluginDriver.currentSchema }
+            return implicitSchemaName ?? pluginDriver.currentSchema
+        }
         return databaseName
     }
 

--- a/TableProTests/Core/Plugins/ExportDataSourceAdapterImplicitSchemaTests.swift
+++ b/TableProTests/Core/Plugins/ExportDataSourceAdapterImplicitSchemaTests.swift
@@ -25,6 +25,28 @@ private final class SchemaAwareStubDriver: PluginDatabaseDriver, @unchecked Send
     }
 }
 
+private final class SchemaLessStubDriver: PluginDatabaseDriver, @unchecked Sendable {
+    var supportsSchemas: Bool { false }
+    var currentSchema: String? { nil }
+
+    func connect() async throws {}
+    func disconnect() {}
+    func execute(query: String) async throws -> PluginQueryResult { .empty }
+    func fetchTables(schema: String?) async throws -> [PluginTableInfo] { [] }
+    func fetchColumns(table: String, schema: String?) async throws -> [PluginColumnInfo] { [] }
+    func fetchIndexes(table: String, schema: String?) async throws -> [PluginIndexInfo] { [] }
+    func fetchForeignKeys(table: String, schema: String?) async throws -> [PluginForeignKeyInfo] { [] }
+    func fetchTableDDL(table: String, schema: String?) async throws -> String { "" }
+    func fetchViewDefinition(view: String, schema: String?) async throws -> String { "" }
+    func fetchTableMetadata(table: String, schema: String?) async throws -> PluginTableMetadata {
+        PluginTableMetadata(tableName: table)
+    }
+    func fetchDatabases() async throws -> [String] { [] }
+    func fetchDatabaseMetadata(_ database: String) async throws -> PluginDatabaseMetadata {
+        PluginDatabaseMetadata(name: database)
+    }
+}
+
 @Suite("Export data source and the implicit schema")
 struct ExportDataSourceAdapterImplicitSchemaTests {
     private func adapter(for type: DatabaseType) -> ExportDataSourceAdapter {
@@ -56,5 +78,19 @@ struct ExportDataSourceAdapterImplicitSchemaTests {
         #expect(postgres.pluginDatabaseName(for: "") == "")
         #expect(postgres.exportSchema(for: "") == "sales")
         #expect(postgres.exportSchema(for: "public") == "public")
+    }
+
+    /// The export names its groups after databases on an engine with no schema layer, and that name
+    /// is the container the driver has to read in. Withholding it left a MySQL dump taking its DDL
+    /// and column metadata from whichever database the connection was on while the rows came from
+    /// the one the export named.
+    @Test("A driver with no schema layer is handed the container the export named")
+    func schemaLessDriverIsHandedTheContainer() {
+        let driver = PluginDriverAdapter(
+            connection: TestFixtures.makeConnection(type: .mysql), pluginDriver: SchemaLessStubDriver()
+        )
+        let mysql = ExportDataSourceAdapter(driver: driver, databaseType: .mysql)
+        #expect(mysql.exportSchema(for: "crm") == "crm")
+        #expect(mysql.exportSchema(for: "") == nil)
     }
 }

--- a/TableProTests/Plugins/ObjectCatalogQueryTests.swift
+++ b/TableProTests/Plugins/ObjectCatalogQueryTests.swift
@@ -181,6 +181,43 @@ struct MySQLObjectQueryTests {
     func identifiersAreQuoted() {
         #expect(MySQLObjectQueries.quoteIdentifier("we`ird") == "`we``ird`")
     }
+
+    /// A caller that names no database means the one the connection is on. Dropping the one it did
+    /// name is what made a read about another database answer about the session's.
+    @Test("A named schema wins over the active database, and only a missing one falls back")
+    func effectiveSchemaPrefersTheNamedDatabase() {
+        #expect(MySQLObjectQueries.effectiveSchema("crm", activeDatabase: "app") == "crm")
+        #expect(MySQLObjectQueries.effectiveSchema(nil, activeDatabase: "app") == "app")
+        #expect(MySQLObjectQueries.effectiveSchema("", activeDatabase: "app") == "app")
+    }
+
+    /// A connection with no database selected has nothing to qualify against, and MySQL takes no
+    /// empty qualifier, so the bare name is the only form left.
+    @Test("With no database selected the name stays unqualified")
+    func effectiveSchemaIsEmptyWithoutADatabase() {
+        let resolved = MySQLObjectQueries.effectiveSchema(nil, activeDatabase: "")
+        #expect(resolved.isEmpty)
+        #expect(MySQLObjectQueries.qualifiedIdentifier(schema: resolved, name: "t") == "`t`")
+    }
+
+    /// Databend answers the same driver protocol and escapes a backtick-bearing name by switching to
+    /// double quotes, so a catalog statement must qualify with the caller's quoter, not this one's.
+    @Test("The qualifier is rendered with the quoter the caller passes")
+    func qualifiedIdentifierUsesTheCallersQuoter() {
+        let shouty: (String) -> String = { "<\($0)>" }
+        #expect(MySQLObjectQueries.qualifiedIdentifier(schema: "crm", name: "t", quote: shouty) == "<crm>.<t>")
+        #expect(MySQLObjectQueries.qualifiedIdentifier(schema: nil, name: "t", quote: shouty) == "<t>")
+        #expect(MySQLObjectQueries.qualifiedIdentifier(schema: "crm", name: "t") == "`crm`.`t`")
+    }
+
+    /// A backslash is an escape character to MySQL unless NO_BACKSLASH_ESCAPES is set, so a literal
+    /// that only doubles the quote leaves a database name ending in one able to escape its own
+    /// closing quote.
+    @Test("A literal escapes the backslash as well as the quote")
+    func literalsEscapeBackslashes() {
+        #expect(MySQLObjectQueries.escapeLiteral("a\\") == "a\\\\")
+        #expect(MySQLObjectQueries.escapeLiteral("it's") == "it''s")
+    }
 }
 
 @Suite("MSSQL Object Catalog Queries")

--- a/scripts/check-mysql-cross-database-catalog.sh
+++ b/scripts/check-mysql-cross-database-catalog.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+#
+# Check that the MySQL driver's catalog statements still reach another database.
+#
+# Every metadata read in MySQLPluginDriver names the database the caller asked for rather than
+# letting the name resolve against whatever database the connection is on, because an unqualified
+# name silently answers about a same-named table in the session's database. Which qualifier form
+# each statement takes is not uniform and is transcribed by hand: SHOW FULL COLUMNS, SHOW INDEX,
+# SHOW CREATE TABLE, SHOW CREATE VIEW and DROP TRIGGER take a dotted name, while SHOW TABLE STATUS
+# takes a FROM clause of its own. Emitting both forms is worse than emitting neither: the trailing
+# FROM silently overrides the dotted qualifier and answers about the wrong database.
+#
+# This builds two databases holding same-named tables with different columns, runs each statement
+# from a session on the wrong one, and fails if any of them answers about the session's database
+# or stops accepting the form the driver emits. Run it against any MySQL-protocol engine the
+# plugin claims to support before trusting a new flavor: MySQL, MariaDB, TiDB, OceanBase.
+#
+# Usage:
+#   scripts/check-mysql-cross-database-catalog.sh [host] [port] [user]
+#
+# Needs the mysql client and an account that can create and drop databases. The password, if any,
+# comes from MYSQL_PWD. Exits non-zero on a disagreement.
+
+set -uo pipefail
+
+HOST="${1:-127.0.0.1}"
+PORT="${2:-3306}"
+USER_NAME="${3:-root}"
+
+# Fixed names would let this drop somebody's existing database, and two runs would delete each
+# other's fixtures, so each run takes names nothing else holds and arms the cleanup only once the
+# CREATE has succeeded. CREATE DATABASE without IF NOT EXISTS makes a collision an error rather
+# than an adoption.
+SUFFIX="$$_${RANDOM}"
+REF_DB="tp_xdb_referenced_$SUFFIX"
+SESSION_DB="tp_xdb_session_$SUFFIX"
+
+command -v mysql > /dev/null || {
+    echo "mysql client not found" >&2
+    exit 3
+}
+
+MYSQL=(mysql --no-defaults -h "$HOST" -P "$PORT" -u "$USER_NAME" -N -B -r --default-character-set=utf8mb4)
+if ! "${MYSQL[@]}" -e "SELECT 1" > /dev/null 2>&1; then
+    echo "no MySQL-protocol server at $HOST:$PORT for $USER_NAME" >&2
+    exit 3
+fi
+
+"${MYSQL[@]}" -e "CREATE DATABASE \`$REF_DB\`; CREATE DATABASE \`$SESSION_DB\`;" || {
+    echo "could not create the scratch databases" >&2
+    exit 3
+}
+drop_fixture() {
+    "${MYSQL[@]}" -e "DROP DATABASE IF EXISTS \`$REF_DB\`; DROP DATABASE IF EXISTS \`$SESSION_DB\`;" > /dev/null 2>&1
+}
+trap drop_fixture EXIT
+
+# Every fixture carries a marker only its own database has, including the index name and the table
+# comment: without those, SHOW INDEX and SHOW TABLE STATUS answer identically for both databases
+# and their checks would pass through a regression in the qualifier.
+"${MYSQL[@]}" <<SQL || exit 3
+CREATE TABLE \`$REF_DB\`.customers (
+    id INT PRIMARY KEY, referenced_only VARCHAR(8),
+    UNIQUE KEY idx_referenced_only (referenced_only)
+) COMMENT = 'referenced_comment';
+CREATE TABLE \`$SESSION_DB\`.customers (
+    id INT PRIMARY KEY, session_only VARCHAR(8),
+    UNIQUE KEY idx_session_only (session_only)
+) COMMENT = 'session_comment';
+CREATE VIEW \`$REF_DB\`.customer_view AS SELECT id FROM \`$REF_DB\`.customers;
+CREATE VIEW \`$SESSION_DB\`.customer_view AS SELECT id FROM \`$SESSION_DB\`.customers;
+SQL
+
+FAILURES=0
+
+# Every statement runs from a session on SESSION_DB and must answer about REF_DB. The marker
+# column exists only in REF_DB, so its absence means the statement resolved against the session.
+check() {
+    local label="$1" statement="$2" marker="$3"
+    local output
+    if ! output="$("${MYSQL[@]}" -D "$SESSION_DB" -e "$statement" 2>&1)"; then
+        echo "FAIL $label: the server rejected the statement"
+        echo "     $statement"
+        echo "     ${output//$'\n'/$'\n'     }"
+        FAILURES=$((FAILURES + 1))
+        return
+    fi
+    if ! grep -q -- "$marker" <<< "$output"; then
+        echo "FAIL $label: answered about $SESSION_DB, not $REF_DB"
+        echo "     $statement"
+        FAILURES=$((FAILURES + 1))
+        return
+    fi
+    echo "ok   $label"
+}
+
+check "SHOW FULL COLUMNS" \
+    "SHOW FULL COLUMNS FROM \`$REF_DB\`.\`customers\`" referenced_only
+check "SHOW INDEX" \
+    "SHOW INDEX FROM \`$REF_DB\`.\`customers\`" idx_referenced_only
+check "SHOW CREATE TABLE" \
+    "SHOW CREATE TABLE \`$REF_DB\`.\`customers\`" referenced_only
+check "SHOW CREATE VIEW" \
+    "SHOW CREATE VIEW \`$REF_DB\`.\`customer_view\`" "$REF_DB"
+check "SHOW TABLE STATUS" \
+    "SHOW TABLE STATUS FROM \`$REF_DB\` WHERE Name = 'customers'" referenced_comment
+check "INFORMATION_SCHEMA.COLUMNS" \
+    "SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = '$REF_DB' AND TABLE_NAME = 'customers'" \
+    referenced_only
+
+# The trap the driver must never spring: both qualifier forms at once. The trailing FROM wins, so
+# a statement carrying both answers about the session's database while looking correct.
+BOTH="$("${MYSQL[@]}" -D "$SESSION_DB" \
+    -e "SHOW FULL COLUMNS FROM \`$REF_DB\`.\`customers\` FROM \`$SESSION_DB\`" 2>&1)"
+if grep -q -- referenced_only <<< "$BOTH"; then
+    echo "note two qualifier forms no longer conflict on this server; the driver still emits one"
+else
+    echo "ok   two qualifier forms conflict, as the driver assumes: the trailing FROM wins"
+fi
+
+if [ "$FAILURES" -ne 0 ]; then
+    echo
+    echo "$FAILURES catalog statement(s) do not reach another database on this server." >&2
+    echo "MySQLPluginDriver+Schema.swift and MySQLObjectQueries.swift assume they do." >&2
+    exit 1
+fi
+
+echo
+echo "every catalog statement reached $REF_DB from a session on $SESSION_DB"


### PR DESCRIPTION
## Root cause

`MySQLPluginDriver` declares `schema:` on 23 `PluginDatabaseDriver` requirements and discards it on 13 of them, resolving the object name against whatever database the connection happens to be on. Its own header says what the argument means:

> The database a metadata read is scoped to. MySQL has no schema level, so this is what a caller means by "schema" everywhere in the catalog queries.

Ten of the driver's methods already honour it, through `routineSchema(_:)` and `MySQLObjectQueries.qualifiedIdentifier(schema:name:)`. PostgreSQL, MSSQL, Oracle and Cockroach all honour theirs. MySQL was the outlier.

For #2769 that means the foreign key picker asks for `crm.customers`' columns and `SHOW FULL COLUMNS FROM \`customers\`` answers about the browsing database's `customers` instead. The row search on the next call reads the right table, because it renders the qualified name into the SQL text itself through `SchemaQualifiedName`, so the picker lists one table's columns while searching another's. Where the browsing database has no same-named table the lookup throws instead.

The same cause is reachable well beyond the picker. Every caller that passes a schema hits it: schema compare, table transfer, the export tree, MCP, and the structure editor's own Ref Columns menu.

One of those callers could not be fixed in the driver alone. `ExportDataSourceAdapter.exportSchema(for:)` withheld the export's own container name from any driver reporting `supportsSchemas == false`, so a MySQL SQL dump read its DDL and its bulk column and foreign key metadata from whatever database the connection was on while `streamRows` qualified the rows by the database the export actually named. A dump could therefore mix one database's schema with another's rows, or lose the DDL entirely when the active database had no same-named table. That name is the container the driver has to read in, which is exactly what `schema:` means to an engine with no schema layer, so it is now passed through.

## The fix

One rule, in one place. `MySQLObjectQueries.effectiveSchema(_:activeDatabase:)` answers "which database does this read mean" (the one the caller named, else the one the connection is on), and every catalog statement is built from it. `routineSchema(_:)` and the copy inlined in `fetchTriggers` now call it too, so the rule has one spelling rather than four.

Statements fixed: `fetchColumns`, `fetchGenerationExpressions`, `fetchIndexes`, `fetchForeignKeys`, `fetchAllForeignKeys`, `fetchAllColumns`, `fetchCheckConstraints`, `fetchTableDDL`, `fetchViewDefinition`, `fetchTableMetadata`, `fetchApproximateRowCount`, `fetchTables`, `fetchEvents`, `fetchEventDDL`, `allTablesMetadataSQL`, `createTriggerTemplate`, `generateDropTriggerSQL`, the Databend arms, and TiDB's `tidbCheckConstraints`.

Three details that are not free choices:

- **Quoting belongs to the caller.** `qualifiedIdentifier` takes a `quote:` closure. Databend answers the same protocol through the same driver and escapes a backtick-bearing name by switching to double quotes, so rendering one with the MySQL quoter would corrupt it.
- **`SHOW TABLE STATUS` takes `FROM db`, not a dotted name.** Its grammar puts the database in a clause of its own.
- **Exactly one qualifier form per statement.** Measured: `SHOW FULL COLUMNS FROM \`crm\`.\`customers\` FROM \`app\`` returns `app.customers`. The trailing `FROM` silently overrides the dotted qualifier, so emitting both is worse than emitting neither.

`SHOW` is kept over `INFORMATION_SCHEMA` deliberately. Measured, a missing database, a missing table and a denied privilege all raise from `SHOW` but come back from `INFORMATION_SCHEMA` as an empty column list, and an empty list is the silent plausible-wrong-data failure this issue is about.

Five methods also built their SQL literals with a quote-only escape while the plugin's own `mysqlEscapeStringLiteral` (which escapes the backslash too) sat two call sites away. A backslash is an escape character to MySQL unless `NO_BACKSLASH_ESCAPES` is set, so a database name ending in one could escape its own closing quote. They now use the full escaper, and so does `MySQLObjectQueries.escapeLiteral`.

No signature changes and no PluginKit change, so no ABI bump. MySQL is a bundled plugin, so this ships with the next app release and needs no plugin tag.

## Verification

| Step | Result |
| --- | --- |
| `verify.sh build` | PASS |
| `verify.sh test` (8 suites) | PASS, 137 executed, 137 passed |
| `verify.sh lint Plugins/MySQLDriverPlugin …` | PASS, 0 violations |
| `verify.sh plugins` | FAIL, pre-existing and unrelated (see below) |

`AllPlugins` fails on `unknown attribute 'usableFromInlinenonisolated'` from a `@TaskLocal` macro expansion inside the vendored `oracle-nio` package (`SourcePackages/checkouts/oracle-nio/...`). Zero MySQL errors in that log, and it aborts before reaching the MySQL target. The MySQL plugin is covered by the app build instead, which is where it actually ships: `MySQLPluginDriver+Schema.swift` compiles there and `MySQLDriver.tableplugin` is produced.

### Measured against live servers

`scripts/check-mysql-cross-database-catalog.sh` is new and committed here. It builds two databases holding same-named tables with different columns, runs each statement the driver emits from a session on the wrong one, and fails if any answers about the session's database. It also asserts the two-qualifier trap still behaves as the driver assumes.

Passing on MySQL 8.4.11, MySQL 5.7.44, TiDB v8.5.0 and OceanBase CE 4.4.2.1. MariaDB 12.3.3 was confirmed separately during the investigation to accept both qualified forms; the script needs create-database rights, which the local MariaDB account does not have.

Each fixture carries a marker only its own database has, the index name and the table comment included, because both fixtures are otherwise identical enough that `SHOW INDEX` and `SHOW TABLE STATUS` would answer the same either way and pass through a regression. Fixture names are unique per run and the cleanup arms only after the `CREATE` succeeds, so the script cannot drop a database somebody already had.

Which qualifier form each statement takes is transcribed by hand, so the script exists to re-check it when a flavor is added or a server is upgraded, the way `check-mysql-charset-decoding.sh` does for the charset tables.

### Tests

Four cases added to the existing `MySQLObjectQueryTests` suite in `ObjectCatalogQueryTests.swift`, covering the fallback rule, a connection with no database selected, the caller-supplied quoter, and backslash escaping. One more in `ExportDataSourceAdapterImplicitSchemaTests` pins that a driver with no schema layer is handed the container the export named.

No UI automation: the flow needs a live MySQL server with two databases and a cross-database foreign key, which does not run deterministically on CI.

## Not in this PR

The scope half of #2769 is being fixed separately: `ForeignKeyLookupService.targetScope` files the referenced database into `DatabaseScope.schema`, which is inert on an engine with no schema layer, so the pooled connection never leaves the origin database. That work also covers the two defects that reach the driver through the no-schema overloads, which this change cannot repair.

Fixes #2769


https://claude.ai/code/session_01SP8Cj5R28unz7YhwL2BtiM
