### PR TITLE
fix(coordinator): read a foreign key's target through the scope that named it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - MySQL and MariaDB reads of an object in another database answering about the current database's same-named one, including the foreign key picker's column list. (#2769)
+- Nested foreign key chevrons in the row inspector pointing into the database the sidebar is on rather than the referenced one.
+- Ref Columns in the structure editor offering only **Custom…** for the rest of the tab after one failed read, with no error and no retry.
+- Ref Columns reading the sidebar's database instead of the tab's.
+- Empty **Ref Table** menu in the structure editor on MySQL, MariaDB, TiDB, PostgreSQL, CockroachDB, Redshift, SQL Server and DuckDB.
+- **New Trigger** pre-filling a template naming the sidebar's database, and **Drop Trigger** naming it in the statement it ran elsewhere.
+- `describe_table` over MCP answering with one database's columns beside another's indexes, foreign keys, row count and DDL.
 - Select All painting the whole column header row as selected, and leaving a cell cursor on the first cell.
 - Column header shown as selected after a cell drag reached the first and last row of the page.
 - No outline around a swept cell block whose rows reached both ends of the page.

--- a/TablePro/Core/Database/DatabaseDriver.swift
+++ b/TablePro/Core/Database/DatabaseDriver.swift
@@ -119,6 +119,20 @@ protocol DatabaseDriver: AnyObject, Sendable {
     /// Fetch foreign keys for a specific table
     func fetchForeignKeys(table: String) async throws -> [ForeignKeyInfo]
 
+    /// The same reads for a table in a named container, for a caller that knows which one it means.
+    ///
+    /// A caller that names a container for one part of a table's description and not the rest gets
+    /// a description of two different tables: the columns of one and the indexes, keys and size of
+    /// whichever the connection happens to be on. Each of these defaults to the unqualified read,
+    /// so a driver that cannot tell containers apart is unaffected.
+    func fetchIndexes(table: String, schema: String?) async throws -> [IndexInfo]
+    func fetchForeignKeys(table: String, schema: String?) async throws -> [ForeignKeyInfo]
+    func fetchCheckConstraints(table: String, schema: String?) async throws -> [CheckConstraintInfo]
+    func fetchApproximateRowCount(table: String, schema: String?) async throws -> Int?
+    func fetchTableDDL(table: String, schema: String?) async throws -> String
+    func fetchIndexDDL(table: String, schema: String?) async throws -> [String]
+    func fetchCommentDDL(table: String, schema: String?) async throws -> [String]
+
     /// Fetch triggers for a specific table
     func fetchTriggers(table: String) async throws -> [TriggerInfo]
     func fetchCheckConstraints(table: String) async throws -> [CheckConstraintInfo]
@@ -401,6 +415,34 @@ extension DatabaseDriver {
 
     func fetchColumns(table: String, schema: String?) async throws -> [ColumnInfo] {
         try await fetchColumns(table: table)
+    }
+
+    func fetchIndexes(table: String, schema: String?) async throws -> [IndexInfo] {
+        try await fetchIndexes(table: table)
+    }
+
+    func fetchForeignKeys(table: String, schema: String?) async throws -> [ForeignKeyInfo] {
+        try await fetchForeignKeys(table: table)
+    }
+
+    func fetchCheckConstraints(table: String, schema: String?) async throws -> [CheckConstraintInfo] {
+        try await fetchCheckConstraints(table: table)
+    }
+
+    func fetchApproximateRowCount(table: String, schema: String?) async throws -> Int? {
+        try await fetchApproximateRowCount(table: table)
+    }
+
+    func fetchTableDDL(table: String, schema: String?) async throws -> String {
+        try await fetchTableDDL(table: table)
+    }
+
+    func fetchIndexDDL(table: String, schema: String?) async throws -> [String] {
+        try await fetchIndexDDL(table: table)
+    }
+
+    func fetchCommentDDL(table: String, schema: String?) async throws -> [String] {
+        try await fetchCommentDDL(table: table)
     }
 
     func fetchPartitions(table: String, schema: String?) async throws -> [TableInfo] { [] }

--- a/TablePro/Core/Database/TableDDLComposer.swift
+++ b/TablePro/Core/Database/TableDDLComposer.swift
@@ -46,15 +46,19 @@ internal enum TableDDLComposer {
     /// tab's DDL, Show DDL and Copy DDL all come through here, so the three can never disagree about
     /// the same object. `includesDependencies` adds the sequences and enum types the table's columns
     /// use, which the Structure tab writes first so its text runs on its own.
+    /// `schema` names the container the caller means, for the callers that know it. All three reads
+    /// take it together: a DDL composed from one container's CREATE TABLE and another's indexes and
+    /// comments describes a table that does not exist.
     internal static func fetchDDL(
         for table: String,
         using driver: DatabaseDriver,
-        includesDependencies: Bool
+        includesDependencies: Bool,
+        schema: String? = nil
     ) async throws -> String {
         let preamble = includesDependencies ? try await dependencyPreamble(for: table, using: driver) : ""
-        let baseDDL = try await driver.fetchTableDDL(table: table)
-        let indexDDL = (try? await driver.fetchIndexDDL(table: table)) ?? []
-        let commentDDL = (try? await driver.fetchCommentDDL(table: table)) ?? []
+        let baseDDL = try await driver.fetchTableDDL(table: table, schema: schema)
+        let indexDDL = (try? await driver.fetchIndexDDL(table: table, schema: schema)) ?? []
+        let commentDDL = (try? await driver.fetchCommentDDL(table: table, schema: schema)) ?? []
         return compose(
             tableDDL: baseDDL,
             indexDDL: indexDDL,

--- a/TablePro/Core/Database/TriggerEditing.swift
+++ b/TablePro/Core/Database/TriggerEditing.swift
@@ -103,10 +103,14 @@ enum TriggerEditing {
         name: String,
         gate: any ExecutionGate = ExecutionGateProvider.shared
     ) async throws {
-        guard let driver = DatabaseManager.shared.driver(for: connection.id) else {
-            throw TriggerEditingError.notConnected
+        /// Built on a driver in the scope that will run it, the way `apply` builds its own inside
+        /// the lease. The session driver is wherever the sidebar last went, and an engine that
+        /// qualifies its DDL with the connection's current database writes that name into a
+        /// statement the pooled connection then runs somewhere else.
+        let generated = try await DatabaseManager.shared.withMetadataDriver(scope: scope) { driver in
+            driver.generateDropTriggerSQL(name: name, table: tableName)
         }
-        guard let dropSQL = driver.generateDropTriggerSQL(name: name, table: tableName) else {
+        guard let dropSQL = generated else {
             throw TriggerEditingError.dropUnavailable
         }
 

--- a/TablePro/Core/MCP/MCPConnectionBridge+Schema.swift
+++ b/TablePro/Core/MCP/MCPConnectionBridge+Schema.swift
@@ -51,11 +51,15 @@ extension MCPConnectionBridge {
 
         return try await DatabaseManager.shared.withMetadataDriver(scope: scope) { driver in
             let columns = try await driver.fetchColumns(table: table, schema: schema)
-            let indexes = try await driver.fetchIndexes(table: table)
-            let foreignKeys = try await driver.fetchForeignKeys(table: table)
-            let checkConstraints = (try? await driver.fetchCheckConstraints(table: table)) ?? []
-            let approximateRowCount = (try? await driver.fetchApproximateRowCount(table: table)) ?? nil
-            let ddl = await MCPConnectionBridge.composedTableDDL(driver: driver, table: table)
+            let indexes = try await driver.fetchIndexes(table: table, schema: schema)
+            let foreignKeys = try await driver.fetchForeignKeys(table: table, schema: schema)
+            let checkConstraints = (try? await driver.fetchCheckConstraints(table: table, schema: schema)) ?? []
+            let approximateRowCount = (
+                try? await driver.fetchApproximateRowCount(table: table, schema: schema)
+            ) ?? nil
+            let ddl = await MCPConnectionBridge.composedTableDDL(
+                driver: driver, table: table, schema: schema
+            )
 
             var result: [String: JsonValue] = [
                 "table": .string(table),
@@ -97,14 +101,18 @@ extension MCPConnectionBridge {
 
     /// The table's own statement plus the indexes it does not declare, because a caller asking for
     /// a table's DDL wants what recreates it, not the half the export replays first.
-    static func composedTableDDL(driver: DatabaseDriver, table: String) async -> String? {
-        try? await TableDDLComposer.fetchDDL(for: table, using: driver, includesDependencies: false)
+    static func composedTableDDL(driver: DatabaseDriver, table: String, schema: String?) async -> String? {
+        try? await TableDDLComposer.fetchDDL(
+            for: table, using: driver, includesDependencies: false, schema: schema
+        )
     }
 
     func getTableDDL(scope: DatabaseScope, table: String) async throws -> JsonValue {
         try await ensureConnected(scope.connectionId)
         let ddl = try await DatabaseManager.shared.withMetadataDriver(scope: scope) { driver in
-            try await TableDDLComposer.fetchDDL(for: table, using: driver, includesDependencies: false)
+            try await TableDDLComposer.fetchDDL(
+                for: table, using: driver, includesDependencies: false, schema: scope.schema
+            )
         }
         return .object([
             "table": .string(table),

--- a/TablePro/Core/Plugins/PluginDriverAdapter.swift
+++ b/TablePro/Core/Plugins/PluginDriverAdapter.swift
@@ -300,7 +300,13 @@ final class PluginDriverAdapter: DatabaseDriver, SchemaSwitchable, DatabaseRepor
     }
 
     func fetchIndexes(table: String) async throws -> [IndexInfo] {
-        let pluginIndexes = try await pluginDriver.fetchIndexes(table: table, schema: pluginDriver.currentSchema)
+        try await fetchIndexes(table: table, schema: nil)
+    }
+
+    func fetchIndexes(table: String, schema: String?) async throws -> [IndexInfo] {
+        let pluginIndexes = try await pluginDriver.fetchIndexes(
+            table: table, schema: schema ?? pluginDriver.currentSchema
+        )
         return pluginIndexes.map(Self.mapPluginIndex)
     }
 
@@ -333,7 +339,13 @@ final class PluginDriverAdapter: DatabaseDriver, SchemaSwitchable, DatabaseRepor
     }
 
     func fetchForeignKeys(table: String) async throws -> [ForeignKeyInfo] {
-        let pluginFKs = try await pluginDriver.fetchForeignKeys(table: table, schema: pluginDriver.currentSchema)
+        try await fetchForeignKeys(table: table, schema: nil)
+    }
+
+    func fetchForeignKeys(table: String, schema: String?) async throws -> [ForeignKeyInfo] {
+        let pluginFKs = try await pluginDriver.fetchForeignKeys(
+            table: table, schema: schema ?? pluginDriver.currentSchema
+        )
         return pluginFKs.map { fk in
             ForeignKeyInfo(
                 name: fk.name,
@@ -348,8 +360,12 @@ final class PluginDriverAdapter: DatabaseDriver, SchemaSwitchable, DatabaseRepor
     }
 
     func fetchCheckConstraints(table: String) async throws -> [CheckConstraintInfo] {
+        try await fetchCheckConstraints(table: table, schema: nil)
+    }
+
+    func fetchCheckConstraints(table: String, schema: String?) async throws -> [CheckConstraintInfo] {
         let pluginConstraints = try await pluginDriver.fetchCheckConstraints(
-            table: table, schema: pluginDriver.currentSchema
+            table: table, schema: schema ?? pluginDriver.currentSchema
         )
         return pluginConstraints.map { constraint in
             CheckConstraintInfo(
@@ -398,7 +414,13 @@ final class PluginDriverAdapter: DatabaseDriver, SchemaSwitchable, DatabaseRepor
     var unsupportedIndexTypes: Set<String> { pluginDriver.unsupportedIndexTypes }
 
     func fetchApproximateRowCount(table: String) async throws -> Int? {
-        try await pluginDriver.fetchApproximateRowCount(table: table, schema: pluginDriver.currentSchema)
+        try await fetchApproximateRowCount(table: table, schema: nil)
+    }
+
+    func fetchApproximateRowCount(table: String, schema: String?) async throws -> Int? {
+        try await pluginDriver.fetchApproximateRowCount(
+            table: table, schema: schema ?? pluginDriver.currentSchema
+        )
     }
 
     func fetchFilteredRowCount(table: String, filters: [TableFilter], logicMode: FilterLogicMode) async throws -> Int? {
@@ -425,15 +447,27 @@ final class PluginDriverAdapter: DatabaseDriver, SchemaSwitchable, DatabaseRepor
     }
 
     func fetchTableDDL(table: String) async throws -> String {
-        try await pluginDriver.fetchTableDDL(table: table, schema: pluginDriver.currentSchema)
+        try await fetchTableDDL(table: table, schema: nil)
+    }
+
+    func fetchTableDDL(table: String, schema: String?) async throws -> String {
+        try await pluginDriver.fetchTableDDL(table: table, schema: schema ?? pluginDriver.currentSchema)
     }
 
     func fetchIndexDDL(table: String) async throws -> [String] {
-        try await pluginDriver.fetchIndexDDL(table: table, schema: pluginDriver.currentSchema)
+        try await fetchIndexDDL(table: table, schema: nil)
+    }
+
+    func fetchIndexDDL(table: String, schema: String?) async throws -> [String] {
+        try await pluginDriver.fetchIndexDDL(table: table, schema: schema ?? pluginDriver.currentSchema)
     }
 
     func fetchCommentDDL(table: String) async throws -> [String] {
-        try await pluginDriver.fetchCommentDDL(table: table, schema: pluginDriver.currentSchema)
+        try await fetchCommentDDL(table: table, schema: nil)
+    }
+
+    func fetchCommentDDL(table: String, schema: String?) async throws -> [String] {
+        try await pluginDriver.fetchCommentDDL(table: table, schema: schema ?? pluginDriver.currentSchema)
     }
 
     func fetchDependentTypes(forTable table: String) async throws -> [(name: String, labels: [String])] {

--- a/TablePro/Core/Services/Query/ForeignKeyRowFetcher.swift
+++ b/TablePro/Core/Services/Query/ForeignKeyRowFetcher.swift
@@ -30,37 +30,48 @@ enum ForeignKeyRowFetcher {
     ///
     /// `includeForeignKeys` costs a metadata read for the referenced table's own constraints, which
     /// only the inspector needs: it is what makes a nested key clickable in turn.
+    ///
+    /// The row and those constraints are read through one scope. A qualified name only reaches
+    /// inside the database the connection is already on, so a row taken from the session driver
+    /// while the keys came from the reference's own scope described two different tables wherever
+    /// the tab and the sidebar had drifted apart.
     static func fetch(
-        connectionId: UUID,
+        origin: DatabaseScope,
         databaseType: DatabaseType,
         reference: JSONForeignKeyRef,
         value: String,
         includeForeignKeys: Bool = false
     ) async throws -> FetchedRow? {
-        guard let driver = DatabaseManager.shared.driver(for: connectionId) else {
+        guard DatabaseManager.shared.driver(for: origin.connectionId) != nil else {
             throw FetchFailure.noConnection
         }
-
-        let quotedTable = SchemaQualifiedName.render(
-            name: reference.referencedTable,
-            schema: reference.referencedSchema,
-            databaseType: databaseType,
-            quote: driver.quoteIdentifier
+        let target = ForeignKeyTargetScope.resolve(
+            origin: origin,
+            referencedSchema: reference.referencedSchema,
+            databaseType: databaseType
         )
+        let dialect = PluginManager.shared.sqlDialect(for: databaseType)
 
-        let query = ForeignKeyPreviewQuery.singleRow(
-            quotedTable: quotedTable,
-            quotedColumn: driver.quoteIdentifier(reference.referencedColumn),
-            escapedValue: driver.escapeStringLiteral(value),
-            stringLiteralPrefix: SQLStringLiteralPrefix.forDatabaseType(databaseType),
-            dialect: PluginManager.shared.sqlDialect(for: databaseType)
-        )
-
-        let result = try await driver.execute(query: query)
+        let result = try await DatabaseManager.shared.withMetadataDriver(scope: target) { driver in
+            let quotedTable = SchemaQualifiedName.render(
+                name: reference.referencedTable,
+                schema: target.schema,
+                databaseType: databaseType,
+                quote: driver.quoteIdentifier
+            )
+            let query = ForeignKeyPreviewQuery.singleRow(
+                quotedTable: quotedTable,
+                quotedColumn: driver.quoteIdentifier(reference.referencedColumn),
+                escapedValue: driver.escapeStringLiteral(value),
+                stringLiteralPrefix: SQLStringLiteralPrefix.forDatabaseType(databaseType),
+                dialect: dialect
+            )
+            return try await driver.execute(query: query)
+        }
         guard let firstRow = result.rows.first else { return nil }
 
         let foreignKeys = includeForeignKeys
-            ? await referencedTableForeignKeys(connectionId: connectionId, reference: reference)
+            ? await referencedTableForeignKeys(target: target, reference: reference)
             : [:]
 
         return FetchedRow(
@@ -73,15 +84,16 @@ enum ForeignKeyRowFetcher {
 
     /// Answers from the schema prefetch when it covers the table, so following a chain of keys in
     /// the same schema costs no extra round trips.
+    ///
+    /// Resolved from the grid's own scope, never the sidebar's: the row above it is read from a
+    /// name qualified by the reference itself, so taking the nested keys from the browse cursor
+    /// instead put a chevron on a row of one database that navigated into another's. And the
+    /// referenced value goes through `ForeignKeyTargetScope` rather than into `schema:` directly,
+    /// because on an engine with no schema layer it names a database and the schema slot is inert.
     private static func referencedTableForeignKeys(
-        connectionId: UUID,
+        target targetScope: DatabaseScope,
         reference: JSONForeignKeyRef
     ) async -> [String: JSONForeignKeyRef] {
-        guard let scope = DatabaseManager.shared.browseScope(for: connectionId) else { return [:] }
-        let targetScope = reference.referencedSchema.map {
-            DatabaseScope(connectionId: connectionId, database: scope.database, schema: $0)
-        } ?? scope
-
         if let cached = SchemaForeignKeyStore.shared.foreignKeysByColumn(
             for: targetScope,
             table: reference.referencedTable

--- a/TablePro/Models/UI/JSON/JSONRowSnapshot.swift
+++ b/TablePro/Models/UI/JSON/JSONRowSnapshot.swift
@@ -25,6 +25,9 @@ struct JSONRowSnapshot: Equatable, Sendable {
     let foreignKeys: [String: JSONForeignKeyRef]
     /// Carried on the snapshot so the panel can hand it to the view model without the view, which
     /// is what keeps the model in step with the row a render is about to draw.
-    let connectionId: UUID
+    ///
+    /// The whole scope rather than the connection alone: a foreign key expansion reads another
+    /// table, and which database that lands in is the tab's answer, not the sidebar's.
+    let scope: DatabaseScope
     let databaseType: DatabaseType
 }

--- a/TablePro/ViewModels/JSONRowInspectorViewModel.swift
+++ b/TablePro/ViewModels/JSONRowInspectorViewModel.swift
@@ -12,7 +12,7 @@ import os
 /// The referenced-row lookup a foreign key expansion runs, held as a value so a test can drive the
 /// model's cancellation and generation rules without a database behind it.
 typealias JSONForeignKeyRowFetch = @MainActor (
-    _ connectionId: UUID,
+    _ origin: DatabaseScope,
     _ databaseType: DatabaseType,
     _ reference: JSONForeignKeyRef,
     _ value: String
@@ -36,7 +36,7 @@ final class JSONRowInspectorViewModel {
     /// Bumped by every rebuild and every reset. A fetch that returns after one discards itself,
     /// because `Task.cancel()` cannot interrupt a query already in flight.
     private var generation = 0
-    private var connectionId: UUID?
+    private var scope: DatabaseScope?
     private var databaseType: DatabaseType?
     @ObservationIgnored private let fetchRow: JSONForeignKeyRowFetch
 
@@ -47,13 +47,13 @@ final class JSONRowInspectorViewModel {
     }
 
     private static func fetchThroughDatabase(
-        connectionId: UUID,
+        origin: DatabaseScope,
         databaseType: DatabaseType,
         reference: JSONForeignKeyRef,
         value: String
     ) async throws -> ForeignKeyRowFetcher.FetchedRow? {
         try await ForeignKeyRowFetcher.fetch(
-            connectionId: connectionId,
+            origin: origin,
             databaseType: databaseType,
             reference: reference,
             value: value,
@@ -77,7 +77,7 @@ final class JSONRowInspectorViewModel {
             reset()
             return
         }
-        connectionId = snapshot.connectionId
+        scope = snapshot.scope
         databaseType = snapshot.databaseType
 
         guard snapshot != lastSnapshot else { return }
@@ -217,7 +217,7 @@ final class JSONRowInspectorViewModel {
 
     private func expandForeignKey(at path: JSONNodePath, in root: JSONRowNode) {
         guard fetches[path] == nil,
-              let connectionId,
+              let scope,
               let databaseType,
               let node = node(at: path, from: root),
               let reference = node.foreignKey,
@@ -228,7 +228,7 @@ final class JSONRowInspectorViewModel {
             path: path,
             reference: reference,
             value: JSONScalarText.unquoted(scalar),
-            connectionId: connectionId,
+            origin: scope,
             databaseType: databaseType
         )
     }
@@ -237,7 +237,7 @@ final class JSONRowInspectorViewModel {
         path: JSONNodePath,
         reference: JSONForeignKeyRef,
         value: String,
-        connectionId: UUID,
+        origin: DatabaseScope,
         databaseType: DatabaseType
     ) {
         let visit = JSONForeignKeyVisit(ref: reference, value: value)
@@ -262,7 +262,7 @@ final class JSONRowInspectorViewModel {
             defer { self?.finishFetch(at: path, generation: generation) }
             do {
                 guard let fetch = self?.fetchRow else { return }
-                let fetched = try await fetch(connectionId, databaseType, reference, value)
+                let fetched = try await fetch(origin, databaseType, reference, value)
                 guard let self, !Task.isCancelled, generation == self.generation else { return }
                 guard let fetched else {
                     self.states.failures[path] = .notFound

--- a/TablePro/Views/Main/Extensions/MainContentView+Bindings.swift
+++ b/TablePro/Views/Main/Extensions/MainContentView+Bindings.swift
@@ -105,7 +105,8 @@ extension MainContentView {
     var jsonRowSnapshotForSidebar: JSONRowSnapshot? {
         guard gridSelectionOwner == .dataGrid,
               let tab = coordinator.tabManager.selectedTab,
-              let firstDisplayIndex = coordinator.selectionState.indices.min() else { return nil }
+              let firstDisplayIndex = coordinator.selectionState.indices.min(),
+              let scope = coordinator.scope(for: tab) else { return nil }
         let tableRows = coordinator.tabSessionRegistry.tableRows(for: tab.id)
         guard !tableRows.columns.isEmpty,
               let row = DisplayRowMapping.row(
@@ -120,7 +121,7 @@ extension MainContentView {
             columnTypes: tableRows.columnTypes,
             values: Array(row.values),
             foreignKeys: tableRows.columnForeignKeys.mapValues(JSONForeignKeyRef.init),
-            connectionId: coordinator.connection.id,
+            scope: scope,
             databaseType: coordinator.connection.type
         )
     }

--- a/TablePro/Views/Results/Extensions/DataGridView+Popovers.swift
+++ b/TablePro/Views/Results/Extensions/DataGridView+Popovers.swift
@@ -33,6 +33,22 @@ extension TableViewCoordinator {
         showForeignKeyPreview(tableView: tableView, row: row, column: column, columnIndex: columnIndex)
     }
 
+    /// The grid's own scope, which every foreign key affordance on it has to start from.
+    ///
+    /// The picker and the preview are two reads of one cell, so they resolve their target from one
+    /// expression rather than two: built separately they drift, and a preview that resolves its
+    /// target differently from the picker beside it reads one table while offering another's rows.
+    /// The tab's own database comes first, because a tab stays where it opened while the sidebar
+    /// moves; the browse cursor is the fallback for a grid that never carried one.
+    var gridOriginScope: DatabaseScope? {
+        guard let connectionId else { return nil }
+        return DatabaseScope(
+            connectionId: connectionId,
+            database: databaseName ?? DatabaseManager.shared.browseScope(for: connectionId)?.database ?? "",
+            schema: schemaName
+        )
+    }
+
     func showForeignKeyPreview(tableView: NSTableView, row: Int, column: Int, columnIndex: Int) {
         let tableRows = tableRowsProvider()
         guard columnIndex >= 0, columnIndex < tableRows.columns.count else { return }
@@ -41,6 +57,8 @@ extension TableViewCoordinator {
         let cellValue = cellValue(at: row, column: columnIndex)
         guard let databaseType, let connectionId else { return }
         guard presentsCell(row: row, tableColumnIndex: column) else { return }
+
+        guard let scope = gridOriginScope else { return }
 
         let model = FKPreviewModel(cellValue: cellValue, fkInfo: fkInfo)
         let cellRect = tableView.rect(ofRow: row).intersection(tableView.rect(ofColumn: column))
@@ -51,7 +69,7 @@ extension TableViewCoordinator {
         ) { [weak self] dismiss in
             ForeignKeyPreviewView(
                 model: model,
-                connectionId: connectionId,
+                scope: scope,
                 databaseType: databaseType,
                 onNavigate: { [weak self, model] in
                     dismiss()
@@ -284,11 +302,10 @@ extension TableViewCoordinator {
             return
         }
 
-        let scope = DatabaseScope(
-            connectionId: connectionId,
-            database: databaseName ?? DatabaseManager.shared.browseScope(for: connectionId)?.database ?? "",
-            schema: schemaName
-        )
+        guard let scope = gridOriginScope else {
+            beginCellEdit(row: row, tableColumnIndex: column)
+            return
+        }
 
         let currentValue = cellValue(at: row, column: columnIndex)
         let isNullable = tableRows.columnNullable[columnName] ?? true

--- a/TablePro/Views/Results/ForeignKeyPreviewView.swift
+++ b/TablePro/Views/Results/ForeignKeyPreviewView.swift
@@ -28,7 +28,7 @@ private struct FKPreviewTaskKey: Equatable {
 
 struct ForeignKeyPreviewView: View {
     let model: FKPreviewModel
-    let connectionId: UUID
+    let scope: DatabaseScope
     let databaseType: DatabaseType
     let onNavigate: () -> Void
     let onDismiss: () -> Void
@@ -178,7 +178,7 @@ struct ForeignKeyPreviewView: View {
 
         do {
             let fetched = try await ForeignKeyRowFetcher.fetch(
-                connectionId: connectionId,
+                origin: scope,
                 databaseType: databaseType,
                 reference: JSONForeignKeyRef(fkInfo),
                 value: value

--- a/TablePro/Views/Structure/CreateTableGridDelegate.swift
+++ b/TablePro/Views/Structure/CreateTableGridDelegate.swift
@@ -47,7 +47,9 @@ final class CreateTableGridDelegate: DataGridViewDelegate {
         self.structureChangeManager = structureChangeManager
         self.structureTab = structureTab
         self.connection = connection
-        self.referenceMenus = ForeignKeyReferenceMenus(connectionId: connection.id)
+        self.referenceMenus = ForeignKeyReferenceMenus(
+            connectionId: connection.id, databaseType: connection.type
+        )
     }
 
     // MARK: - DataGridViewDelegate

--- a/TablePro/Views/Structure/ForeignKeyReferenceMenus.swift
+++ b/TablePro/Views/Structure/ForeignKeyReferenceMenus.swift
@@ -4,6 +4,7 @@
 //
 
 import Foundation
+import os
 import TableProPluginKit
 
 /// The menus behind the Foreign Keys grid's Columns, Ref Table and Ref Columns cells.
@@ -19,19 +20,77 @@ final class ForeignKeyReferenceMenus {
     static let rowDependentColumns: Set<Int> = [1, 2, 3]
 
     private let connectionId: UUID
+    private let databaseType: DatabaseType
 
     /// The schema the grid is browsing, used when a row names no Ref Schema of its own.
     var schemaName: String?
+
+    /// The scope the grid's own tab is bound to, which every reference read starts from. A tab stays
+    /// on the database it opened while the sidebar moves. Nil for a grid with no tab behind it, such
+    /// as the Create Table draft, which creates its table wherever the connection is browsing.
+    var origin: DatabaseScope?
 
     /// Fired when a referenced table's columns arrive. A menu built before the fetch landed shows
     /// `Loading…` and nothing else would rebuild it until an unrelated edit.
     var onListsChanged: (() -> Void)?
 
-    private var columnCache: [String: [String]] = [:]
-    private var inFlight: Set<String> = []
+    /// Which list, in which container. The kind is part of the key because a container's table list
+    /// and one of its tables' column lists are both `[String]`: keyed on the container alone they
+    /// overwrite each other, and the Ref Table menu starts offering column names.
+    private struct ListKey: Hashable {
+        enum Kind: Hashable {
+            case tables
+            case columns(String)
+        }
 
-    init(connectionId: UUID) {
+        let database: String
+        let schema: String?
+        let kind: Kind
+    }
+
+    private var lists: [ListKey: [String]] = [:]
+
+    /// Keys whose read failed. Separate from `lists` because an empty list and a read that could not
+    /// run are different answers, and storing the failure as `[]` made the menu offer nothing but
+    /// Custom for the life of the tab, with no error and no retry.
+    private var failedKeys: Set<ListKey> = []
+    private var inFlight: Set<ListKey> = []
+
+    private enum ListState {
+        case loading
+        case loaded([String])
+        case failed
+
+        var names: [String] {
+            guard case .loaded(let names) = self else { return [] }
+            return names
+        }
+
+        var isLoading: Bool {
+            guard case .loading = self else { return false }
+            return true
+        }
+    }
+
+    private static let logger = Logger(subsystem: "com.TablePro", category: "ForeignKeyReferenceMenus")
+
+    private let provider: any ScopedMetadataProviding
+
+    /// Read per use rather than stored, because a plugin's capabilities settle when it loads and a
+    /// slot resolved at construction would freeze whatever was known before that.
+    private let resolveSlot: @MainActor (DatabaseType) -> EngineNamespaceSlot
+
+    init(
+        connectionId: UUID,
+        databaseType: DatabaseType,
+        provider: any ScopedMetadataProviding = DatabaseManager.shared,
+        resolveSlot: @escaping @MainActor (DatabaseType) -> EngineNamespaceSlot =
+            EngineNamespaceSlot.init(databaseType:)
+    ) {
         self.connectionId = connectionId
+        self.databaseType = databaseType
+        self.provider = provider
+        self.resolveSlot = resolveSlot
     }
 
     /// - Parameter tableColumns: the columns of the table being edited, which the referencing
@@ -47,11 +106,13 @@ final class ForeignKeyReferenceMenus {
             return listOptions(
                 names: tableColumns.filter { !$0.isEmpty },
                 appendingTo: foreignKey.columns,
-                loading: false
+                state: .loaded(tableColumns)
             )
         case 2:
-            return ForeignKeyReferenceVocabulary.options(
-                names: referencedTableNames(schema: foreignKey.referencedSchema), loading: false
+            let tables = listState(.tables, schema: foreignKey.referencedSchema)
+            return reporting(
+                tables,
+                over: ForeignKeyReferenceVocabulary.options(names: tables.names, loading: tables.isLoading)
             )
         case 3:
             let table = foreignKey.referencedTable.trimmingCharacters(in: .whitespaces)
@@ -59,72 +120,140 @@ final class ForeignKeyReferenceMenus {
                 return [.custom(title: String(localized: "Custom…"))]
             }
             let schema = foreignKey.referencedSchema
+            let state = listState(.columns(table), schema: schema)
             return listOptions(
-                names: referencedColumnNames(of: table, schema: schema),
+                names: state.names,
                 appendingTo: foreignKey.referencedColumns,
-                loading: columnCache[cacheKey(table: table, schema: schema)] == nil
+                state: state
             )
         default:
             return nil
         }
     }
 
+    /// Drops what a schema refresh can have changed. The column lists survive: a refresh that
+    /// changed a referenced table's columns did not change which tables exist, and re-reading every
+    /// one of them on every refresh costs a round trip per open menu.
+    func invalidateTableLists() {
+        for key in lists.keys where key.kind == .tables {
+            lists.removeValue(forKey: key)
+        }
+        failedKeys = failedKeys.filter { $0.kind != .tables }
+    }
+
+    /// Warms the list before the chevron is opened. A key that already failed is left alone: the
+    /// retry belongs to the user reopening the menu, not to a render.
     func prefetchReferencedColumns(of table: String, schema: String?) {
         let trimmed = table.trimmingCharacters(in: .whitespaces)
-        guard !trimmed.isEmpty, columnCache[cacheKey(table: trimmed, schema: schema)] == nil else { return }
-        loadReferencedColumns(of: trimmed, schema: schema)
+        guard !trimmed.isEmpty, let resolved = resolvedList(.columns(trimmed), schema: schema) else { return }
+        guard lists[resolved.key] == nil, !failedKeys.contains(resolved.key) else { return }
+        load(resolved.key, from: resolved.target)
     }
 
     /// A cell holding a comma-separated list appends rather than replaces, so each entry carries the
     /// whole new list as the value it writes. That keeps the menu machinery untouched: it still just
     /// sets the cell to the selected option's SQL.
-    private func listOptions(names: [String], appendingTo current: [String], loading: Bool) -> [GridMenuOption] {
+    private func listOptions(
+        names: [String],
+        appendingTo current: [String],
+        state: ListState
+    ) -> [GridMenuOption] {
         let joined = current.joined(separator: ", ")
-        return ForeignKeyReferenceVocabulary.options(names: names, loading: loading).map { option in
-            guard case .value(let title, _) = option else { return option }
-            return .value(title: title, sql: ForeignKeyReferenceVocabulary.appending(title, to: joined))
-        }
+        let options = ForeignKeyReferenceVocabulary
+            .options(names: names, loading: state.isLoading)
+            .map { option -> GridMenuOption in
+                guard case .value(let title, _) = option else { return option }
+                return .value(title: title, sql: ForeignKeyReferenceVocabulary.appending(title, to: joined))
+            }
+        return reporting(state, over: options)
     }
 
-    /// Views are left out. `SchemaService.tables` returns them alongside tables on every engine that
-    /// reports both, SQLite included, and a foreign key cannot target one: offering it makes a
-    /// constraint the server refuses.
-    private func referencedTableNames(schema: String?) -> [String] {
-        let service = SchemaService.shared
-        let scopeSchema = schema ?? schemaName
-        let tables = scopeSchema.map { service.tables(for: connectionId, schema: $0) }
-            ?? service.tables(for: connectionId)
-        return tables.filter { $0.type.isForeignKeyTarget }.map(\.name)
+    /// A read that could not run and a container that holds nothing produce the same empty list, so
+    /// the menu says which it was rather than offering nothing and looking settled.
+    private func reporting(_ state: ListState, over options: [GridMenuOption]) -> [GridMenuOption] {
+        guard case .failed = state else { return options }
+        return [.sectionHeader(String(localized: "Couldn't read the referenced table"))] + options
     }
 
-    private func referencedColumnNames(of table: String, schema: String?) -> [String] {
-        if let cached = columnCache[cacheKey(table: table, schema: schema)] {
-            return cached
-        }
-        loadReferencedColumns(of: table, schema: schema)
-        return []
+    /// Reopening the menu is the retry: a failure is reported once and the read starts again behind
+    /// it, so a list that was briefly unreachable fills in by the next open.
+    private func listState(_ kind: ListKey.Kind, schema: String?) -> ListState {
+        guard let resolved = resolvedList(kind, schema: schema) else { return .loading }
+        if let cached = lists[resolved.key] { return .loaded(cached) }
+        load(resolved.key, from: resolved.target)
+        guard failedKeys.remove(resolved.key) != nil else { return .loading }
+        return .failed
     }
 
-    private func loadReferencedColumns(of table: String, schema: String?) {
-        let key = cacheKey(table: table, schema: schema)
+    /// Read through the tab's own driver rather than `SchemaService`, whose per-schema lists are
+    /// filled only for an engine that groups its tree by schema under a database. On every other
+    /// engine that store is never written, so a Ref Table menu asking it for a named schema got an
+    /// empty list on PostgreSQL, MySQL and the rest, whatever the connection actually holds.
+    private func load(_ key: ListKey, from target: DatabaseScope) {
         guard !inFlight.contains(key) else { return }
-        guard let scope = DatabaseManager.shared.browseScope(for: connectionId) else { return }
         inFlight.insert(key)
 
         Task { @MainActor in
             defer { inFlight.remove(key) }
-            let columns = try? await DatabaseManager.shared.withMetadataDriver(scope: scope) { driver in
-                try await driver.fetchColumns(table: table, schema: schema)
+            do {
+                let names = try await names(for: key.kind, in: target)
+                failedKeys.remove(key)
+                lists[key] = names
+            } catch {
+                Self.logger.error("Reference list read failed: \(error.localizedDescription)")
+                failedKeys.insert(key)
             }
-            columnCache[key] = (columns ?? []).map(\.name)
             onListsChanged?()
         }
     }
 
-    /// The row's own Ref Schema, not the grid's. Two rows pointing at `public.users` and
-    /// `audit.users` are different tables with different columns, and one key for both hands the
-    /// second row the first one's list.
-    private func cacheKey(table: String, schema: String?) -> String {
-        "\(connectionId.uuidString)|\(schema ?? schemaName ?? "")|\(table)"
+    /// Views are left out of the table list. Every engine that reports both returns them alongside
+    /// tables, SQLite included, and a foreign key cannot target one: offering it makes a constraint
+    /// the server refuses.
+    private func names(for kind: ListKey.Kind, in target: DatabaseScope) async throws -> [String] {
+        switch kind {
+        case .tables:
+            let tables = try await provider.withMetadataDriver(scope: target) { driver in
+                try await driver.fetchTables(schema: target.schema)
+            }
+            return tables.filter { $0.type.isForeignKeyTarget }.map(\.name)
+        case .columns(let table):
+            let columns = try await provider.withMetadataDriver(scope: target) { driver in
+                try await driver.fetchColumns(table: table, schema: target.schema)
+            }
+            return columns.map(\.name)
+        }
+    }
+
+    /// The row names its target in whatever the engine's catalog calls a schema, which on an engine
+    /// with no schema layer is a database, so it goes through `ForeignKeyTargetScope` rather than
+    /// into the schema slot, where it would be inert.
+    private func targetScope(for schema: String?) -> DatabaseScope? {
+        guard let origin = origin ?? provider.browseScope(for: connectionId) else {
+            return nil
+        }
+        return ForeignKeyTargetScope.resolve(
+            origin: origin, referencedSchema: schema, slot: resolveSlot(databaseType)
+        )
+    }
+
+    /// The row's own Ref Schema, not the grid's, and resolved the way the read is. Two rows
+    /// pointing at `public.users` and `audit.users` are different tables with different columns, and
+    /// one key for both hands the second row the first one's list. Keying on the raw value instead
+    /// collapses two databases to one entry on an engine whose catalog calls a database a schema.
+    ///
+    /// The key and the scope it was resolved from travel together: the key has already collapsed a
+    /// schema-less engine's reference into its database, so re-deriving the scope from the key would
+    /// read the tab's own container instead of the referenced one.
+    ///
+    /// Nil where no scope can be resolved at all, which is a connection with nothing to read rather
+    /// than a list that happens to be empty, so nothing is cached under it.
+    private func resolvedList(
+        _ kind: ListKey.Kind,
+        schema: String?
+    ) -> (key: ListKey, target: DatabaseScope)? {
+        guard let target = targetScope(for: schema) else { return nil }
+        let key = ListKey(database: target.database, schema: target.schema ?? schemaName, kind: kind)
+        return (key, target)
     }
 }

--- a/TablePro/Views/Structure/StructureGridDelegate.swift
+++ b/TablePro/Views/Structure/StructureGridDelegate.swift
@@ -85,7 +85,9 @@ final class StructureGridDelegate: DataGridViewDelegate {
         self.tableName = tableName
         self.objectKind = objectKind
         self.coordinator = coordinator
-        self.referenceMenus = ForeignKeyReferenceMenus(connectionId: connection.id)
+        self.referenceMenus = ForeignKeyReferenceMenus(
+            connectionId: connection.id, databaseType: connection.type
+        )
     }
 
     // MARK: - Index Translation
@@ -115,6 +117,7 @@ final class StructureGridDelegate: DataGridViewDelegate {
         guard sourceRowIndex >= 0, sourceRowIndex < structureChangeManager.workingForeignKeys.count else {
             return nil
         }
+        referenceMenus.origin = coordinator?.selectedTabScope
         return referenceMenus.options(
             columnIndex: columnIndex,
             foreignKey: structureChangeManager.workingForeignKeys[sourceRowIndex],
@@ -151,6 +154,7 @@ final class StructureGridDelegate: DataGridViewDelegate {
             StructureEditingSupport.updateForeignKey(&fk, at: column, with: newValue ?? "")
             structureChangeManager.updateForeignKey(id: fk.id, with: fk)
             if column == 2 {
+                referenceMenus.origin = coordinator?.selectedTabScope
                 referenceMenus.prefetchReferencedColumns(
                     of: fk.referencedTable, schema: fk.referencedSchema
                 )

--- a/TablePro/Views/Structure/TableStructureView+DataLoading.swift
+++ b/TablePro/Views/Structure/TableStructureView+DataLoading.swift
@@ -173,6 +173,7 @@ extension TableStructureView {
 
     private func reloadAllTabs() async {
         tabData.markAllStale()
+        session.gridDelegate.referenceMenus.invalidateTableLists()
         partsReloadToken += 1
         await reloadCoreTabs()
         if selectedTab == .ddl {

--- a/TablePro/Views/Structure/TriggerDetailView.swift
+++ b/TablePro/Views/Structure/TriggerDetailView.swift
@@ -132,11 +132,20 @@ struct TriggerDetailView: View {
         )
     }
 
+    /// Read through the tab's own scope rather than the session driver, which follows the sidebar:
+    /// an engine that qualifies its template with the connection's current database pre-fills a
+    /// statement that creates the trigger on a same-named table in whatever database that is.
     private func newTrigger() {
-        let driver = DatabaseManager.shared.driver(for: connection.id)
-        let template = driver?.createTriggerTemplate(table: tableName)
-            ?? "CREATE TRIGGER trigger_name\nAFTER INSERT ON \(tableName)\nBEGIN\nEND;"
-        editorSheet = TriggerEditorSheetItem(mode: .create, sql: template)
+        let scope = scope
+        let tableName = tableName
+        Task {
+            let generated = try? await DatabaseManager.shared.withMetadataDriver(scope: scope) { driver in
+                driver.createTriggerTemplate(table: tableName)
+            }
+            let template = (generated ?? nil)
+                ?? "CREATE TRIGGER trigger_name\nAFTER INSERT ON \(tableName)\nBEGIN\nEND;"
+            editorSheet = TriggerEditorSheetItem(mode: .create, sql: template)
+        }
     }
 
     private func editTrigger(_ trigger: TriggerInfo) {

--- a/TableProTests/Models/JSON/JSONRowSnapshotChangeTests.swift
+++ b/TableProTests/Models/JSON/JSONRowSnapshotChangeTests.swift
@@ -34,7 +34,11 @@ struct JSONRowSnapshotChangeTests {
             columnTypes: columnTypes,
             values: values,
             foreignKeys: foreignKeys,
-            connectionId: UUID(uuidString: "00000000-0000-0000-0000-0000000000AA") ?? UUID(),
+            scope: DatabaseScope(
+                connectionId: UUID(uuidString: "00000000-0000-0000-0000-0000000000AA") ?? UUID(),
+                database: "main",
+                schema: nil
+            ),
             databaseType: .sqlite
         )
     }

--- a/TableProTests/ViewModels/JSONRowInspectorViewModelTests.swift
+++ b/TableProTests/ViewModels/JSONRowInspectorViewModelTests.swift
@@ -68,7 +68,7 @@ struct JSONRowInspectorViewModelTests {
             columnTypes: [.integer(rawType: "INT"), .integer(rawType: "INT")],
             values: [.text("7"), artistId],
             foreignKeys: foreignKeys,
-            connectionId: connectionId,
+            scope: DatabaseScope(connectionId: connectionId, database: "main", schema: nil),
             databaseType: .sqlite
         )
     }

--- a/TableProTests/Views/Structure/ForeignKeyReferenceMenusTests.swift
+++ b/TableProTests/Views/Structure/ForeignKeyReferenceMenusTests.swift
@@ -1,0 +1,225 @@
+//
+//  ForeignKeyReferenceMenusTests.swift
+//  TableProTests
+//
+//  The Ref Columns menu's read: which container it asks, and what it does with a read that failed.
+//
+
+import Foundation
+@testable import TablePro
+import TableProPluginKit
+import Testing
+
+@MainActor
+private final class ScriptedColumnProvider: ScopedMetadataProviding {
+    private let driver = MockDatabaseDriver()
+    var browseDatabase: String? = "sidebar_db"
+    var failuresRemaining = 0
+    private(set) var requestedScopes: [DatabaseScope] = []
+
+    init(
+        table: String = "customers",
+        columns: [String] = ["id", "display_name"],
+        tables: [String] = ["customers", "orders"]
+    ) {
+        driver.columnsToReturn[table] = columns.map {
+            ColumnInfo(name: $0, dataType: "TEXT", isNullable: true, isPrimaryKey: false)
+        }
+        driver.tablesToReturn = tables.map {
+            TableInfo(name: $0, type: .table, rowCount: nil, schema: nil, comment: nil)
+        } + [TableInfo(name: "customer_view", type: .view, rowCount: nil, schema: nil, comment: nil)]
+    }
+
+    func withMetadataDriver<T: Sendable>(
+        scope: DatabaseScope,
+        workload: MetadataConnectionPool.Workload,
+        _ body: @Sendable @escaping (DatabaseDriver) async throws -> T
+    ) async throws -> T {
+        requestedScopes.append(scope)
+        if failuresRemaining > 0 {
+            failuresRemaining -= 1
+            throw DatabaseError.queryFailed("Table 'sidebar_db.customers' doesn't exist")
+        }
+        return try await body(driver)
+    }
+
+    func browseScope(for connectionId: UUID) -> DatabaseScope? {
+        guard let browseDatabase else { return nil }
+        return DatabaseScope(connectionId: connectionId, database: browseDatabase, schema: nil)
+    }
+}
+
+@Suite("Foreign key reference menus")
+@MainActor
+struct ForeignKeyReferenceMenusTests {
+    private static let connectionId = UUID(uuidString: "00000000-0000-0000-0000-0000000000CD") ?? UUID()
+
+    private func settle() async {
+        for _ in 0..<8 { await Task.yield() }
+    }
+
+    private func menus(
+        provider: ScriptedColumnProvider,
+        databaseType: DatabaseType = .mysql,
+        slot: EngineNamespaceSlot = .database,
+        origin: DatabaseScope? = DatabaseScope(
+            connectionId: ForeignKeyReferenceMenusTests.connectionId, database: "tab_db", schema: nil
+        )
+    ) -> ForeignKeyReferenceMenus {
+        let menus = ForeignKeyReferenceMenus(
+            connectionId: Self.connectionId,
+            databaseType: databaseType,
+            provider: provider,
+            resolveSlot: { _ in slot }
+        )
+        menus.origin = origin
+        return menus
+    }
+
+    private func refTableOptions(
+        _ menus: ForeignKeyReferenceMenus,
+        referencedSchema: String? = nil
+    ) -> [GridMenuOption] {
+        var foreignKey = EditableForeignKeyDefinition.placeholder()
+        foreignKey.referencedSchema = referencedSchema
+        return menus.options(columnIndex: 2, foreignKey: foreignKey, tableColumns: []) ?? []
+    }
+
+    private func refColumnOptions(
+        _ menus: ForeignKeyReferenceMenus,
+        table: String = "customers",
+        referencedSchema: String? = nil
+    ) -> [GridMenuOption] {
+        var foreignKey = EditableForeignKeyDefinition.placeholder()
+        foreignKey.referencedTable = table
+        foreignKey.referencedSchema = referencedSchema
+        return menus.options(columnIndex: 3, foreignKey: foreignKey, tableColumns: []) ?? []
+    }
+
+    private func titles(_ options: [GridMenuOption]) -> [String] {
+        options.compactMap { option in
+            switch option {
+            case .value(let title, _): return title
+            case .sectionHeader(let title): return title
+            case .custom(let title): return title
+            case .clear(let title): return title
+            }
+        }
+    }
+
+    /// A tab stays on the database it opened while the sidebar moves, so a read routed through the
+    /// browse cursor asked about whichever database the sidebar had reached.
+    @Test("The read routes through the tab's own scope, not the sidebar's")
+    func readsThroughTheTabScope() async {
+        let provider = ScriptedColumnProvider()
+        let menus = menus(provider: provider)
+        _ = refColumnOptions(menus)
+        await settle()
+
+        #expect(provider.requestedScopes.first?.database == "tab_db")
+        #expect(provider.requestedScopes.allSatisfy { $0.database != "sidebar_db" })
+    }
+
+    /// On an engine with no schema layer the row's Ref Schema names a database, so it belongs in the
+    /// database slot. Left in the schema slot it is inert and the read stays on the tab's database.
+    @Test("A referenced schema on a schema-less engine routes to that database")
+    func referencedSchemaBecomesTheDatabase() async {
+        let provider = ScriptedColumnProvider()
+        let menus = menus(provider: provider)
+        _ = refColumnOptions(menus, referencedSchema: "crm")
+        await settle()
+
+        #expect(provider.requestedScopes.first?.database == "crm")
+        #expect(provider.requestedScopes.first?.schema == nil)
+    }
+
+    /// The defect: a failed read cached as an empty list is indistinguishable from a table with no
+    /// columns, so the menu offered nothing but Custom for the life of the tab.
+    @Test("A failed read is reported and retried, not cached as no columns")
+    func failedReadRetriesOnReopen() async {
+        let provider = ScriptedColumnProvider()
+        provider.failuresRemaining = 1
+        let menus = menus(provider: provider)
+
+        _ = refColumnOptions(menus)
+        await settle()
+
+        let afterFailure = titles(refColumnOptions(menus))
+        #expect(afterFailure.contains { $0.contains("Couldn't read") })
+        await settle()
+
+        let afterRetry = titles(refColumnOptions(menus))
+        #expect(afterRetry.contains("display_name"))
+        #expect(!afterRetry.contains { $0.contains("Couldn't read") })
+    }
+
+    /// `SchemaService`'s per-schema lists are filled only for an engine that groups its tree by
+    /// schema under a database, so asking it for a named schema on MySQL or PostgreSQL returned an
+    /// empty list whatever the connection held, and the Ref Table menu offered nothing.
+    @Test("Ref Table lists the referenced container's tables, views excluded")
+    func refTableListsTablesFromTheDriver() async {
+        let provider = ScriptedColumnProvider()
+        let menus = menus(provider: provider)
+        _ = refTableOptions(menus, referencedSchema: "crm")
+        await settle()
+
+        let names = titles(refTableOptions(menus, referencedSchema: "crm"))
+        #expect(names.contains("customers"))
+        #expect(names.contains("orders"))
+        #expect(!names.contains("customer_view"))
+        #expect(provider.requestedScopes.first?.database == "crm")
+    }
+
+    /// Both lists are `[String]` in the same container, so a key that does not separate them has the
+    /// table list and a table's column list overwrite each other.
+    @Test("A container's table list and its columns do not share a cache entry")
+    func tableAndColumnListsDoNotCollide() async {
+        let provider = ScriptedColumnProvider()
+        let menus = menus(provider: provider)
+        _ = refTableOptions(menus)
+        _ = refColumnOptions(menus)
+        await settle()
+
+        let tables = titles(refTableOptions(menus))
+        let columns = titles(refColumnOptions(menus))
+        #expect(tables.contains("orders"))
+        #expect(columns.contains("display_name"))
+        #expect(!columns.contains("orders"))
+    }
+
+    /// A successful read still answers from the cache rather than asking again on every open.
+    @Test("A loaded list is served from the cache")
+    func loadedListIsCached() async {
+        let provider = ScriptedColumnProvider()
+        let menus = menus(provider: provider)
+        _ = refColumnOptions(menus)
+        await settle()
+        let requestsAfterFirstLoad = provider.requestedScopes.count
+
+        _ = refColumnOptions(menus)
+        await settle()
+
+        #expect(provider.requestedScopes.count == requestsAfterFirstLoad)
+    }
+
+    /// Two tabs on different databases name the same placeholder table, and on a schema-less engine
+    /// the raw Ref Schema is nil for both, so a key that ignores the database serves one the other's
+    /// columns.
+    @Test("Two databases with the same table name do not share a cache entry")
+    func cacheKeySeparatesDatabases() async {
+        let provider = ScriptedColumnProvider()
+        let first = menus(provider: provider)
+        _ = refColumnOptions(first)
+        await settle()
+
+        let second = menus(
+            provider: provider,
+            origin: DatabaseScope(connectionId: Self.connectionId, database: "other_db", schema: nil)
+        )
+        _ = refColumnOptions(second)
+        await settle()
+
+        #expect(provider.requestedScopes.map(\.database).contains("tab_db"))
+        #expect(provider.requestedScopes.map(\.database).contains("other_db"))
+    }
+}


### PR DESCRIPTION
Six defects in the foreign key and structure subsystem, all one class: a read or a statement resolving against whichever container the connection happens to be on, when the caller named another. Found while investigating #2769 and verified against a live MySQL 8.4.11 after both halves of that fix landed (#2797, #2798).

Two of them are regressions #2798 introduced, and they are the reason this is a PR rather than a note. A peer session found the Ref Table one and dropped its overlapping branch so this could land whole.

## What was wrong

**Nested chevrons in the row inspector pointed at the wrong database.** `ForeignKeyRowFetcher` read the referenced row through a name it qualified itself, so the row was right, then read that row's *own* foreign keys through `browseScope` plus a hand-built `DatabaseScope(database: origin, schema: referencedSchema)`. That scope shape is inert on an engine with no schema layer, so the nested read asked the sidebar's database. Where both databases had a same-named table, the crm row got a chevron that navigated into the app-side target.

**Ref Columns went permanently empty after one failed read.** `try? await ... fetchColumns` then `columnCache[key] = (columns ?? [])` stored a failure as "this table has no columns". Nothing retried, nothing logged, and `loading:` was `cache == nil`, so the menu showed only **Custom…** for the life of the tab with no error. It also read through `browseScope` rather than the tab's own scope, and keyed its cache on `schema ?? schemaName`, which is nil on a schema-less engine and collapses two databases to one entry.

**Ref Table was empty on most engines.** `referencedTableNames` read `SchemaService.tables(for:schema:)`, whose `perSchemaStates` store is written only by `runSchemaLoad`. All four of its callers are gated on `.hierarchicalSchema`: `SchemaRefreshService.swift:117` explicitly, and the three sidebar paths are schema-node expansions that only exist on such a tree. MySQL is `.byDatabase` and PostgreSQL and DuckDB are `.bySchema`, so that store is never written for them. The dropdown was therefore permanently empty on PostgreSQL, CockroachDB, Redshift, SQL Server and DuckDB, where the tab's schema is always set, and empty on MySQL, MariaDB and TiDB the moment a row named a Ref Schema, which is exactly the cross-database case. It worked only where both the tab schema and the row's Ref Schema are nil: SQLite, libSQL, D1.

**New Trigger and Drop Trigger named the wrong database.** Both built their SQL on `DatabaseManager.driver(for:)`, the session driver, which follows the sidebar. #2798 made MySQL's `createTriggerTemplate` and `generateDropTriggerSQL` qualify with the connection's current database, so the template pre-filled `ON \`sidebar_db\`.\`customers\`` for a tab on another database, and Drop Trigger built `DROP TRIGGER \`sidebar_db\`.\`trg\`` and then ran it on a pooled connection pinned somewhere else. Before #2798 those statements were unqualified and resolved against the executing connection, which was correct by accident. `apply()` already built its own drop SQL inside the lease; `drop()` did not.

**`describe_table` over MCP answered about two tables at once.** It passed `scope.schema` to `fetchColumns` and dropped it for indexes, foreign keys, check constraints, row count and DDL, which fell back to the session's container. #2798 is what created the split: before it, every part read the same wrong place, so the answer was at least self-consistent. Measured on the live fixture: columns came back as `id/display_name/region varchar(8)` from one database while `foreign_keys` reported `region -> tp2769_app.regions` from the other, so one description had `region` as both an unindexed varchar and an indexed integer key.

## The fix

Each read now starts from the scope its caller owns, and each statement is built on the driver that will run it.

- `ForeignKeyRowFetcher.fetch` takes an `origin: DatabaseScope`, resolves the target through `ForeignKeyTargetScope` (the helper #2797 added) and reads both the row and its nested keys through that one scope. It used to take the row off the raw session driver, and a qualified name only reaches inside the database the connection is already on, so once the tab and the sidebar drifted apart the row and its key map described two different tables. `JSONRowSnapshot` carries the scope instead of a bare connection id, filled from `coordinator.scope(for: tab)`.
- The picker and the preview now share one `gridOriginScope` on `TableViewCoordinator`. They were two expressions for one cell's target, which is how they drifted.
- `ForeignKeyReferenceMenus` takes the tab's `origin` and a `ScopedMetadataProviding` seam, routes through `ForeignKeyTargetScope`, keys its cache on the resolved scope, and keeps failures in a separate set so a reopen retries and the menu says **Couldn't read the referenced table** instead of silently offering nothing. It no longer reads `SchemaService` at all: both lists now come from the tab's own driver, through one cache whose key carries the kind as well as the container, because a container's table list and one of its tables' column lists are both `[String]` and would otherwise overwrite each other.
- `TriggerEditing.drop` builds its statement inside a lease on the target scope; `TriggerDetailView.newTrigger` reads its template the same way.
- `DatabaseDriver` gains `schema:` overloads for `fetchIndexes`, `fetchForeignKeys`, `fetchCheckConstraints`, `fetchApproximateRowCount`, `fetchTableDDL`, `fetchIndexDDL` and `fetchCommentDDL`, each defaulting to the unqualified read exactly as `fetchColumns` already did, so no conformer changes. `TableDDLComposer.fetchDDL` takes a schema and passes it to all three of its reads, and MCP's `describeTable` passes `scope.schema` everywhere.

This is the app-level protocol, not PluginKit, so no ABI bump.

## Verification

| Step | Result |
| --- | --- |
| `verify.sh build` | PASS |
| `verify.sh test` (12 suites) | PASS, 95 executed, 95 passed |
| `verify.sh lint TablePro …` | PASS, 0 violations |

Seven new cases in `ForeignKeyReferenceMenusTests` cover the Ref Table list coming from the driver with views excluded, the table and column lists not colliding in the cache, the tab-scope routing, a referenced schema resolving to a database on a schema-less engine, a failure being reported and retried rather than cached, a loaded list still being served from the cache, and two databases with the same table name not sharing an entry.

No UI automation: every one of these needs a live MySQL server with two databases and a cross-database foreign key, which does not run deterministically on CI.

One pre-existing lint violation sits at `JSONRowSnapshotChangeTests.swift:63` (`snapshot() == snapshot()`, flagged as `identical_operands`). It is on a line this PR does not touch, and `.swiftlint.yml` scopes to `TablePro`, so CI never sees it. Left alone.

Codex reviewed the diff and found four issues; all four are addressed. One was a real defect I had left: the row read still went through the session driver while its nested keys came from the resolved scope, so the fix was half applied. The other two substantive ones were Ref Table swallowing its own failure the way Ref Columns used to, and the table list never being dropped on a schema refresh, so a created or renamed table did not appear until the tab closed. On the fourth, asking for the new `///` blocks to be deleted under the no-comments rule, I trimmed the two that narrated caller history and kept the rest: that rule bans comments describing what code does, and this codebase records why a non-obvious choice was made in exactly this form.

## Not in this PR

`RowImportSheet` reads its table list and column mapping off the unpinned session driver (`:668`, `:674`, `:752`, `:758`) while its writes lease the browse scope. Verified real against the live fixture: after following a cross-database foreign key, the tab's database and the session driver's diverge, so the sheet can map fields against one database's `customers` and insert into another's. Pre-existing, independent of this change, and large enough to deserve its own PR.

https://claude.ai/code/session_01SP8Cj5R28unz7YhwL2BtiM
