### PR TITLE
fix(editor): give the results divider one record per connection instead of one per tab ever opened

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -188,6 +188,6 @@ custom_rules:
   storage_environment_defaults:
     name: "Storage Environment Defaults"
     regex: 'UserDefaults\.standard'
-    excluded: ".*/(AppStorageEnvironment|GeneralSettings|WorkspaceRailViewController)\\.swift"
+    excluded: ".*/(AppStorageEnvironment|GeneralSettings|WorkspaceRailViewController|SplitViewAutosaveSweep)\\.swift"
     message: "Resolve preferences through AppStorageEnvironment.shared.defaults. Only a macOS-owned system preference reads the standard domain."
     severity: error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Editor and results divider of one query tab following whichever tab in the pane was opened first.
+- Divider position of every query tab ever opened kept in preferences forever, slowing every launch.
 - Data grid and bottom bar cut off at both edges in a narrow window, with rows and pagination buttons out of reach.
 - Filter panel wider than the pane when a table has a long column name.
 - `bytea` values written as a bit string in a PostgreSQL SQL export, which no restore accepts. (#2533)

--- a/TablePro/Core/Services/Infrastructure/PostLaunchWork.swift
+++ b/TablePro/Core/Services/Infrastructure/PostLaunchWork.swift
@@ -49,6 +49,11 @@ internal enum PostLaunchWork {
             await SQLFavoriteManager.shared.pruneOrphaned(activeConnectionIds: activeIds)
         }
 
+        /// The retired per-tab split name left one permanent defaults record per query tab ever
+        /// opened, and AppKit offers no way to forget one. Here rather than in the delegate because
+        /// removing thousands is measurably slow and nothing observes them before the first frame.
+        Task { await SplitViewAutosaveSweep.sweepIfNeeded() }
+
         let mcp = AppSettingsManager.shared.mcp
         guard mcp.enabled else { return }
         Task { await MCPServerManager.shared.start(port: UInt16(clamping: mcp.port)) }

--- a/TablePro/Core/Storage/SplitViewAutosaveSweep.swift
+++ b/TablePro/Core/Storage/SplitViewAutosaveSweep.swift
@@ -1,0 +1,111 @@
+//
+//  SplitViewAutosaveSweep.swift
+//  TablePro
+//
+
+import AppKit
+import Foundation
+import os
+
+/// What one `NSSplitView` autosave record describes.
+///
+/// `NSSplitView` files a record under `"NSSplitView Subview Frames <autosaveName>"`, one key per
+/// name, in the app's own standard defaults domain. Apple documents neither the spelling nor any way
+/// to forget one: `autosaveName` is the whole API, and where `NSTableView` documents that setting it
+/// to nil clears the saved data, `NSSplitView` says nothing. `removeObject` is the only route.
+internal enum SplitViewAutosaveRecord: Equatable {
+    /// A record of the retired `QuerySplit-<connectionId>-<tabId>` family. Nothing writes or reads
+    /// that name any more, so no connection and no tab can make one of these live again.
+    case retiredPerTabQuerySplit
+    /// Every other name, which this sweep leaves alone. A name it does not recognise is one whose
+    /// lifetime it cannot reason about, and guessing costs a reader their saved layout.
+    case unrecognised
+
+    /// Undocumented by Apple, so `SplitViewAutosaveSweepTests` derives it from a real `NSSplitView`
+    /// rather than trusting this transcription.
+    internal static let keyPrefix = "NSSplitView Subview Frames "
+
+    private static let uuidLength = 36
+
+    /// Parses a defaults key, or returns nil when the key is not an autosave record at all.
+    internal static func parse(key: String) -> SplitViewAutosaveRecord? {
+        guard key.hasPrefix(keyPrefix) else { return nil }
+        let name = String(key.dropFirst(keyPrefix.count))
+        guard let rest = name.dropPrefixIfPresent(SplitViewAutosaveName.querySplitPrefix) else {
+            return .unrecognised
+        }
+        return isRetiredPerTabRemainder(rest) ? .retiredPerTabQuerySplit : .unrecognised
+    }
+
+    /// Two UUIDs joined by a hyphen, which is also the separator inside each of them, so the shape
+    /// is checked by length rather than by searching for the separator. A name carrying a UI test's
+    /// sandbox suffix is longer than this and stays `unrecognised`, which is what keeps one test
+    /// case's record out of a rule written for the real domain.
+    private static func isRetiredPerTabRemainder(_ text: String) -> Bool {
+        guard text.count == uuidLength * 2 + 1 else { return false }
+        let boundary = text.index(text.startIndex, offsetBy: uuidLength)
+        guard text[boundary] == "-" else { return false }
+        return UUID(uuidString: String(text[text.startIndex ..< boundary])) != nil
+            && UUID(uuidString: String(text[text.index(after: boundary)...])) != nil
+    }
+}
+
+/// Removes the records of the retired per-tab query split, and nothing else.
+///
+/// That name minted one permanent record per query tab ever opened, because `QueryTab.id` persists
+/// across launches and is never reused. Measured on one developer machine: 795 of them in a
+/// 12,476-key, 1.9 MB `com.TablePro.plist`, which `UserDefaults` parses in full on first access
+/// during launch, linearly at 0.93us per key.
+///
+/// Deliberately no liveness set. Judging a record by whether its connection still exists needs an
+/// answer to "which connections exist" that `ConnectionStorage` cannot give: a linked-folder or
+/// team-library connection is built and opened transiently and never saved, so it would read as
+/// deleted on every launch and lose its geometry every time. The retired family needs no such
+/// answer, because no code can reach it at all.
+///
+/// Runs from `PostLaunchWork`, which `LaunchEnvironment.finishLaunch()` reaches after marking the
+/// first frame presented: removing thousands of keys costs 165ms to 230ms, and
+/// `applicationDidBecomeActive` fires before that frame. Safe there because AppKit reads a record
+/// once, when `autosaveName` is assigned, and measured, removing a record a live split view still
+/// owns changes no geometry on screen and is rewritten by that view's next save.
+@MainActor
+internal enum SplitViewAutosaveSweep {
+    private static let logger = Logger(subsystem: "com.TablePro", category: "Launch")
+
+    private static var hasSwept = false
+
+    /// The records to drop, given every defaults key present.
+    internal static func deadKeys(among keys: some Sequence<String>) -> [String] {
+        keys.filter { SplitViewAutosaveRecord.parse(key: $0) == .retiredPerTabQuerySplit }
+    }
+
+    /// Idempotent, matching `PostLaunchWork.start()`, which more than one path reaches.
+    internal static func sweepIfNeeded() async {
+        guard !hasSwept else { return }
+        hasSwept = true
+
+        /// AppKit files these in the process's own standard domain, which a UI test's redirected
+        /// suite never receives; `SplitViewAutosaveName` exists to stop cases inheriting each
+        /// other's geometry through it. A sandboxed run therefore shares the developer's real
+        /// records and has no business deleting them.
+        guard !AppStorageEnvironment.shared.isIsolated else { return }
+
+        let defaults = UserDefaults.standard
+        let doomed = deadKeys(among: defaults.dictionaryRepresentation().keys)
+
+        guard !doomed.isEmpty else { return }
+        for key in doomed {
+            defaults.removeObject(forKey: key)
+        }
+        logger.info("swept \(doomed.count) retired per-tab split-view autosave records")
+    }
+}
+
+private extension String {
+    /// Nil when the prefix is absent, so a caller can tell "not this family" from "this family with
+    /// an empty remainder".
+    func dropPrefixIfPresent(_ prefix: String) -> String? {
+        guard hasPrefix(prefix) else { return nil }
+        return String(dropFirst(prefix.count))
+    }
+}

--- a/TablePro/Models/UI/SplitViewAutosaveName.swift
+++ b/TablePro/Models/UI/SplitViewAutosaveName.swift
@@ -30,6 +30,37 @@ internal enum SplitViewAutosaveName {
     /// the user has and leaves the old keys orphaned.
     internal static let base = "com.TablePro.mainSplit"
 
+    /// The drawer that carries one connection's query history.
+    ///
+    /// Declared here rather than spelled at the call site, so the name and anything that has to
+    /// recognise it share one spelling instead of two lists nothing forces to agree.
+    internal static let historyDrawerPrefix = "HistoryDrawer-"
+
+    /// The editor/results divider of one connection's query pane.
+    ///
+    /// Per connection, not per tab, because a per-tab record is not reachable through
+    /// `autosaveName` at all. `VerticalCollapsibleSplitView` assigns the name in
+    /// `makeNSViewController` only, and the query tab branch of `MainEditorContentView` is the one
+    /// tab-content branch with no `.id(tab.id)`, so switching between two query tabs reuses the same
+    /// `NSSplitViewController` with the name it was born with: both tabs autosaved into the first
+    /// tab's record and the second never had one. Measured before this changed: 164 persisted query
+    /// tabs against 1 tab id with a record, beside 795 records naming tabs that were gone.
+    ///
+    /// Reassigning the name on update cannot fix it. `MainSplitViewController` records the same
+    /// lesson one layer up: assigning a name to a split view that has already laid out does not
+    /// re-apply the saved frames. Giving the branch its own identity per tab would, and would also
+    /// rebuild the editor on every tab switch, discarding the find panel, the undo stack and the
+    /// grid's scroll and selection. So the honest name is the one the pane actually has.
+    internal static let querySplitPrefix = "QuerySplit-"
+
+    internal static func historyDrawer(connectionId: UUID) -> String {
+        "\(historyDrawerPrefix)\(connectionId.uuidString)"
+    }
+
+    internal static func querySplit(connectionId: UUID) -> String {
+        "\(querySplitPrefix)\(connectionId.uuidString)"
+    }
+
     /// - Parameter sandboxIdentifier: something unique to one test case. The sandbox root's last
     ///   path component is a fresh UUID per case, which is exactly that.
     internal static func resolved(isIsolated: Bool, sandboxIdentifier: String?) -> String {

--- a/TablePro/Views/Components/VerticalCollapsibleSplitView.swift
+++ b/TablePro/Views/Components/VerticalCollapsibleSplitView.swift
@@ -59,9 +59,11 @@ struct VerticalCollapsibleSplitView<TopContent: View, BottomContent: View>: NSVi
         }
         context.coordinator.observeCollapse(of: bottomItem)
 
-        if isBottomCollapsed {
-            bottomItem.isCollapsed = true
-        }
+        /// Assigned either way, so the tab's own state wins over whatever the autosave record
+        /// restored. Collapsing only when the binding says so let a record that was saved collapsed
+        /// leave a pane collapsed against a tab whose `isResultsCollapsed` is false, and nothing
+        /// afterwards expanded it.
+        bottomItem.isCollapsed = isBottomCollapsed
 
         return splitViewController
     }

--- a/TablePro/Views/Main/Child/MainEditorContentView.swift
+++ b/TablePro/Views/Main/Child/MainEditorContentView.swift
@@ -96,7 +96,7 @@ struct MainEditorContentView: View {
                 get: { !historyState.isVisible },
                 set: { historyState.isVisible = !$0 }
             ),
-            autosaveName: "HistoryDrawer-\(connectionId)",
+            autosaveName: SplitViewAutosaveName.historyDrawer(connectionId: connectionId),
             topMinimumThickness: Self.tabContentMinimumHeight,
             bottomMinimumThickness: 180,
             topContent: {
@@ -420,7 +420,7 @@ struct MainEditorContentView: View {
                     _ = coordinator.tabManager.mutate(tabId: tab.id) { $0.display.isResultsCollapsed = collapsed }
                 }
             ),
-            autosaveName: "QuerySplit-\(connectionId)-\(tab.id)",
+            autosaveName: SplitViewAutosaveName.querySplit(connectionId: connectionId),
             topContent: {
                 VStack(spacing: 0) {
                     if tab.content.externalModificationDetected,

--- a/TableProTests/Storage/SplitViewAutosaveSweepTests.swift
+++ b/TableProTests/Storage/SplitViewAutosaveSweepTests.swift
@@ -1,0 +1,174 @@
+//
+//  SplitViewAutosaveSweepTests.swift
+//  TableProTests
+//
+
+import AppKit
+import Foundation
+import Testing
+
+@testable import TablePro
+
+@Suite("SplitViewAutosaveSweep")
+@MainActor
+struct SplitViewAutosaveSweepTests {
+    private func key(_ name: String) -> String {
+        SplitViewAutosaveRecord.keyPrefix + name
+    }
+
+    private func retiredName(connectionId: UUID = UUID(), tabId: UUID = UUID()) -> String {
+        "\(SplitViewAutosaveName.querySplitPrefix)\(connectionId.uuidString)-\(tabId.uuidString)"
+    }
+
+    // MARK: - The undocumented key spelling
+
+    /// Apple documents `autosaveName` and nothing else: no key format, and no way to forget a
+    /// record, which is why the sweep reaches into the domain by hand. The spelling is therefore a
+    /// transcription, and this derives it from a real `NSSplitView` instead of trusting it.
+    @Test("The key prefix is the one AppKit actually writes")
+    func keyPrefixMatchesAppKit() {
+        let name = "SplitViewAutosaveSweepTests-\(UUID().uuidString)"
+        let defaults = UserDefaults.standard
+        let expected = key(name)
+        defaults.removeObject(forKey: expected)
+
+        let controller = NSSplitViewController()
+        controller.splitView.isVertical = true
+        for _ in 0 ..< 2 {
+            let pane = NSViewController()
+            pane.view = NSView(frame: NSRect(x: 0, y: 0, width: 200, height: 200))
+            controller.addSplitViewItem(NSSplitViewItem(viewController: pane))
+        }
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 200),
+            styleMask: [.titled, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentViewController = controller
+        controller.splitView.autosaveName = NSSplitView.AutosaveName(name)
+        window.orderFront(nil)
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.4))
+
+        defer {
+            window.orderOut(nil)
+            defaults.removeObject(forKey: expected)
+        }
+        #expect(
+            defaults.object(forKey: expected) != nil,
+            "AppKit no longer writes its record under \(expected), so the sweep matches a stale spelling"
+        )
+    }
+
+    // MARK: - Parsing
+
+    /// The retired name joined two UUIDs with the character that also separates their own groups, so
+    /// the shape is recognised by length. A parser that searched for the hyphen would find one
+    /// inside the connection id and read the rest as a tab.
+    @Test("The retired per-tab name is recognised")
+    func parsesRetiredPerTabName() {
+        #expect(SplitViewAutosaveRecord.parse(key: key(retiredName())) == .retiredPerTabQuerySplit)
+    }
+
+    /// The name that replaced it carries one UUID, so it must not look retired.
+    @Test("The per-connection name that replaced it is not treated as retired")
+    func perConnectionNameIsNotRetired() {
+        let current = SplitViewAutosaveName.querySplit(connectionId: UUID())
+        #expect(SplitViewAutosaveRecord.parse(key: key(current)) == .unrecognised)
+    }
+
+    @Test("A key that is not an autosave record parses as nothing at all")
+    func ignoresUnrelatedKeys() {
+        #expect(SplitViewAutosaveRecord.parse(key: "com.TablePro.someSetting") == nil)
+        #expect(SplitViewAutosaveRecord.parse(key: "NSWindow Frame ValueViewerWindow") == nil)
+    }
+
+    @Test(
+        "A name the sweep does not own is unrecognised rather than guessed at",
+        arguments: [
+            "com.TablePro.mainSplit",
+            "com.TablePro.usersRoles.privilegeSplit",
+            "com.TablePro.queryPlanTreeSplit",
+            "ServerDashboardSplit",
+            "SomeNameAddedLater",
+        ]
+    )
+    func otherNamesAreUnrecognised(name: String) {
+        #expect(SplitViewAutosaveRecord.parse(key: key(name)) == .unrecognised)
+    }
+
+    @Test("A connection's history drawer is never touched")
+    func historyDrawerIsUnrecognised() {
+        let drawer = SplitViewAutosaveName.historyDrawer(connectionId: UUID())
+        #expect(SplitViewAutosaveRecord.parse(key: key(drawer)) == .unrecognised)
+    }
+
+    /// `SplitViewAutosaveName.resolved` appends a sandbox suffix under a UI test, and the suffix is
+    /// whatever the sandbox directory is called: measured on one machine as UUIDs and as `sandbox`,
+    /// `sb`, `pr2`, `shot` and `sb-repro1`. A suffixed record belongs to a test case and must not be
+    /// judged by a rule written for the real domain.
+    @Test(
+        "A sandbox-suffixed retired name is left alone",
+        arguments: ["sandbox", "sb", "pr2", "shot", "sb-repro1", "0E5A1D48-1D0E-4F2E-9C21-2C19F0E3A77B"]
+    )
+    func sandboxSuffixedNamesAreUnrecognised(suffix: String) {
+        #expect(SplitViewAutosaveRecord.parse(key: key("\(retiredName()).\(suffix)")) == .unrecognised)
+    }
+
+    @Test("A malformed identifier is unrecognised rather than parsed into a random UUID")
+    func malformedIdentifiersAreUnrecognised() {
+        #expect(SplitViewAutosaveRecord.parse(key: key("QuerySplit-")) == .unrecognised)
+        #expect(SplitViewAutosaveRecord.parse(key: key("QuerySplit-nope-nope")) == .unrecognised)
+        #expect(SplitViewAutosaveRecord.parse(key: key("HistoryDrawer-not-a-uuid")) == .unrecognised)
+    }
+
+    // MARK: - What gets swept
+
+    /// No liveness enters into it: the family is unreachable from any code path, so a record under
+    /// it is dead whichever connection and tab it names.
+    @Test("Every retired record is swept, whichever connection it names")
+    func sweepsEveryRetiredRecord() {
+        let connectionId = UUID()
+        let records = [
+            key(retiredName(connectionId: connectionId)),
+            key(retiredName(connectionId: connectionId)),
+            key(retiredName()),
+        ]
+        #expect(Set(SplitViewAutosaveSweep.deadKeys(among: records)) == Set(records))
+    }
+
+    @Test("Nothing else is ever swept")
+    func neverSweepsAnythingElse() {
+        let untouchable = [
+            key(SplitViewAutosaveName.querySplit(connectionId: UUID())),
+            key(SplitViewAutosaveName.historyDrawer(connectionId: UUID())),
+            key("com.TablePro.mainSplit"),
+            key("com.TablePro.mainSplit.0E5A1D48-1D0E-4F2E-9C21-2C19F0E3A77B"),
+            key("com.TablePro.usersRoles.mainSplit"),
+            key("ServerDashboardSplit"),
+            "com.TablePro.unrelatedSetting",
+            "NSWindow Frame JSONViewerWindow",
+        ]
+        #expect(SplitViewAutosaveSweep.deadKeys(among: untouchable).isEmpty)
+    }
+
+    @Test("A mixed domain loses only its retired records")
+    func sweepsOnlyRetiredFromAMixedDomain() {
+        let retired = key(retiredName())
+        let kept = [
+            key(SplitViewAutosaveName.querySplit(connectionId: UUID())),
+            key(SplitViewAutosaveName.historyDrawer(connectionId: UUID())),
+            key("com.TablePro.mainSplit"),
+        ]
+        #expect(SplitViewAutosaveSweep.deadKeys(among: kept + [retired]) == [retired])
+    }
+
+    /// A record written under the name the app builds today must not be one the sweep removes, or
+    /// the reader loses the divider they just set.
+    @Test("The name the app builds today survives the sweep")
+    func currentNameSurvives() {
+        let connectionId = UUID()
+        let current = key(SplitViewAutosaveName.querySplit(connectionId: connectionId))
+        #expect(SplitViewAutosaveSweep.deadKeys(among: [current]).isEmpty)
+    }
+}


