### PR TITLE
fix(coordinator): name the container a read or a statement means instead of the session's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- ClickHouse **Drop Partition** and **Detach Partition** acting on the sidebar's database instead of the table on screen, and running without the connection's destructive-statement confirmation.
+- Import listing one database's tables and mapping their columns while the rows went to another.
+- **New Table** created in the database the sidebar moved to rather than the one its own tab names.
+- **Show All Tables** listing whichever database a cross-database tab last left the connection on.
+- Sidebar **Refresh** reloading the object list from a container the user is not browsing.
+- Wrong export row total where the objects picked span more than one database.
 - Snowflake foreign keys into another database opening the current database's same-named table.
 - Wrong database read, and written, by a connection whose startup commands select one of their own.
 - **None** in the foreign key picker's Label menu forgotten on reopen.

--- a/TablePro/Core/Services/Export/ExportService.swift
+++ b/TablePro/Core/Services/Export/ExportService.swift
@@ -138,10 +138,10 @@ final class ExportService {
             throw ExportError.notConnected
         }
 
-        state.totalRows = await fetchTotalRowCount(
-            for: objects.filter { $0.kind.carriesRows }, driver: driver)
-
         let dataSource = ExportDataSourceAdapter(driver: driver, databaseType: databaseType)
+
+        state.totalRows = await fetchTotalRowCount(
+            for: objects.filter { $0.kind.carriesRows }, driver: driver, dataSource: dataSource)
 
         let nsProgress = Progress(totalUnitCount: Int64(state.totalRows))
         let progress = PluginExportProgress(progress: nsProgress)
@@ -381,7 +381,15 @@ final class ExportService {
         )
     }
 
