### PR TITLE
fix(datagrid): open a foreign key reference in its own tab instead of taking over the one it was followed from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TablePlus import saving a password for a connection TablePlus was set never to store one for.
 - TablePlus import reading the CA certificate and client key paths the wrong way round.
 - MySQL and MariaDB reads of an object in another database answering about the current database's same-named one, including the foreign key picker's column list. (#2769)
+- Foreign key arrow replacing the tab you were reading. (#1421)
+- Applied filter left in the panel after cancelling the unsaved-changes alert on a foreign key jump.
 - Select All painting the whole column header row as selected, and leaving a cell cursor on the first cell.
 - Column header shown as selected after a cell drag reached the first and last row of the page.
 - No outline around a swept cell block whose rows reached both ends of the page.

--- a/TablePro/Core/Coordinators/FilterCoordinator.swift
+++ b/TablePro/Core/Coordinators/FilterCoordinator.swift
@@ -26,35 +26,63 @@ final class FilterCoordinator {
         let capturedLogicMode = logicMode
         parent.confirmDiscardChangesIfNeeded(action: .filter) { [weak self] confirmed in
             guard let self, confirmed else { return }
-            guard capturedTabIndex < parent.tabManager.tabs.count else { return }
-
-            if let capturedLogicMode {
-                parent.tabManager.mutate(at: capturedTabIndex) {
-                    $0.filterState.filterLogicMode = capturedLogicMode
-                    $0.filterState.isVisible = true
-                }
-            }
-            parent.tabManager.mutate(at: capturedTabIndex) { $0.pagination.reset() }
-
-            let tab = parent.tabManager.tabs[capturedTabIndex]
-            let queryColumns = parent.queryColumns(for: tab)
-            let newQuery = parent.queryBuilder.buildFilteredQuery(
-                tableName: capturedTableName,
-                schemaName: tab.tableContext.schemaName,
-                filters: capturedFilters,
-                logicMode: tab.filterState.filterLogicMode,
-                sortState: tab.sortState,
-                columns: queryColumns.columns,
-                columnTypes: queryColumns.columnTypes,
-                selectColumns: parent.selectColumns(for: tab),
-                limit: tab.pagination.pageSize,
-                offset: tab.pagination.currentOffset
+            commitFilters(
+                capturedFilters,
+                logicMode: capturedLogicMode,
+                tabIndex: capturedTabIndex,
+                tableName: capturedTableName
             )
-
-            parent.tabManager.mutate(at: capturedTabIndex) { $0.content.query = newQuery }
-            saveLastFilters(for: capturedTableName)
-            parent.runQuery()
         }
+    }
+
+    /// Writes the one predicate a reference jump carries and re-queries for it.
+    ///
+    /// The caller has already taken the discard guard, because it also records the view the tab is
+    /// leaving and both have to land on the same side of a refusal.
+    func commitReferenceFilter(_ filter: TableFilter) {
+        guard let (tab, tabIndex) = parent.tabManager.selectedTabAndIndex,
+              let tableName = tab.tableContext.tableName else { return }
+        setFKFilter(filter)
+        commitFilters([filter], logicMode: nil, tabIndex: tabIndex, tableName: tableName)
+    }
+
+    private func commitFilters(
+        _ filters: [TableFilter],
+        logicMode: FilterLogicMode?,
+        tabIndex: Int,
+        tableName: String
+    ) {
+        guard tabIndex < parent.tabManager.tabs.count else { return }
+
+        if let logicMode {
+            parent.tabManager.mutate(at: tabIndex) {
+                $0.filterState.filterLogicMode = logicMode
+                $0.filterState.isVisible = true
+            }
+        }
+        parent.tabManager.mutate(at: tabIndex) { $0.pagination.reset() }
+
+        let tab = parent.tabManager.tabs[tabIndex]
+        let queryColumns = parent.queryColumns(for: tab)
+        let newQuery = parent.queryBuilder.buildFilteredQuery(
+            tableName: tableName,
+            schemaName: tab.tableContext.schemaName,
+            filters: filters,
+            logicMode: tab.filterState.filterLogicMode,
+            sortState: tab.sortState,
+            columns: queryColumns.columns,
+            columnTypes: queryColumns.columnTypes,
+            selectColumns: parent.selectColumns(for: tab),
+            limit: tab.pagination.pageSize,
+            offset: tab.pagination.currentOffset
+        )
+
+        parent.tabManager.mutate(at: tabIndex) {
+            $0.content.query = newQuery
+            $0.filterState.executedFilters = filters
+        }
+        saveLastFilters(for: tableName)
+        parent.runQuery()
     }
 
     func clearFiltersAndReload() {
@@ -81,7 +109,10 @@ final class FilterCoordinator {
                 offset: tab.pagination.currentOffset
             )
 
-            parent.tabManager.mutate(at: capturedTabIndex) { $0.content.query = newQuery }
+            parent.tabManager.mutate(at: capturedTabIndex) {
+                $0.content.query = newQuery
+                $0.filterState.executedFilters = []
+            }
             clearLastFilters(for: capturedTableName)
             parent.runQuery()
         }
@@ -216,7 +247,11 @@ final class FilterCoordinator {
             )
         }
 
-        parent.tabManager.mutate(at: tabIndex) { $0.content.query = newQuery }
+        let executed = hasFilters ? tab.filterState.appliedFilters : []
+        parent.tabManager.mutate(at: tabIndex) {
+            $0.content.query = newQuery
+            $0.filterState.executedFilters = executed
+        }
     }
 
     // MARK: - Filter State

--- a/TablePro/Models/Database/TableFilter.swift
+++ b/TablePro/Models/Database/TableFilter.swift
@@ -261,6 +261,15 @@ struct TabFilterState: Equatable, Hashable, Codable {
     var keyPattern: String
     var keyTypeScope: String?
 
+    /// The filters the rows on screen were actually fetched with.
+    ///
+    /// `filters` is the panel's editable draft, and `appliedFilters` resolves from it, so both
+    /// describe a query that has not run the moment a reader types into a filter row without
+    /// pressing Apply. Anything asking what a tab is *showing*, rather than what its panel says,
+    /// has to read this. It is written wherever a query is built from the filters and is
+    /// deliberately not persisted: a restored tab rebuilds its query on first load, which fills it.
+    var executedFilters: [TableFilter] = []
+
     init(isVisible: Bool = false) {
         self.filters = []
         self.commit = nil

--- a/TablePro/Models/Query/ReferenceNavigationPlan.swift
+++ b/TablePro/Models/Query/ReferenceNavigationPlan.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// What the reader asked for when they followed a foreign key.
+///
+/// A Bool cannot say this. The decision has three destinations, not two, and `false` meaning
+/// "take over the tab I am looking at" read backwards at every call site.
+internal enum ReferenceOpenIntent: Equatable, Sendable {
+    /// The ordinary gesture: a click on the cell's arrow, the row inspector's link, the preview
+    /// popover's button, the menu's plain item.
+    case follow
+    /// Command-click, and the menu item that spells it out. Always its own tab, even when one is
+    /// already open on the same reference.
+    case newTab
+}
+
+/// The one thing a reference jump does with the window's tabs.
+///
+/// No outcome re-points the selected tab at a different table. A reference can only be followed
+/// from a grid, so the tab it is followed from is always one the reader is reading, and retargeting
+/// it left them nowhere to go back to, which is the whole defect. Re-filtering a tab that is
+/// already on the referenced table is not that: it stays in the table they are in, and Back undoes
+/// it.
+internal enum ReferenceNavigationPlan: Equatable, Sendable {
+    /// The selected tab is already on the referenced table, so only its filter changes.
+    case refilterSelectedTab
+    /// Another tab is already showing exactly this reference; bring it forward rather than
+    /// building a second one beside it.
+    case revealExistingTab
+    /// A tab of its own, leaving whatever the reader was looking at where it was.
+    case openNewTab
+}
+
+/// What the window looks like from the jump's point of view.
+internal struct ReferenceNavigationContext: Equatable, Sendable {
+    let intent: ReferenceOpenIntent
+    /// The selected tab is browsing the referenced table already, whatever it is filtered to.
+    let selectedTabShowsTarget: Bool
+    /// Re-filtering that tab in place is safe. Staged structure edits say it is not: the discard
+    /// alert clears cell changes and nothing else, so re-querying under them would promise
+    /// something this path cannot keep.
+    let selectedTabAcceptsRefilter: Bool
+    /// Some tab, in this window or a sibling on the same connection, is already showing exactly
+    /// this reference.
+    let anotherTabShowsReference: Bool
+}
+
+/// Resolves a reference jump to exactly one outcome.
+///
+/// Pure, so the choice can be tested without a window, a coordinator or a tab manager. It used to
+/// be an open-coded chain of guards inside `navigateToFKReference`, which is how it came to take
+/// over a tab that every other way of opening a table would have left alone.
+internal enum ReferenceNavigationPlanner {
+    static func plan(for context: ReferenceNavigationContext) -> ReferenceNavigationPlan {
+        guard context.intent == .follow else { return .openNewTab }
+
+        if context.selectedTabShowsTarget, context.selectedTabAcceptsRefilter {
+            return .refilterSelectedTab
+        }
+        /// Landing on the tab that already answers the question beats building a second one beside
+        /// it, which is also the order `openTableTab` takes with `activateIfAlreadyOpen`.
+        if context.anotherTabShowsReference { return .revealExistingTab }
+        return .openNewTab
+    }
+}

--- a/TablePro/Views/Main/Child/DataTabGridDelegate.swift
+++ b/TablePro/Views/Main/Child/DataTabGridDelegate.swift
@@ -92,8 +92,8 @@ final class DataTabGridDelegate: DataGridViewDelegate {
         coordinator?.canClearActiveQueryResults ?? false
     }
 
-    func dataGridNavigateFK(value: String, fkInfo: ForeignKeyInfo, openInNewTab: Bool) {
-        coordinator?.navigateToFKReference(value: value, fkInfo: fkInfo, openInNewTab: openInNewTab)
+    func dataGridNavigateFK(value: String, fkInfo: ForeignKeyInfo, intent: ReferenceOpenIntent) {
+        coordinator?.navigateToFKReference(value: value, fkInfo: fkInfo, intent: intent)
     }
 
     /// The panel reads the selection, not a row this is told about.

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+FKNavigation.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+FKNavigation.swift
@@ -27,18 +27,23 @@ extension MainContentCoordinator {
                 referencedColumn: reference.referencedColumn,
                 referencedSchema: reference.referencedSchema
             ),
-            openInNewTab: false
+            intent: .follow
         )
     }
 
     /// Navigate to the referenced table filtered by the FK value.
-    /// Reuses the current tab when it holds nothing the user authored, and otherwise opens the
-    /// reference in its own tab so the originating query or edits survive.
-    func navigateToFKReference(value: String, fkInfo: ForeignKeyInfo, openInNewTab: Bool) {
+    ///
+    /// The choice is `ReferenceNavigationPlanner`'s, so it can be read and tested in one place. It
+    /// never re-points the selected tab at a different table. A tab already on the referenced table
+    /// is re-filtered, which is a move within the table the reader is in and which Back undoes.
+    /// Retargeting used to be guarded by a predicate of its own, which knew about unsaved edits but
+    /// not about applied filters, a sort or pinned results, so the arrow in a cell took over a tab
+    /// the sidebar would have left alone and the reader lost the rows they were reading.
+    func navigateToFKReference(value: String, fkInfo: ForeignKeyInfo, intent: ReferenceOpenIntent) {
         let referencedTable = fkInfo.referencedTable
         let referencedColumn = fkInfo.referencedColumn
 
-        fkNavigationLogger.debug("FK navigate: \(referencedTable).\(referencedColumn) = \(value) newTab=\(openInNewTab)")
+        fkNavigationLogger.debug("FK navigate: \(referencedTable).\(referencedColumn) = \(value) intent=\(String(describing: intent))")
 
         let filter = TableFilter(
             columnName: referencedColumn,
@@ -62,47 +67,73 @@ extension MainContentCoordinator {
         let targetDatabase = target.database
         let targetSchema = target.schema
 
-        if !openInNewTab,
-           let current = tabManager.selectedTab,
-           matchesFKTarget(current, table: referencedTable, database: targetDatabase, schema: targetSchema) {
-            /// Re-filtering the tab in place is a jump like any other, so it goes on the history.
-            /// Clicking the reference the tab is already showing is not, and recording it would
-            /// stack identical entries a reader has to press Back through.
-            let departing = showsOnlyFKPredicate(current, filter: filter) ? nil : captureNavigationEntry()
-            applyFKFilter(filter, for: referencedTable)
-            commitNavigationEntry(departing)
-            return
-        }
+        let selectedTab = tabManager.selectedTab
+        let showsTarget = selectedTab.map {
+            matchesFKTarget($0, table: referencedTable, database: targetDatabase, schema: targetSchema)
+        } ?? false
+        let existing = intent == .follow ? openFKTargetTab(
+            table: referencedTable,
+            database: targetDatabase,
+            schema: targetSchema,
+            filter: filter
+        ) : nil
 
-        guard openInNewTab || selectedTabHoldsProtectedContent else {
-            replaceSelectedTabWithFKTarget(
-                referencedTable: referencedTable,
+        let plan = ReferenceNavigationPlanner.plan(
+            for: ReferenceNavigationContext(
+                intent: intent,
+                selectedTabShowsTarget: showsTarget,
+                /// The discard alert clears staged cell edits and nothing else, so re-querying
+                /// under a staged structure edit would promise something this path cannot keep.
+                /// Back and Forward stand down on the same tab for the same reason.
+                selectedTabAcceptsRefilter: selectedTab.map { !hasStagedStructureEdits(in: $0) } ?? false,
+                anotherTabShowsReference: existing != nil
+            )
+        )
+
+        /// Both jumps that leave the tab keep it. The reader navigated away from it rather than
+        /// clicking past it, so the next sidebar click must not retarget it; `openTableTab` promotes
+        /// before it hands off for the same reason. Re-filtering stays on the tab, so it does not.
+        switch plan {
+        case .refilterSelectedTab:
+            refilterSelectedTab(with: filter, showsReferenceAlready: selectedTab.map {
+                showsOnlyFKPredicate($0, filter: filter)
+            } ?? false)
+        case .revealExistingTab:
+            promotePreviewTab()
+            guard let existing, hostedTabRouting.reveal(existing.coordinator, existing.tabId) else {
+                openReferenceInNewTab(
+                    filter: filter,
+                    referencedTable: referencedTable,
+                    databaseName: targetDatabase,
+                    schemaName: targetSchema
+                )
+                return
+            }
+        case .openNewTab:
+            promotePreviewTab()
+            openReferenceInNewTab(
                 filter: filter,
+                referencedTable: referencedTable,
                 databaseName: targetDatabase,
                 schemaName: targetSchema
             )
-            return
         }
+    }
 
-        if !openInNewTab,
-           let existing = openFKTargetTab(
-               table: referencedTable,
-               database: targetDatabase,
-               schema: targetSchema,
-               filter: filter
-           ) {
-            existing.coordinator.selectTabAndFocusWindow(existing.tabId)
-            return
-        }
-
-        promotePreviewTab()
-        let payload = makeFKReferencePayload(
-            filter: filter,
-            referencedTable: referencedTable,
-            databaseName: targetDatabase,
-            schemaName: targetSchema
+    private func openReferenceInNewTab(
+        filter: TableFilter,
+        referencedTable: String,
+        databaseName: String,
+        schemaName: String?
+    ) {
+        openTabInNewWindow(
+            makeFKReferencePayload(
+                filter: filter,
+                referencedTable: referencedTable,
+                databaseName: databaseName,
+                schemaName: schemaName
+            )
         )
-        openTabInNewWindow(payload)
     }
 
     func makeFKReferencePayload(
@@ -172,8 +203,13 @@ extension MainContentCoordinator {
 
     /// Whether this tab is already showing exactly this reference and nothing else. One definition,
     /// because the reuse search and the history both have to agree on what "already here" means.
+    ///
+    /// Asked of what the rows were fetched with, never of `appliedFilters`, which resolves from the
+    /// panel's editable draft. Typing `id = 42` into a tab showing `id = 7` and not pressing Apply
+    /// made that tab answer yes, and revealing it runs no query, so the reader landed on the rows
+    /// for 7 while the app reported it had found the reference.
     private func showsOnlyFKPredicate(_ tab: QueryTab, filter: TableFilter) -> Bool {
-        let applied = tab.filterState.appliedFilters
+        let applied = tab.filterState.executedFilters
         guard applied.count == 1 else { return false }
         return isSameFKPredicate(applied[0], filter)
     }
@@ -195,61 +231,31 @@ extension MainContentCoordinator {
             return (self, match.id)
         }
 
-        for sibling in MainContentCoordinator.allActiveCoordinators()
-            where sibling !== self && sibling.connectionId == connectionId {
+        /// Hosted coordinators, not `allActiveCoordinators()`, which is a registry of every
+        /// coordinator SwiftUI has built and can hold one whose window is gone. A reveal has to
+        /// land somewhere the reader can see.
+        for sibling in hostedTabRouting.coordinators(connectionId) where sibling !== self {
             guard let match = sibling.tabManager.tabs.first(where: matches) else { continue }
             return (sibling, match.id)
         }
         return nil
     }
 
-    private func replaceSelectedTabWithFKTarget(
-        referencedTable: String,
-        filter: TableFilter,
-        databaseName: String,
-        schemaName: String?
-    ) {
-        let departing = captureNavigationEntry()
-        if let outgoingTable = tabManager.selectedTab?.tableContext.tableName {
-            saveLastFilters(for: outgoingTable)
+    /// Re-points the tab the reader is already on at another row of the same table.
+    ///
+    /// Everything happens inside one discard guard. The pair this replaced ran `applyFilters`,
+    /// which defers behind the alert, beside `setFKFilter`, which does not, so refusing the alert
+    /// left the panel showing an applied filter the grid was never re-queried for and pushed a
+    /// history entry for a jump that never happened, dropping the forward stack with it.
+    private func refilterSelectedTab(with filter: TableFilter, showsReferenceAlready: Bool) {
+        /// Re-filtering the tab in place is a jump like any other, so it goes on the history.
+        /// Clicking the reference the tab is already showing is not, and recording it would stack
+        /// identical entries a reader has to press Back through.
+        let departing = showsReferenceAlready ? nil : captureNavigationEntry()
+        confirmDiscardChangesIfNeeded(action: .filter) { [weak self] confirmed in
+            guard let self, confirmed else { return }
+            filterCoordinator.commitReferenceFilter(filter)
+            commitNavigationEntry(departing)
         }
-
-        let replaced: Bool
-        do {
-            replaced = try tabManager.replaceTabContent(
-                tableName: referencedTable,
-                databaseType: connection.type,
-                isView: false,
-                databaseName: databaseName,
-                schemaName: schemaName
-            )
-        } catch {
-            fkNavigationLogger.error("navigateToFKReference replaceTabContent failed: \(error.localizedDescription, privacy: .public)")
-            return
-        }
-
-        commitNavigationEntry(departing)
-        guard replaced, let (replacedTab, tabIndex) = tabManager.selectedTabAndIndex else {
-            applyFKFilter(filter, for: referencedTable)
-            return
-        }
-
-        /// The load goes through the first-load path like every other retarget, because the new
-        /// table has no rows to type the filter value from and that path waits for its schema.
-        cancelTableLoad(for: replacedTab.id)
-        discardRowsForRetarget()
-        restoreLastHiddenColumnsForTable()
-        updateFilterState(filter, for: referencedTable)
-        rebuildTableQuery(at: tabIndex)
-        lazyLoadCurrentTabIfNeeded()
-    }
-
-    private func applyFKFilter(_ filter: TableFilter, for tableName: String) {
-        applyFilters([filter])
-        updateFilterState(filter, for: tableName)
-    }
-
-    private func updateFilterState(_ filter: TableFilter, for tableName: String) {
-        setFKFilter(filter)
     }
 }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+FilterState.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+FilterState.swift
@@ -24,10 +24,6 @@ extension MainContentCoordinator {
         filterCoordinator.addFilterForColumn(columnName)
     }
 
-    func setFKFilter(_ filter: TableFilter) {
-        filterCoordinator.setFKFilter(filter)
-    }
-
     func duplicateFilter(_ filter: TableFilter) {
         filterCoordinator.duplicateFilter(filter)
     }

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Navigation.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Navigation.swift
@@ -395,6 +395,10 @@ extension MainContentCoordinator {
         return false
     }
 
+    /// Whether browsing the object list may take the selected tab over.
+    ///
+    /// Only browsing asks. Following a foreign key never takes a tab over, because a reference can
+    /// only be followed from a grid and the row the reader clicked is in that grid.
     var isActiveTabReusable: Bool {
         guard let tab = tabManager.selectedTab else { return false }
         if selectedTabHoldsProtectedContent { return false }

--- a/TablePro/Views/Main/HostedTabRouting.swift
+++ b/TablePro/Views/Main/HostedTabRouting.swift
@@ -1,0 +1,42 @@
+import AppKit
+import Foundation
+
+/// How a tab that belongs to another window is found and put in front of the reader.
+///
+/// Both questions go through the window layer, which is the record of what is actually on screen.
+/// `MainContentCoordinator.allActiveCoordinators()` is a registry of every coordinator SwiftUI has
+/// built and can hold one whose window is gone, so a reveal resolved through it can select a tab
+/// nobody can see. Held as one injected value because a unit test has no windows.
+@MainActor
+internal struct HostedTabRouting {
+    /// The coordinators for a connection that a window actually hosts.
+    internal var coordinators: (UUID) -> [MainContentCoordinator]
+
+    /// Brings one of those coordinators' tabs forward, its connection workspace with it.
+    ///
+    /// One window hosts several connections, so raising it is not enough: the connection the tab
+    /// belongs to has to be the one that window is showing, or the reader is handed a window
+    /// displaying a different connection's tabs.
+    ///
+    /// - Returns: whether the tab was made visible. False is the caller's cue to open the content
+    ///   itself rather than leave the click doing nothing.
+    internal var reveal: (MainContentCoordinator, UUID) -> Bool
+
+    internal static let live = HostedTabRouting(
+        coordinators: { WindowManager.shared.coordinators(for: $0) },
+        reveal: { coordinator, tabId in
+            /// This coordinator's own window, not `WindowManager.window(for:)`. Detaching a tab
+            /// leaves one connection hosted by several windows, and that lookup names an arbitrary
+            /// one of them, so raising it can leave the tab the reader asked for off screen while
+            /// reporting success.
+            guard let windowId = coordinator.windowId,
+                  let window = WindowLifecycleMonitor.shared.window(for: windowId),
+                  let host = window.contentViewController as? MainSplitViewController,
+                  host.workspaces.contains(coordinator.connectionId) else { return false }
+            host.selectHostedConnection(coordinator.connectionId)
+            coordinator.tabManager.selectedTabId = tabId
+            window.makeKeyAndOrderFront(nil)
+            return true
+        }
+    )
+}

--- a/TablePro/Views/Main/MainContentCoordinator.swift
+++ b/TablePro/Views/Main/MainContentCoordinator.swift
@@ -298,6 +298,8 @@ final class MainContentCoordinator {
         ConnectionStorage.shared.loadConnections().contains { $0.id == id }
     }
 
+    @ObservationIgnored var hostedTabRouting = HostedTabRouting.live
+
     /// Routing failures report through here so a test can observe the message instead of raising a
     /// real alert. `AlertHelper.present` runs application-modal when no window qualifies, and a
     /// unit test host has no window, so calling it directly parks the main thread in a modal loop

--- a/TablePro/Views/Results/Cells/DataGridCellAccessoryDelegate.swift
+++ b/TablePro/Views/Results/Cells/DataGridCellAccessoryDelegate.swift
@@ -7,7 +7,7 @@ import Foundation
 
 @MainActor
 protocol DataGridCellAccessoryDelegate: AnyObject {
-    func dataGridCellDidClickFKArrow(row: Int, columnIndex: Int, openInNewTab: Bool)
+    func dataGridCellDidClickFKArrow(row: Int, columnIndex: Int, intent: ReferenceOpenIntent)
     func dataGridCellDidClickChevron(row: Int, columnIndex: Int)
     func dataGridCellDidDoubleClick(row: Int, columnIndex: Int)
 }

--- a/TablePro/Views/Results/DataGridCoordinator.swift
+++ b/TablePro/Views/Results/DataGridCoordinator.swift
@@ -1437,8 +1437,8 @@ final class TableViewCoordinator: NSObject, NSTableViewDelegate, NSTableViewData
 // MARK: - DataGridCellAccessoryDelegate
 
 extension TableViewCoordinator: DataGridCellAccessoryDelegate {
-    func dataGridCellDidClickFKArrow(row: Int, columnIndex: Int, openInNewTab: Bool) {
-        handleFKArrowAction(row: row, columnIndex: columnIndex, openInNewTab: openInNewTab)
+    func dataGridCellDidClickFKArrow(row: Int, columnIndex: Int, intent: ReferenceOpenIntent) {
+        handleFKArrowAction(row: row, columnIndex: columnIndex, intent: intent)
     }
 
     func dataGridCellDidClickChevron(row: Int, columnIndex: Int) {

--- a/TablePro/Views/Results/DataGridRowView.swift
+++ b/TablePro/Views/Results/DataGridRowView.swift
@@ -134,7 +134,7 @@ class DataGridRowView: NSTableRowView {
             coordinator.dataGridCellDidClickFKArrow(
                 row: rowIndex,
                 columnIndex: dataColumn,
-                openInNewTab: modifiers.contains(.command)
+                intent: modifiers.contains(.command) ? .newTab : .follow
             )
             return true
         case .chevron where !visualState.isDeleted:
@@ -790,14 +790,14 @@ class DataGridRowView: NSTableRowView {
     }
 
     @objc private func navigateToForeignKey(_ sender: NSMenuItem) {
-        performForeignKeyNavigation(from: sender, openInNewTab: false)
+        performForeignKeyNavigation(from: sender, intent: .follow)
     }
 
     @objc private func navigateToForeignKeyInNewTab(_ sender: NSMenuItem) {
-        performForeignKeyNavigation(from: sender, openInNewTab: true)
+        performForeignKeyNavigation(from: sender, intent: .newTab)
     }
 
-    private func performForeignKeyNavigation(from sender: NSMenuItem, openInNewTab: Bool) {
+    private func performForeignKeyNavigation(from sender: NSMenuItem, intent: ReferenceOpenIntent) {
         guard let columnIndex = sender.representedObject as? Int,
               let coordinator else { return }
         let tableRows = coordinator.tableRowsProvider()
@@ -805,7 +805,7 @@ class DataGridRowView: NSTableRowView {
         let columnName = tableRows.columns[columnIndex]
         guard let fkInfo = tableRows.columnForeignKeys[columnName],
               let value = coordinator.cellValue(at: rowIndex, column: columnIndex) else { return }
-        coordinator.delegate?.dataGridNavigateFK(value: value, fkInfo: fkInfo, openInNewTab: openInNewTab)
+        coordinator.delegate?.dataGridNavigateFK(value: value, fkInfo: fkInfo, intent: intent)
     }
 }
 

--- a/TablePro/Views/Results/DataGridViewDelegate.swift
+++ b/TablePro/Views/Results/DataGridViewDelegate.swift
@@ -21,7 +21,7 @@ protocol DataGridViewDelegate: AnyObject {
     func dataGridSortStateChanged(_ state: SortState)
     func dataGridConfirmDisplayOrderChange(then apply: @escaping () -> Void)
     func dataGridFilterColumn(_ columnName: String)
-    func dataGridNavigateFK(value: String, fkInfo: ForeignKeyInfo, openInNewTab: Bool)
+    func dataGridNavigateFK(value: String, fkInfo: ForeignKeyInfo, intent: ReferenceOpenIntent)
     func dataGridShowRowAsJSON()
     func dataGridDuplicateRow()
     func dataGridExportResults()
@@ -67,7 +67,7 @@ extension DataGridViewDelegate {
     func dataGridSortStateChanged(_ state: SortState) {}
     func dataGridConfirmDisplayOrderChange(then apply: @escaping () -> Void) { apply() }
     func dataGridFilterColumn(_ columnName: String) {}
-    func dataGridNavigateFK(value: String, fkInfo: ForeignKeyInfo, openInNewTab: Bool) {}
+    func dataGridNavigateFK(value: String, fkInfo: ForeignKeyInfo, intent: ReferenceOpenIntent) {}
     func dataGridShowRowAsJSON() {}
     func dataGridDuplicateRow() {}
     func dataGridExportResults() {}

--- a/TablePro/Views/Results/Extensions/DataGridView+Click.swift
+++ b/TablePro/Views/Results/Extensions/DataGridView+Click.swift
@@ -136,7 +136,7 @@ extension TableViewCoordinator {
 
     // MARK: - FK Navigation
 
-    func handleFKArrowAction(row: Int, columnIndex: Int, openInNewTab: Bool) {
+    func handleFKArrowAction(row: Int, columnIndex: Int, intent: ReferenceOpenIntent) {
         let tableRows = tableRowsProvider()
         guard row >= 0 && row < cachedRowCount,
               columnIndex >= 0 && columnIndex < tableRows.columns.count else { return }
@@ -147,7 +147,7 @@ extension TableViewCoordinator {
         let value = cellValue(at: row, column: columnIndex)
         guard let value = value, !value.isEmpty else { return }
 
-        delegate?.dataGridNavigateFK(value: value, fkInfo: fkInfo, openInNewTab: openInNewTab)
+        delegate?.dataGridNavigateFK(value: value, fkInfo: fkInfo, intent: intent)
     }
 
     // MARK: - Type Picker Popover

--- a/TablePro/Views/Results/Extensions/DataGridView+Popovers.swift
+++ b/TablePro/Views/Results/Extensions/DataGridView+Popovers.swift
@@ -56,7 +56,7 @@ extension TableViewCoordinator {
                 onNavigate: { [weak self, model] in
                     dismiss()
                     guard let value = model.cellValue else { return }
-                    self?.delegate?.dataGridNavigateFK(value: value, fkInfo: model.fkInfo, openInNewTab: false)
+                    self?.delegate?.dataGridNavigateFK(value: value, fkInfo: model.fkInfo, intent: .follow)
                 },
                 onDismiss: dismiss
             )

--- a/TableProTests/Models/Query/ReferenceNavigationPlannerTests.swift
+++ b/TableProTests/Models/Query/ReferenceNavigationPlannerTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Testing
+
+@testable import TablePro
+
+struct ReferenceNavigationPlannerTests {
+    private func context(
+        intent: ReferenceOpenIntent = .follow,
+        showsTarget: Bool = false,
+        acceptsRefilter: Bool = true,
+        anotherTab: Bool = false
+    ) -> ReferenceNavigationContext {
+        ReferenceNavigationContext(
+            intent: intent,
+            selectedTabShowsTarget: showsTarget,
+            selectedTabAcceptsRefilter: acceptsRefilter,
+            anotherTabShowsReference: anotherTab
+        )
+    }
+
+    @Test("A table tab the reader is in keeps its place, and the reference gets its own tab")
+    func followFromATableTabOpensItsOwnTab() {
+        #expect(ReferenceNavigationPlanner.plan(for: context()) == .openNewTab)
+    }
+
+    @Test("The tab already on the referenced table is re-filtered rather than duplicated")
+    func followOnTheTargetTableRefiltersInPlace() {
+        #expect(ReferenceNavigationPlanner.plan(for: context(showsTarget: true)) == .refilterSelectedTab)
+    }
+
+    /// The discard alert clears staged cell edits and nothing else, so a re-query under a staged
+    /// structure edit would promise something the path cannot keep. Back and Forward stand down on
+    /// the same tab for the same reason.
+    @Test("A staged structure edit sends the reference to its own tab instead of re-filtering")
+    func stagedStructureEditsRefuseTheRefilter() {
+        let plan = ReferenceNavigationPlanner.plan(
+            for: context(showsTarget: true, acceptsRefilter: false)
+        )
+        #expect(plan == .openNewTab)
+    }
+
+    @Test("A tab already showing this reference is brought forward rather than built again")
+    func followRevealsTheTabAlreadyShowingTheReference() {
+        #expect(ReferenceNavigationPlanner.plan(for: context(anotherTab: true)) == .revealExistingTab)
+    }
+
+    @Test("Re-filtering the tab the reader is on wins over revealing another")
+    func refilterBeatsReveal() {
+        let plan = ReferenceNavigationPlanner.plan(for: context(showsTarget: true, anotherTab: true))
+        #expect(plan == .refilterSelectedTab)
+    }
+
+    @Test("Command-click always takes a tab of its own")
+    func newTabIgnoresEveryOtherOutcome() {
+        for showsTarget in [true, false] {
+            for anotherTab in [true, false] {
+                let plan = ReferenceNavigationPlanner.plan(
+                    for: context(intent: .newTab, showsTarget: showsTarget, anotherTab: anotherTab)
+                )
+                #expect(plan == .openNewTab)
+            }
+        }
+    }
+}

--- a/TableProTests/Views/Main/FKNavigationTests.swift
+++ b/TableProTests/Views/Main/FKNavigationTests.swift
@@ -36,9 +36,9 @@ struct FKNavigationTests {
         #expect(payload.initialFilterState?.isVisible == true)
     }
 
-    @Test("Plain click navigates the referenced table into the current tab")
+    @Test("Plain click opens the reference in its own tab and leaves the table tab it came from")
     @MainActor
-    func plainClickReplacesCurrentTab() throws {
+    func plainClickKeepsTheTableTabItCameFrom() throws {
         let connection = TestFixtures.makeConnection(database: "db_a")
         let tabManager = QueryTabManager()
         let coordinator = MainContentCoordinator(
@@ -55,12 +55,21 @@ struct FKNavigationTests {
             databaseName: coordinator.browseDatabaseName
         )
         #expect(tabManager.tabs.count == 1)
+        let sourceTabId = tabManager.selectedTab?.id
+
+        var opened: [EditorTabPayload] = []
+        coordinator.openTabInNewWindow = { opened.append($0) }
 
         let fkInfo = TestFixtures.makeForeignKeyInfo(referencedTable: "users", referencedColumn: "id")
-        coordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, openInNewTab: false)
+        coordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, intent: .follow)
 
         #expect(tabManager.tabs.count == 1)
-        #expect(tabManager.selectedTab?.tableContext.tableName == "users")
+        #expect(tabManager.selectedTab?.id == sourceTabId)
+        #expect(tabManager.selectedTab?.tableContext.tableName == "orders")
+        #expect(opened.count == 1)
+        #expect(opened.first?.tableName == "users")
+        #expect(opened.first?.forcesNewTab == true)
+        #expect(opened.first?.initialFilterState?.appliedFilters.first?.value == "42")
     }
 
     @Test("Plain click on the already-open referenced table does not open a second tab")
@@ -85,7 +94,7 @@ struct FKNavigationTests {
         #expect(tabManager.tabs.count == 1)
 
         let fkInfo = TestFixtures.makeForeignKeyInfo(referencedTable: "users", referencedColumn: "id")
-        coordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, openInNewTab: false)
+        coordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, intent: .follow)
 
         #expect(tabManager.tabs.count == 1)
         #expect(tabManager.selectedTab?.id == tabId)
@@ -95,9 +104,9 @@ struct FKNavigationTests {
     /// The target table has no rows yet, so the only thing that can type the value is its schema.
     /// Built from the empty buffer instead, `0123` went to a text key as the number `0123`, which
     /// MySQL compares numerically and PostgreSQL rejects outright.
-    @Test("An in-place hop types the reference value from the target table's columns")
+    @Test("A hop within the same table types the reference value from that table's columns")
     @MainActor
-    func inPlaceHopTypesTheValueFromTheTargetSchema() throws {
+    func sameTableHopTypesTheValueFromTheSchema() throws {
         let connection = TestFixtures.makeConnection(database: "db_a")
         let tabManager = QueryTabManager()
         let coordinator = MainContentCoordinator(
@@ -119,14 +128,15 @@ struct FKNavigationTests {
                 primaryKeys: ["id"],
                 columnTypes: ["id": .integer(rawType: "INT"), "code": .text(rawType: "VARCHAR(20)")]
             ),
-            for: coordinator.schemaColumnsKey("users", scope: coordinator.selectedTabScope)
+            for: coordinator.schemaColumnsKey("orders", scope: coordinator.selectedTabScope)
         )
 
-        let fkInfo = TestFixtures.makeForeignKeyInfo(referencedTable: "users", referencedColumn: "code")
-        coordinator.navigateToFKReference(value: "0123", fkInfo: fkInfo, openInNewTab: false)
+        let fkInfo = TestFixtures.makeForeignKeyInfo(referencedTable: "orders", referencedColumn: "code")
+        coordinator.navigateToFKReference(value: "0123", fkInfo: fkInfo, intent: .follow)
 
         let query = try #require(tabManager.selectedTab?.content.query)
-        #expect(tabManager.selectedTab?.tableContext.tableName == "users")
+        #expect(tabManager.tabs.count == 1)
+        #expect(tabManager.selectedTab?.tableContext.tableName == "orders")
         #expect(query.contains("'0123'"))
         #expect(!query.contains("= 0123"))
     }
@@ -155,11 +165,14 @@ struct FKNavigationTests {
             databaseName: coordinator.browseDatabaseName
         )
 
-        let fkInfo = TestFixtures.makeForeignKeyInfo(referencedTable: "users", referencedColumn: "id")
-        coordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, openInNewTab: false)
+        var opened: [EditorTabPayload] = []
+        coordinator.openTabInNewWindow = { opened.append($0) }
 
-        #expect(tabManager.selectedTab?.tableContext.tableName == "users")
-        #expect(tabManager.selectedTab?.tableContext.schemaName == "sales")
+        let fkInfo = TestFixtures.makeForeignKeyInfo(referencedTable: "users", referencedColumn: "id")
+        coordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, intent: .follow)
+
+        #expect(opened.first?.tableName == "users")
+        #expect(opened.first?.schemaName == "sales")
     }
 
     @Test("Plain click from an executed query tab opens a new tab and leaves the query tab intact")
@@ -183,7 +196,7 @@ struct FKNavigationTests {
         coordinator.openTabInNewWindow = { opened.append($0) }
 
         let fkInfo = TestFixtures.makeForeignKeyInfo(referencedTable: "users", referencedColumn: "id")
-        coordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, openInNewTab: false)
+        coordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, intent: .follow)
 
         #expect(tabManager.tabs.count == 1)
         #expect(tabManager.selectedTab?.id == originalTabId)
@@ -215,7 +228,7 @@ struct FKNavigationTests {
         coordinator.openTabInNewWindow = { opened.append($0) }
 
         let fkInfo = TestFixtures.makeForeignKeyInfo(referencedTable: "users", referencedColumn: "id")
-        coordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, openInNewTab: false)
+        coordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, intent: .follow)
 
         #expect(tabManager.tabs.count == 1)
         #expect(tabManager.selectedTab?.id == originalTabId)
@@ -248,7 +261,7 @@ struct FKNavigationTests {
         coordinator.openTabInNewWindow = { opened.append($0) }
 
         let fkInfo = TestFixtures.makeForeignKeyInfo(referencedTable: "users", referencedColumn: "id")
-        coordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, openInNewTab: false)
+        coordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, intent: .follow)
 
         #expect(tabManager.tabs.count == 1)
         #expect(tabManager.selectedTab?.tableContext.tableName == "orders")
@@ -277,6 +290,13 @@ struct FKNavigationTests {
             toolbarState: ConnectionToolbarState()
         )
         targetCoordinator.registerEagerly()
+        originCoordinator.hostedTabRouting = HostedTabRouting(
+            coordinators: { _ in [targetCoordinator] },
+            reveal: { coordinator, tabId in
+                coordinator.tabManager.selectedTabId = tabId
+                return true
+            }
+        )
 
         defer {
             originCoordinator.teardown()
@@ -295,8 +315,10 @@ struct FKNavigationTests {
             databaseName: targetCoordinator.browseDatabaseName
         )
         targetTabManager.mutate(at: 0) {
-            $0.filterState.filters = [TableFilter(columnName: "id", filterOperator: .equal, value: "42")]
+            let applied = TableFilter(columnName: "id", filterOperator: .equal, value: "42")
+            $0.filterState.filters = [applied]
             $0.filterState.commit = .all
+            $0.filterState.executedFilters = [applied]
         }
         let existingTargetTabId = targetTabManager.selectedTab?.id
 
@@ -304,12 +326,77 @@ struct FKNavigationTests {
         originCoordinator.openTabInNewWindow = { opened.append($0) }
 
         let fkInfo = TestFixtures.makeForeignKeyInfo(referencedTable: "users", referencedColumn: "id")
-        originCoordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, openInNewTab: false)
+        originCoordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, intent: .follow)
 
         #expect(opened.isEmpty)
         #expect(originTabManager.tabs.count == 1)
         #expect(targetTabManager.tabs.count == 1)
         #expect(targetTabManager.selectedTab?.id == existingTargetTabId)
+    }
+
+    /// Revealing a tab elsewhere leaves the source behind the same way opening a new one does, so
+    /// it has to be kept for the same reason: a preview tab the reader navigated away from would
+    /// otherwise be retargeted by their next sidebar click.
+    @Test("Revealing an open tab keeps the preview tab the reference was followed from")
+    @MainActor
+    func revealingAnOpenTabPromotesTheSourcePreviewTab() throws {
+        let connection = TestFixtures.makeConnection(database: "db_a")
+
+        let originTabManager = QueryTabManager()
+        let originCoordinator = MainContentCoordinator(
+            connection: connection,
+            tabManager: originTabManager,
+            changeManager: DataChangeManager(),
+            toolbarState: ConnectionToolbarState()
+        )
+        originCoordinator.registerEagerly()
+
+        let targetTabManager = QueryTabManager()
+        let targetCoordinator = MainContentCoordinator(
+            connection: connection,
+            tabManager: targetTabManager,
+            changeManager: DataChangeManager(),
+            toolbarState: ConnectionToolbarState()
+        )
+        targetCoordinator.registerEagerly()
+        originCoordinator.hostedTabRouting = HostedTabRouting(
+            coordinators: { _ in [targetCoordinator] },
+            reveal: { coordinator, tabId in
+                coordinator.tabManager.selectedTabId = tabId
+                return true
+            }
+        )
+
+        defer {
+            originCoordinator.teardown()
+            targetCoordinator.teardown()
+        }
+
+        try originTabManager.addTableTab(
+            tableName: "orders",
+            databaseType: connection.type,
+            databaseName: originCoordinator.browseDatabaseName,
+            isPreview: true
+        )
+        #expect(originTabManager.selectedTab?.isPreview == true)
+
+        try targetTabManager.addTableTab(
+            tableName: "users",
+            databaseType: connection.type,
+            databaseName: targetCoordinator.browseDatabaseName
+        )
+        targetTabManager.mutate(at: 0) {
+            let applied = TableFilter(columnName: "id", filterOperator: .equal, value: "42")
+            $0.filterState.filters = [applied]
+            $0.filterState.commit = .all
+            $0.filterState.executedFilters = [applied]
+        }
+
+        let fkInfo = TestFixtures.makeForeignKeyInfo(referencedTable: "users", referencedColumn: "id")
+        originCoordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, intent: .follow)
+
+        #expect(originTabManager.tabs.count == 1)
+        #expect(originTabManager.tabs[0].isPreview == false)
     }
 
     @Test("A reference to a different row does not re-filter a tab opened for another row")
@@ -334,6 +421,13 @@ struct FKNavigationTests {
             toolbarState: ConnectionToolbarState()
         )
         targetCoordinator.registerEagerly()
+        originCoordinator.hostedTabRouting = HostedTabRouting(
+            coordinators: { _ in [targetCoordinator] },
+            reveal: { coordinator, tabId in
+                coordinator.tabManager.selectedTabId = tabId
+                return true
+            }
+        )
 
         defer {
             originCoordinator.teardown()
@@ -352,6 +446,77 @@ struct FKNavigationTests {
             databaseName: targetCoordinator.browseDatabaseName
         )
         targetTabManager.mutate(at: 0) {
+            let applied = TableFilter(columnName: "id", filterOperator: .equal, value: "42")
+            $0.filterState.filters = [applied]
+            $0.filterState.commit = .all
+            $0.filterState.executedFilters = [applied]
+        }
+
+        var opened: [EditorTabPayload] = []
+        originCoordinator.openTabInNewWindow = { opened.append($0) }
+
+        let fkInfo = TestFixtures.makeForeignKeyInfo(referencedTable: "users", referencedColumn: "id")
+        originCoordinator.navigateToFKReference(value: "99", fkInfo: fkInfo, intent: .follow)
+
+        #expect(opened.count == 1)
+        #expect(opened.first?.initialFilterState?.appliedFilters.first?.value == "99")
+        #expect(targetTabManager.selectedTab?.filterState.appliedFilters.first?.value == "42")
+    }
+
+    /// `appliedFilters` resolves from the panel's editable draft, so a filter row edited and not
+    /// applied made a tab claim a reference it was not showing. Revealing it runs no query, so the
+    /// reader landed on the rows the tab really held while the app reported it had found the row.
+    @Test("A tab whose filter edit was never applied is not treated as showing the reference")
+    @MainActor
+    func anUnappliedFilterEditDoesNotCountAsShowingTheReference() throws {
+        let connection = TestFixtures.makeConnection(database: "db_a")
+
+        let originTabManager = QueryTabManager()
+        let originCoordinator = MainContentCoordinator(
+            connection: connection,
+            tabManager: originTabManager,
+            changeManager: DataChangeManager(),
+            toolbarState: ConnectionToolbarState()
+        )
+        originCoordinator.registerEagerly()
+
+        let targetTabManager = QueryTabManager()
+        let targetCoordinator = MainContentCoordinator(
+            connection: connection,
+            tabManager: targetTabManager,
+            changeManager: DataChangeManager(),
+            toolbarState: ConnectionToolbarState()
+        )
+        targetCoordinator.registerEagerly()
+        originCoordinator.hostedTabRouting = HostedTabRouting(
+            coordinators: { _ in [targetCoordinator] },
+            reveal: { coordinator, tabId in
+                coordinator.tabManager.selectedTabId = tabId
+                return true
+            }
+        )
+
+        defer {
+            originCoordinator.teardown()
+            targetCoordinator.teardown()
+        }
+
+        try originTabManager.addTableTab(
+            tableName: "orders",
+            databaseType: connection.type,
+            databaseName: originCoordinator.browseDatabaseName
+        )
+
+        try targetTabManager.addTableTab(
+            tableName: "users",
+            databaseType: connection.type,
+            databaseName: targetCoordinator.browseDatabaseName
+        )
+        /// Fetched for 7, then edited to 42 in the panel without pressing Apply.
+        targetTabManager.mutate(at: 0) {
+            $0.filterState.executedFilters = [
+                TableFilter(columnName: "id", filterOperator: .equal, value: "7"),
+            ]
             $0.filterState.filters = [TableFilter(columnName: "id", filterOperator: .equal, value: "42")]
             $0.filterState.commit = .all
         }
@@ -360,11 +525,72 @@ struct FKNavigationTests {
         originCoordinator.openTabInNewWindow = { opened.append($0) }
 
         let fkInfo = TestFixtures.makeForeignKeyInfo(referencedTable: "users", referencedColumn: "id")
-        originCoordinator.navigateToFKReference(value: "99", fkInfo: fkInfo, openInNewTab: false)
+        originCoordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, intent: .follow)
 
         #expect(opened.count == 1)
-        #expect(opened.first?.initialFilterState?.appliedFilters.first?.value == "99")
-        #expect(targetTabManager.selectedTab?.filterState.appliedFilters.first?.value == "42")
+        #expect(opened.first?.tableName == "users")
+        #expect(targetTabManager.tabs.count == 1)
+    }
+
+    /// A window hosts several connections, so a reveal that cannot put the tab in front of the
+    /// reader has to open the reference rather than leave the click doing nothing.
+    @Test("A reveal that cannot be shown falls back to opening the reference")
+    @MainActor
+    func anUnreachableRevealOpensTheReferenceInstead() throws {
+        let connection = TestFixtures.makeConnection(database: "db_a")
+
+        let originTabManager = QueryTabManager()
+        let originCoordinator = MainContentCoordinator(
+            connection: connection,
+            tabManager: originTabManager,
+            changeManager: DataChangeManager(),
+            toolbarState: ConnectionToolbarState()
+        )
+        originCoordinator.registerEagerly()
+
+        let targetTabManager = QueryTabManager()
+        let targetCoordinator = MainContentCoordinator(
+            connection: connection,
+            tabManager: targetTabManager,
+            changeManager: DataChangeManager(),
+            toolbarState: ConnectionToolbarState()
+        )
+        targetCoordinator.registerEagerly()
+        originCoordinator.hostedTabRouting = HostedTabRouting(
+            coordinators: { _ in [targetCoordinator] },
+            reveal: { _, _ in false }
+        )
+
+        defer {
+            originCoordinator.teardown()
+            targetCoordinator.teardown()
+        }
+
+        try originTabManager.addTableTab(
+            tableName: "orders",
+            databaseType: connection.type,
+            databaseName: originCoordinator.browseDatabaseName
+        )
+
+        try targetTabManager.addTableTab(
+            tableName: "users",
+            databaseType: connection.type,
+            databaseName: targetCoordinator.browseDatabaseName
+        )
+        targetTabManager.mutate(at: 0) {
+            $0.filterState.executedFilters = [
+                TableFilter(columnName: "id", filterOperator: .equal, value: "42"),
+            ]
+        }
+
+        var opened: [EditorTabPayload] = []
+        originCoordinator.openTabInNewWindow = { opened.append($0) }
+
+        let fkInfo = TestFixtures.makeForeignKeyInfo(referencedTable: "users", referencedColumn: "id")
+        originCoordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, intent: .follow)
+
+        #expect(opened.count == 1)
+        #expect(opened.first?.tableName == "users")
     }
 
     @Test("Cmd-click opens a new tab even when the same reference is already open")
@@ -388,8 +614,10 @@ struct FKNavigationTests {
             databaseName: originCoordinator.browseDatabaseName
         )
         originTabManager.mutate(at: 0) {
-            $0.filterState.filters = [TableFilter(columnName: "id", filterOperator: .equal, value: "42")]
+            let applied = TableFilter(columnName: "id", filterOperator: .equal, value: "42")
+            $0.filterState.filters = [applied]
             $0.filterState.commit = .all
+            $0.filterState.executedFilters = [applied]
         }
         try originTabManager.addTableTab(
             tableName: "orders",
@@ -401,78 +629,18 @@ struct FKNavigationTests {
         originCoordinator.openTabInNewWindow = { opened.append($0) }
 
         let fkInfo = TestFixtures.makeForeignKeyInfo(referencedTable: "users", referencedColumn: "id")
-        originCoordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, openInNewTab: true)
+        originCoordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, intent: .newTab)
 
         #expect(opened.count == 1)
         #expect(originTabManager.selectedTab?.tableContext.tableName == "orders")
     }
 
-    @Test("An in-place hop saves the outgoing table's filters and restores the target's hidden columns")
+    /// The hop that still records history is the one that stays in the tab: a reference into the
+    /// table the tab is already showing. A jump that opens its own tab records nothing, because
+    /// the tab it came from is still there to go back to.
+    @Test("A hop within the same table records the source view, and Back restores it")
     @MainActor
-    func inPlaceHopKeepsPerTableSettings() throws {
-        let connection = TestFixtures.makeConnection(database: "db_a")
-        let tabManager = QueryTabManager()
-        let coordinator = MainContentCoordinator(
-            connection: connection,
-            tabManager: tabManager,
-            changeManager: DataChangeManager(),
-            toolbarState: ConnectionToolbarState()
-        )
-        defer { coordinator.teardown() }
-
-        let ordersKey = ColumnLayoutTableKey(
-            connectionId: connection.id,
-            databaseName: coordinator.browseDatabaseName,
-            schemaName: nil,
-            tableName: "orders"
-        )
-        let usersKey = ColumnLayoutTableKey(
-            connectionId: connection.id,
-            databaseName: coordinator.browseDatabaseName,
-            schemaName: nil,
-            tableName: "users"
-        )
-        defer {
-            FileColumnLayoutPersister.shared.clear(for: ordersKey)
-            FileColumnLayoutPersister.shared.clear(for: usersKey)
-            FilterSettingsStorage.shared.clearLastFilters(
-                for: "orders",
-                connectionId: connection.id,
-                databaseName: coordinator.browseDatabaseName,
-                schemaName: nil
-            )
-        }
-        FileColumnLayoutPersister.shared.saveHiddenColumns(["ssn"], for: usersKey)
-
-        try tabManager.addTableTab(
-            tableName: "orders",
-            databaseType: connection.type,
-            databaseName: coordinator.browseDatabaseName
-        )
-        let outgoingFilter = TableFilter(columnName: "status", filterOperator: .equal, value: "open")
-        tabManager.mutate(at: 0) {
-            $0.filterState.filters = [outgoingFilter]
-            $0.filterState.commit = .all
-        }
-
-        let fkInfo = TestFixtures.makeForeignKeyInfo(referencedTable: "users", referencedColumn: "id")
-        coordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, openInNewTab: false)
-
-        #expect(tabManager.selectedTab?.tableContext.tableName == "users")
-        #expect(tabManager.selectedTab?.columnLayout.hiddenColumns == ["ssn"])
-
-        let savedForOrders = FilterSettingsStorage.shared.loadLastFilters(
-            for: "orders",
-            connectionId: connection.id,
-            databaseName: coordinator.browseDatabaseName,
-            schemaName: nil
-        )
-        #expect(savedForOrders.contains { $0.columnName == "status" && $0.value == "open" })
-    }
-
-    @Test("An in-place hop records the source view, and Back restores it")
-    @MainActor
-    func inPlaceHopRecordsHistoryAndBackRestoresIt() throws {
+    func sameTableHopRecordsHistoryAndBackRestoresIt() throws {
         let connection = TestFixtures.makeConnection(database: "db_a")
         let tabManager = QueryTabManager()
         let coordinator = MainContentCoordinator(
@@ -497,10 +665,10 @@ struct FKNavigationTests {
         }
         #expect(coordinator.canNavigateBack == false)
 
-        let fkInfo = TestFixtures.makeForeignKeyInfo(referencedTable: "users", referencedColumn: "id")
-        coordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, openInNewTab: false)
+        let fkInfo = TestFixtures.makeForeignKeyInfo(referencedTable: "orders", referencedColumn: "id")
+        coordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, intent: .follow)
 
-        #expect(tabManager.selectedTab?.tableContext.tableName == "users")
+        #expect(tabManager.selectedTab?.filterState.appliedFilters.first?.value == "42")
         #expect(coordinator.canNavigateBack)
         #expect(coordinator.canNavigateForward == false)
 
@@ -534,14 +702,14 @@ struct FKNavigationTests {
             databaseName: coordinator.browseDatabaseName
         )
 
-        let fkInfo = TestFixtures.makeForeignKeyInfo(referencedTable: "users", referencedColumn: "id")
-        coordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, openInNewTab: false)
+        let fkInfo = TestFixtures.makeForeignKeyInfo(referencedTable: "orders", referencedColumn: "id")
+        coordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, intent: .follow)
         coordinator.navigateBack()
-        #expect(tabManager.selectedTab?.tableContext.tableName == "orders")
+        #expect(tabManager.selectedTab?.filterState.appliedFilters.isEmpty == true)
 
         coordinator.navigateForward()
 
-        #expect(tabManager.selectedTab?.tableContext.tableName == "users")
+        #expect(tabManager.selectedTab?.tableContext.tableName == "orders")
         #expect(tabManager.selectedTab?.filterState.appliedFilters.first?.value == "42")
         #expect(coordinator.canNavigateForward == false)
         #expect(coordinator.canNavigateBack)
@@ -566,15 +734,14 @@ struct FKNavigationTests {
             databaseName: coordinator.browseDatabaseName
         )
 
-        let users = TestFixtures.makeForeignKeyInfo(referencedTable: "users", referencedColumn: "id")
-        coordinator.navigateToFKReference(value: "42", fkInfo: users, openInNewTab: false)
+        let byId = TestFixtures.makeForeignKeyInfo(referencedTable: "orders", referencedColumn: "id")
+        coordinator.navigateToFKReference(value: "42", fkInfo: byId, intent: .follow)
         coordinator.navigateBack()
         #expect(coordinator.canNavigateForward)
 
-        let regions = TestFixtures.makeForeignKeyInfo(referencedTable: "regions", referencedColumn: "id")
-        coordinator.navigateToFKReference(value: "7", fkInfo: regions, openInNewTab: false)
+        coordinator.navigateToFKReference(value: "7", fkInfo: byId, intent: .follow)
 
-        #expect(tabManager.selectedTab?.tableContext.tableName == "regions")
+        #expect(tabManager.selectedTab?.filterState.appliedFilters.first?.value == "7")
         #expect(coordinator.canNavigateForward == false)
         #expect(coordinator.canNavigateBack)
     }
@@ -601,7 +768,7 @@ struct FKNavigationTests {
         coordinator.openTabInNewWindow = { opened.append($0) }
 
         let fkInfo = TestFixtures.makeForeignKeyInfo(referencedTable: "users", referencedColumn: "id")
-        coordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, openInNewTab: true)
+        coordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, intent: .newTab)
 
         #expect(opened.count == 1)
         #expect(tabManager.selectedTab?.tableContext.tableName == "orders")
@@ -628,10 +795,10 @@ struct FKNavigationTests {
         )
 
         let fkInfo = TestFixtures.makeForeignKeyInfo(referencedTable: "users", referencedColumn: "id")
-        coordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, openInNewTab: false)
+        coordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, intent: .follow)
         #expect(coordinator.canNavigateBack)
 
-        coordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, openInNewTab: false)
+        coordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, intent: .follow)
         coordinator.navigateBack()
 
         #expect(coordinator.canNavigateBack == false)
@@ -663,8 +830,8 @@ struct FKNavigationTests {
             databaseName: coordinator.browseDatabaseName
         )
 
-        let fkInfo = TestFixtures.makeForeignKeyInfo(referencedTable: "users", referencedColumn: "id")
-        coordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, openInNewTab: false)
+        let fkInfo = TestFixtures.makeForeignKeyInfo(referencedTable: "orders", referencedColumn: "id")
+        coordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, intent: .follow)
         #expect(coordinator.canNavigateBack)
 
         coordinator.changeManager.hasChanges = true
@@ -694,8 +861,8 @@ struct FKNavigationTests {
             databaseName: coordinator.browseDatabaseName
         )
 
-        let fkInfo = TestFixtures.makeForeignKeyInfo(referencedTable: "users", referencedColumn: "id")
-        coordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, openInNewTab: false)
+        let fkInfo = TestFixtures.makeForeignKeyInfo(referencedTable: "orders", referencedColumn: "id")
+        coordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, intent: .follow)
         #expect(coordinator.canNavigateBack)
 
         let tabId = try #require(tabManager.selectedTabId)
@@ -727,8 +894,8 @@ struct FKNavigationTests {
             databaseType: connection.type,
             databaseName: coordinator.browseDatabaseName
         )
-        let fkInfo = TestFixtures.makeForeignKeyInfo(referencedTable: "users", referencedColumn: "id")
-        coordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, openInNewTab: false)
+        let fkInfo = TestFixtures.makeForeignKeyInfo(referencedTable: "orders", referencedColumn: "id")
+        coordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, intent: .follow)
         let tabId = try #require(tabManager.selectedTab?.id)
         #expect(coordinator.navigationHistories[tabId]?.canGoBack == true)
 