### PR DESCRIPTION
Found while investigating the narrow-window clipping in #2808 and reported there as collateral. Two user-visible defects, one root cause: the editor/results divider's autosave name was built per tab, which `NSSplitView` cannot honour.

## The per-tab divider name never worked

`VerticalCollapsibleSplitView` assigns `autosaveName` in `makeNSViewController` only, and `queryTabContent` is the one tab-content branch with no `.id(tab.id)` where seven siblings have one. So switching between two query tabs reuses the same `NSSplitViewController` under the name it was born with: both tabs autosaved into the first tab's record and the second never got one. Drag tab A's divider to 70/30, switch to B and drag to 20/80, come back to A and A is 20/80.

Measured before this change: 164 persisted query tabs against exactly 1 tab id with a record, beside 795 records naming tabs that were already gone.

Reassigning the name on update cannot fix it, and `MainSplitViewController` already records that lesson one layer up: assigning a name to a split view that has already laid out does not re-apply the saved frames. Giving the branch its own identity per tab would work and would also rebuild the editor on every tab switch, discarding the find panel, the undo stack and the grid's scroll and selection.

So the name is now per connection, which is what the pane actually is. The divider stops changing under the reader, and the family stops growing.

## The records grew without bound

`NSSplitView` files one `UserDefaults` key per autosave name, spelled `NSSplitView Subview Frames <name>`, in the app process's own standard domain. Apple documents neither the spelling nor any way to forget a record: `autosaveName` is the whole API, and where `NSTableView` documents that setting it to nil clears the saved data, `NSSplitView` says nothing. `removeObject` is the only route.

