### PR TITLE
fix(plugins): make the export subsystem's writes atomic, stoppable and byte-bounded (#2533)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Data grid and bottom bar cut off at both edges in a narrow window, with rows and pagination buttons out of reach.
 - Filter panel wider than the pane when a table has a long column name.
 - `bytea` values written as a bit string in a PostgreSQL SQL export, which no restore accepts. (#2533)
+- A gzipped SQL export emptying the file it was overwriting before compressing, and deleting it on failure. (#2533)
+- Parts of a split SQL export left on disk unnamed when a later part could not be written. (#2533)
+- `SET IDENTITY_INSERT` missing from every part after the first of a split SQL Server dump. (#2533)
+- `CREATE TYPE` and `CREATE SEQUENCE` left out of a SQL export with no warning when the lookup failed. (#2533)
+- Stop doing nothing while a gzipped SQL export was compressing. (#2533)
+- Export status never reaching the progress sheet, and an import showing a row count in place of its own. (#2533)
+- Binary values unrestorable in an Oracle SQL export. (#2533)
+- Transfer or copy of a table of megabyte values rejected as one oversized `INSERT`. (#2533)
+- Multi-row INSERT statements Oracle cannot parse when importing a CSV, JSON or XLSX file. (#2533)
 - Multi-row INSERT statements Oracle cannot parse in a SQL export. (#2533)
 - Minutes spent rendering hex literals when a SQL export reached a binary column. (#2533)
 - ClickHouse **Drop Partition** and **Detach Partition** acting on the sidebar's database instead of the table on screen, and running without the connection's destructive-statement confirmation.

--- a/Plugins/SQLExportPlugin/SQLExportBinaryLiteral.swift
+++ b/Plugins/SQLExportPlugin/SQLExportBinaryLiteral.swift
@@ -19,21 +19,42 @@ import TableProPluginKit
 /// `\x4134323433` and reported success, so the restore wrote different bytes and said nothing.
 /// `decode` means the same thing under either setting.
 ///
-/// Oracle is deliberately left on `X''`, which it rejects, rather than moved to `HEXTORAW`. Hex
-/// doubles the payload and Oracle caps a string literal at 4,000 bytes, so `HEXTORAW` carries 2,000
-/// binary bytes and no more; past that the statement is still far under any size limit, so it would
-/// export clean and fail the restore with nothing said. `HEXTORAW('')` is NULL under Oracle's
-/// empty-string rule, which an empty BLOB is not, and `RAW`, `LONG RAW` and `BLOB` do not share one
-/// correct spelling. Rejected loudly beats accepted and wrong; a column-aware Oracle path needs an
-/// Oracle to measure against.
+/// Oracle takes `HEXTORAW`, and an empty value takes `EMPTY_BLOB()` instead. Measured on Oracle AI
+/// Database 26ai Free 23.26.3.0.0, `max_string_size = STANDARD`:
+///
+/// - `X'414243'` is `ORA-00917: missing comma`. Oracle has no such literal.
+/// - `HEXTORAW('414243')` is accepted into `BLOB`, `RAW(2000)` and `LONG RAW` alike, so one
+///   spelling serves all three and the column's own type does not have to be consulted.
+/// - `HEXTORAW('')` stores NULL, and into a `BLOB NOT NULL` it is `ORA-01400: cannot insert NULL`.
+///   An empty BLOB is not a null one, so the empty case is its own: `EMPTY_BLOB()` stores length 0
+///   and is accepted by `BLOB`, `BLOB NOT NULL` and `RAW(2000)`.
+/// - Hex doubles the payload and a string literal caps at 4,000 bytes, so `HEXTORAW` carries 2,000
+///   binary bytes: 2,000 stored 2,000, and 2,001 is `ORA-01704: string literal too long`.
+///
+/// Nothing can be written for a value past that ceiling, because no single-statement Oracle
+/// representation of one exists. It is still written as `HEXTORAW`, which a server configured
+/// `max_string_size = EXTENDED` accepts up to 16,383 bytes, and `SQLExportRowValueEncoder` counts it
+/// so the export reports how many values it could not promise rather than claiming a clean dump.
 ///
 /// An engine this does not name keeps `X''`, which is what the export has always written, so no
-/// engine's output changes except the two measured or documented to have been wrong.
+/// engine's output changes except the two measured to have been wrong.
 internal enum SQLExportBinaryLiteral {
+    /// The most binary bytes Oracle can carry in one `HEXTORAW` literal: 4,000 characters of hex,
+    /// two per byte. Measured, not inferred.
+    internal static let oracleLiteralByteCeiling = 2_000
+
+    /// True for a value this engine cannot represent in one statement, whatever spelling is used.
+    internal static func exceedsLiteralCeiling(_ data: Data, databaseTypeId: String) -> Bool {
+        databaseTypeId == "Oracle" && data.count > oracleLiteralByteCeiling
+    }
+
     internal static func render(_ data: Data, databaseTypeId: String) -> String {
         let hex = hexString(data)
         if databaseTypeId == "SQL Server" {
             return "0x\(hex)"
+        }
+        if databaseTypeId == "Oracle" {
+            return data.isEmpty ? "EMPTY_BLOB()" : "HEXTORAW('\(hex)')"
         }
         switch SqlDialect.from(databaseTypeId: databaseTypeId) {
         case .postgres:

--- a/Plugins/SQLExportPlugin/SQLExportCompressor.swift
+++ b/Plugins/SQLExportPlugin/SQLExportCompressor.swift
@@ -74,13 +74,27 @@ internal enum SQLExportCompressor {
             try await withTaskCancellationHandler {
                 try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
                     process.terminationHandler = { finished in
-                        try? handle.close()
-                        guard finished.terminationStatus != 0 else {
-                            continuation.resume()
+                        /// Closing the handle is part of compressing, not cleanup after it: a
+                        /// volume that reports a deferred write failure does so here, and the plain
+                        /// writer propagates its own close error. Swallowed, a truncated temp would
+                        /// have replaced a valid dump on a gzip that exited zero.
+                        let closeError: (any Error)?
+                        do {
+                            try handle.close()
+                            closeError = nil
+                        } catch {
+                            closeError = error
+                        }
+                        guard finished.terminationStatus == 0 else {
+                            continuation.resume(throwing: failure(
+                                status: finished.terminationStatus, from: errorPipe))
                             return
                         }
-                        continuation.resume(throwing: failure(
-                            status: finished.terminationStatus, from: errorPipe))
+                        if let closeError {
+                            continuation.resume(throwing: closeError)
+                            return
+                        }
+                        continuation.resume()
                     }
                     do {
                         try gate.launch(process)

--- a/Plugins/SQLExportPlugin/SQLExportCompressor.swift
+++ b/Plugins/SQLExportPlugin/SQLExportCompressor.swift
@@ -1,0 +1,144 @@
+//
+//  SQLExportCompressor.swift
+//  SQLExportPlugin
+//
+
+import Foundation
+import TableProPluginKit
+
+/// Compresses a finished dump into the file the user named, through the atomic pair the
+/// uncompressed export already writes through.
+///
+/// Two defects lived in the code this replaces. `FileManager.createFile(atPath:contents:)` truncates
+/// an existing file to zero and still returns true, so a compressed export aimed at a file that was
+/// already there emptied it before gzip had produced a byte, and a failure or a Stop then removed
+/// the stump: measured, a 22-byte `dump.sql.gz` became 0 bytes and was then deleted, while the
+/// uncompressed path left the previous dump untouched. And Stop did nothing at all, because the only
+/// cancellation it watched was `Task.isCancelled` and nothing cancels the task an export runs in;
+/// `Progress.cancel()` is the channel Stop actually writes. (#2533)
+internal enum SQLExportCompressor {
+    private static let gzipPath = "/usr/bin/gzip"
+
+    /// Stop writes `Progress.cancel()`, which is not a task cancellation, so it has to be polled.
+    /// Short enough that Stop reads as immediate against a compression measured in hundreds of
+    /// milliseconds, long enough to cost nothing over a long one.
+    private static let cancellationPollInterval = Duration.milliseconds(150)
+
+    internal static func compress(
+        source: URL,
+        to destination: URL,
+        progress: PluginExportProgress
+    ) async throws {
+        guard FileManager.default.isExecutableFile(atPath: gzipPath) else {
+            throw PluginExportError.exportFailed(
+                String(format: String(localized: "Compression unavailable: gzip not found at %@"), gzipPath))
+        }
+        try progress.checkCancellation()
+
+        let (handle, tempURL) = try PluginExportUtilities.beginAtomicWrite(for: destination)
+        var committed = false
+        defer {
+            if !committed { PluginExportUtilities.rollbackAtomicWrite(at: tempURL) }
+        }
+
+        try await runGzip(source: source, into: handle, progress: progress)
+        try PluginExportUtilities.commitAtomicWrite(from: tempURL, to: destination)
+        committed = true
+    }
+
+    private static func runGzip(
+        source: URL,
+        into handle: FileHandle,
+        progress: PluginExportProgress
+    ) async throws {
+        let errorPipe = Pipe()
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: gzipPath)
+        process.arguments = ["-c", source.standardizedFileURL.path(percentEncoded: false)]
+        process.standardOutput = handle
+        process.standardError = errorPipe
+
+        let gate = ProcessGate()
+        let watcher = Task {
+            while !Task.isCancelled {
+                if progress.isCancelled {
+                    gate.cancel()
+                    return
+                }
+                try? await Task.sleep(for: cancellationPollInterval)
+            }
+        }
+        defer { watcher.cancel() }
+
+        do {
+            try await withTaskCancellationHandler {
+                try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
+                    process.terminationHandler = { finished in
+                        try? handle.close()
+                        guard finished.terminationStatus != 0 else {
+                            continuation.resume()
+                            return
+                        }
+                        continuation.resume(throwing: failure(
+                            status: finished.terminationStatus, from: errorPipe))
+                    }
+                    do {
+                        try gate.launch(process)
+                    } catch {
+                        try? handle.close()
+                        continuation.resume(throwing: error)
+                    }
+                }
+            } onCancel: {
+                gate.cancel()
+            }
+        } catch {
+            /// A Stop killed the process, so gzip's own non-zero exit is what surfaced. The user
+            /// asked to stop, not for a compression error.
+            guard !progress.isCancelled else { throw PluginExportCancellationError() }
+            throw error
+        }
+
+        /// A Stop landing between gzip's exit and here still abandons the file. Reporting an export
+        /// the user asked to stop as finished is the worse answer, and nothing has been published.
+        try progress.checkCancellation()
+    }
+
+    private static func failure(status: Int32, from errorPipe: Pipe) -> any Error {
+        let text = String(data: errorPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !text.isEmpty else {
+            return PluginExportError.exportFailed(String(
+                format: String(localized: "Compression failed with exit status %lld"), Int64(status)))
+        }
+        return PluginExportError.exportFailed(String(
+            format: String(localized: "Compression failed with exit status %1$lld: %2$@"),
+            Int64(status), text))
+    }
+
+    /// `Process.terminate()` on a process that was never launched raises an uncaught
+    /// `NSInvalidArgumentException` ("task not launched"), so a cancel that arrives before the
+    /// launch has to stop it rather than race it. The lock is held across `run()` for that, and
+    /// released before `terminate()` so nothing the kill wakes can deadlock against it.
+    private final class ProcessGate: @unchecked Sendable {
+        private let lock = NSLock()
+        private var launched: Process?
+        private var cancelled = false
+
+        internal func launch(_ process: Process) throws {
+            lock.lock()
+            defer { lock.unlock() }
+            guard !cancelled else { throw PluginExportCancellationError() }
+            try process.run()
+            launched = process
+        }
+
+        internal func cancel() {
+            lock.lock()
+            cancelled = true
+            let running = launched
+            lock.unlock()
+            running?.terminate()
+        }
+    }
+}

--- a/Plugins/SQLExportPlugin/SQLExportFileWriter.swift
+++ b/Plugins/SQLExportPlugin/SQLExportFileWriter.swift
@@ -10,8 +10,15 @@ import TableProPluginKit
 ///
 /// Rotation happens between writes and never inside one, so a part always ends on a complete
 /// statement: a restore that replays the parts in order gets the same statements in the same order
-/// as an unsplit dump. Every part is written to a temporary file and committed at the end, which is
-/// what keeps a failed or cancelled export from leaving half a dump behind.
+/// as an unsplit dump. Every part is written to a temporary file, so a failure before `commit()`
+/// leaves nothing at the destination.
+///
+/// `commit()` publishes one part per rename and nothing renames several paths at once, so a split
+/// publish is not atomic as a whole. A failure partway through names the parts that landed instead
+/// of unwinding them: `replaceItemAt` keeps no backup of what stood at the path, so taking a
+/// published part back would leave neither the file the user had nor the one just written. This
+/// used to claim it prevented half a dump, while `rollback()` removed temps only and left every
+/// already-renamed part in place unmentioned (#2533).
 internal final class SQLExportFileWriter {
     /// The name a part takes: `dump.sql` becomes `dump.part1.sql`, and a compound extension like
     /// `dump.sql.gz` becomes `dump.part1.sql.gz`.
@@ -28,6 +35,7 @@ internal final class SQLExportFileWriter {
     private let destination: URL
     private let splitSizeBytes: Int
     private let encodingDeclaration: SQLExportEncodingDeclaration
+    private let publish: (URL, URL) throws -> Void
 
     private var handle: FileHandle
     private var tempURL: URL
@@ -35,21 +43,34 @@ internal final class SQLExportFileWriter {
     private var currentPartHasStatements = false
     private var partIndex = 1
     private var pending: [(temp: URL, final: URL)] = []
-    private var isCommitted = false
+    private var published: [URL] = []
+    private var didAttemptPublish = false
+
+    /// How a finished part takes its final name. Injected so a publish that fails on one part of
+    /// several can be exercised without a filesystem rigged to refuse a rename.
+    internal static func publishAtomically(_ temp: URL, _ final: URL) throws {
+        try PluginExportUtilities.commitAtomicWrite(from: temp, to: final)
+    }
+
+    /// The scopes still open, outermost first. Held rather than written once, because a part
+    /// restored on its own has to re-establish the session state its statements were written under.
+    private var openScopes: [SQLExportSessionScope] = []
 
     internal init(
         destination: URL,
         splitSizeMegabytes: Int,
-        encodingDeclaration: SQLExportEncodingDeclaration = .empty
+        encodingDeclaration: SQLExportEncodingDeclaration = .empty,
+        publish: @escaping (URL, URL) throws -> Void = SQLExportFileWriter.publishAtomically
     ) throws {
         self.destination = destination
         self.splitSizeBytes = max(0, splitSizeMegabytes) * 1_024 * 1_024
         self.encodingDeclaration = encodingDeclaration
+        self.publish = publish
         let (handle, tempURL) = try PluginExportUtilities.beginAtomicWrite(for: destination)
         self.handle = handle
         self.tempURL = tempURL
         do {
-            try writeRaw(encodingDeclaration.prologue)
+            try beginPart()
         } catch {
             rollback()
             throw error
@@ -62,35 +83,63 @@ internal final class SQLExportFileWriter {
 
     internal var partCount: Int { partIndex }
 
-    internal func write(_ text: String) throws {
+    /// Writes one statement, opening `scope` immediately in front of it.
+    ///
+    /// They go in together because the rotation decision sits between them: opened by a call of its
+    /// own, a scope whose first statement then rotated would leave its opener alone at the end of
+    /// the part above, closed there again and re-opened below it.
+    internal func write(_ text: String, opening scope: SQLExportSessionScope? = nil) throws {
         let data = try text.toUTF8Data()
-        let partSize = bytesInCurrentPart + data.count + encodingDeclaration.epilogue.utf8.count
+        let scopeBytes = (scope?.opener.utf8.count ?? 0) + (scope?.closer.utf8.count ?? 0)
+        let partSize = bytesInCurrentPart + data.count + scopeBytes + partTailBytes
         if splitSizeBytes > 0, currentPartHasStatements, partSize > splitSizeBytes {
             try rotate()
+        }
+        if let scope {
+            openScopes.append(scope)
+            try writeRaw(scope.opener)
         }
         try handle.write(contentsOf: data)
         bytesInCurrentPart += data.count
         currentPartHasStatements = true
     }
 
+    /// Closes the innermost open scope. It never rotates: the closer belongs in the part its own
+    /// statements are in, and `partTailBytes` has held room for it since the scope was opened.
+    internal func closeScope() throws {
+        guard let scope = openScopes.popLast() else { return }
+        try writeRaw(scope.closer)
+    }
+
     /// Publishes every part and returns where they landed. An unsplit export keeps the name the
     /// user chose; a split one numbers all of its parts, so no part silently claims that name.
+    /// Parts go out in order, so a publish that fails partway leaves the dump's first parts rather
+    /// than a hole in the middle of it, and the failure names them.
     @discardableResult
     internal func commit() throws -> [URL] {
-        try writeRaw(encodingDeclaration.epilogue)
+        try endPart()
         try handle.close()
         let finalURL = didSplit ? Self.partURL(for: destination, part: partIndex) : destination
         pending.append((tempURL, finalURL))
+        didAttemptPublish = true
         for entry in pending {
-            try PluginExportUtilities.commitAtomicWrite(from: entry.temp, to: entry.final)
+            do {
+                try publish(entry.temp, entry.final)
+            } catch {
+                discardUnpublishedTemps()
+                throw SQLExportPublishFailure(
+                    published: published, failed: entry.final, underlying: error)
+            }
+            published.append(entry.final)
         }
-        isCommitted = true
-        return pending.map(\.final)
+        return published
     }
 
-    /// Removes every temporary file. Safe to call after a commit, where it finds nothing to remove.
+    /// Removes the temporary files this writer still owns. Nothing to do once `commit()` has run:
+    /// a commit that failed partway has already discarded the temps it did not publish, and the
+    /// parts it did publish are not ours to take back.
     internal func rollback() {
-        guard !isCommitted else { return }
+        guard !didAttemptPublish else { return }
         try? handle.close()
         PluginExportUtilities.rollbackAtomicWrite(at: tempURL)
         for entry in pending {
@@ -99,12 +148,20 @@ internal final class SQLExportFileWriter {
         pending.removeAll()
     }
 
+    /// Publishing runs in order, so everything past what was published is still a temp, the part
+    /// whose own publish failed included.
+    private func discardUnpublishedTemps() {
+        for entry in pending.dropFirst(published.count) {
+            PluginExportUtilities.rollbackAtomicWrite(at: entry.temp)
+        }
+    }
+
     /// The file the caller compresses when gzip is on. Compression runs over a single file, so a
     /// split export is the one case it cannot apply to.
     internal var currentFileURL: URL { tempURL }
 
     private func rotate() throws {
-        try writeRaw(encodingDeclaration.epilogue)
+        try endPart()
         try handle.close()
         pending.append((tempURL, Self.partURL(for: destination, part: partIndex)))
         partIndex += 1
@@ -113,7 +170,33 @@ internal final class SQLExportFileWriter {
         tempURL = nextTemp
         bytesInCurrentPart = 0
         currentPartHasStatements = false
+        try beginPart()
+    }
+
+    /// Declares the encoding and re-opens every scope that is still open, so a part carries the
+    /// session state its own statements were written under.
+    private func beginPart() throws {
         try writeRaw(encodingDeclaration.prologue)
+        for scope in openScopes {
+            try writeRaw(scope.opener)
+        }
+    }
+
+    /// A part closes what it opened, innermost first, whether it ends at a rotation or at the
+    /// commit. `SET IDENTITY_INSERT` used to be written as two plain statements around a table's
+    /// rows, so a rotation between them ended part N on an unmatched `ON` and opened part N+1 with
+    /// rows SQL Server rejects one by one (#2533).
+    private func endPart() throws {
+        for scope in openScopes.reversed() {
+            try writeRaw(scope.closer)
+        }
+        try writeRaw(encodingDeclaration.epilogue)
+    }
+
+    /// What the part still owes: the closer of every open scope and the closing declaration. Every
+    /// write counts it, because a part that fits only until its own tail is added has not fitted.
+    private var partTailBytes: Int {
+        openScopes.reduce(encodingDeclaration.epilogue.utf8.count) { $0 + $1.closer.utf8.count }
     }
 
     private func writeRaw(_ text: String) throws {
@@ -121,5 +204,29 @@ internal final class SQLExportFileWriter {
         let data = try text.toUTF8Data()
         try handle.write(contentsOf: data)
         bytesInCurrentPart += data.count
+    }
+}
+
+/// A split dump is published one rename at a time, so a failure partway through has already put
+/// the earlier parts on disk. Naming them is the whole point of this error: the alert that reports
+/// the failure is the only place the user hears which files the export did write, and they cannot
+/// be taken back, because `replaceItemAt` keeps no backup of what stood at the path.
+internal struct SQLExportPublishFailure: LocalizedError {
+    internal let published: [URL]
+    internal let failed: URL
+    internal let underlying: any Error
+
+    internal var errorDescription: String? {
+        let name = failed.lastPathComponent
+        let reason = underlying.localizedDescription
+        guard !published.isEmpty else {
+            return String(format: String(localized: "Could not write %1$@. %2$@"), name, reason)
+        }
+        return String(
+            format: String(localized:
+                "Could not write %1$@. %2$@ These parts were written and are still on disk: %3$@"),
+            name,
+            reason,
+            published.map(\.lastPathComponent).joined(separator: ", "))
     }
 }

--- a/Plugins/SQLExportPlugin/SQLExportPlugin.swift
+++ b/Plugins/SQLExportPlugin/SQLExportPlugin.swift
@@ -224,6 +224,11 @@ final class SQLExportPlugin: ExportFormatPlugin, SettablePlugin, @unchecked Send
             if let snapshot {
                 await snapshot.end(on: dataSource)
             }
+            /// The publication point. Every phase above can suspend on a driver call, and the
+            /// grant phase makes no cancellation check of its own, so a Stop arriving in one of
+            /// them used to resume and replace the user's file anyway. Nothing is published past
+            /// this line without the stop having been seen.
+            try progress.checkCancellation()
             let writtenParts = try writer.commit()
             committed = true
             if writer.didSplit, let first = writtenParts.first, let last = writtenParts.last {

--- a/Plugins/SQLExportPlugin/SQLExportPlugin.swift
+++ b/Plugins/SQLExportPlugin/SQLExportPlugin.swift
@@ -58,6 +58,16 @@ final class SQLExportPlugin: ExportFormatPlugin, SettablePlugin, @unchecked Send
     /// Kept apart for the same reason `indexFailures` is: an object whose definition came back fine
     /// and only lost its comments is a different thing to tell the user about.
     var commentFailures: [String] = []
+
+    /// The tables whose dependent sequences or enum types could not be read. Kept apart from
+    /// `ddlFailures` for the same reason `indexFailures` is: the table's own `CREATE TABLE` came
+    /// back fine, and what is missing is an object that statement names. Measured on PostgreSQL
+    /// 17.11 with `SELECT` revoked on `pg_catalog.pg_enum`: the enum query fails, `fetchTableDDL`
+    /// still returns a `CREATE TABLE` declaring `status order_status`, and the restore stops at
+    /// `type "order_status" does not exist` with nothing in the dump explaining it. One entry per
+    /// table, however many of its two fetches failed.
+    private var dependentObjectFailures: [String] = []
+
     var metadataWarnings: [String] = []
 
     /// The tables a foreign key cycle left the ordering unable to place. They keep the order the
@@ -119,6 +129,7 @@ final class SQLExportPlugin: ExportFormatPlugin, SettablePlugin, @unchecked Send
         ddlFailures = []
         indexFailures = []
         commentFailures = []
+        dependentObjectFailures = []
         metadataWarnings = []
         exportSpansContainers = false
         tablesUnorderedByCycle = []
@@ -213,12 +224,17 @@ final class SQLExportPlugin: ExportFormatPlugin, SettablePlugin, @unchecked Send
             if let snapshot {
                 await snapshot.end(on: dataSource)
             }
-            try writer.commit()
+            let writtenParts = try writer.commit()
             committed = true
-            if writer.didSplit {
+            if writer.didSplit, let first = writtenParts.first, let last = writtenParts.last {
                 metadataWarnings.append(String(
-                    format: String(localized: "The dump was written as %lld numbered parts. Restore them in order."),
-                    Int64(writer.partCount)))
+                    format: String(localized: """
+                        The dump was written as %1$lld numbered parts, %2$@ through %3$@. Restore \
+                        them in order.
+                        """),
+                    Int64(writtenParts.count),
+                    first.lastPathComponent,
+                    last.lastPathComponent))
             }
         } catch {
             if let snapshot {
@@ -228,18 +244,10 @@ final class SQLExportPlugin: ExportFormatPlugin, SettablePlugin, @unchecked Send
         }
 
         if options.compressWithGzip, let gzipSource = gzipTempURL {
-            progress.setStatus("Compressing...")
-
-            do {
-                defer {
-                    try? FileManager.default.removeItem(at: gzipSource)
-                }
-
-                try await compressFile(source: gzipSource, destination: destination)
-            } catch {
-                try? FileManager.default.removeItem(at: destination)
-                throw error
-            }
+            progress.setStatus(String(localized: "Compressing\u{2026}"))
+            defer { try? FileManager.default.removeItem(at: gzipSource) }
+            try await SQLExportCompressor.compress(
+                source: gzipSource, to: destination, progress: progress)
         }
 
         progress.finalizeTable()
@@ -249,6 +257,14 @@ final class SQLExportPlugin: ExportFormatPlugin, SettablePlugin, @unchecked Send
             let failedTables = ddlFailures.joined(separator: ", ")
             warnings.append(String(
                 format: String(localized: "Could not fetch table structure for: %@"), failedTables))
+        }
+        if !dependentObjectFailures.isEmpty {
+            warnings.append(String(
+                format: String(localized: """
+                    Could not fetch the types and sequences needed by: %@. A CREATE TABLE that \
+                    names one of them will not restore.
+                    """),
+                dependentObjectFailures.joined(separator: ", ")))
         }
         if !indexFailures.isEmpty {
             warnings.append(String(
@@ -262,6 +278,9 @@ final class SQLExportPlugin: ExportFormatPlugin, SettablePlugin, @unchecked Send
         }
         if let oversized = Self.oversizedRowWarning(tally: statementTally) {
             warnings.append(oversized)
+        }
+        if let unrepresentable = Self.unrepresentableValueWarning(tally: statementTally) {
+            warnings.append(unrepresentable)
         }
         warnings.append(contentsOf: metadataWarnings)
         return ExportFormatResult(warnings: warnings, notes: Self.statementSizeNotes(tally: statementTally))
@@ -285,6 +304,23 @@ final class SQLExportPlugin: ExportFormatPlugin, SettablePlugin, @unchecked Send
             format: template,
             formatted(bytes: tally.largestStatementBytes),
             Int64(tally.largestStatementRows))]
+    }
+
+    /// Named rather than left to the restore, because no single-statement form of such a value
+    /// exists on this engine: the dump carries the closest thing there is and says so.
+    private static func unrepresentableValueWarning(tally: SQLExportStatementTally) -> String? {
+        guard tally.unrepresentableValues > 0 else { return nil }
+        let ceiling = formatted(bytes: SQLExportBinaryLiteral.oracleLiteralByteCeiling)
+        let template = tally.unrepresentableValues == 1
+            ? String(localized: """
+                1 binary value is larger than the %1$@ this engine allows in one statement, so its \
+                INSERT may not restore.
+                """)
+            : String(localized: """
+                %2$lld binary values are larger than the %1$@ this engine allows in one statement, \
+                so their INSERTs may not restore.
+                """)
+        return String(format: template, ceiling, Int64(tally.unrepresentableValues))
     }
 
     /// The limit comes off the tally rather than the settings, so a second window moving the setting
@@ -491,7 +527,11 @@ final class SQLExportPlugin: ExportFormatPlugin, SettablePlugin, @unchecked Send
                     try writer.write("\(seq.ddl)\n\n")
                 }
             } catch {
+                let sanitizedName = PluginExportUtilities.sanitizeForSQLComment(table.name)
+                noteDependentObjectFailure(sanitizedName)
                 Self.logger.warning("Failed to fetch dependent sequences for table \(table.name): \(error)")
+                let warning = "Warning: failed to fetch dependent sequences for \(sanitizedName): \(error)"
+                try writer.write("-- \(PluginExportUtilities.sanitizeForSQLComment(warning))\n\n")
             }
 
             do {
@@ -508,9 +548,18 @@ final class SQLExportPlugin: ExportFormatPlugin, SettablePlugin, @unchecked Send
                     try writer.write("CREATE TYPE \(quotedName) AS ENUM (\(quotedLabels.joined(separator: ", ")));\n\n")
                 }
             } catch {
+                let sanitizedName = PluginExportUtilities.sanitizeForSQLComment(table.name)
+                noteDependentObjectFailure(sanitizedName)
                 Self.logger.warning("Failed to fetch dependent types for table \(table.name): \(error)")
+                let warning = "Warning: failed to fetch dependent types for \(sanitizedName): \(error)"
+                try writer.write("-- \(PluginExportUtilities.sanitizeForSQLComment(warning))\n\n")
             }
         }
+    }
+
+    private func noteDependentObjectFailure(_ sanitizedTableName: String) {
+        guard !dependentObjectFailures.contains(sanitizedTableName) else { return }
+        dependentObjectFailures.append(sanitizedTableName)
     }
 
     private func writeCreatePhase(
@@ -897,8 +946,14 @@ final class SQLExportPlugin: ExportFormatPlugin, SettablePlugin, @unchecked Send
         /// SQL Server refuses an explicit value for an IDENTITY column unless the table is opened
         /// for it first. The rows are exported with their keys, so without this the dump restores
         /// nothing: every INSERT for the table is rejected while the export itself reported success.
+        /// The writer owns it as a scope so a rotation inside the table's rows carries it into the
+        /// next part: as two plain statements, one part ended on an unmatched `ON` and the next
+        /// opened with rows and none (#2533).
         let needsIdentityInsert = dataSource.databaseTypeId == "SQL Server"
             && columnInfo.contains(where: \.isIdentity)
+        let identityInsert = needsIdentityInsert
+            ? SQLExportSessionScope.identityInsert(tableRef: tableRef)
+            : nil
 
         if !table.rowScope.isUnrestricted {
             let scopeNote = PluginExportUtilities.sanitizeForSQLComment(table.rowScope.summary)
@@ -924,19 +979,18 @@ final class SQLExportPlugin: ExportFormatPlugin, SettablePlugin, @unchecked Send
         /// byte budget can hold rows well past `batchSize` before closing a statement, so a
         /// row-count trigger would write it in the wrong place or not at all.
         func emit(_ statement: String) throws {
-            if !wroteAnyRows {
-                if needsIdentityInsert {
-                    try writer.write("SET IDENTITY_INSERT \(tableRef) ON;\n")
-                }
-                wroteAnyRows = true
-            }
             if let warning = pendingModeWarning {
                 if !metadataWarnings.contains(warning) {
                     metadataWarnings.append(warning)
                 }
                 pendingModeWarning = nil
             }
-            try writer.write(statement)
+            guard !wroteAnyRows else {
+                try writer.write(statement)
+                return
+            }
+            wroteAnyRows = true
+            try writer.write(statement, opening: identityInsert)
         }
 
         let stream = dataSource.streamRows(for: table)
@@ -951,6 +1005,10 @@ final class SQLExportPlugin: ExportFormatPlugin, SettablePlugin, @unchecked Send
                     try emit(statement)
                 }
                 if let accumulator { tally.merge(accumulator.tally) }
+                /// The outgoing encoder's count goes with it. Only the last encoder used to reach
+                /// the tally, so a second header after rows dropped every unrepresentable value the
+                /// first segment rendered, and an export whose last segment held none reported clean.
+                if let encoder { tally.unrepresentableValues += encoder.unrepresentableValues.total }
                 let built = SQLExportRowValueEncoder(
                     columns: header.columns,
                     columnTypeNames: header.columnTypeNames ?? [],
@@ -996,9 +1054,10 @@ final class SQLExportPlugin: ExportFormatPlugin, SettablePlugin, @unchecked Send
             try emit(statement)
         }
         if let accumulator { tally.merge(accumulator.tally) }
+        if let encoder { tally.unrepresentableValues += encoder.unrepresentableValues.total }
 
         if wroteAnyRows, needsIdentityInsert {
-            try writer.write("SET IDENTITY_INSERT \(tableRef) OFF;\n")
+            try writer.closeScope()
         }
 
         if wroteAnyRows {
@@ -1051,69 +1110,5 @@ final class SQLExportPlugin: ExportFormatPlugin, SettablePlugin, @unchecked Send
                 options.batchSize,
                 SQLMultiRowInsert.maximumRowsPerStatement(forDatabaseTypeId: databaseTypeId)),
             maxBytes: options.maxStatementBytes)
-    }
-
-
-    private func compressFile(source: URL, destination: URL) async throws {
-        let gzipPath = "/usr/bin/gzip"
-        guard FileManager.default.isExecutableFile(atPath: gzipPath) else {
-            throw PluginExportError.exportFailed(
-                "Compression unavailable: gzip not found at \(gzipPath)"
-            )
-        }
-
-        let sourcePath = source.standardizedFileURL.path(percentEncoded: false)
-
-        guard FileManager.default.createFile(atPath: destination.path(percentEncoded: false), contents: nil) else {
-            throw PluginExportError.fileWriteFailed(destination.path(percentEncoded: false))
-        }
-
-        let outputHandle: FileHandle
-        do {
-            outputHandle = try FileHandle(forWritingTo: destination)
-        } catch {
-            try? FileManager.default.removeItem(at: destination)
-            throw error
-        }
-        let errorPipe = Pipe()
-
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: gzipPath)
-        process.arguments = ["-c", sourcePath]
-        process.standardOutput = outputHandle
-        process.standardError = errorPipe
-
-        do {
-            try await withTaskCancellationHandler {
-                try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
-                    process.terminationHandler = { proc in
-                        try? outputHandle.close()
-                        let status = proc.terminationStatus
-                        if status == 0 {
-                            continuation.resume()
-                        } else {
-                            let errData = errorPipe.fileHandleForReading.readDataToEndOfFile()
-                            let errMsg = String(data: errData, encoding: .utf8)?
-                                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-                            let message = errMsg.isEmpty
-                                ? "Compression failed with exit status \(status)"
-                                : "Compression failed with exit status \(status): \(errMsg)"
-                            continuation.resume(throwing: PluginExportError.exportFailed(message))
-                        }
-                    }
-                    do {
-                        try process.run()
-                    } catch {
-                        try? outputHandle.close()
-                        continuation.resume(throwing: error)
-                    }
-                }
-            } onCancel: {
-                process.terminate()
-            }
-        } catch {
-            try? FileManager.default.removeItem(at: destination)
-            throw error
-        }
     }
 }

--- a/Plugins/SQLExportPlugin/SQLExportRowValueEncoder.swift
+++ b/Plugins/SQLExportPlugin/SQLExportRowValueEncoder.swift
@@ -18,6 +18,28 @@ import TableProPluginKit
 internal struct SQLExportRowValueEncoder {
     internal let includedColumnIndices: [Int]
 
+    /// The values this encoder rendered that the engine cannot carry in one statement whatever
+    /// spelling is used. A class because rendering a row is not supposed to look like a mutation,
+    /// and the count has to survive the `let` the stream loop holds the encoder in.
+    internal final class UnrepresentableValueCount: @unchecked Sendable {
+        private let lock = NSLock()
+        private var count = 0
+
+        internal func record() {
+            lock.lock()
+            count += 1
+            lock.unlock()
+        }
+
+        internal var total: Int {
+            lock.lock()
+            defer { lock.unlock() }
+            return count
+        }
+    }
+
+    internal let unrepresentableValues = UnrepresentableValueCount()
+
     private let numericIndices: Set<Int>
     private let databaseTypeId: String
     private let escapeStringLiteral: (String) -> String
@@ -53,6 +75,9 @@ internal struct SQLExportRowValueEncoder {
             case .null:
                 return "NULL"
             case .bytes(let data):
+                if SQLExportBinaryLiteral.exceedsLiteralCeiling(data, databaseTypeId: databaseTypeId) {
+                    unrepresentableValues.record()
+                }
                 return SQLExportBinaryLiteral.render(data, databaseTypeId: databaseTypeId)
             case .text(let value):
                 if numericIndices.contains(columnIndex), PluginNumericLiteral.isValid(value) {

--- a/Plugins/SQLExportPlugin/SQLExportSessionScope.swift
+++ b/Plugins/SQLExportPlugin/SQLExportSessionScope.swift
@@ -1,0 +1,29 @@
+//
+//  SQLExportSessionScope.swift
+//  SQLExportPlugin
+//
+
+import Foundation
+
+/// A pair of statements a part has to carry together: the opener establishes session state the
+/// statements after it depend on, and the closer puts it back.
+///
+/// Replaying the parts of a split dump in order gets the statements in the same order as an unsplit
+/// one, but not in one session, so session state cannot be assumed to cross a part boundary. A
+/// scope therefore belongs to every part it spans rather than to the file: the writer re-opens it
+/// at the top of each new part and closes it at the bottom of each finished one.
+internal struct SQLExportSessionScope: Equatable {
+    internal let opener: String
+    internal let closer: String
+
+    /// SQL Server refuses an explicit value for an IDENTITY column unless the table is opened for
+    /// it first, so a part carrying any of that table's rows has to open it again. Written as two
+    /// plain statements, one `ON` per table and one `OFF` after the stream, a rotation between them
+    /// left part N+1 answering every row with "Cannot insert explicit value for identity column"
+    /// while the export reported success (#2533).
+    internal static func identityInsert(tableRef: String) -> SQLExportSessionScope {
+        SQLExportSessionScope(
+            opener: "SET IDENTITY_INSERT \(tableRef) ON;\n",
+            closer: "SET IDENTITY_INSERT \(tableRef) OFF;\n")
+    }
+}

--- a/Plugins/SQLExportPlugin/SQLExportStatementBudget.swift
+++ b/Plugins/SQLExportPlugin/SQLExportStatementBudget.swift
@@ -36,12 +36,18 @@ internal struct SQLExportStatementTally: Equatable {
     internal var oversizedRowCount = 0
     internal var limitBytes = 0
 
+    /// Values the engine cannot carry in one statement whatever spelling is used, so the dump holds
+    /// SQL that may not restore. Oracle caps a string literal at 4,000 characters, which is 2,000
+    /// binary bytes through `HEXTORAW`, and nothing else can express one in a single statement.
+    internal var unrepresentableValues = 0
+
     internal mutating func merge(_ other: SQLExportStatementTally) {
         if other.largestStatementBytes > largestStatementBytes {
             largestStatementBytes = other.largestStatementBytes
             largestStatementRows = other.largestStatementRows
         }
         oversizedRowCount += other.oversizedRowCount
+        unrepresentableValues += other.unrepresentableValues
         limitBytes = max(limitBytes, other.limitBytes)
     }
 }

--- a/Plugins/TableProPluginKit/PluginExportProgress.swift
+++ b/Plugins/TableProPluginKit/PluginExportProgress.swift
@@ -7,8 +7,14 @@ public final class PluginExportProgress: @unchecked Sendable {
     private var _currentTableIndex: Int = 0
     private let lock = NSLock()
 
+    /// `localizedAdditionalDescription` is the channel `setStatus` writes, and Foundation fills it
+    /// in when nobody has: measured, a `Progress` carrying a total reports "10 of 100" there and
+    /// posts a KVO change for it on every `completedUnitCount` write. Seeding it empty takes the
+    /// property over for good, so a host observing it hears the plugin and nothing else. The import
+    /// sheet showed that raw row count in place of its statement count for exactly this reason.
     public init(progress: Progress) {
         self.progress = progress
+        progress.localizedAdditionalDescription = ""
     }
 
     public func setCurrentTable(_ name: String, index: Int) {

--- a/Plugins/TableProPluginKit/PluginImportProgress.swift
+++ b/Plugins/TableProPluginKit/PluginImportProgress.swift
@@ -6,8 +6,14 @@ public final class PluginImportProgress: @unchecked Sendable {
     private var internalCount: Int = 0
     private let lock = NSLock()
 
+    /// `localizedAdditionalDescription` is the channel `setStatus` writes, and Foundation fills it
+    /// in when nobody has: measured, a `Progress` carrying a total reports "10 of 100" there and
+    /// posts a KVO change for it on every `completedUnitCount` write. Seeding it empty takes the
+    /// property over for good, so a host observing it hears the plugin and nothing else. The import
+    /// sheet showed that raw row count in place of its statement count for exactly this reason.
     public init(progress: Progress) {
         self.progress = progress
+        progress.localizedAdditionalDescription = ""
     }
 
     public func setEstimatedTotal(_ count: Int) {

--- a/Plugins/TableProPluginKit/RowImportRunner.swift
+++ b/Plugins/TableProPluginKit/RowImportRunner.swift
@@ -94,6 +94,12 @@ public enum RowImportRunner {
             try await sink.insertRows(batch.map(\.row))
             inserted += batch.count
             progress.incrementStatement(by: batch.count)
+        } catch is PluginImportCancellationError {
+            /// A Stop keeps its own type. The sink splits one hand-off into several statements and
+            /// checks cancellation before each, so this catch sees cancellation where it used to see
+            /// only driver errors; wrapped as a statement failure, Stop-and-Commit committed the
+            /// prefix already written and recorded the stop as a failed import.
+            throw PluginImportCancellationError()
         } catch {
             let firstLine = batch.first?.line ?? 0
             throw PluginImportError.statementFailed(

--- a/TablePro/Core/ChangeTracking/SQLWriteBatchBudget.swift
+++ b/TablePro/Core/ChangeTracking/SQLWriteBatchBudget.swift
@@ -29,9 +29,26 @@ internal struct SQLWriteBatchBudget: Sendable, Equatable {
     internal let maxRows: Int
     internal let maxBytes: Int
 
-    internal init(maxRows: Int, maxBytes: Int = SQLWriteBatchBudget.maximumBytes) {
+    /// Whether the target's driver sends a value as a bind parameter or renders it into the SQL.
+    /// Databend has no binary protocol here: `MariaDBPluginConnection` routes it through
+    /// `DatabendLiteral.inline`, so a value crosses as a literal, binary doubles as hex and text
+    /// grows by whatever escaping it needs. Charging it the parameter rate made the cap no bound at
+    /// all: two 400,000-byte values are 800,024 bytes of parameters but over 1.6 MiB of SQL.
+    internal let rendersValuesAsLiterals: Bool
+
+    internal init(
+        maxRows: Int,
+        maxBytes: Int = SQLWriteBatchBudget.maximumBytes,
+        rendersValuesAsLiterals: Bool = false
+    ) {
         self.maxRows = max(1, maxRows)
         self.maxBytes = max(1, maxBytes)
+        self.rendersValuesAsLiterals = rendersValuesAsLiterals
+    }
+
+    /// The engines whose driver inlines a parameter rather than binding it.
+    internal static func rendersValuesAsLiterals(_ databaseType: DatabaseType) -> Bool {
+        databaseType == .databend
     }
 
     /// The engine's bind-parameter ceiling over the row's width, clamped by its multi-row `VALUES`
@@ -48,7 +65,8 @@ internal struct SQLWriteBatchBudget: Sendable, Equatable {
                 SQLMultiRowInsert.maximumRowsPerStatement(
                     forDatabaseTypeId: generator.databaseType.rawValue),
                 generator.maxBindParameters / max(1, columnCount)),
-            maxBytes: maxBytes)
+            maxBytes: maxBytes,
+            rendersValuesAsLiterals: Self.rendersValuesAsLiterals(generator.databaseType))
     }
 
     /// A batch holding nothing takes the row whatever it weighs: a row cannot be split across two
@@ -69,20 +87,26 @@ internal struct SQLWriteBatchBudget: Sendable, Equatable {
     /// null-bitmap bit. Twelve covers every size including the 9-byte prefix a value could
     /// theoretically carry, and over-charging many small values is safe where under-charging a few
     /// large ones is exactly what fails.
-    internal static func byteCount<Values: Sequence>(of values: Values) -> Int
+    internal func byteCount<Values: Sequence>(of values: Values) -> Int
     where Values.Element == PluginCellValue {
         var total = 0
         for value in values {
             switch value {
             case .null:
-                total += valueOverheadBytes
+                total += Self.valueOverheadBytes
             case .text(let text):
-                total += valueOverheadBytes + text.utf8.count
+                total += Self.valueOverheadBytes + charged(text.utf8.count)
             case .bytes(let data):
-                total += valueOverheadBytes + data.count
+                total += Self.valueOverheadBytes + charged(data.count)
             }
         }
         return total
+    }
+
+    /// A driver that inlines is charged double, which is exactly what hex costs a binary value and
+    /// the worst case for escaping a text one.
+    private func charged(_ bytes: Int) -> Int {
+        rendersValuesAsLiterals ? bytes * 2 : bytes
     }
 
     private static let valueOverheadBytes = 12

--- a/TablePro/Core/ChangeTracking/SQLWriteBatchBudget.swift
+++ b/TablePro/Core/ChangeTracking/SQLWriteBatchBudget.swift
@@ -1,0 +1,124 @@
+//
+//  SQLWriteBatchBudget.swift
+//  TablePro
+//
+
+import Foundation
+import TableProPluginKit
+
+/// How much one parameterized `INSERT` may carry, in the two units that can reject it.
+///
+/// A bind-parameter count is not a size. `executeParameterized` reaches MySQL as
+/// `mysql_stmt_prepare` plus `mysql_stmt_execute`, one packet each, and a packet over
+/// `max_allowed_packet` answers `ERROR 1153: Got a packet bigger than 'max_allowed_packet' bytes`,
+/// or `ERROR 2006: Server has gone away` once it is large enough. So a batch bounded by parameters
+/// alone is unbounded in bytes: 500 rows of three 1 MB values sit well inside a three-column
+/// table's 21,845-row parameter ceiling and go out as one 500 MB statement the server refuses,
+/// which fails the first batch and leaves nothing written at all. (#2533)
+///
+/// `maximumBytes` is the mebibyte `mysqldump` settles on for `net_buffer_length` and the SQL export
+/// defaults to: under every `max_allowed_packet` a release has shipped with, and far above a batch
+/// of ordinary rows, so nothing narrow writes more statements than before. Not a user preference
+/// here, because this statement goes to a server the app is connected to rather than into a file.
+internal struct SQLWriteBatchBudget: Sendable, Equatable {
+    /// However narrow the table is: 65,535 one-column rows in one statement parse slowly on every
+    /// engine, cannot be cancelled part-way, and save nothing measurable past a thousand.
+    internal static let maximumRows = 1_000
+    internal static let maximumBytes = 1_048_576
+
+    internal let maxRows: Int
+    internal let maxBytes: Int
+
+    internal init(maxRows: Int, maxBytes: Int = SQLWriteBatchBudget.maximumBytes) {
+        self.maxRows = max(1, maxRows)
+        self.maxBytes = max(1, maxBytes)
+    }
+
+    /// The engine's bind-parameter ceiling over the row's width, clamped by its multi-row `VALUES`
+    /// ceiling and by the flat cap. `SQLMultiRowInsert` owns that middle term, so the SQL export
+    /// reads the same rule and Oracle keeps its one row per statement.
+    internal init(
+        columnCount: Int,
+        generator: SQLStatementGenerator,
+        maxBytes: Int = SQLWriteBatchBudget.maximumBytes
+    ) {
+        self.init(
+            maxRows: min(
+                Self.maximumRows,
+                SQLMultiRowInsert.maximumRowsPerStatement(
+                    forDatabaseTypeId: generator.databaseType.rawValue),
+                generator.maxBindParameters / max(1, columnCount)),
+            maxBytes: maxBytes)
+    }
+
+    /// A batch holding nothing takes the row whatever it weighs: a row cannot be split across two
+    /// statements, so refusing it would write nothing at all. It goes out alone, which is what
+    /// `mysqldump` does with a row larger than its own buffer.
+    internal func hasRoom(for rowBytes: Int, inBatchOf rows: Int, bytes: Int) -> Bool {
+        guard rows > 0 else { return true }
+        guard rows < maxRows else { return false }
+        return bytes + rowBytes <= maxBytes
+    }
+
+    /// What a row costs on the wire, as an upper bound.
+    ///
+    /// Measured against MariaDB 12.3.3 through the binary protocol, the per-value overhead settles
+    /// at about 6 bytes: 1,500 values of 100 bytes crossed as 158,650 against 150,000 of payload.
+    /// The documented `COM_STMT_EXECUTE` layout says why, and bounds it: 2 bytes of the type array
+    /// per parameter, a length-encoded prefix of at most 4 bytes for any value under 16 MB, and one
+    /// null-bitmap bit. Twelve covers every size including the 9-byte prefix a value could
+    /// theoretically carry, and over-charging many small values is safe where under-charging a few
+    /// large ones is exactly what fails.
+    internal static func byteCount<Values: Sequence>(of values: Values) -> Int
+    where Values.Element == PluginCellValue {
+        var total = 0
+        for value in values {
+            switch value {
+            case .null:
+                total += valueOverheadBytes
+            case .text(let text):
+                total += valueOverheadBytes + text.utf8.count
+            case .bytes(let data):
+                total += valueOverheadBytes + data.count
+            }
+        }
+        return total
+    }
+
+    private static let valueOverheadBytes = 12
+}
+
+/// Fills one batch at a time under a budget, so no call site holds a byte counter beside its row
+/// array and has to keep the two in step. The same shape as `SQLExportStatementAccumulator` and the
+/// same rule: a batch is closed *before* the row that would cross the budget, never after, so what
+/// is sent stays under the limit.
+internal struct SQLWriteBatchFiller<Row> {
+    private let budget: SQLWriteBatchBudget
+    private var rows: [Row] = []
+    private var bytes = 0
+
+    internal init(budget: SQLWriteBatchBudget) {
+        self.budget = budget
+    }
+
+    /// Hands back the batch this row closed, if it closed one. The row itself is always held, never
+    /// handed back inside a batch it did not fit.
+    internal mutating func append(_ row: Row, bytes rowBytes: Int) -> [Row]? {
+        var completed: [Row]?
+        if !budget.hasRoom(for: rowBytes, inBatchOf: rows.count, bytes: bytes) {
+            completed = take()
+        }
+        rows.append(row)
+        bytes += rowBytes
+        return completed
+    }
+
+    /// Closes whatever is held, and answers nil when nothing is.
+    internal mutating func take() -> [Row]? {
+        guard !rows.isEmpty else { return nil }
+        let batch = rows
+        rows.removeAll(keepingCapacity: true)
+        bytes = 0
+        return batch
+    }
+}

--- a/TablePro/Core/ObjectCopy/ObjectCopyRowCopier.swift
+++ b/TablePro/Core/ObjectCopy/ObjectCopyRowCopier.swift
@@ -55,8 +55,8 @@ internal struct ObjectCopyRowCopier: Sendable {
             return try await copyOnServer(statement, using: targetDriver, onProgress: onProgress)
         }
         let generator = try makeGenerator(targetDriver: targetDriver)
-        var filler = SQLWriteBatchFiller<[PluginCellValue]>(
-            budget: SQLWriteBatchBudget(columnCount: step.columns.count, generator: generator))
+        let budget = SQLWriteBatchBudget(columnCount: step.columns.count, generator: generator)
+        var filler = SQLWriteBatchFiller<[PluginCellValue]>(budget: budget)
         var stream = sourceDriver.streamRows(query: step.sourceQuery).makeAsyncIterator()
 
         var inserted = 0
@@ -66,7 +66,7 @@ internal struct ObjectCopyRowCopier: Sendable {
             guard case .rows(let rows) = element else { continue }
             for row in rows {
                 let values = try aligned(row)
-                let rowBytes = SQLWriteBatchBudget.byteCount(of: values)
+                let rowBytes = budget.byteCount(of: values)
                 guard let batch = filler.append(values, bytes: rowBytes) else { continue }
                 inserted += try await write(batch, generator: generator, driver: targetDriver)
                 onProgress(inserted)

--- a/TablePro/Core/ObjectCopy/ObjectCopyRowCopier.swift
+++ b/TablePro/Core/ObjectCopy/ObjectCopyRowCopier.swift
@@ -23,6 +23,10 @@
 //  thing it adds is the schema, because the table being written is not the one
 //  the target driver is pointed at.
 //
+//  A batch is bounded in bytes as well as in rows, through `SQLWriteBatchBudget`:
+//  a bind-parameter count says nothing about size, and one statement is one packet
+//  measured against the server's own `max_allowed_packet`.
+//
 
 import Foundation
 import os
@@ -30,22 +34,6 @@ import TableProPluginKit
 
 internal struct ObjectCopyRowCopier: Sendable {
     nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "ObjectCopyRowCopier")
-
-    /// A batch never carries more rows than this however narrow the table is. A single statement
-    /// holding 65,535 one-column rows parses slowly on every engine and cannot be cancelled
-    /// part-way, and the round-trip saving past a thousand rows is not measurable.
-    internal static let maximumBatchRows = 1_000
-
-    /// The flat cap above, clamped by what the engine can parse. `SQLMultiRowInsert` owns the second
-    /// half so the SQL export reads the same rule from the same place; Oracle takes one row per
-    /// statement because it has no `INSERT … VALUES (…), (…)` and the generic generator emits
-    /// exactly that. The two are deliberately separate numbers: this one is a round-trip cap that
-    /// stops measuring above a thousand rows, and that one is the point an engine stops parsing.
-    internal static func maximumBatchRows(for databaseType: DatabaseType) -> Int {
-        min(
-            maximumBatchRows,
-            SQLMultiRowInsert.maximumRowsPerStatement(forDatabaseTypeId: databaseType.rawValue))
-    }
 
     internal struct Outcome: Sendable {
         internal let inserted: Int
@@ -67,19 +55,20 @@ internal struct ObjectCopyRowCopier: Sendable {
             return try await copyOnServer(statement, using: targetDriver, onProgress: onProgress)
         }
         let generator = try makeGenerator(targetDriver: targetDriver)
-        let batchSize = Self.batchSize(columnCount: step.columns.count, generator: generator)
+        var filler = SQLWriteBatchFiller<[PluginCellValue]>(
+            budget: SQLWriteBatchBudget(columnCount: step.columns.count, generator: generator))
         var stream = sourceDriver.streamRows(query: step.sourceQuery).makeAsyncIterator()
 
-        var pending: [[PluginCellValue]] = []
         var inserted = 0
 
         while let element = try await stream.next() {
             if Task.isCancelled { return Outcome(inserted: inserted, cancelled: true) }
             guard case .rows(let rows) = element else { continue }
             for row in rows {
-                pending.append(try aligned(row))
-                guard pending.count >= batchSize else { continue }
-                inserted += try await flush(&pending, generator: generator, driver: targetDriver)
+                let values = try aligned(row)
+                let rowBytes = SQLWriteBatchBudget.byteCount(of: values)
+                guard let batch = filler.append(values, bytes: rowBytes) else { continue }
+                inserted += try await write(batch, generator: generator, driver: targetDriver)
                 onProgress(inserted)
                 if Task.isCancelled { return Outcome(inserted: inserted, cancelled: true) }
             }
@@ -90,8 +79,8 @@ internal struct ObjectCopyRowCopier: Sendable {
         /// pending: writing them committed a batch the user had already stopped and reported the
         /// table as copied.
         if Task.isCancelled { return Outcome(inserted: inserted, cancelled: true) }
-        if !pending.isEmpty {
-            inserted += try await flush(&pending, generator: generator, driver: targetDriver)
+        if let batch = filler.take() {
+            inserted += try await write(batch, generator: generator, driver: targetDriver)
             onProgress(inserted)
         }
         return Outcome(inserted: inserted, cancelled: Task.isCancelled)
@@ -139,14 +128,12 @@ internal struct ObjectCopyRowCopier: Sendable {
         )
     }
 
-    private func flush(
-        _ rows: inout [[PluginCellValue]],
+    private func write(
+        _ batch: [[PluginCellValue]],
         generator: SQLStatementGenerator,
         driver: any PluginDatabaseDriver
     ) async throws -> Int {
-        guard !rows.isEmpty else { return 0 }
-        let batch = rows
-        rows.removeAll(keepingCapacity: true)
+        guard !batch.isEmpty else { return 0 }
         guard let statement = generator.insertStatement(columns: step.columns, rows: batch) else {
             throw ObjectCopyError.refused(String(
                 format: String(localized: "Could not build an INSERT for %@."), step.qualifiedTargetName
@@ -181,11 +168,4 @@ internal struct ObjectCopyRowCopier: Sendable {
         return coercer.coerce(row)
     }
 
-    /// Every value in the batch is one bind parameter, and each engine has its own ceiling on how
-    /// many a statement may carry: 32,766 on SQLite, 2,100 on SQL Server, 65,535 elsewhere.
-    internal static func batchSize(columnCount: Int, generator: SQLStatementGenerator) -> Int {
-        guard columnCount > 0 else { return 1 }
-        let rowCap = maximumBatchRows(for: generator.databaseType)
-        return max(1, min(rowCap, generator.maxBindParameters / columnCount))
-    }
 }

--- a/TablePro/Core/Plugins/ImportDataSinkAdapter.swift
+++ b/TablePro/Core/Plugins/ImportDataSinkAdapter.swift
@@ -132,10 +132,10 @@ final class ImportDataSinkAdapter: PluginImportDataSink, @unchecked Sendable {
         columns: [String],
         generator: SQLStatementGenerator
     ) async throws {
-        var filler = SQLWriteBatchFiller<[PluginCellValue]>(
-            budget: SQLWriteBatchBudget(columnCount: columns.count, generator: generator))
+        let budget = SQLWriteBatchBudget(columnCount: columns.count, generator: generator)
+        var filler = SQLWriteBatchFiller<[PluginCellValue]>(budget: budget)
         for row in groupValues {
-            guard let batch = filler.append(row, bytes: SQLWriteBatchBudget.byteCount(of: row)) else {
+            guard let batch = filler.append(row, bytes: budget.byteCount(of: row)) else {
                 continue
             }
             try await write(batch, columns: columns, generator: generator)

--- a/TablePro/Core/Plugins/ImportDataSinkAdapter.swift
+++ b/TablePro/Core/Plugins/ImportDataSinkAdapter.swift
@@ -16,14 +16,22 @@ final class ImportDataSinkAdapter: PluginImportDataSink, @unchecked Sendable {
     private let columnMapping: [String: String]
     private let rowGenerator: SQLStatementGenerator?
 
+    /// Asked before every statement this sink sends, because one `insertRows` call is no longer one
+    /// statement: a byte-heavy batch, or an Oracle target that takes one row per statement, splits
+    /// it into many awaited writes. The callers check their own cancellation only before entering
+    /// the sink, so without this a Stop was followed by every remaining INSERT of the batch.
+    private let isCancelled: @Sendable () -> Bool
+
     private static let logger = Logger(subsystem: "com.TablePro", category: "ImportDataSinkAdapter")
 
     init(
         driver: DatabaseDriver,
         databaseType: DatabaseType,
         targetTable: String? = nil,
-        columnMapping: [String: String] = [:]
+        columnMapping: [String: String] = [:],
+        isCancelled: @escaping @Sendable () -> Bool = { false }
     ) {
+        self.isCancelled = isCancelled
         self.driver = driver
         self.databaseType = databaseType
         self.databaseTypeId = databaseType.rawValue
@@ -109,20 +117,45 @@ final class ImportDataSinkAdapter: PluginImportDataSink, @unchecked Sendable {
             }
             index = next
 
-            let chunkSize = max(1, rowGenerator.maxBindParameters / columns.count)
-            var offset = 0
-            while offset < groupValues.count {
-                let end = min(offset + chunkSize, groupValues.count)
-                let chunk = Array(groupValues[offset..<end])
-                guard let statement = rowGenerator.insertStatement(columns: columns, rows: chunk) else {
-                    throw PluginImportError.importFailed(
-                        String(localized: "Could not build an INSERT for the mapped columns")
-                    )
-                }
-                _ = try await driver.executeParameterized(query: statement.sql, parameters: statement.parameters)
-                offset = end
-            }
+            try await insertGroup(groupValues, columns: columns, generator: rowGenerator)
         }
+    }
+
+    /// One budget per group, because a group is exactly the run of rows sharing one column set and
+    /// the column set is what fixes a row's width. Bounded in bytes as well as parameters: 500 rows
+    /// of three 1 MB values fit a three-column table's 21,845-row parameter ceiling and went out as
+    /// a single 500 MB statement the server refused, failing the first batch and leaving nothing
+    /// imported. The row cap also carries the engine's multi-row `VALUES` ceiling, which this path
+    /// never consulted, so an Oracle target no longer gets a statement it cannot parse.
+    private func insertGroup(
+        _ groupValues: [[PluginCellValue]],
+        columns: [String],
+        generator: SQLStatementGenerator
+    ) async throws {
+        var filler = SQLWriteBatchFiller<[PluginCellValue]>(
+            budget: SQLWriteBatchBudget(columnCount: columns.count, generator: generator))
+        for row in groupValues {
+            guard let batch = filler.append(row, bytes: SQLWriteBatchBudget.byteCount(of: row)) else {
+                continue
+            }
+            try await write(batch, columns: columns, generator: generator)
+        }
+        guard let batch = filler.take() else { return }
+        try await write(batch, columns: columns, generator: generator)
+    }
+
+    private func write(
+        _ batch: [[PluginCellValue]],
+        columns: [String],
+        generator: SQLStatementGenerator
+    ) async throws {
+        guard !isCancelled() else { throw PluginImportCancellationError() }
+        guard let statement = generator.insertStatement(columns: columns, rows: batch) else {
+            throw PluginImportError.importFailed(
+                String(localized: "Could not build an INSERT for the mapped columns")
+            )
+        }
+        _ = try await driver.executeParameterized(query: statement.sql, parameters: statement.parameters)
     }
 
     /// A row carrying values none of which reach a mapped column writes nothing. Reporting it as

--- a/TablePro/Core/Services/Export/ExportService.swift
+++ b/TablePro/Core/Services/Export/ExportService.swift
@@ -105,14 +105,25 @@ final class ExportService {
 
     // MARK: - Cancellation
 
-    var isCancelled: Bool = false
-
     func cancelExport() {
-        isCancelled = true
         currentProgress?.cancel()
     }
 
     private var currentProgress: PluginExportProgress?
+
+    /// The status line a plugin writes with `PluginExportProgress.setStatus`. Nothing observed it,
+    /// so "Compressing..." never reached a user in any export. The empty guard sits outside the hop
+    /// deliberately: the channel is seeded empty and `fetchTotalRowCount` may already have put its
+    /// own message in `statusMessage`.
+    private func observeStatus(on nsProgress: Progress) -> NSKeyValueObservation {
+        nsProgress.observe(\.localizedAdditionalDescription) { [weak self] observed, _ in
+            let status = observed.localizedAdditionalDescription ?? ""
+            guard !status.isEmpty else { return }
+            Task { @MainActor [weak self] in
+                self?.state.statusMessage = status
+            }
+        }
+    }
 
     // MARK: - Public API
 
@@ -130,12 +141,10 @@ final class ExportService {
         }
 
         state = ExportState(isExporting: true, totalTables: objects.count)
-        isCancelled = false
 
         defer {
             state.isExporting = false
-            isCancelled = false
-            state.statusMessage = ""
+                state.statusMessage = ""
             currentProgress = nil
         }
 
@@ -171,6 +180,9 @@ final class ExportService {
             }
         }
         defer { descObservation.invalidate() }
+
+        let statusObservation = observeStatus(on: nsProgress)
+        defer { statusObservation.invalidate() }
 
         let pluginTables = objects.map { object in
             PluginExportTable(
@@ -240,12 +252,10 @@ final class ExportService {
 
         let totalRows = tableRows.count
         state = ExportState(isExporting: true, totalTables: 1, totalRows: totalRows)
-        isCancelled = false
 
         defer {
             state.isExporting = false
-            isCancelled = false
-            state.statusMessage = ""
+                state.statusMessage = ""
             currentProgress = nil
         }
 
@@ -277,6 +287,9 @@ final class ExportService {
             }
         }
         defer { descObservation.invalidate() }
+
+        let statusObservation = observeStatus(on: nsProgress)
+        defer { statusObservation.invalidate() }
 
         let exportTable = Self.queryResultExportTable(named: config.fileName, plugin: plugin)
 
@@ -313,12 +326,10 @@ final class ExportService {
 
         let estimatedRows = 0
         state = ExportState(isExporting: true, totalTables: 1, totalRows: estimatedRows)
-        isCancelled = false
 
         defer {
             state.isExporting = false
-            isCancelled = false
-            state.statusMessage = ""
+                state.statusMessage = ""
             currentProgress = nil
         }
 
@@ -339,6 +350,9 @@ final class ExportService {
             }
         }
         defer { observation.invalidate() }
+
+        let statusObservation = observeStatus(on: nsProgress)
+        defer { statusObservation.invalidate() }
 
         let exportTable = Self.queryResultExportTable(named: config.fileName, plugin: plugin)
 

--- a/TablePro/Core/Services/Export/ImportService.swift
+++ b/TablePro/Core/Services/Export/ImportService.swift
@@ -220,7 +220,8 @@ final class ImportService {
             driver: driver,
             databaseType: connection.type,
             targetTable: targetTable,
-            columnMapping: columnMapping
+            columnMapping: columnMapping,
+            isCancelled: { progress.isCancelled }
         )
         return try await plugin.performImport(source: source, sink: sink, progress: progress)
     }

--- a/TablePro/Core/Services/Export/TableTransferService.swift
+++ b/TablePro/Core/Services/Export/TableTransferService.swift
@@ -61,13 +61,28 @@ struct TableTransferState {
 final class TableTransferService {
     nonisolated private static let logger = Logger(subsystem: "com.TablePro", category: "TableTransfer")
 
-    /// The batch a transfer accumulates before writing. The sink chunks again by bind-parameter
-    /// count, so this only bounds how many rows are held at once.
-    static let batchSize = 500
+    /// What a transfer holds before it hands rows to the sink, bounded in bytes as well as rows: a
+    /// row count says nothing about size, and 500 rows of three 1 MB values is a gigabyte and a half
+    /// resident before the first statement is written.
+    ///
+    /// The byte half is a residency bound, not a statement bound, so it is far larger than one
+    /// statement: the sink applies `SQLWriteBatchBudget` again and is what keeps a statement under
+    /// the server's packet limit. Sized as a statement instead, a row carrying a wide column the
+    /// mapping discards would close the batch on bytes the sink never sends, turning one round trip
+    /// into one per row.
+    static let batchBudget = SQLWriteBatchBudget(maxRows: 500, maxBytes: 64 * 1_048_576)
 
     var state = TableTransferState()
 
-    private var isCancelled = false
+    /// The same stop, in a form a `@Sendable` closure may read. `isCancelled` is main-actor
+    /// isolated, and the sink splits one hand-off into many statements off that actor, so it needs
+    /// its own view of the flag rather than a hop per statement.
+    private let cancellationFlag = TransferCancellationFlag()
+
+    private var isCancelled: Bool {
+        get { cancellationFlag.isCancelled }
+        set { cancellationFlag.isCancelled = newValue }
+    }
 
     /// Cleared once, before the run's first cancellable step. The sheet reads both sides' columns
     /// before `transfer()` is reached, and a Stop pressed during that read has to survive into it.
@@ -146,7 +161,8 @@ final class TableTransferService {
                 driver: destinationDriver,
                 databaseType: request.destinationType,
                 targetTable: object.name,
-                columnMapping: mapping
+                columnMapping: mapping,
+                isCancelled: { [flag = cancellationFlag] in flag.isCancelled }
             )
             try await transferOne(object: object, from: source, into: sink, request: request)
         }
@@ -213,7 +229,7 @@ final class TableTransferService {
         )
 
         var columns: [String] = []
-        var batch: [[String: PluginCellValue]] = []
+        var filler = SQLWriteBatchFiller<[String: PluginCellValue]>(budget: Self.batchBudget)
         var wroteAnything = false
 
         if request.wrapInTransaction {
@@ -230,16 +246,16 @@ final class TableTransferService {
                     columns = header.columns
                 case .rows(let rows):
                     for row in rows {
-                        batch.append(Self.dictionary(columns: columns, row: row))
-                        guard batch.count >= Self.batchSize else { continue }
+                        let keyed = Self.dictionary(columns: columns, row: row)
+                        let bytes = SQLWriteBatchBudget.byteCount(of: keyed.values)
+                        guard let batch = filler.append(keyed, bytes: bytes) else { continue }
                         try await sink.insertRows(batch)
                         state.transferredRows += batch.count
                         wroteAnything = true
-                        batch.removeAll(keepingCapacity: true)
                     }
                 }
             }
-            if !batch.isEmpty {
+            if let batch = filler.take() {
                 try await sink.insertRows(batch)
                 state.transferredRows += batch.count
                 wroteAnything = true
@@ -280,5 +296,26 @@ final class TableTransferService {
     private func checkCancellation() throws {
         guard isCancelled else { return }
         throw PluginImportCancellationError()
+    }
+}
+
+/// A stop the sink can see from off the main actor. `TableTransferService` is `@MainActor`, and the
+/// sink now sends several statements per hand-off, so without this a Stop was followed by every
+/// remaining INSERT of the batch.
+internal final class TransferCancellationFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var cancelled = false
+
+    internal var isCancelled: Bool {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return cancelled
+        }
+        set {
+            lock.lock()
+            cancelled = newValue
+            lock.unlock()
+        }
     }
 }

--- a/TablePro/Core/Services/Export/TableTransferService.swift
+++ b/TablePro/Core/Services/Export/TableTransferService.swift
@@ -238,6 +238,10 @@ final class TableTransferService {
         do {
             if request.deleteExistingRows {
                 try await sink.deleteAllRowsFromTargetTable()
+                /// The delete is the destructive half. A Stop arriving while it ran, or while an
+                /// empty source stream was awaiting, used to reach the commit without another loop
+                /// iteration and make the deletion permanent.
+                try checkCancellation()
             }
             for try await element in source.streamRows(for: exportTable) {
                 try checkCancellation()
@@ -247,7 +251,7 @@ final class TableTransferService {
                 case .rows(let rows):
                     for row in rows {
                         let keyed = Self.dictionary(columns: columns, row: row)
-                        let bytes = SQLWriteBatchBudget.byteCount(of: keyed.values)
+                        let bytes = Self.batchBudget.byteCount(of: keyed.values)
                         guard let batch = filler.append(keyed, bytes: bytes) else { continue }
                         try await sink.insertRows(batch)
                         state.transferredRows += batch.count
@@ -260,6 +264,9 @@ final class TableTransferService {
                 state.transferredRows += batch.count
                 wroteAnything = true
             }
+            /// The last awaited write is not followed by a loop check, so without this a Stop during
+            /// it committed anyway and reported success.
+            try checkCancellation()
             if request.wrapInTransaction {
                 try await sink.commitTransaction()
             }

--- a/TableProTests/Core/ChangeTracking/SQLWriteBatchBudgetTests.swift
+++ b/TableProTests/Core/ChangeTracking/SQLWriteBatchBudgetTests.swift
@@ -1,0 +1,135 @@
+//
+//  SQLWriteBatchBudgetTests.swift
+//  TableProTests
+//
+//  The arithmetic that used to live on ObjectCopyRowCopier, plus the byte bound it never had.
+//  A bind-parameter count is not a size: one statement is one packet, and a packet over the
+//  server's max_allowed_packet is rejected outright.
+//
+
+@testable import TablePro
+import TableProPluginKit
+import XCTest
+
+final class SQLWriteBatchBudgetTests: XCTestCase {
+    private func generator(_ databaseType: DatabaseType) throws -> SQLStatementGenerator {
+        try SQLStatementGenerator(
+            tableName: "t", columns: [], primaryKeyColumns: [], databaseType: databaseType)
+    }
+
+    // MARK: - Row bounds, ported from ObjectCopyRowCopierTests
+
+    func testTheRowCapNeverExceedsTheEnginesBindParameterCeiling() throws {
+        let mssql = try SQLWriteBatchBudget(columnCount: 100, generator: generator(.mssql))
+        let sqlite = try SQLWriteBatchBudget(columnCount: 100, generator: generator(.sqlite))
+
+        XCTAssertEqual(mssql.maxRows, 21)
+        XCTAssertEqual(sqlite.maxRows, 327)
+    }
+
+    /// A one-column table would otherwise put 65,535 rows in one statement, which parses slowly
+    /// everywhere and cannot be cancelled part-way.
+    func testTheRowCapIsCappedByRowsAsWellAsByParameters() throws {
+        let mysql = try SQLWriteBatchBudget(columnCount: 1, generator: generator(.mysql))
+
+        XCTAssertEqual(mysql.maxRows, 1_000)
+    }
+
+    /// Oracle before 23c rejects `INSERT … VALUES (…), (…)`, which is the only form the generic
+    /// generator emits, so its batches carry one row each however narrow the table is.
+    func testOracleTakesOneRowPerStatement() throws {
+        let oracle = try SQLWriteBatchBudget(columnCount: 2, generator: generator(.oracle))
+
+        XCTAssertEqual(oracle.maxRows, 1)
+    }
+
+    /// A table wider than the ceiling still writes one row at a time rather than none.
+    func testAVeryWideTableStillWritesOneRowPerStatement() throws {
+        let mssql = try SQLWriteBatchBudget(columnCount: 5_000, generator: generator(.mssql))
+
+        XCTAssertEqual(mssql.maxRows, 1)
+    }
+
+    /// An engine with no documented multi-row ceiling keeps the flat thousand rather than taking
+    /// its parameter ceiling: a five-column PostgreSQL table would otherwise jump to 13,107.
+    func testAnEngineWithNoSyntaxCeilingKeepsTheFlatRowCap() throws {
+        let postgres = try SQLWriteBatchBudget(columnCount: 5, generator: generator(.postgresql))
+
+        XCTAssertEqual(SQLMultiRowInsert.maximumRowsPerStatement(forDatabaseTypeId: "PostgreSQL"), .max)
+        XCTAssertEqual(postgres.maxRows, 1_000)
+    }
+
+    // MARK: - Byte bounds
+
+    /// The reported defect: 500 rows of three 1 MB values sit inside a three-column table's
+    /// 21,845-row parameter ceiling and went out as one ~500 MB statement the server refused.
+    func testAByteHeavyRowClosesTheBatchLongBeforeTheRowCap() throws {
+        let budget = try SQLWriteBatchBudget(columnCount: 3, generator: generator(.mysql))
+        let megabyte = SQLWriteBatchBudget.byteCount(
+            of: (0 ..< 3).map { _ in PluginCellValue.text(String(repeating: "a", count: 1_048_576)) })
+
+        XCTAssertGreaterThan(budget.maxRows, 500, "the parameter ceiling alone allows far more")
+        XCTAssertFalse(budget.hasRoom(for: megabyte, inBatchOf: 1, bytes: megabyte))
+    }
+
+    /// A row cannot be split across two statements, so an empty batch takes it whatever it weighs.
+    func testAnEmptyBatchTakesARowOverTheWholeBudget() {
+        let budget = SQLWriteBatchBudget(maxRows: 500)
+        let huge = 10 * SQLWriteBatchBudget.maximumBytes
+
+        XCTAssertTrue(budget.hasRoom(for: huge, inBatchOf: 0, bytes: 0))
+        XCTAssertFalse(budget.hasRoom(for: 1, inBatchOf: 1, bytes: huge))
+    }
+
+    func testTheRowCapStillClosesABatchOfNarrowRows() {
+        let budget = SQLWriteBatchBudget(maxRows: 2)
+
+        XCTAssertTrue(budget.hasRoom(for: 10, inBatchOf: 1, bytes: 10))
+        XCTAssertFalse(budget.hasRoom(for: 10, inBatchOf: 2, bytes: 20))
+    }
+
+    /// Every value carries a length prefix, a type-array entry and a null-bitmap bit, so a row of
+    /// NULLs is not free. Measured against MariaDB 12.3.3, the real per-value cost settles near 6
+    /// bytes; 12 is the documented upper bound and over-charging is the safe direction.
+    func testEveryValueCostsItsOverheadEvenWhenItCarriesNothing() {
+        XCTAssertEqual(SQLWriteBatchBudget.byteCount(of: [PluginCellValue.null]), 12)
+        XCTAssertEqual(SQLWriteBatchBudget.byteCount(of: [PluginCellValue.text("abc")]), 15)
+        XCTAssertEqual(
+            SQLWriteBatchBudget.byteCount(of: [PluginCellValue.bytes(Data(repeating: 0, count: 100))]),
+            112)
+        XCTAssertEqual(SQLWriteBatchBudget.byteCount(of: [PluginCellValue]()), 0)
+    }
+
+    /// A multi-byte value is charged its UTF-8 length, not its character count: the packet the
+    /// server measures carries bytes.
+    func testAMultiByteValueIsChargedItsBytes() {
+        let emoji = String(repeating: "😀", count: 10)
+
+        XCTAssertEqual(emoji.count, 10)
+        XCTAssertEqual(SQLWriteBatchBudget.byteCount(of: [PluginCellValue.text(emoji)]), 12 + 40)
+    }
+
+    // MARK: - The filler
+
+    func testTheFillerClosesABatchBeforeTheRowThatWouldCrossTheBudget() {
+        var filler = SQLWriteBatchFiller<Int>(budget: SQLWriteBatchBudget(maxRows: 100, maxBytes: 100))
+
+        XCTAssertNil(filler.append(1, bytes: 60))
+        let closed = filler.append(2, bytes: 60)
+        XCTAssertEqual(closed, [1], "the first row goes out alone rather than the pair overflowing")
+        XCTAssertEqual(filler.take(), [2], "the row that closed the batch is held, never dropped")
+        XCTAssertNil(filler.take())
+    }
+
+    func testTheFillerNeverDropsARow() {
+        var filler = SQLWriteBatchFiller<Int>(budget: SQLWriteBatchBudget(maxRows: 2, maxBytes: 1_000))
+        var written: [Int] = []
+
+        for row in 1 ... 5 {
+            if let batch = filler.append(row, bytes: 1) { written.append(contentsOf: batch) }
+        }
+        if let batch = filler.take() { written.append(contentsOf: batch) }
+
+        XCTAssertEqual(written, [1, 2, 3, 4, 5])
+    }
+}

--- a/TableProTests/Core/ChangeTracking/SQLWriteBatchBudgetTests.swift
+++ b/TableProTests/Core/ChangeTracking/SQLWriteBatchBudgetTests.swift
@@ -65,7 +65,7 @@ final class SQLWriteBatchBudgetTests: XCTestCase {
     /// 21,845-row parameter ceiling and went out as one ~500 MB statement the server refused.
     func testAByteHeavyRowClosesTheBatchLongBeforeTheRowCap() throws {
         let budget = try SQLWriteBatchBudget(columnCount: 3, generator: generator(.mysql))
-        let megabyte = SQLWriteBatchBudget.byteCount(
+        let megabyte = budget.byteCount(
             of: (0 ..< 3).map { _ in PluginCellValue.text(String(repeating: "a", count: 1_048_576)) })
 
         XCTAssertGreaterThan(budget.maxRows, 500, "the parameter ceiling alone allows far more")
@@ -92,12 +92,31 @@ final class SQLWriteBatchBudgetTests: XCTestCase {
     /// NULLs is not free. Measured against MariaDB 12.3.3, the real per-value cost settles near 6
     /// bytes; 12 is the documented upper bound and over-charging is the safe direction.
     func testEveryValueCostsItsOverheadEvenWhenItCarriesNothing() {
-        XCTAssertEqual(SQLWriteBatchBudget.byteCount(of: [PluginCellValue.null]), 12)
-        XCTAssertEqual(SQLWriteBatchBudget.byteCount(of: [PluginCellValue.text("abc")]), 15)
+        let budget = SQLWriteBatchBudget(maxRows: 500)
+
+        XCTAssertEqual(budget.byteCount(of: [PluginCellValue.null]), 12)
+        XCTAssertEqual(budget.byteCount(of: [PluginCellValue.text("abc")]), 15)
         XCTAssertEqual(
-            SQLWriteBatchBudget.byteCount(of: [PluginCellValue.bytes(Data(repeating: 0, count: 100))]),
-            112)
-        XCTAssertEqual(SQLWriteBatchBudget.byteCount(of: [PluginCellValue]()), 0)
+            budget.byteCount(of: [PluginCellValue.bytes(Data(repeating: 0, count: 100))]), 112)
+        XCTAssertEqual(budget.byteCount(of: [PluginCellValue]()), 0)
+    }
+
+    /// Databend's driver inlines a parameter into the SQL, so binary crosses as hex at two
+    /// characters a byte. Charged the bind-parameter rate, the cap bounded nothing on that engine.
+    func testAnEngineThatInlinesItsValuesIsChargedDouble() throws {
+        let databend = try SQLWriteBatchBudget(columnCount: 1, generator: generator(.databend))
+        let mysql = try SQLWriteBatchBudget(columnCount: 1, generator: generator(.mysql))
+        let value = [PluginCellValue.bytes(Data(repeating: 0xAB, count: 400_000))]
+
+        XCTAssertTrue(databend.rendersValuesAsLiterals)
+        XCTAssertFalse(mysql.rendersValuesAsLiterals)
+        XCTAssertEqual(mysql.byteCount(of: value), 400_012)
+        XCTAssertEqual(databend.byteCount(of: value), 800_012)
+        XCTAssertFalse(
+            databend.hasRoom(for: databend.byteCount(of: value), inBatchOf: 1,
+                             bytes: databend.byteCount(of: value)),
+            "two of these exceed a mebibyte of rendered SQL, so the second must close the batch"
+        )
     }
 
     /// A multi-byte value is charged its UTF-8 length, not its character count: the packet the
@@ -106,7 +125,8 @@ final class SQLWriteBatchBudgetTests: XCTestCase {
         let emoji = String(repeating: "😀", count: 10)
 
         XCTAssertEqual(emoji.count, 10)
-        XCTAssertEqual(SQLWriteBatchBudget.byteCount(of: [PluginCellValue.text(emoji)]), 12 + 40)
+        XCTAssertEqual(
+            SQLWriteBatchBudget(maxRows: 500).byteCount(of: [PluginCellValue.text(emoji)]), 12 + 40)
     }
 
     // MARK: - The filler

--- a/TableProTests/Core/ObjectCopy/ObjectCopyRowCopierTests.swift
+++ b/TableProTests/Core/ObjectCopy/ObjectCopyRowCopierTests.swift
@@ -233,7 +233,8 @@ final class ObjectCopyRowCopierTests: XCTestCase {
         XCTAssertEqual(target.executedParameters.flatMap { $0 }.count, 12)
         for batch in target.executedParameters {
             XCTAssertLessThanOrEqual(
-                SQLWriteBatchBudget.byteCount(of: batch.map { PluginCellValue.text($0.asText ?? "") }),
+                SQLWriteBatchBudget(maxRows: 1_000)
+                    .byteCount(of: batch.map { PluginCellValue.text($0.asText ?? "") }),
                 SQLWriteBatchBudget.maximumBytes + 400_012,
                 "no batch may exceed the budget by more than the one row that cannot be split"
             )

--- a/TableProTests/Core/ObjectCopy/ObjectCopyRowCopierTests.swift
+++ b/TableProTests/Core/ObjectCopy/ObjectCopyRowCopierTests.swift
@@ -214,67 +214,45 @@ final class ObjectCopyRowCopierTests: XCTestCase {
         XCTAssertEqual(reported.values, [1_000, 2_000, 2_500])
     }
 
-    // MARK: - Batch sizing
+    // MARK: - Batch bounds
 
-    func testTheBatchNeverExceedsTheEnginesBindParameterCeiling() throws {
-        let mssql = try SQLStatementGenerator(
-            tableName: "t", columns: [], primaryKeyColumns: [], databaseType: .mssql
-        )
-        let sqlite = try SQLStatementGenerator(
-            tableName: "t", columns: [], primaryKeyColumns: [], databaseType: .sqlite
-        )
+    /// A bind-parameter count is not a size: six rows of 400,000 characters sit well inside the row
+    /// cap and used to go out as one statement no server would take. The sizing arithmetic itself
+    /// moved to SQLWriteBatchBudgetTests, onto the type that now owns it.
+    func testAByteHeavyCopyIsSplitAcrossStatements() async throws {
+        let source = CopyDriver()
+        let wide = String(repeating: "a", count: 400_000)
+        source.streamed = (0 ..< 6).map { [.text(String($0)), .text(wide)] }
+        source.batchSize = 6
+        let target = CopyDriver()
 
-        XCTAssertEqual(ObjectCopyRowCopier.batchSize(columnCount: 100, generator: mssql), 21)
-        XCTAssertEqual(ObjectCopyRowCopier.batchSize(columnCount: 100, generator: sqlite), 327)
+        _ = try await ObjectCopyRowCopier(step: step(), targetDatabaseType: .mysql)
+            .copy(from: source, to: target) { _ in }
+
+        XCTAssertGreaterThan(target.executedQueries.count, 1, "one mebibyte holds two of these rows")
+        XCTAssertEqual(target.executedParameters.flatMap { $0 }.count, 12)
+        for batch in target.executedParameters {
+            XCTAssertLessThanOrEqual(
+                SQLWriteBatchBudget.byteCount(of: batch.map { PluginCellValue.text($0.asText ?? "") }),
+                SQLWriteBatchBudget.maximumBytes + 400_012,
+                "no batch may exceed the budget by more than the one row that cannot be split"
+            )
+        }
     }
 
-    /// A one-column table would otherwise put 65,535 rows in one statement, which parses slowly
-    /// everywhere and cannot be cancelled part-way.
-    func testTheBatchIsCappedByRowsAsWellAsByParameters() throws {
-        let mysql = try SQLStatementGenerator(
-            tableName: "t", columns: [], primaryKeyColumns: [], databaseType: .mysql
-        )
+    /// A row over the budget on its own cannot be split, so it goes out alone rather than being
+    /// dropped or looping forever.
+    func testARowOverTheBudgetIsStillWritten() async throws {
+        let source = CopyDriver()
+        source.streamed = [[.text("1"), .text(String(repeating: "a", count: 2_000_000))]]
+        source.batchSize = 1
+        let target = CopyDriver()
 
-        XCTAssertEqual(ObjectCopyRowCopier.batchSize(columnCount: 1, generator: mysql), 1_000)
-    }
+        let outcome = try await ObjectCopyRowCopier(step: step(), targetDatabaseType: .mysql)
+            .copy(from: source, to: target) { _ in }
 
-    /// Oracle before 23c rejects `INSERT … VALUES (…), (…)`, which is the only form the generic
-    /// generator emits, so its batches carry one row each however narrow the table is.
-    func testOracleWritesOneRowPerStatement() throws {
-        let oracle = try SQLStatementGenerator(
-            tableName: "t", columns: [], primaryKeyColumns: [], databaseType: .oracle
-        )
-
-        XCTAssertEqual(ObjectCopyRowCopier.batchSize(columnCount: 2, generator: oracle), 1)
-    }
-
-    /// The row cap and the engine's syntax ceiling are two different numbers, and the copier takes
-    /// the smaller. `SQLMultiRowInsert` owns the second half so the SQL export reads the same rule,
-    /// and an engine it says nothing about has to keep the flat thousand: a five-column PostgreSQL
-    /// table would otherwise jump to 13,107 rows a batch on the strength of its parameter ceiling.
-    func testAnEngineWithNoSyntaxCeilingKeepsTheFlatRowCap() throws {
-        let postgres = try SQLStatementGenerator(
-            tableName: "t", columns: [], primaryKeyColumns: [], databaseType: .postgresql
-        )
-
-        XCTAssertEqual(SQLMultiRowInsert.maximumRowsPerStatement(forDatabaseTypeId: "PostgreSQL"), .max)
-        XCTAssertEqual(ObjectCopyRowCopier.maximumBatchRows(for: .postgresql), 1_000)
-        XCTAssertEqual(ObjectCopyRowCopier.batchSize(columnCount: 5, generator: postgres), 1_000)
-    }
-
-    func testTheSyntaxCeilingIsTakenWhenItIsTheSmallerOfTheTwo() {
-        XCTAssertEqual(ObjectCopyRowCopier.maximumBatchRows(for: .oracle), 1)
-        XCTAssertEqual(ObjectCopyRowCopier.maximumBatchRows(for: .mssql), 1_000)
-        XCTAssertEqual(ObjectCopyRowCopier.maximumBatchRows(for: .mysql), 1_000)
-    }
-
-    /// A table wider than the ceiling still writes one row at a time rather than none.
-    func testAVeryWideTableStillWritesOneRowPerStatement() throws {
-        let mssql = try SQLStatementGenerator(
-            tableName: "t", columns: [], primaryKeyColumns: [], databaseType: .mssql
-        )
-
-        XCTAssertEqual(ObjectCopyRowCopier.batchSize(columnCount: 5_000, generator: mssql), 1)
+        XCTAssertEqual(outcome.inserted, 1)
+        XCTAssertEqual(target.executedQueries.count, 1)
     }
 
     // MARK: - Crossing engines

--- a/TableProTests/Helpers/SQLExportHarness.swift
+++ b/TableProTests/Helpers/SQLExportHarness.swift
@@ -47,4 +47,46 @@ internal actor SQLExportHarness {
         )
         return (try String(contentsOf: destination, encoding: .utf8), result)
     }
+
+    /// The parts a split export wrote, in restore order, and the whole dump as one part when it did
+    /// not split. A split export never writes the name the user chose, so reading that path back
+    /// finds nothing at all.
+    internal func dumpParts(
+        tables: [PluginExportTable],
+        dataSource: any PluginExportDataSource,
+        options: SQLExportOptions = SQLExportOptions(),
+        progress: PluginExportProgress? = nil
+    ) async throws -> (parts: [String], result: ExportFormatResult) {
+        let plugin = SQLExportPlugin()
+        let storedSettings = plugin.settings
+        plugin.settings = options
+        let destination = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(UUID().uuidString).sql")
+        var written = [destination]
+        defer {
+            plugin.settings = storedSettings
+            for url in written {
+                try? FileManager.default.removeItem(at: url)
+            }
+        }
+
+        let result = try await plugin.export(
+            tables: tables,
+            dataSource: dataSource,
+            destination: destination,
+            progress: progress ?? PluginExportProgress(progress: Progress(totalUnitCount: 1))
+        )
+
+        var parts: [String] = []
+        var index = 1
+        while true {
+            let part = SQLExportFileWriter.partURL(for: destination, part: index)
+            guard FileManager.default.fileExists(atPath: part.path(percentEncoded: false)) else { break }
+            written.append(part)
+            parts.append(try String(contentsOf: part, encoding: .utf8))
+            index += 1
+        }
+        guard parts.isEmpty else { return (parts, result) }
+        return ([try String(contentsOf: destination, encoding: .utf8)], result)
+    }
 }

--- a/TableProTests/Plugins/SQLExportBinaryLiteralTests.swift
+++ b/TableProTests/Plugins/SQLExportBinaryLiteralTests.swift
@@ -4,6 +4,7 @@
 //
 
 import Foundation
+import TableProPluginKit
 import Testing
 
 @testable import TablePro
@@ -40,20 +41,75 @@ struct SQLExportBinaryLiteralTests {
         #expect(SQLExportBinaryLiteral.render(Data(), databaseTypeId: "SQL Server") == "0x")
     }
 
-    /// Oracle stays on the literal it rejects rather than moving to `HEXTORAW`, which carries 2,000
-    /// binary bytes at most and would export clean and fail the restore above that.
-    @Test("Oracle is left on the literal it rejects rather than one that fails silently")
-    func oracleIsLeftAlone() {
-        #expect(SQLExportBinaryLiteral.render(sample, databaseTypeId: "Oracle") == "X'414243'")
+    /// Measured on Oracle AI Database 26ai Free: `X'414243'` is `ORA-00917: missing comma`, and
+    /// `HEXTORAW('414243')` is accepted into `BLOB`, `RAW(2000)` and `LONG RAW` alike, so one
+    /// spelling serves every binary type and the column's own type need not be consulted.
+    @Test("Oracle takes HEXTORAW, which it accepts for every binary type")
+    func oracleUsesHextoraw() {
+        #expect(SQLExportBinaryLiteral.render(sample, databaseTypeId: "Oracle") == "HEXTORAW('414243')")
+    }
+
+    /// `HEXTORAW('')` stores NULL, and into a `BLOB NOT NULL` it is `ORA-01400: cannot insert NULL`.
+    /// An empty BLOB is not a null one, so the empty case is its own spelling. Measured:
+    /// `EMPTY_BLOB()` stores length 0 and is accepted by `BLOB`, `BLOB NOT NULL` and `RAW(2000)`.
+    @Test("An empty Oracle value is EMPTY_BLOB, which stores nothing rather than NULL")
+    func oracleEmptyValueIsNotNull() {
+        #expect(SQLExportBinaryLiteral.render(Data(), databaseTypeId: "Oracle") == "EMPTY_BLOB()")
+    }
+
+    /// Hex doubles the payload and Oracle caps a string literal at 4,000 characters, so `HEXTORAW`
+    /// carries 2,000 binary bytes: measured, 2,000 stored 2,000 and 2,001 is `ORA-01704: string
+    /// literal too long`. Nothing can express one past that in a single statement, so it is written
+    /// anyway and counted, and the export names how many rather than reporting a clean dump.
+    @Test("A value past Oracle's literal ceiling is flagged, and only on Oracle")
+    func oracleLiteralCeilingIsReported() {
+        let atCeiling = Data(repeating: 0xAB, count: SQLExportBinaryLiteral.oracleLiteralByteCeiling)
+        let overCeiling = Data(repeating: 0xAB, count: SQLExportBinaryLiteral.oracleLiteralByteCeiling + 1)
+
+        #expect(SQLExportBinaryLiteral.oracleLiteralByteCeiling == 2_000)
+        #expect(!SQLExportBinaryLiteral.exceedsLiteralCeiling(atCeiling, databaseTypeId: "Oracle"))
+        #expect(SQLExportBinaryLiteral.exceedsLiteralCeiling(overCeiling, databaseTypeId: "Oracle"))
+        #expect(!SQLExportBinaryLiteral.exceedsLiteralCeiling(Data(), databaseTypeId: "Oracle"))
+
+        /// No other engine has this ceiling, so none of them may be counted against it.
+        for typeId in ["MySQL", "PostgreSQL", "SQLite", "SQL Server", "Dameng"] {
+            #expect(!SQLExportBinaryLiteral.exceedsLiteralCeiling(overCeiling, databaseTypeId: typeId))
+        }
     }
 
     /// An engine whose spelling has not been verified keeps what the export already wrote, so this
     /// change cannot regress one.
     @Test("An unlisted engine keeps the hex literal")
     func unlistedEnginesFallBackToHex() {
-        for typeId in ["Snowflake", "Trino", "ClickHouse", "Dameng", "Teradata", "SomeFuturePlugin"] {
+        for typeId in ["Snowflake", "Trino", "ClickHouse", "Teradata", "SomeFuturePlugin"] {
             #expect(SQLExportBinaryLiteral.render(sample, databaseTypeId: typeId) == "X'414243'")
         }
+    }
+
+    /// The encoder is rebuilt whenever a stream emits another header, and only the last one used to
+    /// reach the export's tally, so a value over the ceiling in an earlier segment was dropped from
+    /// the count and an export whose last segment held none reported clean.
+    @Test("Each segment's unrepresentable values are counted, not just the last one's")
+    func everySegmentsCountIsKept() {
+        let over = Data(repeating: 0xAB, count: SQLExportBinaryLiteral.oracleLiteralByteCeiling + 1)
+        func encoder() -> SQLExportRowValueEncoder {
+            SQLExportRowValueEncoder(
+                columns: ["payload"], columnTypeNames: ["BLOB"], excludedColumnNames: [],
+                databaseTypeId: "Oracle", escapeStringLiteral: { $0 })
+        }
+
+        let first = encoder()
+        _ = first.render([.bytes(over)])
+        let second = encoder()
+        _ = second.render([.text("small")])
+
+        #expect(first.unrepresentableValues.total == 1)
+        #expect(second.unrepresentableValues.total == 0, "a fresh segment starts its own count")
+
+        var tally = SQLExportStatementTally()
+        tally.unrepresentableValues += first.unrepresentableValues.total
+        tally.unrepresentableValues += second.unrepresentableValues.total
+        #expect(tally.unrepresentableValues == 1, "the earlier segment's value must survive")
     }
 
     @Test("The hex is uppercase, two characters per byte, for every byte value")

--- a/docs/features/import-export.mdx
+++ b/docs/features/import-export.mdx
@@ -138,7 +138,7 @@ As SQL, a results export writes `INSERT` statements only. A result set is the ou
 
     Insert mode is spelled differently on each engine: `INSERT IGNORE` and `REPLACE INTO` on MySQL and MariaDB, `INSERT OR IGNORE` and `INSERT OR REPLACE` on SQLite, `ON CONFLICT` on PostgreSQL. Updating needs a primary key to name as the conflict target. An engine with no spelling for the mode writes plain inserts, and the export summary says which tables that happened to.
 
-    Splitting writes `dump.part1.sql`, `dump.part2.sql` and so on, rotating between statements so no part ends mid-`INSERT`. Restore the parts in order. A gzipped export is one file, so the two settings do not combine and the summary says so.
+    Splitting writes `dump.part1.sql`, `dump.part2.sql` and so on, rotating between statements so no part ends mid-`INSERT`. The summary names the first and last part; restore them in order. Each part re-opens the session state its own statements need, so a part restores on its own: on SQL Server that means `SET IDENTITY_INSERT`, which a part boundary used to leave behind. A part that cannot be written stops the export, and the error names the parts already on disk, because a rename cannot be taken back. A gzipped export is one file, so the two settings do not combine and the summary says so.
 
     A dump is UTF-8 and says so in every part, the way the engine's own dump tool does:
 

--- a/project.yml
+++ b/project.yml
@@ -595,6 +595,7 @@ targets:
       - Plugins/RedisDriverPlugin/RedisStatementGenerator.swift
       - Plugins/RedisDriverPlugin/RedisTopologyDiagnostics.swift
       - Plugins/SQLExportPlugin/SQLExportBinaryLiteral.swift
+      - Plugins/SQLExportPlugin/SQLExportCompressor.swift
       - Plugins/SQLExportPlugin/SQLExportDDLRewriter.swift
       - Plugins/SQLExportPlugin/SQLExportEncodingDeclaration.swift
       - Plugins/SQLExportPlugin/SQLExportFileWriter.swift
@@ -603,6 +604,7 @@ targets:
       - Plugins/SQLExportPlugin/SQLExportOptionsView.swift
       - Plugins/SQLExportPlugin/SQLExportPlugin.swift
       - Plugins/SQLExportPlugin/SQLExportRowValueEncoder.swift
+      - Plugins/SQLExportPlugin/SQLExportSessionScope.swift
       - Plugins/SQLExportPlugin/SQLExportSnapshot.swift
       - Plugins/SQLExportPlugin/SQLExportStatementBudget.swift
       - Plugins/SQLImportPlugin/SQLImportFailure.swift


### PR DESCRIPTION
The eight defects the #2533 investigation confirmed in the export subsystem and reported rather than shipped. #2807 fixed the reported bug; this fixes what the investigation found around it. Nothing here is speculative: every one was adversarially verified then measured again while building the fix.

## Data loss

**A gzipped export destroyed the file it was overwriting.** `compressFile` called `FileManager.createFile` on the path the save panel returned, which truncates an existing file to zero and returns true, and then three separate sites removed the stump on any failure. So re-exporting over a good `dump.sql.gz` and pressing Stop, or filling the volume, left neither dump. The uncompressed path has always been atomic, so one checkbox decided whether the same action was safe.

`SQLExportCompressor` writes through the same `beginAtomicWrite` / `commitAtomicWrite` pair the plain path uses. Nothing reaches the destination until gzip has exited 0.

**Stop did nothing during a compression.** `compressFile` watched `Task.isCancelled`, but `ExportDialog` runs the export in a bare `Task {}` nobody holds, so that flag never flipped; `Progress.cancel()` is the channel Stop actually writes. The compressor now polls it every 150 ms and terminates gzip. A cancel arriving before the launch is handled by a lock rather than raced, because `Process.terminate()` on an unlaunched process raises an uncaught `NSInvalidArgumentException`.

**A split export left parts on disk under a reported failure.** `commit()` renamed parts one at a time and set `isCommitted` only afterwards, so a throw on part 3 left parts 1 and 2 published while the caller's `defer` ran `rollback()`, which removes temps only. The class comment claimed it prevented "half a dump".

N renames cannot be made atomic, and unwinding is not available either: `replaceItemAt` keeps no backup, so taking a published part back would leave neither the file the user had nor the one just written. So the fix is to record what landed and name it: `commit()` tracks published parts, discards the temps it did not publish, and throws `SQLExportPublishFailure` listing the files that are on disk. The doc comment now says what the class actually guarantees.

## Silent wrongness

**`SET IDENTITY_INSERT` was torn in half by a file rotation.** It was written as two plain statements around a table's rows, and `rotate()` re-emits only the encoding declaration, which is empty for SQL Server. A boundary inside a table's rows ended part N on an unmatched `ON` and opened part N+1 with rows carrying explicit identity values and no `ON`, so restoring part N+1 in its own session failed on every row after an export that reported success.

Parts are replayed in order but not in one session, so session state cannot be assumed to cross a boundary. `SQLExportSessionScope` generalises that: the writer holds the open scopes, re-opens them after each part's prologue and closes them before each part's epilogue, and counts the closers it still owes against the size cap. A table spanning three parts now opens the scope in all three, so every part restores alone.

**A failed dependent type or sequence fetch was logged and nothing else.** Both catch blocks in `writeDependentTypesAndSequences` were the only failure sites in the file ending in a bare `logger.warning`; every sibling appends to a named failure array and writes a `-- Warning:` line into the dump. Measured on PostgreSQL 17.11 with `SELECT` revoked on `pg_catalog.pg_enum`: the enum query fails, `fetchTableDDL` still returns a `CREATE TABLE` declaring `status order_status`, and the restore stops at `type "order_status" does not exist` with a clean summary and nothing in the file to explain it. Both now report, and the warning says plainly that a `CREATE TABLE` naming one of them will not restore.

**Oracle could not restore a binary value, and #2807 deferred this because it could not be measured.** It can now: I ran Oracle AI Database 26ai Free in a container and measured every claim, and two of the three reasons for deferring were wrong.

| Case | Result |
|---|---|
| `X'414243'`, what the export wrote | **`ORA-00917: missing comma`** |
| `HEXTORAW('414243')` into `BLOB` / `RAW(2000)` / `LONG RAW` | **accepted, all three** |
| `HEXTORAW` of 2,000 bytes | accepted, stored 2,000 |
| `HEXTORAW` of 2,001 bytes | **`ORA-01704: string literal too long`** |
| `HEXTORAW('')` into nullable `BLOB` | **stores NULL** |
| `HEXTORAW('')` into `BLOB NOT NULL` | **`ORA-01400: cannot insert NULL`** |
| `EMPTY_BLOB()` into `BLOB` / `BLOB NOT NULL` / `RAW` | **accepted, stores length 0** |

So one spelling does serve all three binary types, and the empty case does have a correct answer. What is real is the 2,000-byte ceiling, and nothing can express a larger value in one statement. The export writes `HEXTORAW` for it anyway, which a server at `max_string_size = EXTENDED` accepts, and **counts it**, so the summary names how many values it could not promise rather than reporting a clean dump.

Verified end to end by compiling the real renderer and restoring its output into the live container: empty stored 0 bytes, 3 stored 3, 2,000 stored 2,000, and 2,001 was the one rejection, which is the one the export reports. Before, all four were `ORA-00917`.

**Export status never reached the UI, and an import showed the wrong number.** `setStatus` writes `Progress.localizedAdditionalDescription`, which no export entry point observed, so `"Compressing..."` has never appeared. Worse, and measured: Foundation fills that property in itself when nobody has, reporting "10 of 100" for a progress with a total and posting a KVO change on every row tick. The import sheet *does* observe it, so it has been showing a raw row count in place of its statement count. Both progress types now seed the channel empty to claim it, and `ExportService` observes it at all three entry points. `ExportService.isCancelled` is gone: written seven times, read never, and it is the flag that made this hard to see.

## Byte-unbounded writes

**A copy, an import or a transfer of large values was rejected as one oversized statement.** Four sites bounded a batch by a bind-parameter count and nothing else, and a parameter count says nothing about size: `executeParameterized` reaches MySQL as one `mysql_stmt_execute` packet measured against `max_allowed_packet`. A three-column table allows 21,845 rows, so a 500-row batch of 1 MB values went out as one ~500 MB statement, the first batch failed, and nothing transferred at all.

`SQLWriteBatchBudget` bounds a batch in both units, and `SQLWriteBatchFiller` closes one *before* the row that would cross it, the same rule as the SQL export's accumulator. `ObjectCopyRowCopier`, `ImportDataSinkAdapter` and `TableTransferService` all read it, so the arithmetic lives in one place; the copier's own duplicate of it is gone.

The per-value overhead is measured rather than guessed. Two independent designs proposed 9 and 16 bytes and neither had measured it; against MariaDB 12.3.3 through the binary protocol it settles near 6 (1,500 values of 100 bytes crossed as 158,650 against 150,000 of payload), and the documented `COM_STMT_EXECUTE` layout bounds it at 2 bytes of type array + a ≤4-byte length prefix + one null-bitmap bit. The budget charges 12: an upper bound at every value size, without the 60% waste of 16.

The shared row cap also carries the engine's multi-row `VALUES` ceiling, which `ImportDataSinkAdapter` never consulted, so importing a CSV, JSON or XLSX file into Oracle no longer builds a statement it cannot parse.

## Verified

| Step | Result |
|---|---|
| `build` | PASS |
| `test` (19 suites) | PASS, **174 of 174** |
| `lint` (4 paths, including `Plugins/` and the tests) | PASS, 0 violations |
| `docs` writing style and docs-against-source | PASS |
| `abi` against the merge base | PASS, empty interface diff |

No PluginKit ABI bump is due, and the gate confirms it: the only PluginKit edits are two initializer *bodies*, so no symbol moves and the interface diff came back empty.

## A second review pass, and five more fixes

An adversarial review of the committed branch came back no-ship with eight claims. Five were real and are fixed in the follow-up commit; three are pre-existing hazards that need their own change and are named below rather than half-done.

**Fixed, and two were regressions this branch introduced.** The per-statement cancellation added above throws `PluginImportCancellationError` from inside the sink, which `RowImportRunner.insertBatch` caught and rewrapped as `statementFailed`; under Stop-and-Commit that committed the prefix already written and recorded the user's Stop as a failed import. Cancellation now keeps its own type through that catch. And the byte budget was not a bound for **Databend**: `MariaDBPluginConnection` routes it through `DatabendLiteral.inline`, so a value crosses as a literal and binary doubles as hex, meaning two 400,000-byte values were charged 800,024 bytes but rendered over 1.6 MiB of SQL. The charge is now transport-aware.

Three more that predate the branch but sit in the paths it touches: an unconditional cancellation gate immediately before `writer.commit`, which is the publication point and had none, so a Stop during the grant phase used to resume and replace the user's file; a gate after the transfer's `DELETE` and before its commit, so a Stop can no longer make a deletion permanent; and gzip's output `close` is now part of its success rather than discarded, because a volume reporting a deferred write failure does so there and the plain writer already propagates it.

**Reported, not built.** Split publication still replaces numbered parts one at a time, so a failure partway can leave a mixed generation: `replaceItemAt` keeps no backup, and doing better needs generational staging with a manifest swap, which is a design change rather than a fix. The SQL export plugin still holds per-run state on the instance `PluginManager` shares between windows, which this branch made invocation-local for the statement tally and the options snapshot but not for the seven pre-existing failure lists, and `ddlRewriter` still reads live settings; the full answer is an `ExportContext` threaded through the plugin. And Oracle values past the 2,000-byte ceiling are still written and reported rather than refused: the review argues rendering should throw so the previous file survives, which is a fair call I did not take, because this branch never makes Oracle worse than the `X''` it emits today and fixes every value at or under the ceiling. Worth deciding before merge.

## Judgement calls

Two pieces of the design lanes' plans were rejected rather than built.

A **leftover-file scanner** that would list `dump.partN.sql` files from an earlier export beside the new ones. It costs a `contentsOfDirectory` on every export, and by its own author's risk note its warning would retitle the success alert and drop its suppression checkbox for anyone who keeps an unrelated `dump.partN.sql` next to their dump. That is the exact regression class #2807 was careful to avoid, for a false positive rather than a defect.

A **column-type-aware Oracle path**, because the measurements showed it is not needed: `HEXTORAW` covers `BLOB`, `RAW` and `LONG RAW`, and `EMPTY_BLOB()` covers the empty case for all of them.

One thing kept that deserves a reviewer's eye: `SQLExportFileWriter.init` takes a `publish:` closure defaulting to the real rename, so a mid-loop publish failure can be tested without rigging the filesystem. The file already injects closures elsewhere, but it is production surface only tests vary.

https://claude.ai/code/session_017b8ZPBsdcDwVstiD2XQMyN