@@ -791,8 +958,8 @@ struct FKNavigationTests {
             $0.pagination.currentPage = 1
         }
 
-        let fkInfo = TestFixtures.makeForeignKeyInfo(referencedTable: "users", referencedColumn: "id")
-        coordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, openInNewTab: false)
+        let fkInfo = TestFixtures.makeForeignKeyInfo(referencedTable: "orders", referencedColumn: "id")
+        coordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, intent: .follow)
         coordinator.navigateBack()
 
         #expect(tabManager.selectedTab?.tableContext.tableName == "orders")
@@ -819,70 +986,6 @@ struct FKNavigationTests {
         #expect(coordinator.pendingRowAnchors[other] == nil)
         #expect(coordinator.pendingRowAnchors.removeValue(forKey: owning) == ["id": "4021"])
         #expect(coordinator.pendingRowAnchors[owning] == nil)
-    }
-
-    @Test("Retargeting a tab drops a row anchor its navigation never used")
-    @MainActor
-    func retargetDropsAStaleRowAnchor() throws {
-        let connection = TestFixtures.makeConnection(database: "db_a")
-        let tabManager = QueryTabManager()
-        let coordinator = MainContentCoordinator(
-            connection: connection,
-            tabManager: tabManager,
-            changeManager: DataChangeManager(),
-            toolbarState: ConnectionToolbarState()
-        )
-        defer { coordinator.teardown() }
-
-        try tabManager.addTableTab(
-            tableName: "orders",
-            databaseType: connection.type,
-            databaseName: coordinator.browseDatabaseName
-        )
-        let tabId = try #require(tabManager.selectedTab?.id)
-        coordinator.pendingRowAnchors[tabId] = ["id": "4021"]
-
-        let fkInfo = TestFixtures.makeForeignKeyInfo(referencedTable: "users", referencedColumn: "id")
-        coordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, openInNewTab: false)
-
-        #expect(coordinator.pendingRowAnchors[tabId] == nil)
-    }
-
-    @Test("An in-place hop cancels the outgoing tab's in-flight load")
-    @MainActor
-    func inPlaceHopCancelsInFlightLoad() throws {
-        let connection = TestFixtures.makeConnection(database: "db_a")
-        let tabManager = QueryTabManager()
-        let coordinator = MainContentCoordinator(
-            connection: connection,
-            tabManager: tabManager,
-            changeManager: DataChangeManager(),
-            toolbarState: ConnectionToolbarState()
-        )
-        defer { coordinator.teardown() }
-
-        try tabManager.addTableTab(
-            tableName: "orders",
-            databaseType: connection.type,
-            databaseName: coordinator.browseDatabaseName
-        )
-        guard let tabId = tabManager.selectedTab?.id else {
-            Issue.record("expected a selected tab")
-            return
-        }
-
-        let inFlight = Task<Void, Never> {
-            while !Task.isCancelled {
-                await Task.yield()
-            }
-        }
-        coordinator.tableLoadTasks[tabId] = (token: UUID(), task: inFlight)
-
-        let fkInfo = TestFixtures.makeForeignKeyInfo(referencedTable: "users", referencedColumn: "id")
-        coordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, openInNewTab: false)
-
-        #expect(inFlight.isCancelled)
-        #expect(coordinator.tableLoadTasks[tabId] == nil)
     }
 
     @Test("Metadata is not cached until foreign keys were fetched")