`QueryTab.id` persists across launches and is never reused, so the retired name left one permanent record per query tab ever opened. Measured on one developer machine: 795 of them inside a 12,476-key, 1,969,777-byte `com.TablePro.plist`. `UserDefaults` parses the domain in full on first access during launch, and measured across four cold domains per point the cost is linear at 0.93us per autosave key: 5.4ms with none, 8.1-8.8ms with 2,735, 30.2-35.7ms at ten times that.

`SplitViewAutosaveSweep` removes them from `PostLaunchWork.start()`, which `LaunchEnvironment.finishLaunch()` reaches after marking the first frame presented. That placement is forced by measurement: removing thousands of keys costs 165-230ms, and `applicationDidBecomeActive` fires before the first frame. It is safe there because AppKit reads a record once, when `autosaveName` is assigned, so nothing re-reads one mid-session.

## The sweep judges no liveness, deliberately

An earlier version of this change pruned by connection liveness, and that was wrong. A linked-folder or team-library connection is built from its own id and handed straight to `openTransientConnection` without ever being saved, so `ConnectionStorage.loadConnections()` does not list it and its records would have read as orphaned on every launch. Reopening a still-available external connection would have lost its pane geometry every time.

So the sweep removes exactly one thing: records of the retired `QuerySplit-<connectionId>-<tabId>` family. No connection and no tab can make one live again, because no code writes or reads that name. Everything else, including the per-connection names this change introduces and every fixed name a pane declares once, is `unrecognised` and left alone.