-    private func fetchTotalRowCount(for tables: [ExportObjectItem], driver: DatabaseDriver) async -> Int {
+    /// The non-SQL count goes through the data source, which knows the container each object was
+    /// listed under. Asking the driver directly answers about whichever one it is leased to, so an
+    /// export spanning two databases counted one of them twice and reported a total no progress bar
+    /// could reach.
+    private func fetchTotalRowCount(
+        for tables: [ExportObjectItem],
+        driver: DatabaseDriver,
+        dataSource: ExportDataSourceAdapter
+    ) async -> Int {
         guard !tables.isEmpty else { return 0 }
 
         var total = 0
@@ -390,7 +398,10 @@ final class ExportService {
         if PluginManager.shared.editorLanguage(for: databaseType) != .sql {
             for table in tables {
                 do {
-                    if let count = try await driver.fetchApproximateRowCount(table: table.name) {
+                    let count = try await dataSource.fetchApproximateRowCount(
+                        table: table.name, databaseName: table.databaseName
+                    )
+                    if let count {
                         total += count
                     }
                 } catch {

--- a/TablePro/Core/Services/Query/SchemaService.swift
+++ b/TablePro/Core/Services/Query/SchemaService.swift
@@ -597,9 +597,12 @@ final class SchemaService {
         resumeRefreshWaiters(connectionId)
     }
 
+    /// Leased rather than handed the session driver, which is wherever a tab's execution last
+    /// pinned it. The object list follows the browse cursor, so reading from the shared handle
+    /// refreshed the sidebar with a container the user was not browsing.
     func refresh(connectionId: UUID) async {
         guard let session = DatabaseManager.shared.activeSessions[connectionId],
-              let driver = session.driver else {
+              let scope = DatabaseManager.shared.browseScope(for: connectionId) else {
             markLoadFailed(
                 connectionId: connectionId,
                 message: String(localized: "The connection is not available. Reconnect and try again.")
@@ -607,12 +610,19 @@ final class SchemaService {
             return
         }
         await prepareForReload(connectionId: connectionId)
-        await reload(
-            connectionId: connectionId,
-            driver: driver,
-            connection: session.connection,
-            scope: DatabaseManager.shared.browseScope(for: connectionId)
-        )
+        let connection = session.connection
+        do {
+            try await DatabaseManager.shared.withMetadataDriver(scope: scope, workload: .bulk) { [self] driver in
+                await reload(
+                    connectionId: connectionId,
+                    driver: driver,
+                    connection: connection,
+                    scope: scope
+                )
+            }
+        } catch {
+            markLoadFailed(connectionId: connectionId, message: error.localizedDescription)
+        }
     }
 
     func markLoadFailed(connectionId: UUID, message: String) {

--- a/TablePro/Models/Schema/ClickHousePartStatements.swift
+++ b/TablePro/Models/Schema/ClickHousePartStatements.swift
@@ -1,0 +1,77 @@
+//
+//  ClickHousePartStatements.swift
+//  TablePro
+//
+//  The statements the Parts tab issues, built from the tab's own container.
+//
+
+import Foundation
+
+/// ClickHouse carries the database as a request parameter rather than in the session, and the app
+/// moves that parameter whenever any tab runs somewhere else. An unqualified name therefore names
+/// whichever database the connection was last pinned to, which for `DROP PARTITION` is data loss in
+/// a database the user was not looking at.
+internal enum ClickHousePartStatements {
+    internal static func qualifiedName(
+        database: String,
+        table: String,
+        quote: (String) -> String
+    ) -> String {
+        guard !database.isEmpty else { return quote(table) }
+        return "\(quote(database)).\(quote(table))"
+    }
+
+    internal static func optimize(
+        database: String,
+        table: String,
+        quote: (String) -> String
+    ) -> String {
+        "OPTIMIZE TABLE \(qualifiedName(database: database, table: table, quote: quote)) FINAL"
+    }
+
+    internal static func dropPartition(
+        database: String,
+        table: String,
+        partition: String,
+        quote: (String) -> String,
+        escape: (String) -> String
+    ) -> String {
+        let name = qualifiedName(database: database, table: table, quote: quote)
+        return "ALTER TABLE \(name) DROP PARTITION '\(escape(partition))'"
+    }
+
+    internal static func detachPartition(
+        database: String,
+        table: String,
+        partition: String,
+        quote: (String) -> String,
+        escape: (String) -> String
+    ) -> String {
+        let name = qualifiedName(database: database, table: table, quote: quote)
+        return "ALTER TABLE \(name) DETACH PARTITION '\(escape(partition))'"
+    }
+
+    /// A connection saved with no database of its own has none to name, and ClickHouse then resolves
+    /// an unqualified request against its own configured default, which `currentDatabase()` reports.
+    /// Comparing against an empty string instead matches nothing and empties the tab.
+    private static func databasePredicate(_ database: String, escape: (String) -> String) -> String {
+        guard !database.isEmpty else { return "currentDatabase()" }
+        return "'\(escape(database))'"
+    }
+
+    /// Filtered on the named database rather than `currentDatabase()`, which answers with the
+    /// request parameter and so listed another database's parts under this table's name.
+    internal static func parts(
+        database: String,
+        table: String,
+        escape: (String) -> String
+    ) -> String {
+        """
+        SELECT partition, name, rows, bytes_on_disk,
+               toString(modification_time) AS mod_time, active
+        FROM system.parts
+        WHERE database = \(databasePredicate(database, escape: escape)) AND table = '\(escape(table))'
+        ORDER BY partition, name
+        """
+    }
+}

--- a/TablePro/Views/Import/RowImportSheet.swift
+++ b/TablePro/Views/Import/RowImportSheet.swift
@@ -660,18 +660,26 @@ struct RowImportSheet: View {
     /// Both failures used to leave an empty list and say nothing, so the destination picker offered
     /// "Select a table…" and nothing else with no way to tell an empty database from an unreachable
     /// one, and no way to ask again.
+    ///
+    /// Read through the browse scope, which is what the import itself writes to. The shared session
+    /// driver is wherever a tab's execution last pinned it and nothing puts it back, so reading from
+    /// it listed one database's tables and mapped their columns while the rows went to another's.
     @MainActor
     private func loadTables() async {
         guard !isLoadingTables else { return }
         isLoadingTables = true
         defer { isLoadingTables = false }
-        guard let driver = DatabaseManager.shared.driver(for: connection.id) else {
+        guard DatabaseManager.shared.browseScope(for: connection.id) != nil else {
             catalogNameKeys = nil
             tableListError = String(localized: "This connection is not open.")
             return
         }
         do {
-            databaseObjects = try await driver.fetchTables()
+            databaseObjects = try await DatabaseManager.shared.withBrowseMetadataDriver(
+                connectionId: connection.id
+            ) { driver in
+                try await driver.fetchTables()
+            }
             catalogNameKeys = NewTableNaming.comparisonKeys(for: databaseObjects.map(\.name))
             tableListError = nil
             suggestNewTableName()
@@ -749,13 +757,17 @@ struct RowImportSheet: View {
 
     @MainActor
     private func loadExistingContext(table: String) async {
-        guard let driver = DatabaseManager.shared.driver(for: connection.id),
-              let plugin = currentPlugin else { return }
+        guard let plugin = currentPlugin,
+              DatabaseManager.shared.browseScope(for: connection.id) != nil else { return }
         isLoadingContext = true
         loadError = nil
         defer { isLoadingContext = false }
         do {
-            let columns = try await driver.fetchColumns(table: table).map(\.name)
+            let columns = try await DatabaseManager.shared.withBrowseMetadataDriver(
+                connectionId: connection.id
+            ) { driver in
+                try await driver.fetchColumns(table: table)
+            }.map(\.name)
             let fields = try await Self.detectFields(plugin: plugin, at: fileURL, targetTable: table)
             targetColumns = columns
             mappings = fields.map { field in

--- a/TablePro/Views/Main/Child/MainEditorContentView.swift
+++ b/TablePro/Views/Main/Child/MainEditorContentView.swift
@@ -631,6 +631,7 @@ struct MainEditorContentView: View {
             if let draft = coordinator.createTableDrafts[tab.id] {
                 CreateTableView(
                     connection: connection,
+                    scope: structureScope(for: tab),
                     coordinator: coordinator,
                     selectionState: selectionState,
                     draft: draft

--- a/TablePro/Views/Main/Extensions/MainContentCoordinator+Navigation.swift
+++ b/TablePro/Views/Main/Extensions/MainContentCoordinator+Navigation.swift
@@ -450,8 +450,23 @@ extension MainContentCoordinator {
 
         // SQL databases: delegate to plugin driver
         guard let driver = DatabaseManager.shared.driver(for: connectionId) else { return nil }
-        let schema = (driver as? SchemaSwitchable)?.escapedSchema
-        return (driver as? PluginDriverAdapter)?.allTablesMetadataSQL(schema: schema)
+        return (driver as? PluginDriverAdapter)?.allTablesMetadataSQL(schema: allTablesContainer(driver))
+    }
+
+    /// The container this listing is about, named rather than left to the driver.
+    ///
+    /// A schema-less engine answers an unnamed container with whatever database the shared driver
+    /// was last pinned to, which a cross-database tab moves and nothing restores, so the listing
+    /// described a database the user was not browsing.
+    private func allTablesContainer(_ driver: DatabaseDriver) -> String? {
+        switch EngineNamespaceSlot(databaseType: connection.type) {
+        case .schema:
+            return (driver as? SchemaSwitchable)?.escapedSchema
+        case .database:
+            return browseDatabaseName.nilIfEmpty
+        case .unqualified:
+            return nil
+        }
     }
 
     // MARK: - Database Switching

--- a/TablePro/Views/Structure/ClickHousePartsView.swift
+++ b/TablePro/Views/Structure/ClickHousePartsView.swift
@@ -13,7 +13,12 @@ struct ClickHousePartsView: View {
     private static let logger = Logger(subsystem: "com.TablePro", category: "ClickHousePartsView")
 
     let tableName: String
-    let connectionId: UUID
+
+    /// The tab's own scope, not the connection alone. ClickHouse switches database by writing one
+    /// field on the shared driver and nothing puts it back, so a statement built from that driver
+    /// names whichever database the sidebar last reached rather than the table on screen.
+    let scope: DatabaseScope
+    let connection: DatabaseConnection
     let reloadToken: Int
 
     @State private var parts: [ClickHousePartInfo] = []
@@ -108,15 +113,15 @@ struct ClickHousePartsView: View {
     // MARK: - Actions
 
     private func optimizeTable() {
-        Task {
-            guard let driver = DatabaseManager.shared.driver(for: connectionId) else { return }
-            let sql = "OPTIMIZE TABLE \(driver.quoteIdentifier(tableName)) FINAL"
-            do {
-                _ = try await driver.execute(query: sql)
-                await loadParts()
-            } catch {
-                Self.logger.error("Optimize failed: \(error.localizedDescription, privacy: .public)")
-            }
+        Task { @MainActor in
+            guard let driver = DatabaseManager.shared.driver(for: scope.connectionId) else { return }
+            await run(
+                ClickHousePartStatements.optimize(
+                    database: scope.database, table: tableName, quote: driver.quoteIdentifier
+                ),
+                description: String(localized: "Optimize Table"),
+                kind: .maintenance
+            )
         }
     }
 
@@ -134,15 +139,17 @@ struct ClickHousePartsView: View {
             )
             guard confirmed else { return }
 
-            guard let driver = DatabaseManager.shared.driver(for: connectionId) else { return }
-            let sql = "ALTER TABLE \(driver.quoteIdentifier(tableName)) DROP PARTITION '\(driver.escapeStringLiteral(partitionValue))'"
-            do {
-                _ = try await driver.execute(query: sql)
-                selection.removeAll()
-                await loadParts()
-            } catch {
-                Self.logger.error("Drop partition failed: \(error.localizedDescription, privacy: .public)")
-            }
+            guard let driver = DatabaseManager.shared.driver(for: scope.connectionId) else { return }
+            let sql = ClickHousePartStatements.dropPartition(
+                database: scope.database,
+                table: tableName,
+                partition: partitionValue,
+                quote: driver.quoteIdentifier,
+                escape: driver.escapeStringLiteral
+            )
+            guard await run(sql, description: String(localized: "Drop Partition"), kind: .destructiveQuery)
+            else { return }
+            selection.removeAll()
         }
     }
 
@@ -160,15 +167,59 @@ struct ClickHousePartsView: View {
             )
             guard confirmed else { return }
 
-            guard let driver = DatabaseManager.shared.driver(for: connectionId) else { return }
-            let sql = "ALTER TABLE \(driver.quoteIdentifier(tableName)) DETACH PARTITION '\(driver.escapeStringLiteral(partitionValue))'"
-            do {
-                _ = try await driver.execute(query: sql)
-                selection.removeAll()
-                await loadParts()
-            } catch {
-                Self.logger.error("Detach partition failed: \(error.localizedDescription, privacy: .public)")
+            guard let driver = DatabaseManager.shared.driver(for: scope.connectionId) else { return }
+            let sql = ClickHousePartStatements.detachPartition(
+                database: scope.database,
+                table: tableName,
+                partition: partitionValue,
+                quote: driver.quoteIdentifier,
+                escape: driver.escapeStringLiteral
+            )
+            guard await run(sql, description: String(localized: "Detach Partition"), kind: .destructiveQuery)
+            else { return }
+            selection.removeAll()
+        }
+    }
+
+    /// Every statement here names the tab's own database and runs on a driver leased to it, and goes
+    /// through the gate first: a partition drop is data loss, and a connection set to confirm those
+    /// was dropping one on the strength of this view's own alert alone.
+    /// Answers whether the statement actually ran. A denial, a cancelled confirmation or a failure
+    /// leaves the partition where it was, so the caller keeps the user's selection rather than
+    /// clearing it as though the action had gone through.
+    @MainActor
+    @discardableResult
+    private func run(_ sql: String, description: String, kind: OperationKind) async -> Bool {
+        let scope = scope
+        do {
+            let decision = await ExecutionGateProvider.shared.authorize(
+                OperationRequest(
+                    connectionId: scope.connectionId,
+                    databaseType: connection.type,
+                    sql: sql,
+                    kind: kind,
+                    caller: .userInterface,
+                    capabilities: .interactiveUser,
+                    operationDescription: description
+                )
+            )
+            guard case .authorized = decision else {
+                errorMessage = decision.deniedReason
+                return false
             }
+            _ = try await DatabaseManager.shared.withScopedDriver(
+                scope: scope,
+                route: DatabaseManager.shared.schemaChangeRoute(for: scope),
+                cancellation: .protectedWrite
+            ) { driver in
+                try await driver.execute(query: sql)
+            }
+            await loadParts()
+            return true
+        } catch {
+            Self.logger.error("\(description, privacy: .public) failed: \(error.localizedDescription, privacy: .public)")
+            errorMessage = error.localizedDescription
+            return false
         }
     }
 
@@ -185,21 +236,14 @@ struct ClickHousePartsView: View {
         isLoading = true
         errorMessage = nil
 
-        guard let driver = DatabaseManager.shared.driver(for: connectionId) else {
-            errorMessage = String(localized: "Not connected to ClickHouse")
-            isLoading = false
-            return
-        }
-
+        let scope = scope
+        let tableName = tableName
         do {
-            let sql = """
-                SELECT partition, name, rows, bytes_on_disk,
-                       toString(modification_time) AS mod_time, active
-                FROM system.parts
-                WHERE database = currentDatabase() AND table = '\(driver.escapeStringLiteral(tableName))'
-                ORDER BY partition, name
-                """
-            let result = try await driver.execute(query: sql)
+            let result = try await DatabaseManager.shared.withMetadataDriver(scope: scope) { driver in
+                try await driver.execute(query: ClickHousePartStatements.parts(
+                    database: scope.database, table: tableName, escape: driver.escapeStringLiteral
+                ))
+            }
             parts = result.rows.compactMap { row -> ClickHousePartInfo? in
                 guard let name = row[safe: 1]?.asText else { return nil }
                 let partition = row[safe: 0]?.asText ?? ""

--- a/TablePro/Views/Structure/CreateTableView.swift
+++ b/TablePro/Views/Structure/CreateTableView.swift
@@ -32,6 +32,11 @@ struct CreateTableView: View {
     private static let logger = Logger(subsystem: "com.TablePro", category: "CreateTableView")
 
     let connection: DatabaseConnection
+
+    /// The tab's own scope, which is where the table is created. The browse cursor moves when the
+    /// user clicks another database in the sidebar and the open Create Table tab does not follow it,
+    /// so taking the cursor created the table somewhere the tab never named.
+    let scope: DatabaseScope?
     var coordinator: MainContentCoordinator?
     let selectionState: GridSelectionState
 
@@ -60,11 +65,13 @@ struct CreateTableView: View {
 
     init(
         connection: DatabaseConnection,
+        scope: DatabaseScope?,
         coordinator: MainContentCoordinator?,
         selectionState: GridSelectionState,
         draft: CreateTableDraft
     ) {
         self.connection = connection
+        self.scope = scope
         self.coordinator = coordinator
         self.selectionState = selectionState
         self.draft = draft
@@ -405,9 +412,15 @@ struct CreateTableView: View {
     }
 
     private func currentStatements() -> CreateTableStatements {
+        statements(composedWith: DatabaseManager.shared.driver(for: connection.id))
+    }
+
+    /// Several visual-editor drivers write their own current schema or catalog into the statement as
+    /// an explicit qualifier, so the driver the SQL is composed on decides where the table lands.
+    /// Composing on the session driver and executing on the tab's scope pinned only half of it.
+    private func statements(composedWith driver: DatabaseDriver?) -> CreateTableStatements {
         let plan = currentPlan
-        guard let pluginDriver = (DatabaseManager.shared.driver(for: connection.id) as? PluginDriverAdapter)?
-            .schemaPluginDriver else {
+        guard let pluginDriver = (driver as? PluginDriverAdapter)?.schemaPluginDriver else {
             return CreateTableStatements(statements: [], issues: plan.issues, tableName: nil)
         }
         return CreateTableStatementComposer.compose(plan: plan, driver: pluginDriver)
@@ -433,13 +446,12 @@ struct CreateTableView: View {
     /// keep the app's own DDL off the user's connection.
     private func createTable() {
         guard !isCreating else { return }
-        let composed = currentStatements()
-        guard composed.issues.isEmpty, !composed.statements.isEmpty else {
-            errorMessage = composed.issues.map(\.qualifiedMessage).joined(separator: "\n")
+        guard currentStatements().issues.isEmpty else {
+            errorMessage = currentStatements().issues.map(\.qualifiedMessage).joined(separator: "\n")
             showError = true
             return
         }
-        guard let scope = DatabaseManager.shared.browseScope(for: connection.id) else {
+        guard let scope else {
             errorMessage = String(localized: "Not connected to database")
             showError = true
             return
@@ -449,17 +461,26 @@ struct CreateTableView: View {
         errorMessage = nil
         updateCreateTablePendingState()
 
-        let statements = composed.statements
-        let createdName = composed.tableName ?? draft.tableName
         Task {
             defer { isCreating = false }
             do {
+                let composed = try await DatabaseManager.shared.withMetadataDriver(scope: scope) { driver in
+                    await MainActor.run { statements(composedWith: driver) }
+                }
+                guard composed.issues.isEmpty, !composed.statements.isEmpty else {
+                    errorMessage = composed.issues.map(\.qualifiedMessage).joined(separator: "\n")
+                    showError = true
+                    return
+                }
+                let createdName = composed.tableName ?? draft.tableName
                 try await DatabaseManager.shared.executeCreateTable(
-                    statements: statements,
+                    statements: composed.statements,
                     databaseType: connection.type,
                     scope: scope
                 )
-                coordinator?.openTableTab(createdName)
+                coordinator?.openTableTab(
+                    createdName, schema: scope.schema, database: scope.database.nilIfEmpty
+                )
                 AppCommands.shared.refreshData.send(DataRefreshRequest(connectionId: connection.id))
             } catch {
                 Self.logger.error("Create table failed: \(error.localizedDescription, privacy: .public)")

--- a/TablePro/Views/Structure/TableStructureView.swift
+++ b/TablePro/Views/Structure/TableStructureView.swift
@@ -396,7 +396,8 @@ struct TableStructureView: View {
         case .parts:
             ClickHousePartsView(
                 tableName: tableName,
-                connectionId: connection.id,
+                scope: scope,
+                connection: connection,
                 reloadToken: partsReloadToken
             )
         }

--- a/TableProTests/Models/Schema/ClickHousePartStatementsTests.swift
+++ b/TableProTests/Models/Schema/ClickHousePartStatementsTests.swift
@@ -1,0 +1,79 @@
+//
+//  ClickHousePartStatementsTests.swift
+//  TableProTests
+//
+//  The Parts tab's statements name the tab's own database, because ClickHouse resolves an
+//  unqualified one from a request parameter the app moves whenever any tab runs elsewhere.
+//
+
+import Foundation
+@testable import TablePro
+import Testing
+
+@Suite("ClickHouse part statements")
+struct ClickHousePartStatementsTests {
+    private let quote: (String) -> String = { "`\($0.replacingOccurrences(of: "`", with: "``"))`" }
+    private let escape: (String) -> String = { $0.replacingOccurrences(of: "'", with: "\\'") }
+
+    /// The defect: an unqualified DROP PARTITION deleted data from whichever database the shared
+    /// driver was last pinned to, while the tab reported it was acting on its own.
+    @Test("Every statement names the database it was given")
+    func statementsCarryTheDatabase() {
+        #expect(
+            ClickHousePartStatements.optimize(database: "analytics", table: "events", quote: quote)
+                == "OPTIMIZE TABLE `analytics`.`events` FINAL"
+        )
+        #expect(
+            ClickHousePartStatements.dropPartition(
+                database: "analytics", table: "events", partition: "202401",
+                quote: quote, escape: escape
+            ) == "ALTER TABLE `analytics`.`events` DROP PARTITION '202401'"
+        )
+        #expect(
+            ClickHousePartStatements.detachPartition(
+                database: "analytics", table: "events", partition: "202401",
+                quote: quote, escape: escape
+            ) == "ALTER TABLE `analytics`.`events` DETACH PARTITION '202401'"
+        )
+    }
+
+    /// `currentDatabase()` answers with the request parameter, so the list showed another database's
+    /// parts under this table's name.
+    @Test("The parts read filters on the named database, never the connection's current one")
+    func partsReadNamesTheDatabase() {
+        let sql = ClickHousePartStatements.parts(
+            database: "analytics", table: "events", escape: escape
+        )
+        #expect(sql.contains("WHERE database = 'analytics'"))
+        #expect(sql.contains("AND table = 'events'"))
+        #expect(!sql.contains("currentDatabase()"))
+    }
+
+    /// A connection saved with no database of its own has nothing to qualify against, and an empty
+    /// qualifier is a statement the server refuses. The parts read has to fall back too: comparing
+    /// against '' matches nothing, where ClickHouse's own default database is what the user sees.
+    @Test("With no database the name stays unqualified and the read asks the server")
+    func emptyDatabaseLeavesTheNameBare() {
+        #expect(
+            ClickHousePartStatements.qualifiedName(database: "", table: "events", quote: quote)
+                == "`events`"
+        )
+        #expect(
+            ClickHousePartStatements.optimize(database: "", table: "events", quote: quote)
+                == "OPTIMIZE TABLE `events` FINAL"
+        )
+        let sql = ClickHousePartStatements.parts(database: "", table: "events", escape: escape)
+        #expect(sql.contains("WHERE database = currentDatabase()"))
+        #expect(!sql.contains("database = ''"))
+    }
+
+    @Test("A quote in a partition value is escaped, and a backtick in a name is quoted")
+    func valuesAreEscaped() {
+        let sql = ClickHousePartStatements.dropPartition(
+            database: "we`ird", table: "ev`ents", partition: "it's",
+            quote: quote, escape: escape
+        )
+        #expect(sql.contains("`we``ird`.`ev``ents`"))
+        #expect(sql.contains("'it\\'s'"))
+    }
+}


### PR DESCRIPTION
Six more defects of the class #2797, #2798, #2802 and #2803 have been working through: a read or a statement resolving against whichever container the connection happens to be on, when the caller named another. Found by sweeping the app once those landed, each verified against a live MySQL 8.4.11 or by tracing the engine's own behaviour.

One of them destroys data.

## Why the connection drifts

`pin(_:to:)` moves the shared session driver onto a tab's database with a live `USE` and, by its own comment, writes no session state. Nothing puts it back. So after any cross-database tab runs, the session driver and the browse cursor are on different databases, permanently. Anything that reads or writes through the raw driver instead of a scope is then describing the wrong place.

## What was wrong

**ClickHouse Drop Partition deleted data from the wrong database, without asking.** All four actions in the Parts tab took `DatabaseManager.shared.driver(for:)` and emitted unqualified `OPTIMIZE` / `DROP PARTITION` / `DETACH PARTITION`, with the list filtered on `currentDatabase()`. ClickHouse carries the database as a request parameter that `switchDatabase` sets and never restores, so with `analytics.events` open and the sidebar moved to `staging`, dropping a partition deleted it from `staging.events` while the sheet said `analytics`. Worse, none of the three went through `ExecutionGate`: the view's own confirmation alert was the only thing standing in front of a partition drop, so a connection set to confirm destructive statements never got asked. Every sibling sub-tab already reads through the scoped loader; Parts alone was handed a bare `connectionId`.

**The import sheet listed one database's tables and imported into another.** `loadTables()` and `loadExistingContext(table:)` read the raw session driver while the writes lease `browseScope`. Drop a CSV after following a cross-database foreign key and the destination picker lists the other database's tables, maps the CSV's fields against its columns, and inserts into the browsed one. The new-table name-collision check was wrong the same way.

**New Table created the table in the sidebar's database.** `CreateTableView` resolved `browseScope`, documented as "never for an operation an open tab owns". The tab records its own database and `switchDatabase` neither retargets nor closes it, so clicking another database in the sidebar with a Create Table tab open moved where the `CREATE` landed. The same view's type picker already reads the tab.

**Show All Tables listed whichever database the driver was last pinned to.** `allTablesMetadataSQL(schema:)` took the container from live driver state rather than the browse cursor it reads two lines above. On a schema-less engine that resolves to the pinned database.

**Sidebar Refresh reloaded from a container the user was not browsing.** `SchemaService.refresh` is the only sidebar reload that never leases: it handed `session.driver` straight to `reload`. On PostgreSQL, following a foreign key into another schema pins the session driver there and the browse cursor does not follow, so Refresh listed that schema's tables.

**The export row total counted one database twice.** The non-SQL branch of `fetchTotalRowCount` asked the driver with no container while the SQL branch qualifies by `table.databaseName`, so an export spanning two containers reported a total the progress bar could not reach.

## The fix

Each read and each statement now names the container its caller meant.

- `ClickHousePartsView` takes the tab's `DatabaseScope` instead of a connection id. Statement building moved into `ClickHousePartStatements`, which is pure and tested; the parts read leases `metadataRoute`, the three mutations lease `schemaChangeRoute` and go through `ExecutionGate` first, `DROP` and `DETACH` as `.destructiveQuery` and `OPTIMIZE` as `.maintenance`.
- `RowImportSheet` reads through `withBrowseMetadataDriver`, the primitive the sidebar object list already uses, which is the same scope the import writes to.
- `CreateTableView` takes the tab's scope from `structureScope(for:)`, which the call site already computes. The statements are now composed on a driver leased to that scope as well, because several visual-editor drivers write their own current schema or catalog into the SQL, so pinning only the execution would have moved half of it. The table it opens afterwards is named with the same scope.
- `allTablesMetadataSQL` picks its container by `EngineNamespaceSlot`: the schema for a schema-ful engine, the browse database for a schema-less one.
- `SchemaService.refresh` leases the browse scope through `withMetadataDriver`, as `SchemaRefreshService.performRefresh` already does.
- `ExportService` builds its `ExportDataSourceAdapter` before counting and routes the non-SQL count through it, so each object is counted in the container it was listed under.

## Verification

| Step | Result |
| --- | --- |
| `verify.sh build` | PASS |
| `verify.sh test` (11 suites) | PASS, 112 executed, 112 passed |
| `verify.sh lint TablePro …` | PASS, 0 violations |

Four new cases in `ClickHousePartStatementsTests` pin the destructive path: every statement carries the database it was given, the parts read filters on that database and never `currentDatabase()`, a connection saved with no database of its own falls back to `currentDatabase()` rather than matching `''`, and a backtick in a name and a quote in a partition value are escaped.

The other five changes are routing inside SwiftUI views and a service, with no seam that a test can reach without extracting a loader first; the sweep's design lane said the same of the import sheet. Each is a one-expression substitution onto an existing helper, and the tests that cover those helpers already pass.

No UI automation: each needs a live server with two databases and a tab pinned away from the sidebar, which does not run deterministically on CI.

Codex reviewed the diff and found four issues; all four are addressed. Two were real gaps in the fix itself: the `CREATE` statements were still composed on the session driver, so the scope only reached the execution, and the newly created table was opened with no database, which defaults to the browse cursor. The other two were regressions this change introduced: a ClickHouse connection saved with no database of its own got `database = ''` where `currentDatabase()` used to work, emptying the Parts tab, and the drop and detach actions cleared the user's selection even when the gate denied the statement or it never ran. `run` now reports whether the statement executed and surfaces the denial reason.

## Not fixed

`ServerSideExportSheet:263` was reported by the sweep and refuted on verification: the sheet offers only Oracle, BigQuery and Snowflake. Oracle and BigQuery declare `supportsDatabaseSwitching: false`, so `pin` never moves their session driver, and Snowflake's pooled driver shares one authenticated connection whose `fetchTables` reads `currentDatabase`. The container cannot diverge on any of the three.

https://claude.ai/code/session_01SP8Cj5R28unz7YhwL2BtiM