@@ -949,9 +1052,12 @@ struct FKNavigationTests {
         let fkInfo = TestFixtures.makeForeignKeyInfo(
             referencedTable: "users", referencedColumn: "id", referencedSchema: "db_a"
         )
-        coordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, openInNewTab: false)
+        var opened: [EditorTabPayload] = []
+        coordinator.openTabInNewWindow = { opened.append($0) }
 
-        let context = try #require(tabManager.selectedTab?.tableContext)
+        coordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, intent: .follow)
+
+        let context = try #require(opened.first)
         #expect(context.tableName == "users")
         #expect(context.schemaName == nil)
         #expect(context.databaseName == "db_a")
@@ -979,9 +1085,12 @@ struct FKNavigationTests {
         let fkInfo = TestFixtures.makeForeignKeyInfo(
             referencedTable: "tenants", referencedColumn: "id", referencedSchema: "billing"
         )
-        coordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, openInNewTab: false)
+        var opened: [EditorTabPayload] = []
+        coordinator.openTabInNewWindow = { opened.append($0) }
 
-        let context = try #require(tabManager.selectedTab?.tableContext)
+        coordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, intent: .follow)
+
+        let context = try #require(opened.first)
         #expect(context.tableName == "tenants")
         #expect(context.databaseName == "billing")
         #expect(context.schemaName == nil)