The 1,313 `HistoryDrawer-<connectionId>` records are therefore still unbounded, and are reported below rather than swept: pruning them needs an answer to "which connections exist" that `ConnectionStorage` alone cannot give.

## The collapse state now comes from the tab

`makeNSViewController` collapsed the drawer only when the binding said so, never expanding it, so a record restored in the collapsed state could leave a pane collapsed against a tab whose `display.isResultsCollapsed` was false with nothing afterwards to expand it. Assigned unconditionally now, so the tab's own state wins over whatever the record held. That also settles what a per-connection name would otherwise do to a tab detached into its own window.

## Verified

- `verify.sh build` PASS.
- `verify.sh test SplitViewAutosaveSweepTests` PASS, 21 of 21.
- `verify.sh lint TablePro TableProTests TableProUITests` PASS, 0 violations.
- Mutation-checked at the earlier, larger scope: reducing the retired-family classifier to `unrecognised` failed 3 of 24 cases, and they were the three that assert it.
- Measured after the fact: removing 2,735 keys took the plist from 1,969,777 to 1,313,455 bytes. `synchronize()` does not force that; cfprefsd rewrites it within seconds on its own.

`SplitViewAutosaveSweepTests` derives the undocumented key prefix from a real `NSSplitView` rather than trusting the transcription in the source, so a macOS that changes the spelling fails the suite instead of silently sweeping nothing.

