### PR TITLE
fix(datagrid): let the foreign key picker remember that you want no label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **None** in the foreign key picker's Label menu forgotten on reopen.
 - **Prompt for password** lost when importing a TablePlus connection set to **Ask everytime**.
 - TablePlus import saving a password for a connection TablePlus was set never to store one for.
 - TablePlus import reading the CA certificate and client key paths the wrong way round.

--- a/TablePro/Core/Services/Query/ForeignKeyLabelColumn.swift
+++ b/TablePro/Core/Services/Query/ForeignKeyLabelColumn.swift
@@ -9,9 +9,11 @@ import Foundation
 enum ForeignKeyLabelColumn {
     static let preferredNames = ["name", "title", "label", "username", "email", "code", "description"]
 
-    /// `preferred` is the user's stored choice, and it is honoured only when the table still carries
-    /// that column. The name reaches the query as a quoted identifier, so a preference left behind
-    /// by a dropped column, or one written into defaults by hand, must never become one.
+    /// `choice` is the reader's stored answer. A named column is honoured only when the table still
+    /// carries it: the name reaches the query as a quoted identifier, so a preference left behind by
+    /// a dropped column, or one written into defaults by hand, must never become one. **None** is
+    /// honoured unconditionally and never checked against the table, because it names no identifier
+    /// and so nothing about it can go stale.
     ///
     /// Only a column the search can actually pattern-match is offered automatically. A `LIKE`
     /// against a date, an integer, a `uuid`, an enum or an array is a type error on a strict
@@ -20,10 +22,15 @@ enum ForeignKeyLabelColumn {
     static func resolve(
         columns: [ForeignKeyLookupColumn],
         keyColumn: String,
-        preferred: String?
+        choice: ForeignKeyLabelChoice
     ) -> ForeignKeyLookupColumn? {
-        if let preferred, let stored = columns.first(where: { $0.name == preferred }) {
-            return stored
+        switch choice {
+        case .noLabel:
+            return nil
+        case .column(let preferred):
+            if let stored = columns.first(where: { $0.name == preferred }) { return stored }
+        case .unset:
+            break
         }
         let candidates = columns.filter { $0.name != keyColumn && $0.supportsPatternMatch }
         for name in preferredNames {

--- a/TablePro/Core/Storage/ForeignKeyLabelChoice.swift
+++ b/TablePro/Core/Storage/ForeignKeyLabelChoice.swift
@@ -1,0 +1,53 @@
+//
+//  ForeignKeyLabelChoice.swift
+//  TablePro
+//
+
+import Foundation
+
+/// What the reader has said about a referenced table's label column.
+///
+/// Three states, because "I have not chosen" and "I chose to show no label" are different answers
+/// and only one of them should let the heuristic run. Encoding the second as an absent key made it
+/// identical to the first, so **None** was forgotten the moment the picker was reopened.
+///
+/// The stored form is the column name's UTF-8, which is what is already on disk, plus a one-byte
+/// sentinel for `noLabel`. `0xFF` is the sentinel because no Unicode scalar's UTF-8 contains it,
+/// checked over all 1,114,112 of them, so it can never be a column name. An empty value would not
+/// do: SQLite accepts `create table t("" integer)`, so `""` is a name a reader can really pick,
+/// while PostgreSQL and MariaDB refuse it. Keep the sentinel, and do not "simplify" this to an
+/// empty-`Data` check.
+internal enum ForeignKeyLabelChoice: Equatable, Sendable {
+    case unset
+    case noLabel
+    case column(String)
+
+    private static let noLabelSentinel = Data([0xFF])
+
+    internal init(storedData: Data?) {
+        guard let storedData else {
+            self = .unset
+            return
+        }
+        if storedData == Self.noLabelSentinel {
+            self = .noLabel
+            return
+        }
+        guard let name = String(bytes: storedData, encoding: .utf8) else {
+            self = .unset
+            return
+        }
+        self = .column(name)
+    }
+
+    internal var storedData: Data? {
+        switch self {
+        case .unset:
+            return nil
+        case .noLabel:
+            return Self.noLabelSentinel
+        case .column(let name):
+            return Data(name.utf8)
+        }
+    }
+}

--- a/TablePro/Core/Storage/ForeignKeyLabelColumnStore.swift
+++ b/TablePro/Core/Storage/ForeignKeyLabelColumnStore.swift
@@ -11,6 +11,9 @@ import Foundation
 /// a property of the target: `orders.user_id` and `comments.user_id` both want `users.name`, and
 /// setting it once for `users` is what a user means by remembering it. Device-local, so this needs
 /// no CloudKit record type.
+///
+/// Three states, not two: a table nobody has chosen for, one the reader has chosen **None** for,
+/// and one with a named column. `ForeignKeyLabelChoice` owns the encoding.
 @MainActor
 internal final class ForeignKeyLabelColumnStore: TableScopedSettingsStore {
     static let shared = ForeignKeyLabelColumnStore()
@@ -23,20 +26,14 @@ internal final class ForeignKeyLabelColumnStore: TableScopedSettingsStore {
         store = defaults
     }
 
-    func labelColumn(for scope: TableScope) -> String? {
-        guard let data = store.dataValue(forKey: PreferenceKeys.foreignKeyLabelColumn(scope).name) else {
-            return nil
-        }
-        guard let name = String(bytes: data, encoding: .utf8), !name.isEmpty else { return nil }
-        return name
+    func labelChoice(for scope: TableScope) -> ForeignKeyLabelChoice {
+        ForeignKeyLabelChoice(
+            storedData: store.dataValue(forKey: PreferenceKeys.foreignKeyLabelColumn(scope).name)
+        )
     }
 
-    func setLabelColumn(_ name: String?, for scope: TableScope) {
-        guard let name, !name.isEmpty else {
-            store.setDataValue(nil, forKey: PreferenceKeys.foreignKeyLabelColumn(scope).name)
-            return
-        }
-        store.setDataValue(Data(name.utf8), forKey: PreferenceKeys.foreignKeyLabelColumn(scope).name)
+    func setLabelChoice(_ choice: ForeignKeyLabelChoice, for scope: TableScope) {
+        store.setDataValue(choice.storedData, forKey: PreferenceKeys.foreignKeyLabelColumn(scope).name)
     }
 
     func renameTable(from oldScope: TableScope, to newScope: TableScope) {

--- a/TablePro/Views/Results/ForeignKeyPickerView.swift
+++ b/TablePro/Views/Results/ForeignKeyPickerView.swift
@@ -204,6 +204,7 @@ struct ForeignKeyPickerView: View {
             .pickerStyle(.menu)
             .controlSize(.small)
             .disabled(columns.isEmpty)
+            .accessibilityIdentifier("fk-picker-label")
 
             Spacer(minLength: 4)
 
@@ -236,7 +237,12 @@ struct ForeignKeyPickerView: View {
             get: { labelColumnName },
             set: { newValue in
                 labelColumnName = newValue
-                ForeignKeyLabelColumnStore.shared.setLabelColumn(newValue, for: referencedTableScope)
+                /// A cleared menu is the reader choosing to see keys on their own, not the reader
+                /// saying nothing: storing it as absence let the heuristic pick a label again on the
+                /// next open.
+                ForeignKeyLabelColumnStore.shared.setLabelChoice(
+                    newValue.map(ForeignKeyLabelChoice.column) ?? .noLabel, for: referencedTableScope
+                )
             }
         )
     }
@@ -295,11 +301,11 @@ struct ForeignKeyPickerView: View {
                 in: scope, databaseType: databaseType, reference: fkInfo
             )
             guard !Task.isCancelled else { return }
-            let stored = ForeignKeyLabelColumnStore.shared.labelColumn(for: referencedTableScope)
+            let choice = ForeignKeyLabelColumnStore.shared.labelChoice(for: referencedTableScope)
             labelColumnName = ForeignKeyLabelColumn.resolve(
                 columns: fetched,
                 keyColumn: fkInfo.referencedColumn,
-                preferred: stored
+                choice: choice
             )?.name
             columns = fetched
             hasLoadedColumns = true

--- a/TableProTests/Core/Services/ForeignKeyLabelColumnTests.swift
+++ b/TableProTests/Core/Services/ForeignKeyLabelColumnTests.swift
@@ -11,8 +11,11 @@ struct ForeignKeyLabelColumnTests {
         ForeignKeyLookupColumn(name: name, type: .text(rawType: "VARCHAR(64)"))
     }
 
-    private func resolve(_ columns: [ForeignKeyLookupColumn], preferred: String? = nil) -> String? {
-        ForeignKeyLabelColumn.resolve(columns: columns, keyColumn: "id", preferred: preferred)?.name
+    private func resolve(
+        _ columns: [ForeignKeyLookupColumn],
+        choice: ForeignKeyLabelChoice = .unset
+    ) -> String? {
+        ForeignKeyLabelColumn.resolve(columns: columns, keyColumn: "id", choice: choice)?.name
     }
 
     @Test("A preferred name wins over the column order")
@@ -54,15 +57,15 @@ struct ForeignKeyLabelColumnTests {
 
     @Test("A stored choice wins over every heuristic")
     func storedChoiceWins() {
-        #expect(resolve([key, text("name"), text("email")], preferred: "email") == "email")
+        #expect(resolve([key, text("name"), text("email")], choice: .column("email")) == "email")
     }
 
     /// The stored name reaches the query as a quoted identifier. A preference left behind by a
     /// dropped column, or written into defaults by hand, must never become one.
     @Test("A stored choice the table no longer has falls back to the heuristic")
     func storedChoiceMustExist() {
-        #expect(resolve([key, text("name")], preferred: "dropped_column") == "name")
-        #expect(resolve([key, text("name")], preferred: "\" OR 1=1 --") == "name")
+        #expect(resolve([key, text("name")], choice: .column("dropped_column")) == "name")
+        #expect(resolve([key, text("name")], choice: .column("\") OR 1=1 --")) == "name")
     }
 
     /// PostgreSQL refuses `LIKE` on an enum or an array, so neither can carry the picker's search
@@ -81,6 +84,19 @@ struct ForeignKeyLabelColumnTests {
     @Test("A stored choice may be a column the heuristic would have skipped")
     func storedChoiceMayBeNonText() {
         let columns = [key, text("name"), ForeignKeyLookupColumn(name: "score", type: .decimal(rawType: "NUMERIC"))]
-        #expect(resolve(columns, preferred: "score") == "score")
+        #expect(resolve(columns, choice: .column("score")) == "score")
+    }
+
+    @Test("Choosing no label returns no label")
+    func explicitNoneReturnsNoLabel() {
+        #expect(resolve([key, text("name")], choice: .noLabel) == nil)
+    }
+
+    /// Short-circuits before the candidate scan rather than falling through it, so a table carrying
+    /// every preferred name still answers nothing.
+    @Test("Choosing no label ignores every candidate")
+    func explicitNoneIgnoresEveryCandidate() {
+        let columns = [key] + ForeignKeyLabelColumn.preferredNames.map(text)
+        #expect(resolve(columns, choice: .noLabel) == nil)
     }
 }

--- a/TableProTests/Storage/ForeignKeyLabelColumnStoreTests.swift
+++ b/TableProTests/Storage/ForeignKeyLabelColumnStoreTests.swift
@@ -23,33 +23,89 @@ struct ForeignKeyLabelColumnStoreTests {
     @Test("A table with no stored choice answers nil")
     func unsetScopeAnswersNil() throws {
         let store = try makeStore()
-        #expect(store.labelColumn(for: scope(connectionId: UUID())) == nil)
+        #expect(store.labelChoice(for: scope(connectionId: UUID())) == .unset)
     }
 
     @Test("A stored choice comes back")
     func storedChoiceRoundTrips() throws {
         let store = try makeStore()
         let target = scope(connectionId: UUID())
-        store.setLabelColumn("Name", for: target)
-        #expect(store.labelColumn(for: target) == "Name")
+        store.setLabelChoice(.column("Name"), for: target)
+        #expect(store.labelChoice(for: target) == .column("Name"))
     }
 
-    @Test("Nil clears the stored choice")
-    func nilClearsTheChoice() throws {
+    @Test("Unset clears the stored choice")
+    func unsetClearsTheChoice() throws {
         let store = try makeStore()
         let target = scope(connectionId: UUID())
-        store.setLabelColumn("Name", for: target)
-        store.setLabelColumn(nil, for: target)
-        #expect(store.labelColumn(for: target) == nil)
+        store.setLabelChoice(.column("Name"), for: target)
+        store.setLabelChoice(.unset, for: target)
+        #expect(store.labelChoice(for: target) == .unset)
     }
 
-    @Test("An empty name clears rather than storing a blank")
-    func emptyNameClears() throws {
+    /// The reader choosing to see keys on their own is an answer, and it used to be stored as no
+    /// answer at all, so the heuristic picked a label again the moment the picker was reopened.
+    @Test("Choosing no label outlives a reopen")
+    func explicitNoneOutlivesAReopen() throws {
         let store = try makeStore()
         let target = scope(connectionId: UUID())
-        store.setLabelColumn("Name", for: target)
-        store.setLabelColumn("", for: target)
-        #expect(store.labelColumn(for: target) == nil)
+        store.setLabelChoice(.column("Name"), for: target)
+        store.setLabelChoice(.noLabel, for: target)
+        #expect(store.labelChoice(for: target) == .noLabel)
+    }
+
+    @Test("The three states are distinct")
+    func theThreeStatesAreDistinct() throws {
+        let store = try makeStore()
+        let unset = scope(connectionId: UUID())
+        let none = scope(connectionId: UUID())
+        let named = scope(connectionId: UUID())
+        store.setLabelChoice(.noLabel, for: none)
+        store.setLabelChoice(.column("Name"), for: named)
+
+        #expect(store.labelChoice(for: unset) == .unset)
+        #expect(store.labelChoice(for: none) == .noLabel)
+        #expect(store.labelChoice(for: named) == .column("Name"))
+    }
+
+    /// SQLite accepts `create table t("" integer)`, so a zero-length column name is one a reader can
+    /// really pick. It must not read back as either of the other two states.
+    @Test("An empty column name is a choice of its own")
+    func anEmptyColumnNameIsAChoiceOfItsOwn() throws {
+        let store = try makeStore()
+        let target = scope(connectionId: UUID())
+        store.setLabelChoice(.column(""), for: target)
+        #expect(store.labelChoice(for: target) == .column(""))
+    }
+
+    @Test("Choosing no label survives a rename")
+    func explicitNoneSurvivesARename() throws {
+        let store = try makeStore()
+        let old = scope(connectionId: UUID())
+        let new = scope(connectionId: old.connectionId, table: "Performer")
+        store.setLabelChoice(.noLabel, for: old)
+
+        store.renameTable(from: old, to: new)
+
+        #expect(store.labelChoice(for: new) == .noLabel)
+        #expect(store.labelChoice(for: old) == .unset)
+    }
+
+    /// The seam the defect lived in: the store said nothing, so the resolver guessed.
+    @Test("Choosing no label stops the heuristic")
+    func explicitNoneStopsTheHeuristic() throws {
+        let store = try makeStore()
+        let target = scope(connectionId: UUID())
+        store.setLabelChoice(.noLabel, for: target)
+
+        let columns = [
+            ForeignKeyLookupColumn(name: "id", type: .integer(rawType: "INTEGER")),
+            ForeignKeyLookupColumn(name: "name", type: .text(rawType: "VARCHAR(64)"))
+        ]
+        let resolved = ForeignKeyLabelColumn.resolve(
+            columns: columns, keyColumn: "id", choice: store.labelChoice(for: target)
+        )
+        #expect(resolved == nil)
     }
 
     /// The choice belongs to the table being picked from, so two tables of the same name in
@@ -58,23 +114,23 @@ struct ForeignKeyLabelColumnStoreTests {
     func choiceIsScopedToTheTable() throws {
         let store = try makeStore()
         let connection = UUID()
-        store.setLabelColumn("Name", for: scope(connectionId: connection))
-        store.setLabelColumn("Title", for: scope(connectionId: connection, table: "Album"))
-        store.setLabelColumn("Email", for: scope(connectionId: connection, database: "other"))
-        store.setLabelColumn("Code", for: scope(connectionId: UUID()))
+        store.setLabelChoice(.column("Name"), for: scope(connectionId: connection))
+        store.setLabelChoice(.column("Title"), for: scope(connectionId: connection, table: "Album"))
+        store.setLabelChoice(.column("Email"), for: scope(connectionId: connection, database: "other"))
+        store.setLabelChoice(.column("Code"), for: scope(connectionId: UUID()))
 
-        #expect(store.labelColumn(for: scope(connectionId: connection)) == "Name")
-        #expect(store.labelColumn(for: scope(connectionId: connection, table: "Album")) == "Title")
-        #expect(store.labelColumn(for: scope(connectionId: connection, database: "other")) == "Email")
+        #expect(store.labelChoice(for: scope(connectionId: connection)) == .column("Name"))
+        #expect(store.labelChoice(for: scope(connectionId: connection, table: "Album")) == .column("Title"))
+        #expect(store.labelChoice(for: scope(connectionId: connection, database: "other")) == .column("Email"))
     }
 
     @Test("A name with a dot or a quote survives the key encoding")
     func awkwardNamesSurvive() throws {
         let store = try makeStore()
         let target = scope(connectionId: UUID(), schema: "public.v2", table: "user\"s")
-        store.setLabelColumn("full name", for: target)
-        #expect(store.labelColumn(for: target) == "full name")
-        #expect(store.labelColumn(for: scope(connectionId: target.connectionId)) == nil)
+        store.setLabelChoice(.column("full name"), for: target)
+        #expect(store.labelChoice(for: target) == .column("full name"))
+        #expect(store.labelChoice(for: scope(connectionId: target.connectionId)) == .unset)
     }
 
     @Test("A table rename moves its choice and leaves a longer name alone")
@@ -82,19 +138,19 @@ struct ForeignKeyLabelColumnStoreTests {
         let store = try makeStore()
         let connection = UUID()
         let other = UUID()
-        store.setLabelColumn("Name", for: scope(connectionId: connection))
-        store.setLabelColumn("Title", for: scope(connectionId: connection, table: "Artist_archive"))
-        store.setLabelColumn("Code", for: scope(connectionId: other))
+        store.setLabelChoice(.column("Name"), for: scope(connectionId: connection))
+        store.setLabelChoice(.column("Title"), for: scope(connectionId: connection, table: "Artist_archive"))
+        store.setLabelChoice(.column("Code"), for: scope(connectionId: other))
 
         store.renameTable(
             from: scope(connectionId: connection),
             to: scope(connectionId: connection, table: "Performer")
         )
 
-        #expect(store.labelColumn(for: scope(connectionId: connection)) == nil)
-        #expect(store.labelColumn(for: scope(connectionId: connection, table: "Performer")) == "Name")
-        #expect(store.labelColumn(for: scope(connectionId: connection, table: "Artist_archive")) == "Title")
-        #expect(store.labelColumn(for: scope(connectionId: other)) == "Code")
+        #expect(store.labelChoice(for: scope(connectionId: connection)) == .unset)
+        #expect(store.labelChoice(for: scope(connectionId: connection, table: "Performer")) == .column("Name"))
+        #expect(store.labelChoice(for: scope(connectionId: connection, table: "Artist_archive")) == .column("Title"))
+        #expect(store.labelChoice(for: scope(connectionId: other)) == .column("Code"))
     }
 
     @Test("A schema rename moves every table in it and nothing outside it")
@@ -102,38 +158,38 @@ struct ForeignKeyLabelColumnStoreTests {
         let store = try makeStore()
         let connection = UUID()
         let other = UUID()
-        store.setLabelColumn("Name", for: scope(connectionId: connection, schema: "music"))
-        store.setLabelColumn("Title", for: scope(connectionId: connection, schema: "music", table: "Album"))
-        store.setLabelColumn("Code", for: scope(connectionId: connection, schema: "music_old"))
-        store.setLabelColumn("Email", for: scope(connectionId: other, schema: "music"))
+        store.setLabelChoice(.column("Name"), for: scope(connectionId: connection, schema: "music"))
+        store.setLabelChoice(.column("Title"), for: scope(connectionId: connection, schema: "music", table: "Album"))
+        store.setLabelChoice(.column("Code"), for: scope(connectionId: connection, schema: "music_old"))
+        store.setLabelChoice(.column("Email"), for: scope(connectionId: other, schema: "music"))
 
         store.renameContainer(
             connectionId: connection, fromDatabase: "chinook", fromSchema: "music",
             toDatabase: "chinook", toSchema: "catalog"
         )
 
-        #expect(store.labelColumn(for: scope(connectionId: connection, schema: "catalog")) == "Name")
-        #expect(store.labelColumn(for: scope(connectionId: connection, schema: "catalog", table: "Album")) == "Title")
-        #expect(store.labelColumn(for: scope(connectionId: connection, schema: "music")) == nil)
-        #expect(store.labelColumn(for: scope(connectionId: connection, schema: "music_old")) == "Code")
-        #expect(store.labelColumn(for: scope(connectionId: other, schema: "music")) == "Email")
+        #expect(store.labelChoice(for: scope(connectionId: connection, schema: "catalog")) == .column("Name"))
+        #expect(store.labelChoice(for: scope(connectionId: connection, schema: "catalog", table: "Album")) == .column("Title"))
+        #expect(store.labelChoice(for: scope(connectionId: connection, schema: "music")) == .unset)
+        #expect(store.labelChoice(for: scope(connectionId: connection, schema: "music_old")) == .column("Code"))
+        #expect(store.labelChoice(for: scope(connectionId: other, schema: "music")) == .column("Email"))
     }
 
     @Test("A database rename moves its tables and leaves a longer database name alone")
     func renameDatabaseMovesItsTables() throws {
         let store = try makeStore()
         let connection = UUID()
-        store.setLabelColumn("Name", for: scope(connectionId: connection))
-        store.setLabelColumn("Title", for: scope(connectionId: connection, database: "chinook_backup"))
+        store.setLabelChoice(.column("Name"), for: scope(connectionId: connection))
+        store.setLabelChoice(.column("Title"), for: scope(connectionId: connection, database: "chinook_backup"))
 
         store.renameContainer(
             connectionId: connection, fromDatabase: "chinook", fromSchema: nil,
             toDatabase: "music", toSchema: nil
         )
 
-        #expect(store.labelColumn(for: scope(connectionId: connection, database: "music")) == "Name")
-        #expect(store.labelColumn(for: scope(connectionId: connection)) == nil)
-        #expect(store.labelColumn(for: scope(connectionId: connection, database: "chinook_backup")) == "Title")
+        #expect(store.labelChoice(for: scope(connectionId: connection, database: "music")) == .column("Name"))
+        #expect(store.labelChoice(for: scope(connectionId: connection)) == .unset)
+        #expect(store.labelChoice(for: scope(connectionId: connection, database: "chinook_backup")) == .column("Title"))
     }
 
     @Test("Deleting a connection removes its choices and keeps every other connection's")
@@ -141,14 +197,14 @@ struct ForeignKeyLabelColumnStoreTests {
         let store = try makeStore()
         let connection = UUID()
         let other = UUID()
-        store.setLabelColumn("Name", for: scope(connectionId: connection))
-        store.setLabelColumn("Title", for: scope(connectionId: connection, table: "Album"))
-        store.setLabelColumn("Code", for: scope(connectionId: other))
+        store.setLabelChoice(.column("Name"), for: scope(connectionId: connection))
+        store.setLabelChoice(.column("Title"), for: scope(connectionId: connection, table: "Album"))
+        store.setLabelChoice(.column("Code"), for: scope(connectionId: other))
 
         store.purgeConnections([connection])
 
-        #expect(store.labelColumn(for: scope(connectionId: connection)) == nil)
-        #expect(store.labelColumn(for: scope(connectionId: connection, table: "Album")) == nil)
-        #expect(store.labelColumn(for: scope(connectionId: other)) == "Code")
+        #expect(store.labelChoice(for: scope(connectionId: connection)) == .unset)
+        #expect(store.labelChoice(for: scope(connectionId: connection, table: "Album")) == .unset)
+        #expect(store.labelChoice(for: scope(connectionId: other)) == .column("Code"))
     }
 }

--- a/docs/features/data-grid.mdx
+++ b/docs/features/data-grid.mdx
@@ -80,7 +80,7 @@ A foreign key cell carries an arrow on its right edge. Click it to open the refe
 
 Double-click a foreign key cell, press `Return` on it, or open its right-click menu to pick the key rather than type it. The picker lists rows from the referenced table, each key with a label beside it, and narrows as you type. `Return` in the search field commits the text as typed, which covers a key the search has not turned up. **Set NULL** appears on a nullable column.
 
-**Label** at the foot of the picker chooses the column that reads as the row's name. The choice is remembered for the referenced table, so every column pointing at it shows the same one. A search fetches the first 50 matches, which keeps the list quick on a large table.
+**Label** at the foot of the picker chooses the column that reads as the row's name, or **None** to list keys on their own. Either choice is remembered for the referenced table, so every column pointing at it shows the same one. A search fetches the first 50 matches, which keeps the list quick on a large table.
 
 A column of a foreign key that spans several columns keeps the text editor. The picker sets one column, and a key it offered might not pair with the values the row holds in the constraint's other columns. Type the key, or open the referenced table and read the pair off it.
 


### PR DESCRIPTION
Found while investigating #2768.

## The bug

The foreign key picker's Label menu offers **None** as a first-class choice, and choosing it does nothing that survives closing the popover. Pick **None**, reopen the picker, and the auto-detected label is back, along with the second column in the `SELECT` and the `LIKE` on it that goes out on every keystroke.

`ForeignKeyLabelColumnStore.setLabelColumn` mapped both `nil` and `""` to key removal, so "I chose to show no label" was stored as the same thing as "I have not chosen". On the next open `ForeignKeyLabelColumn.resolve` read back `nil`, skipped its `if let preferred` branch, and ran the heuristic again.

The store's own tests pinned the loss as intended, which is why nothing flagged it: `nilClearsTheChoice` and `emptyNameClears` both asserted that an explicit choice reads back as nothing.

## The fix

`ForeignKeyLabelChoice` is the three states the picker actually has: `unset`, `noLabel`, `column(String)`. The store reads and writes it, and `resolve` short-circuits on `noLabel` before any candidate scan. `ValueDisplayFormatService` already models an explicit "no formatting" this way, where `.raw` is a real stored override that beats the detector; the label store was the only one of the five table-scoped stores encoding the user's explicit answer as absence.

## Why a sentinel byte, and why that one

The stored value is the column name's UTF-8, which is what is already on disk. `noLabel` is `Data([0xFF])`.

An empty value would have been the obvious choice and it is wrong: **SQLite accepts `create table t("" integer)`**, so `""` is a column name a user can really pick, while PostgreSQL 17.11 and MariaDB 12.3.3 both refuse it. One shipped engine accepting it is enough to rule out an empty-`Data` sentinel.

`0xFF` cannot collide. Checked over all 1,114,112 Unicode scalars: none has a UTF-8 encoding containing `0xFF`, and `0xFF` alone is not valid UTF-8. So the sentinel is provably not the encoding of any column name, and `.column("")` stays representable for the SQLite case above.

No migration: every value on disk today is the UTF-8 of a non-empty name and still reads back as `.column`. `renameTable`, `renameContainer` and `purgeConnections` are untouched and work for all three states.

## Verification

| Step | Result |
|---|---|
| `verify.sh build` | PASS |
| `verify.sh test` over the 5 suites owning the changed types | PASS, 55 cases |
| `verify.sh lint TablePro TableProTests` | PASS, 0 violations |
| `verify.sh docs` | PASS |

Eight new cases, confirmed present in the run log. The ones that fail before the fix: `explicitNoneOutlivesAReopen`, `theThreeStatesAreDistinct`, `anEmptyColumnNameIsAChoiceOfItsOwn`, `explicitNoneReturnsNoLabel`, `explicitNoneIgnoresEveryCandidate`, and `explicitNoneStopsTheHeuristic`, which composes the store with the resolver and is the seam the defect actually lived in. `explicitNoneSurvivesARename` pins that the sentinel survives `moveValue` and stays visible to `keys(withPrefix:)`. `unsetClearsTheChoice` replaces `nilClearsTheChoice` and keeps the clearing capability pinned under an honest name.

The two tests that codified the loss are rewritten rather than deleted. They encoded a defect, not a contract: the picker has always offered **None** in its menu, so a store that cannot represent it was never matching intended behaviour.

No UI automation. The picker opens only from a data grid cell, and since #2381 the grid draws its cells with CoreText and takes no synthetic input, so the flow cannot be driven deterministically from a UI test. The `Picker` does carry `fk-picker-label` now, so a future UI test can reach it.


https://claude.ai/code/session_01AJc1W7uFR36m7Stzscf55H
