### PR TITLE
fix(connections): read the password mode and per-driver TLS layout TablePlus actually writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Prompt for password** lost when importing a TablePlus connection set to **Ask everytime**.
+- TablePlus import saving a password for a connection TablePlus was set never to store one for.
+- TablePlus import reading the CA certificate and client key paths the wrong way round.
 - Select All painting the whole column header row as selected, and leaving a cell cursor on the first cell.
 - Column header shown as selected after a cell drag reached the first and last row of the page.
 - No outline around a swept cell block whose rows reached both ends of the page.
@@ -236,6 +239,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- TablePlus connections set to VERIFY-IDENTITY or VERIFY-FULL imported with TLS turned off.
 - BigQuery Google sign-in accepting an authorization response without PKCE or a state check.
 - PostgreSQL sessions inheriting `standard_conforming_strings = off`, which let a backslash break out of any quoted literal.
 - PostgreSQL catalog, comment and password literals escaped by quote doubling alone, which a backslash can break out of. (#2726)

--- a/TablePro/Core/Services/Export/ForeignApp/TablePlusFormValues.swift
+++ b/TablePro/Core/Services/Export/ForeignApp/TablePlusFormValues.swift
@@ -1,0 +1,123 @@
+//
+//  TablePlusFormValues.swift
+//  TablePro
+//
+
+import Foundation
+import TableProPluginKit
+
+enum TablePlusPasswordMode: Int {
+    case storeInKeychain = 0
+    case askEveryTime = 1
+    case noPassword = 2
+    case commandLine = 3
+
+    static func resolve(_ raw: Any?) -> TablePlusPasswordMode {
+        guard let index = raw as? Int, let mode = TablePlusPasswordMode(rawValue: index) else {
+            return .storeInKeychain
+        }
+        return mode
+    }
+
+    var storesPasswordInKeychain: Bool {
+        self == .storeInKeychain
+    }
+
+    var promptsForPassword: Bool {
+        self == .askEveryTime || self == .commandLine
+    }
+}
+
+struct TablePlusTLSKeySlots {
+    let clientKey: Int?
+    let clientCertificate: Int?
+    let certificateAuthority: Int?
+
+    static let keyCertificateAuthority = TablePlusTLSKeySlots(
+        clientKey: 0,
+        clientCertificate: 1,
+        certificateAuthority: 2
+    )
+    static let certificateKeyAuthority = TablePlusTLSKeySlots(
+        clientKey: nil,
+        clientCertificate: 0,
+        certificateAuthority: 1
+    )
+    static let authorityOnly = TablePlusTLSKeySlots(
+        clientKey: nil,
+        clientCertificate: nil,
+        certificateAuthority: 0
+    )
+    static let none = TablePlusTLSKeySlots(clientKey: nil, clientCertificate: nil, certificateAuthority: nil)
+}
+
+struct TablePlusTLSForm {
+    let modes: [SSLMode]
+    let slots: TablePlusTLSKeySlots
+}
+
+enum TablePlusTLSVocabulary {
+    private static let mysql = TablePlusTLSForm(
+        modes: [.preferred, .disabled, .required, .verifyCa, .verifyIdentity],
+        slots: .keyCertificateAuthority
+    )
+    private static let mariadb = TablePlusTLSForm(
+        modes: [.preferred, .required, .verifyIdentity],
+        slots: .keyCertificateAuthority
+    )
+    private static let postgres = TablePlusTLSForm(
+        modes: [.preferred, .disabled, .required, .preferred, .verifyCa, .verifyIdentity],
+        slots: .keyCertificateAuthority
+    )
+    private static let cassandra = TablePlusTLSForm(
+        modes: [.disabled, .required, .verifyCa, .verifyIdentity, .verifyIdentity],
+        slots: .keyCertificateAuthority
+    )
+    private static let redis = TablePlusTLSForm(
+        modes: [.disabled, .required, .verifyCa],
+        slots: .keyCertificateAuthority
+    )
+    private static let clickhouse = TablePlusTLSForm(
+        modes: [.disabled, .verifyIdentity, .required],
+        slots: .authorityOnly
+    )
+    private static let mongo = TablePlusTLSForm(
+        modes: [.disabled, .verifyIdentity, .required],
+        slots: .certificateKeyAuthority
+    )
+    private static let elasticsearch = TablePlusTLSForm(
+        modes: [.disabled, .verifyIdentity, .verifyCa, .required],
+        slots: .authorityOnly
+    )
+    private static let oracle = TablePlusTLSForm(
+        modes: [.disabled, .required],
+        slots: .none
+    )
+    private static let withoutPicker = TablePlusTLSForm(modes: [.preferred], slots: .none)
+
+    private static let byDriver: [String: TablePlusTLSForm] = [
+        "MySQL": mysql,
+        "MariaDB": mariadb,
+        "PostgreSQL": postgres,
+        "Cockroach": postgres,
+        "Greenplum": postgres,
+        "Redshift": postgres,
+        "Vertica": postgres,
+        "Cassandra": cassandra,
+        "Redis": redis,
+        "ClickHouse": clickhouse,
+        "Mongo": mongo,
+        "ElasticSearch": elasticsearch,
+        "Oracle": oracle
+    ]
+
+    static func form(forDriver driver: String) -> TablePlusTLSForm {
+        byDriver[driver] ?? withoutPicker
+    }
+
+    static func sslMode(forDriver driver: String, tlsMode: Int) -> SSLMode? {
+        let modes = form(forDriver: driver).modes
+        guard tlsMode >= 0, tlsMode < modes.count else { return nil }
+        return modes[tlsMode]
+    }
+}

--- a/TablePro/Core/Services/Export/ForeignApp/TablePlusImporter.swift
+++ b/TablePro/Core/Services/Export/ForeignApp/TablePlusImporter.swift
@@ -106,7 +106,12 @@ struct TablePlusImporter: ForeignAppImporter {
                 }
 
                 if includePasswords, !credentialsAborted, let connId = entry["ID"] as? String {
-                    let creds = readCredentials(for: connId, abortFlag: &credentialsAborted)
+                    let creds = readCredentials(
+                        for: connId,
+                        databaseMode: TablePlusPasswordMode.resolve(entry["DatabasePasswordMode"]),
+                        serverMode: TablePlusPasswordMode.resolve(entry["ServerPasswordMode"]),
+                        abortFlag: &credentialsAborted
+                    )
                     if creds.password != nil || creds.sshPassword != nil || creds.keyPassphrase != nil {
                         credentials[String(index)] = creds
                     }
@@ -166,7 +171,8 @@ struct TablePlusImporter: ForeignAppImporter {
             throw ForeignAppImportError.parseError("Missing ConnectionName")
         }
 
-        let dbType = Self.databaseType(forDriver: entry["Driver"] as? String ?? "")
+        let driver = entry["Driver"] as? String ?? ""
+        let dbType = Self.databaseType(forDriver: driver)
         let filePathField = ForeignAppDatabaseType.localFilePathField(for: dbType)
         let filePath = filePathField == nil ? nil : (entry["DatabasePath"] as? String).flatMap { $0.isEmpty ? nil : $0 }
 
@@ -181,15 +187,20 @@ struct TablePlusImporter: ForeignAppImporter {
         }
         let username = entry["DatabaseUser"] as? String ?? ""
         let database: String
-        var additionalFields: [String: String]?
+        var additionalFields: [String: String] = [:]
         switch (filePath, filePathField) {
         case (let path?, .database?):
             database = path
         case (let path?, .additionalField(let fieldId)?):
             database = ""
-            additionalFields = [fieldId: path]
+            additionalFields[fieldId] = path
         default:
             database = entry["DatabaseName"] as? String ?? ""
+        }
+
+        let databaseMode = TablePlusPasswordMode.resolve(entry["DatabasePasswordMode"])
+        if databaseMode.promptsForPassword, !Self.hidesBuiltInPassword(dbType, fields: additionalFields) {
+            additionalFields["promptForPassword"] = "true"
         }
 
         let groupName: String?
@@ -200,7 +211,7 @@ struct TablePlusImporter: ForeignAppImporter {
         }
 
         let sshConfig = parseSSHConfig(entry)
-        let sslConfig = parseSSLConfig(entry)
+        let sslConfig = parseSSLConfig(entry, driver: driver)
         let color = mapEnvironmentColor(entry["Enviroment"] as? String)
 
         return ExportableConnection(
@@ -218,7 +229,7 @@ struct TablePlusImporter: ForeignAppImporter {
             sshProfileId: nil,
             safeModeLevel: nil,
             aiPolicy: nil,
-            additionalFields: additionalFields,
+            additionalFields: additionalFields.isEmpty ? nil : additionalFields,
             redisDatabase: nil,
             startupCommands: nil,
             localOnly: nil
@@ -257,33 +268,31 @@ struct TablePlusImporter: ForeignAppImporter {
         return keyFileExists(PathPortability.expandHome(resolved)) ? resolved : ""
     }
 
-    private func parseSSLConfig(_ entry: [String: Any]) -> ExportableSSLConfig? {
+    private func parseSSLConfig(_ entry: [String: Any], driver: String) -> ExportableSSLConfig? {
         guard entry.keys.contains("tLSMode") else { return nil }
         let tlsMode = entry["tLSMode"] as? Int ?? 0
-
-        let mode: String
-        switch tlsMode {
-        case 0: mode = SSLMode.preferred.rawValue
-        case 1: mode = SSLMode.required.rawValue
-        case 2: mode = SSLMode.verifyCa.rawValue
-        case 3: mode = SSLMode.verifyIdentity.rawValue
-        default: return nil
-        }
+        let form = TablePlusTLSVocabulary.form(forDriver: driver)
+        guard tlsMode >= 0, tlsMode < form.modes.count else { return nil }
 
         let paths = entry["TlsKeyPaths"] as? [String] ?? []
-        func certPath(_ index: Int) -> String? {
-            guard index < paths.count, !paths[index].isEmpty else { return nil }
-            return paths[index]
+        func certPath(_ slot: Int?) -> String? {
+            guard let slot, slot < paths.count, !paths[slot].isEmpty else { return nil }
+            return paths[slot]
         }
         return ExportableSSLConfig(
-            mode: mode,
-            caCertificatePath: certPath(0),
-            clientCertificatePath: certPath(1),
-            clientKeyPath: certPath(2)
+            mode: form.modes[tlsMode].rawValue,
+            caCertificatePath: certPath(form.slots.certificateAuthority),
+            clientCertificatePath: certPath(form.slots.clientCertificate),
+            clientKeyPath: certPath(form.slots.clientKey)
         )
     }
 
-    private func readCredentials(for connectionId: String, abortFlag: inout Bool) -> ExportableCredentials {
+    private func readCredentials(
+        for connectionId: String,
+        databaseMode: TablePlusPasswordMode,
+        serverMode: TablePlusPasswordMode,
+        abortFlag: inout Bool
+    ) -> ExportableCredentials {
         func read(_ account: String) -> String? {
             guard !abortFlag else { return nil }
             switch readKeychain(Self.keychainService, account) {
@@ -297,8 +306,8 @@ struct TablePlusImporter: ForeignAppImporter {
             }
         }
 
-        let dbPassword = read("\(connectionId)_database")
-        let sshPassword = read("\(connectionId)_server")
+        let dbPassword = databaseMode.storesPasswordInKeychain ? read("\(connectionId)_database") : nil
+        let sshPassword = serverMode.storesPasswordInKeychain ? read("\(connectionId)_server") : nil
         let keyPassphrase = read("\(connectionId)_server_key")
         return ExportableCredentials(
             password: dbPassword,
@@ -308,6 +317,16 @@ struct TablePlusImporter: ForeignAppImporter {
             totpSecret: nil,
             pluginSecureFields: nil
         )
+    }
+
+    private static func hidesBuiltInPassword(_ typeId: String, fields: [String: String]) -> Bool {
+        guard let snapshot = PluginMetadataRegistry.shared.snapshot(for: DatabaseType(rawValue: typeId)) else {
+            return false
+        }
+        if snapshot.connection.hidesBuiltInPassword {
+            return true
+        }
+        return snapshot.connection.additionalConnectionFields.hidesPassword(forValues: fields)
     }
 
     private static func databaseType(forDriver driver: String) -> String {

--- a/TableProTests/Core/Services/ForeignApp/TablePlusImporterTests.swift
+++ b/TableProTests/Core/Services/ForeignApp/TablePlusImporterTests.swift
@@ -61,7 +61,9 @@ struct TablePlusImporterTests {
         privateKeyPath: String = "",
         tlsMode: Int? = nil,
         tlsKeyPaths: [String] = [],
-        environment: String = ""
+        environment: String = "",
+        databasePasswordMode: Int? = nil,
+        serverPasswordMode: Int? = nil
     ) -> [String: Any] {
         var entry: [String: Any] = [
             "ConnectionName": name,
@@ -87,6 +89,12 @@ struct TablePlusImporterTests {
         }
         if !tlsKeyPaths.isEmpty {
             entry["TlsKeyPaths"] = tlsKeyPaths
+        }
+        if let databasePasswordMode {
+            entry["DatabasePasswordMode"] = databasePasswordMode
+        }
+        if let serverPasswordMode {
+            entry["ServerPasswordMode"] = serverPasswordMode
         }
         return entry
     }
@@ -334,14 +342,14 @@ struct TablePlusImporterTests {
         #expect(ssh?.privateKeyPath == "")
     }
 
-    @Test("importConnections parses SSL config")
+    @Test("importConnections reads TlsKeyPaths in TablePlus order: key, certificate, CA")
     func testImportConnections_parsesSSLConfig() throws {
         try writeConnections([
             makeConnection(
                 name: "SSL DB",
                 id: "ssl-1",
-                tlsMode: 1,
-                tlsKeyPaths: ["/path/to/ca.pem", "/path/to/client-cert.pem", "/path/to/client-key.pem"]
+                tlsMode: 2,
+                tlsKeyPaths: ["/path/to/client-key.pem", "/path/to/client-cert.pem", "/path/to/ca.pem"]
             )
         ])
 
@@ -378,38 +386,160 @@ struct TablePlusImporterTests {
         #expect(ssl?.mode == "Preferred")
     }
 
-    @Test("importConnections SSL mode Verify CA when tLSMode is 2")
-    func testImportConnections_sslModeVerifyCA() throws {
-        try writeConnections([
-            makeConnection(name: "Verify CA", id: "ssl-ca", tlsMode: 2)
-        ])
+    @Test("importConnections reads tLSMode against the popup the driver's own form shows")
+    func testImportConnections_sslModeFollowsDriverVocabulary() throws {
+        let cases: [(driver: String, tlsMode: Int, mode: String)] = [
+            ("MySQL", 0, "Preferred"),
+            ("MySQL", 1, "Disabled"),
+            ("MySQL", 2, "Required"),
+            ("MySQL", 3, "Verify CA"),
+            ("MySQL", 4, "Verify Identity"),
+            ("MariaDB", 1, "Required"),
+            ("MariaDB", 2, "Verify Identity"),
+            ("PostgreSQL", 1, "Disabled"),
+            ("PostgreSQL", 2, "Required"),
+            ("PostgreSQL", 3, "Preferred"),
+            ("PostgreSQL", 4, "Verify CA"),
+            ("PostgreSQL", 5, "Verify Identity"),
+            ("Cockroach", 5, "Verify Identity"),
+            ("Redshift", 4, "Verify CA"),
+            ("Cassandra", 0, "Disabled"),
+            ("Cassandra", 2, "Verify CA"),
+            ("Cassandra", 4, "Verify Identity"),
+            ("Redis", 0, "Disabled"),
+            ("Redis", 2, "Verify CA"),
+            ("ClickHouse", 1, "Verify Identity"),
+            ("ClickHouse", 2, "Required"),
+            ("Mongo", 1, "Verify Identity"),
+            ("ElasticSearch", 1, "Verify Identity"),
+            ("ElasticSearch", 2, "Verify CA"),
+            ("ElasticSearch", 3, "Required"),
+            ("Oracle", 1, "Required")
+        ]
 
-        let result = try importer.importConnections(includePasswords: false)
-        let ssl = result.envelope.connections[0].sslConfig
-        #expect(ssl != nil)
-        #expect(ssl?.mode == "Verify CA")
+        try writeConnections(cases.enumerated().map { index, testCase in
+            makeConnection(
+                name: "\(testCase.driver) \(testCase.tlsMode)",
+                driver: testCase.driver,
+                id: "ssl-\(index)",
+                tlsMode: testCase.tlsMode
+            )
+        })
+
+        let connections = try importer.importConnections(includePasswords: false).envelope.connections
+        for (index, testCase) in cases.enumerated() {
+            #expect(
+                connections[index].sslConfig?.mode == testCase.mode,
+                "\(testCase.driver) tLSMode \(testCase.tlsMode) should map to \(testCase.mode)"
+            )
+        }
     }
 
-    @Test("importConnections SSL mode Verify Identity when tLSMode is 3")
-    func testImportConnections_sslModeVerifyIdentity() throws {
+    @Test("importConnections reads the TLS slots each driver's own form writes")
+    func testImportConnections_tlsKeySlotsFollowDriverForm() throws {
         try writeConnections([
-            makeConnection(name: "Verify Identity", id: "ssl-identity", tlsMode: 3)
+            makeConnection(
+                name: "Cassandra TLS",
+                driver: "Cassandra",
+                id: "tls-cassandra",
+                tlsMode: 2,
+                tlsKeyPaths: ["/path/to/cass-key.pem", "/path/to/cass-cert.pem", "/path/to/cass-ca.pem"]
+            ),
+            makeConnection(
+                name: "Cassandra CA only",
+                driver: "Cassandra",
+                id: "tls-cassandra-ca",
+                tlsMode: 3,
+                tlsKeyPaths: ["", "", "/path/to/cass-ca.pem"]
+            ),
+            makeConnection(
+                name: "Mongo TLS",
+                driver: "Mongo",
+                id: "tls-mongo",
+                tlsMode: 1,
+                tlsKeyPaths: ["/path/to/mongo-certkey.pem", "/path/to/mongo-ca.pem"]
+            ),
+            makeConnection(
+                name: "ClickHouse TLS",
+                driver: "ClickHouse",
+                id: "tls-clickhouse",
+                tlsMode: 1,
+                tlsKeyPaths: ["/path/to/clickhouse-ca.pem"]
+            ),
+            makeConnection(
+                name: "Elasticsearch TLS",
+                driver: "ElasticSearch",
+                id: "tls-es",
+                tlsMode: 2,
+                tlsKeyPaths: ["/path/to/es-ca.pem"]
+            )
         ])
 
-        let result = try importer.importConnections(includePasswords: false)
-        let ssl = result.envelope.connections[0].sslConfig
-        #expect(ssl != nil)
-        #expect(ssl?.mode == "Verify Identity")
+        let connections = try importer.importConnections(includePasswords: false).envelope.connections
+
+        #expect(connections[0].sslConfig?.clientKeyPath == "/path/to/cass-key.pem")
+        #expect(connections[0].sslConfig?.clientCertificatePath == "/path/to/cass-cert.pem")
+        #expect(connections[0].sslConfig?.caCertificatePath == "/path/to/cass-ca.pem")
+
+        #expect(connections[1].sslConfig?.caCertificatePath == "/path/to/cass-ca.pem")
+        #expect(connections[1].sslConfig?.clientKeyPath == nil)
+        #expect(connections[1].sslConfig?.clientCertificatePath == nil)
+
+        #expect(connections[2].sslConfig?.clientCertificatePath == "/path/to/mongo-certkey.pem")
+        #expect(connections[2].sslConfig?.caCertificatePath == "/path/to/mongo-ca.pem")
+        #expect(connections[2].sslConfig?.clientKeyPath == nil)
+
+        #expect(connections[3].sslConfig?.caCertificatePath == "/path/to/clickhouse-ca.pem")
+        #expect(connections[3].sslConfig?.clientCertificatePath == nil)
+        #expect(connections[3].sslConfig?.clientKeyPath == nil)
+
+        #expect(connections[4].sslConfig?.caCertificatePath == "/path/to/es-ca.pem")
+        #expect(connections[4].sslConfig?.clientCertificatePath == nil)
     }
 
-    @Test("importConnections no SSL for unknown tLSMode value")
-    func testImportConnections_noSSLForUnknownTLSMode() throws {
+    @Test("importConnections carries no TLS paths for a driver whose form has no file pickers")
+    func testImportConnections_oracleCarriesNoTLSPaths() throws {
         try writeConnections([
-            makeConnection(name: "Unknown TLS", id: "ssl-unknown", tlsMode: 99)
+            makeConnection(
+                name: "Oracle TLS",
+                driver: "Oracle",
+                id: "tls-oracle",
+                tlsMode: 1,
+                tlsKeyPaths: ["/stray/a.pem", "/stray/b.pem", "/stray/c.pem"]
+            )
         ])
 
-        let result = try importer.importConnections(includePasswords: false)
-        #expect(result.envelope.connections[0].sslConfig == nil)
+        let ssl = try importer.importConnections(includePasswords: false).envelope.connections[0].sslConfig
+        #expect(ssl?.mode == "Required")
+        #expect(ssl?.caCertificatePath == nil)
+        #expect(ssl?.clientCertificatePath == nil)
+        #expect(ssl?.clientKeyPath == nil)
+    }
+
+    @Test("importConnections drops an SSL mode past the end of the driver's own popup")
+    func testImportConnections_noSSLForTLSModePastDriverVocabulary() throws {
+        try writeConnections([
+            makeConnection(name: "Unknown TLS", id: "ssl-unknown", tlsMode: 99),
+            makeConnection(name: "Past MySQL", driver: "MySQL", id: "ssl-past-mysql", tlsMode: 5),
+            makeConnection(name: "Past Oracle", driver: "Oracle", id: "ssl-past-oracle", tlsMode: 2)
+        ])
+
+        let connections = try importer.importConnections(includePasswords: false).envelope.connections
+        #expect(connections[0].sslConfig == nil)
+        #expect(connections[1].sslConfig == nil)
+        #expect(connections[2].sslConfig == nil)
+    }
+
+    @Test("importConnections keeps Preferred for a driver whose form has no SSL picker")
+    func testImportConnections_driverWithoutSSLPicker_staysPreferred() throws {
+        try writeConnections([
+            makeConnection(name: "SQL Server", driver: "MicrosoftSQLServer", id: "ssl-mssql", tlsMode: 0),
+            makeConnection(name: "Snowflake", driver: "Snowflake", id: "ssl-snowflake", tlsMode: 0)
+        ])
+
+        let connections = try importer.importConnections(includePasswords: false).envelope.connections
+        #expect(connections[0].sslConfig?.mode == "Preferred")
+        #expect(connections[1].sslConfig?.mode == "Preferred")
     }
 
     @Test("importConnections treats empty TablePlus TLS paths as none")
@@ -671,6 +801,177 @@ struct TablePlusImporterTests {
         #expect(result.credentialsAborted == true)
         #expect(spy.calls.count == 1)
         #expect(spy.calls.first?.account == "c1_database")
+    }
+
+    // MARK: - Password Mode
+
+    @Test("importConnections carries Ask everytime across as Prompt for password")
+    func testImportConnections_askEveryTime_setsPromptForPassword() throws {
+        try writeConnections([
+            makeConnection(name: "Ask", id: "c1", databasePasswordMode: 1)
+        ])
+
+        let connection = try importer.importConnections(includePasswords: false).envelope.connections[0]
+        #expect(connection.additionalFields?["promptForPassword"] == "true")
+    }
+
+    @Test("importConnections leaves Store in keychain and a missing mode without a prompt")
+    func testImportConnections_storeInKeychainOrAbsentMode_leavesNoPrompt() throws {
+        try writeConnections([
+            makeConnection(name: "Stored", id: "c1", databasePasswordMode: 0),
+            makeConnection(name: "Absent", id: "c2"),
+            makeConnection(name: "Unknown", id: "c3", databasePasswordMode: 47)
+        ])
+
+        let connections = try importer.importConnections(includePasswords: false).envelope.connections
+        #expect(connections[0].additionalFields?["promptForPassword"] == nil)
+        #expect(connections[1].additionalFields?["promptForPassword"] == nil)
+        #expect(connections[2].additionalFields?["promptForPassword"] == nil)
+    }
+
+    @Test("importConnections leaves No password without a prompt")
+    func testImportConnections_noPasswordMode_leavesNoPrompt() throws {
+        try writeConnections([
+            makeConnection(name: "None", id: "c1", databasePasswordMode: 2)
+        ])
+
+        let connection = try importer.importConnections(includePasswords: false).envelope.connections[0]
+        #expect(connection.additionalFields?["promptForPassword"] == nil)
+    }
+
+    @Test("importConnections prompts for a Command Line password TablePro cannot run")
+    func testImportConnections_commandLineMode_setsPromptForPassword() throws {
+        try writeConnections([
+            makeConnection(name: "Command", id: "c1", databasePasswordMode: 3)
+        ])
+
+        let connection = try importer.importConnections(includePasswords: false).envelope.connections[0]
+        #expect(connection.additionalFields?["promptForPassword"] == "true")
+    }
+
+    @Test("importConnections keeps the local file path alongside the prompt flag")
+    func testImportConnections_promptMergesWithFilePathField() throws {
+        var entry = makeConnection(
+            name: "libSQL Ask",
+            driver: "LibSQL",
+            port: "",
+            database: "",
+            id: "c1",
+            databasePasswordMode: 1
+        )
+        entry["DatabasePath"] = "/Users/me/local.db"
+        try writeConnections([entry])
+
+        let connection = try importer.importConnections(includePasswords: false).envelope.connections[0]
+        #expect(connection.additionalFields?["libsqlFilePath"] == "/Users/me/local.db")
+        #expect(connection.additionalFields?["promptForPassword"] == "true")
+    }
+
+    @Test("importConnections keeps a DuckDB file path without an inert prompt")
+    func testImportConnections_duckDBAskEveryTime_keepsPathWithoutPrompt() throws {
+        var entry = makeConnection(
+            name: "DuckDB Ask",
+            driver: "DuckDB",
+            port: "",
+            database: "",
+            id: "c1",
+            databasePasswordMode: 1
+        )
+        entry["DatabasePath"] = "/Users/me/warehouse.duckdb"
+        try writeConnections([entry])
+
+        let connection = try importer.importConnections(includePasswords: false).envelope.connections[0]
+        #expect(connection.additionalFields?["duckdbFilePath"] == "/Users/me/warehouse.duckdb")
+        #expect(connection.additionalFields?["promptForPassword"] == nil)
+    }
+
+    @Test("importConnections skips the keychain for a database password TablePlus does not store")
+    func testImportConnections_nonKeychainDatabaseMode_skipsKeychainRead() throws {
+        try writeConnections([
+            makeConnection(name: "Ask", id: "conn-1", databasePasswordMode: 1)
+        ])
+        let spy = KeychainSpy()
+        spy.responses["conn-1_database"] = .found("stale")
+
+        var imp = importer
+        imp.readKeychain = spy.read
+
+        let result = try imp.importConnections(includePasswords: true)
+
+        #expect(spy.calls.contains { $0.account == "conn-1_database" } == false)
+        #expect(result.envelope.credentials?["0"]?.password == nil)
+    }
+
+    @Test("importConnections skips the SSH password but keeps the separately stored key passphrase")
+    func testImportConnections_nonKeychainServerMode_skipsSSHPasswordOnly() throws {
+        try writeConnections([
+            makeConnection(name: "Ask SSH", id: "conn-1", serverPasswordMode: 1)
+        ])
+        let spy = KeychainSpy()
+        spy.responses["conn-1_server"] = .found("stale")
+        spy.responses["conn-1_server_key"] = .found("passphrase")
+
+        var imp = importer
+        imp.readKeychain = spy.read
+
+        let result = try imp.importConnections(includePasswords: true)
+
+        #expect(Set(spy.calls.map(\.account)) == ["conn-1_database", "conn-1_server_key"])
+        #expect(result.envelope.credentials?["0"]?.sshPassword == nil)
+        #expect(result.envelope.credentials?["0"]?.keyPassphrase == "passphrase")
+    }
+
+    @Test("importConnections reads the keychain for a mode index TablePlus has not shipped yet")
+    func testImportConnections_unknownPasswordMode_readsKeychainWithoutPrompting() throws {
+        try writeConnections([
+            makeConnection(name: "Future", id: "conn-1", databasePasswordMode: 47)
+        ])
+        let spy = KeychainSpy()
+        spy.responses["conn-1_database"] = .found("s3cret")
+
+        var imp = importer
+        imp.readKeychain = spy.read
+
+        let result = try imp.importConnections(includePasswords: true)
+
+        #expect(spy.calls.contains { $0.account == "conn-1_database" })
+        #expect(result.envelope.credentials?["0"]?.password == "s3cret")
+        #expect(result.envelope.connections[0].additionalFields?["promptForPassword"] == nil)
+    }
+
+    @Test("importConnections leaves an inert prompt off a driver whose password field is plugin-owned")
+    func testImportConnections_pluginOwnedPasswordField_setsNoPrompt() throws {
+        try writeConnections([
+            makeConnection(name: "DynamoDB Ask", driver: "DynamoDB", id: "c1", databasePasswordMode: 1)
+        ])
+
+        let connection = try importer.importConnections(includePasswords: false).envelope.connections[0]
+        #expect(connection.additionalFields?["promptForPassword"] == nil)
+    }
+
+    @MainActor
+    @Test("importConnections keeps the prompt flag through analyze and into the connection")
+    func testImportConnections_promptFlagSurvivesTheImportPipeline() throws {
+        try writeConnections([
+            makeConnection(name: "Ask", id: "c1", databasePasswordMode: 1)
+        ])
+
+        let envelope = try importer.importConnections(includePasswords: false).envelope
+        let preview = ConnectionExportService.analyzeImport(
+            envelope,
+            existingConnections: [],
+            registeredTypeIds: ["MySQL"],
+            fileExists: { _ in true }
+        )
+        let connection = ConnectionExportService.buildDatabaseConnection(
+            id: UUID(),
+            from: preview.items[0].connection,
+            name: "Ask",
+            tagIdsByName: [:],
+            groupIdsByName: [:]
+        )
+
+        #expect(connection.promptForPassword)
     }
 }
 

--- a/docs/features/connection-sharing.mdx
+++ b/docs/features/connection-sharing.mdx
@@ -74,7 +74,7 @@ Choose **File > Import > Import from Other App…**, pick the source, then revie
 
 | App | Databases | Passwords | Notes |
 |-----|-----------|-----------|-------|
-| TablePlus | Every TablePlus engine except Vertica and Greenplum | From Keychain | SQLite and DuckDB connections bring their file path. Check the account ID of a Cloudflare D1 connection and the URL of a libSQL one in the connection form after importing |
+| TablePlus | Every TablePlus engine except Vertica and Greenplum | From Keychain, and the password mode with them | SQLite and DuckDB connections bring their file path. Check the account ID of a Cloudflare D1 connection and the URL of a libSQL one in the connection form after importing |
 | Sequel Ace | MySQL | From Keychain | |
 | DBeaver | MySQL, PostgreSQL, SQLite, SQL Server, Oracle, and more | Decrypted from config file | Read from the data folder, so every edition works |
 | DataGrip | MySQL, PostgreSQL, SQLite, SQL Server, Oracle, and more | From Keychain or `c.kdbx` | Reads recent projects with SSH and SSL settings. A master password blocks it |

--- a/docs/switching.mdx
+++ b/docs/switching.mdx
@@ -47,6 +47,8 @@ SSH tunnel and SSL settings come across with the connection. Which engines each 
 
 A DataGrip project protected by a master password cannot be read at all. Import those connections and set their passwords in TablePro.
 
+TablePlus's password dropdown comes across too. **Ask everytime** arrives as **Prompt for password**, and nothing is read from the Keychain for that connection. **Command Line** arrives the same way, since the command itself does not travel: type the password each connect, or set a [password source](/features/connection-sharing#password-sources) on the connection. The SSH pane has the same dropdown and TablePro has no prompt behind it, so a tunnel set to **Ask everytime** or **No password** imports blank. Fill it in before you connect.
+
 ## What does not come across
 
 | Not imported | What to do |


### PR DESCRIPTION
A user reported that importing from TablePlus "didn't work 100%. The **Prompt Password** setting was not transferred."

## Root cause

`TablePlusImporter.parseConnection` read the host, port, user, database, SSH and TLS keys out of TablePlus's `Connections.plist` and never looked at `DatabasePasswordMode` or `ServerPasswordMode`. A connection set to **Ask everytime** was therefore indistinguishable from one set to **Store in keychain**, so it imported as an ordinary saved-password connection.

Nothing downstream was involved. `sanitizedForImport()`, which strips `promptForPassword`, runs only on the JSON-file, deeplink and team-library routes; the foreign-app path builds its envelope in process and hands it straight to `analyzeImport`, so a key the importer sets reaches storage unchanged.

## What TablePlus actually stores

Both keys are `NSPopUpButton.indexOfSelectedItem`, with no `NSTag` on any item. Measured by decompiling every connection form in `/Applications/TablePlus.app` with a NIBArchive parser (16 password popups across 15 driver forms plus the SSH pane), and confirmed by disassembling the x86_64 slice, where the sibling `tLSMode` popup is stored and reloaded through `indexOfSelectedItem` / `selectItemAtIndex:`.

| Value | TablePlus |
|---|---|
| 0 | Store in keychain |
| 1 | Ask everytime |
| 2 | No password |
| 3 | Command Line (MySQL, MariaDB, PostgreSQL, Redshift) / Get from CLI (SQL Server) |

## The fix

`1` and `3` set `promptForPassword`. `3` prompts because TablePlus keeps the command nowhere TablePro can read it: no plist key, nothing in the connection model's field list, no keychain account. Prompting stores no secret and states the truth. `2` sets nothing, since the server wants no password and prompting for one costs an empty-field Return on every connect.

A mode other than **Store in keychain** also skips that connection's keychain read. This is required rather than cosmetic: `restoreCredentials` saves whatever the envelope carries, and `ConnectionStorage` then never reads a stored password back while `promptForPassword` is set, so the import would write a secret that nothing uses.

The flag is left off a driver whose password field is plugin-owned (`hidesBuiltInPassword`, or a field that hides it). `DatabaseManager.connectToSession` skips the prompt for those, so setting it there would make the connection look configured when nothing would ever ask.

`ServerPasswordMode` gates only the `_server` read. TablePlus keeps the private-key passphrase in a separate `privateKeyPassword` property under the `_server_key` account, so a connection can hold a passphrase with no stored SSH password; gating both would have dropped it.

## Also fixed, same function

**The TLS mode table was driver-blind.** `parseSSLConfig` mapped `tLSMode` with one fixed table for every engine, but each driver's form has its own popup. Nine distinct vocabularies, all measured from the nibs:

| Driver(s) | 0 | 1 | 2 | 3 | 4 | 5 |
|---|---|---|---|---|---|---|
| MySQL | PREFERRED | DISABLED | REQUIRED | VERIFY-CA | VERIFY-IDENTITY | |
| MariaDB | PREFERRED | ENFORCE | VERIFY-SERVER-CERT | | | |
| PostgreSQL, Cockroach, Greenplum, Redshift, Vertica | PREFERRED | DISABLED | REQUIRED | ALLOW | VERIFY-CA | VERIFY-FULL |
| Cassandra | NO SSL | SSL VERIFY NONE | SSL VERIFY PEER CERT | SSL VERIFY PEER IDENTITY | SSL VERIFY PEER IDENTITY DNS | |
| Redis | SSL_OFF | SSL_VERIFY_NONE | SSL_VERIFY_PEER | | | |
| ClickHouse | NO SSL | USE SSL | USE SSL (SKIP VALIDATE) | | | |
| Mongo | NO SSL | USE SSL | USE SSL (Allow Invalid Certificates) | | | |
| Elasticsearch | Disabled | System CA (Default) | Custom CA Certificate | Allow Invalid Certificates (Insecure) | | |
| Oracle | DISABLED | REQUIRED | | | | |

Every non-zero value was wrong, and VERIFY-IDENTITY on MySQL (index 4) fell into `default: return nil`, which `buildDatabaseConnection` turns into the default `SSLConfiguration()`. A user who asked for full certificate and hostname verification got a connection with TLS off. Where TablePro has no exact equivalent the mapping never weakens verification: PostgreSQL's ALLOW becomes Preferred, and a validating option becomes Verify Identity rather than Verify CA.

**`TlsKeyPaths` slots were read in the wrong order, and the layout is per driver too.** The three-chooser forms write `[key, cert, CA]`, so reading slot 0 as the CA swapped the CA path and the client key path. The chooser buttons, in nib order:

| Form | Slots |
|---|---|
| MySQL, MariaDB, PostgreSQL, Cockroach, Greenplum, Redshift, Vertica, Redis | `Key…`, `Cert…`, `CA Cert…` |
| Cassandra | `Private key…`, `Cert…`, `Trusted Cert…` |
| Mongo | `Certificate Key`, `Certificate Authority` |
| ClickHouse | `Trusted Cert…` |
| Elasticsearch | `CA Cert…` |
| Oracle | none |

Mongo matters beyond the swap: `MongoDBSSLMapping` sends `clientCertificatePath` as `tlsCertificateKeyFile`, so its two slots have to land on the certificate-key and CA fields rather than on the three-slot layout.

## Tested

- `verify.sh build` PASS
- `verify.sh test` 192 cases, 192 passed, across `TablePlusImporterTests`, the five sibling importer suites and `ConnectionSharingTests`
- `verify.sh lint` 0 violations
- `verify.sh docs` PASS

New coverage: every password mode including an index TablePlus has not shipped, the prompt merging with a local file-path field, the prompt left off a plugin-owned password field, the keychain skip for each mode with a spy asserting which accounts are queried, the passphrase surviving a non-stored `ServerPasswordMode`, every driver's TLS popup index, and each driver's TLS path slots including a CA-only Cassandra array. The old suite pinned the wrong TLS mapping (`1 → Required`, `2 → Verify CA`, `3 → Verify Identity`); those expectations were written from an assumption and are replaced by the measured ones.

No UI automation: the change is in the plist decode, and the import sheet's own flow is unchanged.

Reviewed by Codex (`review` and `adversarial-review`). Both passes found real defects in the first draft, all fixed here: the per-driver TLS path layout, the inert prompt on plugin-owned password fields, the `_server_key` over-gating, and Cassandra's three slots, which I had misread as two.

https://claude.ai/code/session_01RjQjjdG2fjSMoBc2Wc3hCJ