`.swiftlint.yml` adds `SplitViewAutosaveSweep` to the `storage_environment_defaults` exception list, beside the three files already there. The rule is right that app preferences belong to `AppStorageEnvironment.shared.defaults`; these records are AppKit's own and land in the standard domain, which is the whole reason `SplitViewAutosaveName` exists.

## Found and not fixed here

Each verified with a file:line and a failure scenario, left for a separate decision:

- `HistoryDrawer-<connectionId>` still accumulates one record per connection ever deleted, for the liveness reason above.
- `ConnectionLocalState.purge` never removes a deleted connection's `TabState/<id>.json`, so the full SQL text of its tabs is retained forever.
- `QuickSwitcher.frecency.<connectionId>` is a second per-connection `UserDefaults` family that nothing purges.
- `.settings` sync tombstones are written in five places and read in none, so a deleted connection's column layout is recreated from CloudKit on the next sync.
- A failed overflow-sidecar write deletes the previous good sidecar and puts the oversized query back into the JSON the cap exists to protect.
- `UITestCase.sweepLeftoverSuites` removes the test suites but not the suffixed autosave records AppKit writes into the app's real domain, so a UI run still leaves one per case. Fixing it from the runner does not work: `UserDefaults.standard` there names the runner's own domain, so the cleanup has to happen in the app process or reach the app's domain explicitly.

---

https://claude.ai/code/session_0199FyWsqTtfW2avaX9N4rYE