@@ -1010,9 +1119,12 @@ struct FKNavigationTests {
         let fkInfo = TestFixtures.makeForeignKeyInfo(
             referencedTable: "users", referencedColumn: "id", referencedSchema: "audit"
         )
-        coordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, openInNewTab: false)
+        var opened: [EditorTabPayload] = []
+        coordinator.openTabInNewWindow = { opened.append($0) }
 
-        let context = try #require(tabManager.selectedTab?.tableContext)
+        coordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, intent: .follow)
+
+        let context = try #require(opened.first)
         #expect(context.tableName == "users")
         #expect(context.schemaName == "audit")
         #expect(context.databaseName == "db_a")
@@ -1044,9 +1156,12 @@ struct FKNavigationTests {
         let fkInfo = TestFixtures.makeForeignKeyInfo(
             referencedTable: "tenants", referencedColumn: "id", referencedSchema: "billing"
         )
-        coordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, openInNewTab: false)
+        var opened: [EditorTabPayload] = []
+        coordinator.openTabInNewWindow = { opened.append($0) }
 
-        let context = try #require(tabManager.selectedTab?.tableContext)
+        coordinator.navigateToFKReference(value: "42", fkInfo: fkInfo, intent: .follow)
+
+        let context = try #require(opened.first)
         #expect(context.tableName == "tenants")
         #expect(context.databaseName == "billing")
         #expect(context.schemaName == nil)

