### PR TITLE
fix(plugin-snowflake): name the database a foreign key points at, not just its schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Snowflake foreign keys into another database opening the current database's same-named table.
 - **None** in the foreign key picker's Label menu forgotten on reopen.
 - **Prompt for password** lost when importing a TablePlus connection set to **Ask everytime**.
 - TablePlus import saving a password for a connection TablePlus was set never to store one for.

--- a/Plugins/BeancountDriverPlugin/Info.plist
+++ b/Plugins/BeancountDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>29</integer>
+	<integer>30</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Beancount</string>

--- a/Plugins/BigQueryDriverPlugin/Info.plist
+++ b/Plugins/BigQueryDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>29</integer>
+	<integer>30</integer>
 </dict>
 </plist>

--- a/Plugins/CSVExportPlugin/Info.plist
+++ b/Plugins/CSVExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>29</integer>
+	<integer>30</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>csv</string>

--- a/Plugins/CSVImportPlugin/Info.plist
+++ b/Plugins/CSVImportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>29</integer>
+	<integer>30</integer>
 	<key>TableProProvidesImportFormatIds</key>
 	<array>
 		<string>csv</string>

--- a/Plugins/CassandraDriverPlugin/Info.plist
+++ b/Plugins/CassandraDriverPlugin/Info.plist
@@ -21,6 +21,6 @@
 	<key>NSPrincipalClass</key>
 	<string>$(PRODUCT_MODULE_NAME).CassandraPlugin</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>29</integer>
+	<integer>30</integer>
 </dict>
 </plist>

--- a/Plugins/ClickHouseDriverPlugin/Info.plist
+++ b/Plugins/ClickHouseDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>29</integer>
+	<integer>30</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>ClickHouse</string>

--- a/Plugins/CloudflareD1DriverPlugin/Info.plist
+++ b/Plugins/CloudflareD1DriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>29</integer>
+	<integer>30</integer>
 </dict>
 </plist>

--- a/Plugins/CloudflareR2SQLDriverPlugin/Info.plist
+++ b/Plugins/CloudflareR2SQLDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>29</integer>
+	<integer>30</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Cloudflare R2 SQL</string>

--- a/Plugins/DamengDriverPlugin/Info.plist
+++ b/Plugins/DamengDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>29</integer>
+	<integer>30</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Dameng</string>

--- a/Plugins/DuckDBDriverPlugin/Info.plist
+++ b/Plugins/DuckDBDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>29</integer>
+	<integer>30</integer>
 </dict>
 </plist>

--- a/Plugins/DynamoDBDriverPlugin/Info.plist
+++ b/Plugins/DynamoDBDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>29</integer>
+	<integer>30</integer>
 </dict>
 </plist>

--- a/Plugins/ElasticsearchDriverPlugin/Info.plist
+++ b/Plugins/ElasticsearchDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.53.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>29</integer>
+	<integer>30</integer>
 </dict>
 </plist>

--- a/Plugins/EtcdDriverPlugin/Info.plist
+++ b/Plugins/EtcdDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>29</integer>
+	<integer>30</integer>
 </dict>
 </plist>

--- a/Plugins/HTMLExportPlugin/Info.plist
+++ b/Plugins/HTMLExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>29</integer>
+	<integer>30</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>html</string>

--- a/Plugins/JSONExportPlugin/Info.plist
+++ b/Plugins/JSONExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>29</integer>
+	<integer>30</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>json</string>

--- a/Plugins/JSONImportPlugin/Info.plist
+++ b/Plugins/JSONImportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>29</integer>
+	<integer>30</integer>
 	<key>TableProProvidesImportFormatIds</key>
 	<array>
 		<string>json</string>

--- a/Plugins/KafkaDriverPlugin/Info.plist
+++ b/Plugins/KafkaDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>29</integer>
+	<integer>30</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Kafka</string>

--- a/Plugins/LibSQLDriverPlugin/Info.plist
+++ b/Plugins/LibSQLDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>29</integer>
+	<integer>30</integer>
 </dict>
 </plist>