--- a/TableProUITests/ForeignKeyNavigationUITests.swift
+++ b/TableProUITests/ForeignKeyNavigationUITests.swift
@@ -1,0 +1,85 @@
+//
+//  ForeignKeyNavigationUITests.swift
+//  TableProUITests
+//
+//  Following a foreign key leaves the tab it was followed from open. Chinook's Album.ArtistId
+//  references Artist, and Album is the last column of that table, which is what the cell cursor
+//  reaches by walking right.
+//
+
+import AppKit
+import XCTest
+
+final class ForeignKeyNavigationUITests: UITestCase {
+    func testFollowingAReferenceKeepsTheTabItCameFrom() throws {
+        let app = try launchWithSampleDatabase()
+        let window = try readyWindow(of: app)
+        let grid = try albumGrid(in: app, window: window)
+
+        /// Counted rather than asserted against a number: the sample database opens a tab of its
+        /// own before this suite opens Album, and the strip publishes nothing while one tab is
+        /// open, so what this pins is the increase.
+        let tabsBefore = window.descendants(matching: .any)
+            .matching(identifier: "editor-tab").count
+
+        focusTheArtistIdCell(in: app, grid: grid)
+        app.typeKey(XCUIKeyboardKey.space.rawValue, modifierFlags: [])
+
+        let openArtist = window.buttons["Open Artist"].firstMatch
+        XCTAssertTrue(
+            openArtist.waitToExist(timeout: 30),
+            "Preview FK Reference must offer to open the referenced table"
+        )
+        clickAtCenter(openArtist)
+
+        XCTAssertTrue(
+            waitForPredicate(timeout: 30) {
+                window.descendants(matching: .any)
+                    .matching(identifier: "editor-tab").count > tabsBefore
+            },
+            "Following the reference must add a tab rather than retarget the one it came from"
+        )
+        XCTAssertTrue(
+            waitForPredicate(timeout: 20) { window.staticTexts["Album"].exists },
+            "The Album tab must still be in the strip after the reference opened"
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func readyWindow(of app: XCUIApplication) throws -> XCUIElement {
+        let window = app.windows.matching(NSPredicate(format: "identifier != %@", "welcome")).firstMatch
+        XCTAssertTrue(window.waitToExist(timeout: 60), "The sample database produced no window")
+        XCTAssertTrue(
+            waitForPredicate(timeout: 30) { window.outlines.firstMatch.outlineRows.count > 1 },
+            "The object browser must list the sample database's tables"
+        )
+        return window
+    }
+
+    private func albumGrid(in app: XCUIApplication, window: XCUIElement) throws -> XCUIElement {
+        let row = window.outlines.firstMatch.staticTexts
+            .matching(NSPredicate(format: "value == %@", "Table: Album"))
+            .firstMatch
+        XCTAssertTrue(row.waitToExist(timeout: 20), "The object browser must list Album")
+        clickAtCenter(row)
+
+        let grid = window.tables.matching(identifier: "data-grid").firstMatch
+        XCTAssertTrue(grid.waitToExist(timeout: 30), "Album produced no data grid")
+        XCTAssertTrue(waitForClickableRows(in: grid), "Album must load rows before a cell can be read")
+        return grid
+    }
+
+    /// A point offset from the grid rather than a row or cell element, which XCUITest reads as
+    /// obscured by the columns published beside them, with `dy` clearing the 42pt header. The cell
+    /// cursor then walks right until it stops, which is Album's last column, `ArtistId`.
+    private func focusTheArtistIdCell(in app: XCUIApplication, grid: XCUIElement) {
+        grid.coordinate(withNormalizedOffset: .zero)
+            .withOffset(CGVector(dx: 60, dy: 70))
+            .click()
+
+        for _ in 0 ..< 5 {
+            app.typeKey(XCUIKeyboardKey.rightArrow.rawValue, modifierFlags: [])
+        }
+    }
+}

--- a/docs/features/data-grid.mdx
+++ b/docs/features/data-grid.mdx
@@ -76,7 +76,9 @@ Widths, order, and hidden columns are remembered per table, scoped to the connec
 
 ## Foreign keys
 
-A foreign key cell carries an arrow on its right edge. Click it to open the referenced table filtered to the matching row, or right-click for **Preview Referenced Row**, which shows that row in a popover. `Cmd`-click always opens a new tab; otherwise the reference takes over the current tab unless that tab holds a query or unsaved edits.
+A foreign key cell carries an arrow on its right edge. Click it to open the referenced table filtered to the matching row, or right-click for **Preview Referenced Row**, which shows that row in a popover. The reference arrives in a tab of its own, so the rows you were reading stay open behind it. A tab already showing that same reference comes forward instead of a second one opening, and `Cmd`-click opens a new tab even then.
+
+Clicking an arrow that points back into the table the tab already shows re-filters that tab rather than opening another. `Ctrl+Cmd+[` returns to the rows it left.
 
 Double-click a foreign key cell, press `Return` on it, or open its right-click menu to pick the key rather than type it. The picker lists rows from the referenced table, each key with a label beside it, and narrows as you type. `Return` in the search field commits the text as typed, which covers a key the search has not turned up. **Set NULL** appears on a nullable column.
 


### PR DESCRIPTION
Clicking the arrow in a foreign key cell retargeted the tab the reader was on. The rows they were reading, the filters they had applied and the sort they had set all went with it.

Fixes #1421.

## Root cause

Foreign key navigation owned a second, weaker answer to "may I take over the selected tab".

Every other way of opening a table asks `isActiveTabReusable` (`MainContentCoordinator+Navigation.swift:394`), which demands the tab be a preview, an empty query or an untouched Create Table tab, and refuses one carrying applied filters, a user sort or pinned results. `navigateToFKReference` asked `selectedTabHoldsProtectedContent` instead, which only knows about unsaved cell edits, query work and staged structure edits. A table tab the reader was browsing answers "nothing here", so the arrow retargeted it.

The `openInNewTab: Bool` carrying the caller's intent is the other half. It cannot say "reveal the tab that already shows this", which is why a second predicate was invented rather than the first being shared. Five call sites each passed a literal `false` whose meaning was "take over the tab I am looking at".

## The fix

Following a reference never takes the selected tab over. A reference can only be followed from a grid, so the tab it is followed from is always one the reader is in.

- `ReferenceOpenIntent` (`.follow` / `.newTab`) replaces the Bool across the delegate protocols, the arrow, the context menu, the preview popover, the row inspector and the JSON inspector.
- `ReferenceNavigationPlanner` is a pure resolver for the three outcomes, testable without a window, a coordinator or a tab manager: re-filter the selected tab when it is already on the referenced table, reveal a tab already showing that reference, otherwise open a tab of its own.
- Reveal now runs before opening, matching the order `openTableTab` takes with `activateIfAlreadyOpen`.
- The reuse branch and `replaceSelectedTabWithFKTarget` are gone. With the rule above they were unreachable: every entry point needs a result grid, and a query tab that has one is already protected by `holdsQueryWork`.
- A jump that leaves the tab promotes it out of preview first, so the next sidebar click cannot retarget the table the reader navigated away from.

Modifiers keep the Apple convention rather than inverting: plain click follows, `Cmd`-click always takes a new tab. Safari, Finder and Xcode all read that way. The reporter's ask is met by the disposition, not by the modifier.

## Two pre-existing defects this would otherwise have made routine

Both live in the reveal path, which used to run only when the source tab was protected and now runs on every follow.

**A tab was matched on its filter panel, not on its rows.** `showsOnlyFKPredicate` read `appliedFilters`, which resolves from the editable draft: `updateFilter` writes each keystroke straight into `filterState.filters` while `commit` stays set from the last Apply. Fetch `id = 7`, type `42` into the filter row without applying, follow a reference to 42 from another tab, and that tab claimed the reference. Revealing runs no query, so the reader landed on the rows for 7 while the app reported it had found the row. `TabFilterState.executedFilters` now records what the rows were actually fetched with, written wherever a query is built from filters, and the match reads that. It is deliberately not persisted: a restored tab rebuilds its query on first load, which fills it.

**A reveal could raise a window without showing the connection.** One window hosts several connections, and `selectTabAndFocusWindow` only set `selectedTabId` and ordered the window front, so a tab torn into a window since switched to another connection came forward invisible. The sibling search also went through `allActiveCoordinators()`, a registry of every coordinator SwiftUI has built, which can hold one whose window is gone. Both now go through `WindowManager`, which is the record of what is on screen, and a reveal that cannot be made visible falls back to opening the reference instead of leaving the click doing nothing.

## Two residuals, both narrower than what they replace

`executedFilters` is written where the query is built, not where its rows land, so pressing Apply on a tab that already has a query in flight records a filter whose result was never installed. The write belongs at the point a result is installed, and there is no single chokepoint for that today: `setActiveTableRows` also takes the empty buffer a retarget installs. The marker still closes the common case, an edited filter row that was never applied, and this one needs a query that is already running.

A tab created for a reference whose first load has not finished has no marker yet, so following the same reference again opens a second tab rather than revealing the first. The failure is a duplicate tab, not wrong rows.

Both want the same thing: filters recorded against the result that installed them. That is its own change in the execution path and is not attempted here.

## Tested

- `ReferenceNavigationPlannerTests`: every intent against every state.
- `FKNavigationTests`: the source tab survives with its identity; a preview source is kept on both jumps that leave it; reveal beats opening a duplicate; an unapplied filter edit does not count as showing the reference; an unreachable reveal opens the reference; `Cmd`-click always takes its own tab.
- 122 cases across `FKNavigationTests`, `ReferenceNavigationPlannerTests`, `FilterTypingBeforeFirstLoadTests`, `MainContentCoordinatorTabSwitchTests`, `OpenTableTabTests` and `ResultPinningTests`, all passing. Debug build clean, `swiftlint --strict` clean over `TablePro`, `TableProTests` and `TableProUITests`, and both `docs/` checks clean.

`ForeignKeyNavigationUITests` drives the flow through Preview FK Reference and its **Open Artist** button, then asserts the strip gained a tab and the Album tab survived. **It did not run here**: every `TableProUITests` suite on this machine reports `Timed out while enabling automation mode`, which is an unanswered macOS UI-automation prompt rather than a test failure. It needs a run on CI or on a machine where that prompt has been answered.

No before-and-after screenshots: the change is which tab the reference lands in, which a still frame of either state does not show.


https://claude.ai/code/session_01R4D7UrumqUb2UBpPSbQHMb