--- a/Plugins/MQLExportPlugin/Info.plist
+++ b/Plugins/MQLExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>29</integer>
+	<integer>30</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>mql</string>

--- a/Plugins/MSSQLDriverPlugin/Info.plist
+++ b/Plugins/MSSQLDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>29</integer>
+	<integer>30</integer>
 </dict>
 </plist>

--- a/Plugins/MarkdownExportPlugin/Info.plist
+++ b/Plugins/MarkdownExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>29</integer>
+	<integer>30</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>md</string>

--- a/Plugins/MongoDBDriverPlugin/Info.plist
+++ b/Plugins/MongoDBDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>29</integer>
+	<integer>30</integer>
 </dict>
 </plist>

--- a/Plugins/MySQLDriverPlugin/Info.plist
+++ b/Plugins/MySQLDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>29</integer>
+	<integer>30</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>MySQL</string>

--- a/Plugins/OracleDriverPlugin/Info.plist
+++ b/Plugins/OracleDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>29</integer>
+	<integer>30</integer>
 </dict>
 </plist>

--- a/Plugins/ParquetExportPlugin/Info.plist
+++ b/Plugins/ParquetExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>29</integer>
+	<integer>30</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>parquet</string>

--- a/Plugins/PostgreSQLDriverPlugin/Info.plist
+++ b/Plugins/PostgreSQLDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>29</integer>
+	<integer>30</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>PostgreSQL</string>

--- a/Plugins/RedisDriverPlugin/Info.plist
+++ b/Plugins/RedisDriverPlugin/Info.plist
@@ -21,7 +21,7 @@
 	<key>NSPrincipalClass</key>
 	<string>$(PRODUCT_MODULE_NAME).RedisPlugin</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>29</integer>
+	<integer>30</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Redis</string>

--- a/Plugins/SQLExportPlugin/Info.plist
+++ b/Plugins/SQLExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>29</integer>
+	<integer>30</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>sql</string>

--- a/Plugins/SQLImportPlugin/Info.plist
+++ b/Plugins/SQLImportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>29</integer>
+	<integer>30</integer>
 	<key>TableProProvidesImportFormatIds</key>
 	<array>
 		<string>sql</string>

--- a/Plugins/SQLiteDriverPlugin/Info.plist
+++ b/Plugins/SQLiteDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>29</integer>
+	<integer>30</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>SQLite</string>

--- a/Plugins/SnowflakeDriverPlugin/Info.plist
+++ b/Plugins/SnowflakeDriverPlugin/Info.plist
@@ -5,6 +5,6 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.48.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>29</integer>
+	<integer>30</integer>
 </dict>
 </plist>

--- a/Plugins/SnowflakeDriverPlugin/SnowflakePluginDriver.swift
+++ b/Plugins/SnowflakeDriverPlugin/SnowflakePluginDriver.swift
@@ -466,6 +466,7 @@ final class SnowflakePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
               let pkColumnIdx = columnIndex(of: "pk_column_name", in: result) else { return [] }
         let fkNameIdx = columnIndex(of: "fk_name", in: result)
         let pkSchemaIdx = columnIndex(of: "pk_schema_name", in: result)
+        let pkDatabaseIdx = columnIndex(of: "pk_database_name", in: result)
 
         return result.rows.compactMap { row in
             guard let column = Self.text(row, fkColumnIdx),
@@ -476,6 +477,9 @@ final class SnowflakePluginDriver: PluginDatabaseDriver, @unchecked Sendable {
                 column: column,
                 referencedTable: referencedTable,
                 referencedColumn: referencedColumn,
+                referencedDatabase: SnowflakeSchemaQueries.referencedDatabase(
+                    reported: pkDatabaseIdx.flatMap { Self.text(row, $0) }, local: database
+                ),
                 referencedSchema: pkSchemaIdx.flatMap { Self.text(row, $0) }
             )
         }

--- a/Plugins/SnowflakeDriverPlugin/SnowflakeSchemaQueries.swift
+++ b/Plugins/SnowflakeDriverPlugin/SnowflakeSchemaQueries.swift
@@ -80,3 +80,19 @@ enum SnowflakeSchemaQueries {
         parts.map(quote).joined(separator: ".")
     }
 }
+
+internal extension SnowflakeSchemaQueries {
+    /// The database a foreign key points at, or nil when it points at the one it was read from.
+    ///
+    /// `SHOW IMPORTED KEYS` reports `pk_database_name` beside `pk_schema_name`, and the driver used
+    /// to read only the second, so a key into another database resolved to the current one's
+    /// same-named table. Snowflake folds an unquoted identifier to upper case and answers in its own
+    /// spelling, so a same-database key is recognised case-insensitively and reported as nil, which
+    /// keeps every existing key resolving exactly as before.
+    static func referencedDatabase(reported: String?, local: String?) -> String? {
+        guard let reported, !reported.isEmpty else { return nil }
+        guard let local, !local.isEmpty else { return reported }
+        return reported.caseInsensitiveCompare(local) == .orderedSame ? nil : reported
+    }
+}
+

--- a/Plugins/SpannerDriverPlugin/Info.plist
+++ b/Plugins/SpannerDriverPlugin/Info.plist
@@ -5,7 +5,7 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.42.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>29</integer>
+	<integer>30</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Spanner</string>

--- a/Plugins/SurrealDBDriverPlugin/Info.plist
+++ b/Plugins/SurrealDBDriverPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>29</integer>
+	<integer>30</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>SurrealDB</string>

--- a/Plugins/TableProPluginKit/PluginForeignKeyInfo.swift
+++ b/Plugins/TableProPluginKit/PluginForeignKeyInfo.swift
@@ -5,6 +5,11 @@ public struct PluginForeignKeyInfo: Codable, Sendable {
     public let column: String
     public let referencedTable: String
     public let referencedColumn: String
+    /// The database the referenced table lives in, when the engine names objects in three parts and
+    /// the key points outside the one it was read from. Nil everywhere else, including on an engine
+    /// with no schema layer, which names its referenced database in `referencedSchema` because that
+    /// is the column its catalog puts it in.
+    public let referencedDatabase: String?
     public let referencedSchema: String?
     public let onDelete: String
     public let onUpdate: String
@@ -14,6 +19,7 @@ public struct PluginForeignKeyInfo: Codable, Sendable {
         column: String,
         referencedTable: String,
         referencedColumn: String,
+        referencedDatabase: String?,
         referencedSchema: String? = nil,
         onDelete: String = "NO ACTION",
         onUpdate: String = "NO ACTION"
@@ -22,8 +28,37 @@ public struct PluginForeignKeyInfo: Codable, Sendable {
         self.column = column
         self.referencedTable = referencedTable
         self.referencedColumn = referencedColumn
+        self.referencedDatabase = referencedDatabase
         self.referencedSchema = referencedSchema
         self.onDelete = onDelete
         self.onUpdate = onUpdate
+    }
+
+    /// The signature every already-built plugin links against, kept byte for byte.
+    ///
+    /// Adding a parameter to a published initializer replaces its mangled symbol and every plugin
+    /// compiled against the old one fails to load; 0.49.0 shipped exactly that when
+    /// `PluginQueryResult` gained `columnMeta:`. So the new field arrives on a second initializer
+    /// and this one stays, marked `@_disfavoredOverload` so new code resolves to the full one.
+    @_disfavoredOverload
+    public init(
+        name: String,
+        column: String,
+        referencedTable: String,
+        referencedColumn: String,
+        referencedSchema: String? = nil,
+        onDelete: String = "NO ACTION",
+        onUpdate: String = "NO ACTION"
+    ) {
+        self.init(
+            name: name,
+            column: column,
+            referencedTable: referencedTable,
+            referencedColumn: referencedColumn,
+            referencedDatabase: nil,
+            referencedSchema: referencedSchema,
+            onDelete: onDelete,
+            onUpdate: onUpdate
+        )
     }
 }

--- a/Plugins/TeradataDriverPlugin/Info.plist
+++ b/Plugins/TeradataDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>29</integer>
+	<integer>30</integer>
 </dict>
 </plist>

--- a/Plugins/TrinoDriverPlugin/Info.plist
+++ b/Plugins/TrinoDriverPlugin/Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>29</integer>
+	<integer>30</integer>
 </dict>
 </plist>

--- a/Plugins/TypesenseDriverPlugin/Info.plist
+++ b/Plugins/TypesenseDriverPlugin/Info.plist
@@ -5,7 +5,7 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.73.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>29</integer>
+	<integer>30</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Typesense</string>

--- a/Plugins/WeaviateDriverPlugin/Info.plist
+++ b/Plugins/WeaviateDriverPlugin/Info.plist
@@ -5,7 +5,7 @@
 	<key>TableProMinAppVersion</key>
 	<string>0.73.0</string>
 	<key>TableProPluginKitVersion</key>
-	<integer>29</integer>
+	<integer>30</integer>
 	<key>TableProProvidesDatabaseTypeIds</key>
 	<array>
 		<string>Weaviate</string>

--- a/Plugins/XLSXExportPlugin/Info.plist
+++ b/Plugins/XLSXExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>29</integer>
+	<integer>30</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>xlsx</string>

--- a/Plugins/XLSXImportPlugin/Info.plist
+++ b/Plugins/XLSXImportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>29</integer>
+	<integer>30</integer>
 	<key>TableProProvidesImportFormatIds</key>
 	<array>
 		<string>xlsx</string>

--- a/Plugins/XMLExportPlugin/Info.plist
+++ b/Plugins/XMLExportPlugin/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>TableProPluginKitVersion</key>
-	<integer>29</integer>
+	<integer>30</integer>
 	<key>TableProProvidesExportFormatIds</key>
 	<array>
 		<string>xml</string>

--- a/TablePro/Core/Plugins/PluginDriverAdapter.swift
+++ b/TablePro/Core/Plugins/PluginDriverAdapter.swift
@@ -340,6 +340,7 @@ final class PluginDriverAdapter: DatabaseDriver, SchemaSwitchable, DatabaseRepor
                 column: fk.column,
                 referencedTable: fk.referencedTable,
                 referencedColumn: fk.referencedColumn,
+                referencedDatabase: fk.referencedDatabase,
                 referencedSchema: fk.referencedSchema,
                 onDelete: fk.onDelete,
                 onUpdate: fk.onUpdate
@@ -586,7 +587,9 @@ final class PluginDriverAdapter: DatabaseDriver, SchemaSwitchable, DatabaseRepor
         for (table, fks) in pluginResult {
             result[table] = fks.map { fk in
                 ForeignKeyInfo(name: fk.name, column: fk.column, referencedTable: fk.referencedTable,
-                               referencedColumn: fk.referencedColumn, referencedSchema: fk.referencedSchema,
+                               referencedColumn: fk.referencedColumn,
+                               referencedDatabase: fk.referencedDatabase,
+                               referencedSchema: fk.referencedSchema,
                                onDelete: fk.onDelete, onUpdate: fk.onUpdate)
             }
         }

--- a/TablePro/Core/Plugins/PluginManager.swift
+++ b/TablePro/Core/Plugins/PluginManager.swift
@@ -55,7 +55,7 @@ final class PluginManager {
     /// rebuilt CassandraDriver for the v20 requirements it implements none of. Left at 20, such a
     /// plugin passes `validateBundleVersions` in a shipped v20 app and then fails
     /// `Bundle.loadAndReturnError`; at 21 that app refuses it and says to update.
-    nonisolated static let currentPluginKitVersion = 29
+    nonisolated static let currentPluginKitVersion = 30
 
     /// Still 19, so every plugin already published for the previous release keeps loading.
     nonisolated static let minimumCompatiblePluginKitVersion = 19

--- a/TablePro/Core/Services/Query/ForeignKeyLookupService.swift
+++ b/TablePro/Core/Services/Query/ForeignKeyLookupService.swift
@@ -115,7 +115,10 @@ enum ForeignKeyLookupService {
         reference: ForeignKeyInfo
     ) -> DatabaseScope {
         ForeignKeyTargetScope.resolve(
-            origin: origin, referencedSchema: reference.referencedSchema, databaseType: databaseType
+            origin: origin,
+            referencedDatabase: reference.referencedDatabase,
+            referencedSchema: reference.referencedSchema,
+            databaseType: databaseType
         )
     }
 
@@ -126,6 +129,7 @@ enum ForeignKeyLookupService {
     ) -> TableScope {
         ForeignKeyTargetScope.tableScope(
             origin: origin,
+            referencedDatabase: reference.referencedDatabase,
             referencedSchema: reference.referencedSchema,
             referencedTable: reference.referencedTable,
             databaseType: databaseType

--- a/TablePro/Core/Services/Query/ForeignKeyTargetScope.swift
+++ b/TablePro/Core/Services/Query/ForeignKeyTargetScope.swift
@@ -21,14 +21,25 @@ import TableProPluginKit
 internal enum ForeignKeyTargetScope {
     internal static func resolve(
         origin: DatabaseScope,
+        referencedDatabase: String? = nil,
         referencedSchema: String?,
         slot: EngineNamespaceSlot
     ) -> DatabaseScope {
-        guard let referenced = referencedSchema?.nilIfEmpty else { return origin }
+        let database = referencedDatabase?.nilIfEmpty
+        guard let referenced = referencedSchema?.nilIfEmpty else {
+            guard let database, slot == .schema else { return origin }
+            return DatabaseScope(
+                connectionId: origin.connectionId, database: database, schema: origin.schema
+            )
+        }
         switch slot {
         case .schema:
+            /// Only an engine that names objects in three parts reports a referenced database, and
+            /// only that arm can carry one: the others already hold a database in this slot.
             return DatabaseScope(
-                connectionId: origin.connectionId, database: origin.database, schema: referenced
+                connectionId: origin.connectionId,
+                database: database ?? origin.database,
+                schema: referenced
             )
         case .database:
             return DatabaseScope(
@@ -43,11 +54,17 @@ internal enum ForeignKeyTargetScope {
 
     internal static func tableScope(
         origin: DatabaseScope,
+        referencedDatabase: String? = nil,
         referencedSchema: String?,
         referencedTable: String,
         slot: EngineNamespaceSlot
     ) -> TableScope {
-        let scope = resolve(origin: origin, referencedSchema: referencedSchema, slot: slot)
+        let scope = resolve(
+            origin: origin,
+            referencedDatabase: referencedDatabase,
+            referencedSchema: referencedSchema,
+            slot: slot
+        )
         return TableScope(
             connectionId: scope.connectionId,
             database: scope.database.nilIfEmpty,
@@ -61,11 +78,13 @@ internal enum ForeignKeyTargetScope {
 internal extension ForeignKeyTargetScope {
     static func resolve(
         origin: DatabaseScope,
+        referencedDatabase: String? = nil,
         referencedSchema: String?,
         databaseType: DatabaseType
     ) -> DatabaseScope {
         resolve(
             origin: origin,
+            referencedDatabase: referencedDatabase,
             referencedSchema: referencedSchema,
             slot: EngineNamespaceSlot(databaseType: databaseType)
         )
@@ -73,12 +92,14 @@ internal extension ForeignKeyTargetScope {
 
     static func tableScope(
         origin: DatabaseScope,
+        referencedDatabase: String? = nil,
         referencedSchema: String?,
         referencedTable: String,
         databaseType: DatabaseType
     ) -> TableScope {
         tableScope(
             origin: origin,
+            referencedDatabase: referencedDatabase,
             referencedSchema: referencedSchema,
             referencedTable: referencedTable,
             slot: EngineNamespaceSlot(databaseType: databaseType)

--- a/TablePro/Models/Query/QueryResult.swift
+++ b/TablePro/Models/Query/QueryResult.swift
@@ -281,6 +281,10 @@ struct ForeignKeyInfo: Identifiable, Hashable {
     let column: String
     let referencedTable: String
     let referencedColumn: String
+    /// Set only by an engine that names objects in three parts and reports a key pointing outside
+    /// the database it was read from. An engine with no schema layer names its referenced database
+    /// in `referencedSchema` instead, because that is the column its catalog puts it in.
+    let referencedDatabase: String?
     let referencedSchema: String?
     let onDelete: String  // CASCADE, SET NULL, RESTRICT, NO ACTION
     let onUpdate: String
@@ -290,6 +294,7 @@ struct ForeignKeyInfo: Identifiable, Hashable {
         column: String,
         referencedTable: String,
         referencedColumn: String,
+        referencedDatabase: String? = nil,
         referencedSchema: String? = nil,
         onDelete: String = "NO ACTION",
         onUpdate: String = "NO ACTION"
@@ -298,6 +303,7 @@ struct ForeignKeyInfo: Identifiable, Hashable {
         self.column = column
         self.referencedTable = referencedTable
         self.referencedColumn = referencedColumn
+        self.referencedDatabase = referencedDatabase
         self.referencedSchema = referencedSchema
         self.onDelete = onDelete
         self.onUpdate = onUpdate

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+FKNavigation.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+FKNavigation.swift
@@ -62,7 +62,10 @@ extension MainContentCoordinator {
         /// from the same table opened from the sidebar: its own filters, its own column layout, no
         /// tab to reuse, and a rename that never found it.
         let target = ForeignKeyTargetScope.resolve(
-            origin: sourceScope, referencedSchema: fkInfo.referencedSchema, databaseType: connection.type
+            origin: sourceScope,
+            referencedDatabase: fkInfo.referencedDatabase,
+            referencedSchema: fkInfo.referencedSchema,
+            databaseType: connection.type
         )
         let targetDatabase = target.database
         let targetSchema = target.schema

--- a/TableProTests/Core/Services/ForeignKeyTargetScopeTests.swift
+++ b/TableProTests/Core/Services/ForeignKeyTargetScopeTests.swift
@@ -79,6 +79,58 @@ struct ForeignKeyTargetScopeTests {
         #expect(resolved.schema == nil)
     }
 
+    // MARK: - A referenced database
+
+    /// Snowflake names objects in three parts, so a key can point outside the database it was read
+    /// from. Only the schema arm can carry one: the other two already hold a database in that slot.
+    @Test("A schema engine follows a reference into another database")
+    func schemaEngineFollowsAReferencedDatabase() {
+        let resolved = ForeignKeyTargetScope.resolve(
+            origin: origin(database: "analytics", schema: "public"),
+            referencedDatabase: "raw",
+            referencedSchema: "events",
+            slot: .schema
+        )
+        #expect(resolved.database == "raw")
+        #expect(resolved.schema == "events")
+    }
+
+    @Test("A referenced database with no schema of its own keeps the origin's")
+    func referencedDatabaseAloneKeepsTheOriginSchema() {
+        let resolved = ForeignKeyTargetScope.resolve(
+            origin: origin(database: "analytics", schema: "public"),
+            referencedDatabase: "raw",
+            referencedSchema: nil,
+            slot: .schema
+        )
+        #expect(resolved.database == "raw")
+        #expect(resolved.schema == "public")
+    }
+
+    /// An engine with no schema layer already names its referenced database in the schema slot, so
+    /// a second one would be two answers to one question. MySQL cannot move.
+    @Test("A schema-less engine ignores a referenced database", arguments: [EngineNamespaceSlot.database, .unqualified])
+    func schemaLessEngineIgnoresAReferencedDatabase(slot: EngineNamespaceSlot) {
+        let resolved = ForeignKeyTargetScope.resolve(
+            origin: origin(),
+            referencedDatabase: "ignored",
+            referencedSchema: "warehouse",
+            slot: slot
+        )
+        #expect(resolved.database == (slot == .database ? "warehouse" : "shop"))
+        #expect(resolved.schema == nil)
+    }
+
+    @Test("A reference naming neither container still keeps the origin untouched")
+    func neitherContainerKeepsOrigin() {
+        let source = origin(schema: "public")
+        #expect(
+            ForeignKeyTargetScope.resolve(
+                origin: source, referencedDatabase: nil, referencedSchema: nil, slot: .schema
+            ) == source
+        )
+    }
+
     // MARK: - Agreement with the canonical table scope
 
     /// The invariant #2768 broke. A foreign key label, a filter, a column layout, a highlight rule

--- a/TableProTests/Plugins/SnowflakeImportedKeysTests.swift
+++ b/TableProTests/Plugins/SnowflakeImportedKeysTests.swift
@@ -1,0 +1,51 @@
+//
+//  SnowflakeImportedKeysTests.swift
+//  TableProTests
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+/// `SHOW IMPORTED KEYS` reports `pk_database_name` beside `pk_schema_name`, and the driver read only
+/// the second, so a key pointing into another database resolved to the current one's same-named
+/// table. Snowflake names objects in three parts, so the database is the half that was missing.
+@Suite("Snowflake imported keys")
+struct SnowflakeImportedKeysTests {
+    @Test("A key into another database reports that database")
+    func crossDatabaseKeyReportsItsDatabase() {
+        #expect(
+            SnowflakeSchemaQueries.referencedDatabase(reported: "RAW", local: "ANALYTICS") == "RAW"
+        )
+    }
+
+    /// A same-database key must resolve exactly as it did before the fix, or every existing key on
+    /// every Snowflake account moves.
+    @Test("A key into the current database reports nothing")
+    func sameDatabaseKeyReportsNothing() {
+        #expect(
+            SnowflakeSchemaQueries.referencedDatabase(reported: "ANALYTICS", local: "ANALYTICS") == nil
+        )
+    }
+
+    /// Snowflake folds an unquoted identifier to upper case and answers in its own spelling, so the
+    /// two sides can differ in case for one database.
+    @Test("Case alone does not make it another database")
+    func caseAloneIsNotAnotherDatabase() {
+        #expect(
+            SnowflakeSchemaQueries.referencedDatabase(reported: "ANALYTICS", local: "analytics") == nil
+        )
+    }
+
+    /// An older Snowflake, or a result read through a path that does not carry the column.
+    @Test("A result with no database column reports nothing", arguments: [String?.none, ""])
+    func missingDatabaseColumnReportsNothing(reported: String?) {
+        #expect(SnowflakeSchemaQueries.referencedDatabase(reported: reported, local: "ANALYTICS") == nil)
+    }
+
+    @Test("With no current database the reported one is taken at its word")
+    func withoutALocalDatabaseTheReportedOneStands() {
+        #expect(SnowflakeSchemaQueries.referencedDatabase(reported: "RAW", local: nil) == "RAW")
+        #expect(SnowflakeSchemaQueries.referencedDatabase(reported: "RAW", local: "") == "RAW")
+    }
+}


### PR DESCRIPTION
Found while investigating #2768.

## The bug

Snowflake names objects in three parts, `database.schema.table`, and `SHOW IMPORTED KEYS` reports `pk_database_name` beside `pk_schema_name`. The driver read only the second and dropped the first, so a foreign key pointing into another database came back pairing the right schema with the wrong database.

Snowflake gives every database a `PUBLIC` schema, so the wrong scope usually names a table that really exists rather than failing: the arrow opens `ANALYTICS.PUBLIC.customers` for a key that points at `RAW.PUBLIC.customers`, and the value picker lists that table's rows. Snowflake's foreign keys are informational and unenforced, which is why this has gone unnoticed, not why it is harmless.

Snowflake is the only engine in this shape. BigQuery and Trino return no foreign keys at all; SQL Server reads `sys.foreign_keys` per database and forbids a cross-database key; Spanner and DuckDB are one database per connection.

## Why this needs a PluginKit field

`PluginForeignKeyInfo` had nowhere to put a referenced database, and there is no way to smuggle one into `referencedSchema`: `SchemaQualifiedName.render` quotes that slot as a single identifier, so `"RAW.PUBLIC"."customers"` is one name, not two. An engine with no schema layer, MySQL and friends, legitimately puts its referenced *database* in that slot because that is the column its catalog uses, so the slot is already spoken for.

So the field is real and additive:

- `PluginForeignKeyInfo` gains `referencedDatabase`, on a **new** initializer. The published one is kept byte for byte and marked `@_disfavoredOverload`, because adding a parameter to a shipped initializer replaces its mangled symbol and every plugin built against the old one fails to load. That is exactly what 0.49.0 shipped when `PluginQueryResult` gained `columnMeta:`.
- `currentPluginKitVersion` 29 to 30, with `minimumCompatiblePluginKitVersion` left at 19, so every plugin already out there keeps loading and a plugin rebuilt against 30 is refused cleanly by an older app rather than failing at `Bundle.loadAndReturnError`. `TableProPluginKitVersion` is bumped in all 40 plugin `Info.plist` files in the same commit.
- Additive, so no bulk re-release is forced. **The Snowflake fix reaches nobody until that registry-only plugin is tagged and published**, which is a separate act and left to you.

## The resolver

`ForeignKeyTargetScope.resolve` takes the referenced database, and only the `.schema` arm reads it. The other two already hold a database in the schema slot, so a second one would be two answers to one question, and MySQL, MariaDB and TiDB cannot move. A reference naming neither container still returns the origin untouched, which is what keeps DuckDB, Trino, BigQuery, SurrealDB and CloudflareR2SQL correct.

Routing, not qualifying: once the scope names `RAW`, the pooled driver connects there and the read is right. `SnowflakePluginDriver.fetchColumns` hardcodes `connection.currentDatabase`, so qualifying alone could not have worked.

A same-database key reports `nil`, recognised case-insensitively because Snowflake folds unquoted identifiers to upper case and answers in its own spelling. Every key that resolves correctly today resolves identically after this.

## Verification

| Step | Result |
|---|---|
| `verify.sh build` | PASS |
| `verify.sh plugins` (AllPlugins, all 41) | pre-existing failure only, see below |
| `verify.sh test` over the Snowflake, resolver and FK navigation suites | PASS, 65 cases |
| `verify.sh lint TablePro TableProTests Plugins` | PASS, 0 violations |
| `verify.sh abi origin/main` | diff reported, classified additive below |

`AllPlugins` fails on `oracle-nio`'s `@TaskLocal` macro expanding to `unknown attribute 'usableFromInlinenonisolated'`. That is pre-existing and unrelated: it is the only error in the log, the Snowflake plugin and TableProPluginKit both compiled, and no other plugin broke against the new field.

Eleven new cases, confirmed present in the run log. `crossDatabaseKeyReportsItsDatabase` and `schemaEngineFollowsAReferencedDatabase` fail before the fix. The rest pin what must not move: a same-database key, a case-only difference, a result with no `pk_database_name` column at all, a schema-less engine ignoring the new field entirely, and a reference naming neither container.

**The ABI gate reports the diff and asks for a classification, so here is the measurement rather than an assertion.** Built the old and new struct shapes side by side with library evolution on and diffed the exported initializer symbols:

```
old:     _$s1PAAV1a1bABSS_SSSgtcfC
new:     _$s1PAAV1a1bABSS_SSSgtcfC      <- the shipped one, unchanged
         _$s1PAAV1a1c1bABSS_SSSgAFtcfC  <- the new one
in OLD but missing from NEW:  (none)
```

`@_disfavoredOverload` is a resolution hint and is not part of the mangling, so the published initializer keeps its exact symbol and no already-built plugin loses anything it links against. Additive, which is why the floor stays at 19.

No live Snowflake account was reachable, so the column list is taken from the Snowflake JDBC driver's own `SHOW IMPORTED KEYS` fixture, which pins `pk_database_name` as column 1. The fix is a no-op whenever the two databases agree.


https://claude.ai/code/session_01AJc1W7uFR36m7Stzscf55H
